### PR TITLE
handle_file_req handler for crossdomain.xml

### DIFF
--- a/src/couchdb/couch_httpd_misc_handlers.erl
+++ b/src/couchdb/couch_httpd_misc_handlers.erl
@@ -50,6 +50,12 @@ handle_favicon_req(#httpd{method='GET'}=Req, DocumentRoot) ->
 handle_favicon_req(Req, _) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
+handle_file_req(#httpd{method='GET'}=Req, Document) ->
+    couch_httpd:serve_file(Req, filename:basename(Document), filename:dirname(Document));
+
+handle_file_req(Req, _) ->
+    send_method_not_allowed(Req, "GET,HEAD").
+
 handle_utils_dir_req(#httpd{method='GET'}=Req, DocumentRoot) ->
     "/" ++ UrlPath = couch_httpd:path(Req),
     case couch_httpd:partition(UrlPath) of


### PR DESCRIPTION
Add a new handler, handle_file_req, to serve up files like /crossdomain.xml from a couchdb instance. For example, you could add:

[httpd_global_handlers]
crossdomain.xml = {couch_httpd_misc_handlers, handle_file_req, "/usr/share/couchdb/www/crossdomain.xml" }

To your local.ini to serve up crossdomain.xml.
