### PR TITLE
Tried to add clarity to documentation for view function

### DIFF
--- a/share/www/script/jquery.couch.js
+++ b/share/www/script/jquery.couch.js
@@ -861,7 +861,8 @@
          * uploads/all/documentation/couchbase-api-design.html#couchbase-api-
          * design_db-design-designdoc-view-viewname_get">docs for /db/
          * _design/design-doc/_list/l1/v1</a>
-         * @param {String} name View to run list against
+         * @param {String} name View to run list against (string should have 
+         * the design-doc name followed by a slash and the view name)
          * @param {ajaxSettings} options <a href="http://api.jquery.com/
          * jQuery.ajax/#jQuery-ajax-settings">jQuery ajax settings</a>
          */


### PR DESCRIPTION
I couldn't figure out how to use the view function until I read the source and saw that it was splitting on "/", so I tried to add this to the docs.
