### PR TITLE
Avoid error popup when viewing futon on a vhost

### DIFF
--- a/share/www/script/futon.js
+++ b/share/www/script/futon.js
@@ -527,6 +527,9 @@ function $$(node) {
       $.couch.info({
         success: function(info, status) {
           $("#version").text(info.version);
+        },
+        error: function() { // probably a vhost
+          $("#version").text("");
         }
       });
     });


### PR DESCRIPTION
We can't _get_ CouchDB version on a vhost - but we can _ignore_ it :)
