### PR TITLE
Fix for problem with "require"-ing a js module which ends in a line comment

### DIFF
--- a/share/server/util.js
+++ b/share/server/util.js
@@ -87,7 +87,7 @@ var Couch = {
               // create empty exports object before executing the module,
               // stops circular requires from filling the stack
               ddoc._module_cache[newModule.id] = {};
-              var s = "function (module, exports, require) { " + newModule.current + " }";
+              var s = "function (module, exports, require) { " + newModule.current + "\n }";
               try {
                 var func = sandbox ? evalcx(s, sandbox, newModule.id) : eval(s);
                 func.apply(sandbox, [newModule, newModule.exports, function(name) {


### PR DESCRIPTION
"require"-ing a js module which ends in a line comment will fail with a mysterious error message, because the line comment will comment out surrounding code added in /share/server/util.js

This patch adds a newline to terminate comments that might appear at the end of module files.

Note that it doesn't help to add a newline to the end of the module file -- couchdb apparently strips that away.
