### PR TITLE
_session request response no longer cached 

### DIFF
--- a/share/www/script/jquery.couch.js
+++ b/share/www/script/jquery.couch.js
@@ -139,7 +139,7 @@
      */
     session: function(options) {
       options = options || {};
-      $.ajax({
+      ajax({
         type: "GET", url: this.urlPrefix + "/_session",
         beforeSend: function(xhr) {
             xhr.setRequestHeader('Accept', 'application/json');


### PR DESCRIPTION
In IE7 session request response was cached, using the already defined ajax helper function instead of jquery ajax resolves this.
