### PR TITLE
[PATCH] Fix Mochiweb acceptor blocked in ssl handshake

### DIFF
--- a/src/mochiweb/mochiweb_acceptor.erl
+++ b/src/mochiweb/mochiweb_acceptor.erl
@@ -18,13 +18,14 @@ init(Server, Listen, Loop) ->
     case catch mochiweb_socket:accept(Listen) of
         {ok, Socket} ->
             gen_server:cast(Server, {accepted, self(), timer:now_diff(now(), T1)}),
-            call_loop(Loop, Socket);
+            case mochiweb_socket:after_accept(Socket) of
+                ok -> call_loop(Loop, Socket);
+                {error, _} -> exit(normal)
+            end;
         {error, closed} ->
             exit(normal);
         {error, timeout} ->
             init(Server, Listen, Loop);
-        {error, esslaccept} ->
-            exit(normal);
         Other ->
             error_logger:error_report(
               [{application, mochiweb},


### PR DESCRIPTION
Acceptor cannot be recycled until ssl handshake is done,
so it's possible and easy for all acceptors be blocked between the point
where the new socket's connected and the ssl handshake is done.
