### PR TITLE
disallow https for remote loading as well

### DIFF
--- a/share/www/script/couch_test_runner.js
+++ b/share/www/script/couch_test_runner.js
@@ -16,6 +16,7 @@
 function loadScript(url) {
   // disallow loading remote URLs
   if((url.substr(0, 7) == "http://")
+    || (url.substr(0, 7) == "https://")
     || (url.substr(0, 2) == "//")
     || (url.substr(0, 5) == "data:")
     || (url.substr(0, 11) == "javascript:")) {


### PR DESCRIPTION
If we want to prevent remote loading, blocking https is a good idea too.
