### PR TITLE
Rewrite using functions

### DIFF
--- a/share/server/loop.js
+++ b/share/server/loop.js
@@ -60,6 +60,7 @@ var DDoc = (function() {
     "lists"     : Render.list,
     "shows"    : Render.show,
     "filters"   : Filter.filter,
+    "rewrites"  : Render.rewrite,
     "views"     : Filter.filter_view, 
     "updates"  : Render.update,
     "validate_doc_update" : Validate.validate

--- a/share/server/render.js
+++ b/share/server/render.js
@@ -278,10 +278,10 @@ var Render = (function() {
 
   function runRewrite(fun, ddoc, args) {
     try {
-      log(JSON.stringify(args, null, 4));
+      // log(JSON.stringify(args, null, 4));
       var req = args[0];
       var reqPath = req.path.slice(req.path.indexOf("_rewrite") + 1).join("/");
-      log("Path is " + reqPath);
+      // log("Path is " + reqPath);
       var result = fun.apply(ddoc, [req, reqPath]);
       if (!result) {
         throw(["error", "rewrite_error", "rewrite function could not produce mapping"]);

--- a/share/server/render.js
+++ b/share/server/render.js
@@ -276,6 +276,25 @@ var Render = (function() {
     }
   };
 
+  function runRewrite(fun, ddoc, args) {
+    try {
+      var result = fun.apply(ddoc, args);
+      if (!result) {
+        throw(["error", "rewrite_error", "rewrite function could not produce mapping"]);
+      }
+      if (typeof result === "string") {
+        result = { path: result };
+      }
+      if (typeof result !== "object") {
+        throw(["error", "rewrite_error", "incomprehensible response from rewrite function"]);
+      }
+      if (!result.method) result.method = args[0].method;
+      respond(["rew", doc, result]);
+    } catch(e) {
+      renderError(e, fun.toSource());
+    }
+  };
+
   function resetList() {
     gotRow = false;
     lastRow = false;
@@ -335,6 +354,9 @@ var Render = (function() {
     },
     list : function(fun, ddoc, args) {
       runList(fun, ddoc, args);
+    },
+    rewrite : function(fun, ddoc, args) {
+      runRewrite(fun, ddoc, args);
     }
   };
 })();

--- a/share/server/render.js
+++ b/share/server/render.js
@@ -289,7 +289,7 @@ var Render = (function() {
         throw(["error", "rewrite_error", "incomprehensible response from rewrite function"]);
       }
       if (!result.method) result.method = args[0].method;
-      respond(["rew", doc, result]);
+      respond(["rew", result]);
     } catch(e) {
       renderError(e, fun.toSource());
     }

--- a/share/server/render.js
+++ b/share/server/render.js
@@ -278,7 +278,10 @@ var Render = (function() {
 
   function runRewrite(fun, ddoc, args) {
     try {
-      var result = fun.apply(ddoc, args);
+      log(JSON.stringify(args, null, 4));
+      var req = args[0];
+      var reqPath = req.path.slice(req.path.indexOf("_rewrite") + 1).join("/");
+      var result = fun.apply(ddoc, [req, reqPath]);
       if (!result) {
         throw(["error", "rewrite_error", "rewrite function could not produce mapping"]);
       }
@@ -288,7 +291,7 @@ var Render = (function() {
       if (typeof result !== "object") {
         throw(["error", "rewrite_error", "incomprehensible response from rewrite function"]);
       }
-      if (!result.method) result.method = args[0].method;
+      if (!result.method) result.method = req.method;
       respond(["rew", result]);
     } catch(e) {
       renderError(e, fun.toSource());

--- a/share/server/render.js
+++ b/share/server/render.js
@@ -281,6 +281,7 @@ var Render = (function() {
       log(JSON.stringify(args, null, 4));
       var req = args[0];
       var reqPath = req.path.slice(req.path.indexOf("_rewrite") + 1).join("/");
+      log("Path is " + reqPath);
       var result = fun.apply(ddoc, [req, reqPath]);
       if (!result) {
         throw(["error", "rewrite_error", "rewrite function could not produce mapping"]);

--- a/share/www/script/test/rewrite.js
+++ b/share/www/script/test/rewrite.js
@@ -455,7 +455,6 @@ couchTests.rewrite = function(debug) {
 
         // very basic rewrite
         req = CouchDB.request("GET", "/" + dbName + "/_design/funcrew/_rewrite/foo");
-        console.log(req.responseText);
         T(req.responseText == "This is a base64 encoded text");
         T(req.getResponseHeader("Content-Type") == "text/plain");
       }

--- a/share/www/script/test/rewrite.js
+++ b/share/www/script/test/rewrite.js
@@ -435,7 +435,7 @@ couchTests.rewrite = function(debug) {
     }
     db.save(ddoc);
     var res = CouchDB.request("GET", "/"+dbName+"/_design/invalid/_rewrite/foo");
-    TEquals(400, res.status, "should return 400");
+    TEquals(500, res.status, "should return 500");
 
     var ddoc_requested_path = {
       _id: "_design/requested_path",

--- a/share/www/script/test/rewrite.js
+++ b/share/www/script/test/rewrite.js
@@ -437,9 +437,11 @@ couchTests.rewrite = function(debug) {
         value: "X-Couch-Test-Auth"}],
       
       function(){
-        var func_rewrite = function (req) {
-          // console.log(req);
-          return "foo.txt";
+        var func_rewrite = function (req, path) {
+          if (path === "foo") {
+            return "foo.txt";
+          }
+          return false;
         };
         var ddoc_func = {
           _id:        "_design/funcrew",

--- a/share/www/script/test/rewrite.js
+++ b/share/www/script/test/rewrite.js
@@ -459,6 +459,10 @@ couchTests.rewrite = function(debug) {
         req = CouchDB.request("GET", "/" + dbName + "/_design/funcrew/_rewrite/foo");
         T(req.responseText == "This is a base64 encoded text");
         T(req.getResponseHeader("Content-Type") == "text/plain");
+        
+        // rewrite that doesn't exist
+        req = CouchDB.request("GET", "/" + dbName + "/_design/funcrew/_rewrite/does/not/exist");
+        TEquals(500, req.status, "should return 500");
       }
     );
 

--- a/src/couchdb/couch_httpd_rewrite.erl
+++ b/src/couchdb/couch_httpd_rewrite.erl
@@ -106,6 +106,32 @@
 %% {"from": "/a",           /a?foo=b        /some/b             foo =:= b
 %% "to": "/some/:foo",
 %%  }}
+%% 
+%% Alternatively, the rewriting can be performed by a function. It is specified
+%% as follows:
+%% 
+%%  {
+%%      ....
+%%      "rewrites": "function (req, path) {
+%%          // process the request, and return the rewrite
+%%      }"
+%%  }
+%%
+%% The function is called with the request object and a path string. The latter
+%% contains whatever path is left after removing everything up to _rewrite/.
+%% 
+%% Which rewrite takes place depends on what the function returns, which can be
+%% one of three things:
+%% 
+%%   - false, or a falsy value: indicates that the rewrite could not be 
+%%     performed. This translates to a 500 error.
+%%   - "a/path": causes the rewrite to that path to take place, with the
+%%     original method being kept.
+%%   - { path: "a/path", method: "FOO" }: rewrites to that path and changes
+%%     the method to the one provided.
+%%
+%% Rewrite functions are meant to be devoid of side-effects and one should
+%% write under the assumption that they are being cached.
 
 
 

--- a/src/couchdb/couch_httpd_rewrite.erl
+++ b/src/couchdb/couch_httpd_rewrite.erl
@@ -138,9 +138,6 @@ handle_rewrite_req(#httpd{
             couch_httpd:send_error(Req, 404, <<"rewrite_error">>,
                 <<"Invalid path.">>);
         Bin when is_binary(Bin) ->
-            %% XXX TODO
-            %   - needs more tests
-            %   - needs some docs
             case couch_query_servers:rewrite(Req, _Db, DDoc) of
                 undefined ->
                     couch_httpd:send_error(Req, 404, <<"rewrite_error">>,

--- a/src/couchdb/couch_httpd_rewrite.erl
+++ b/src/couchdb/couch_httpd_rewrite.erl
@@ -141,7 +141,6 @@ handle_rewrite_req(#httpd{
             %% XXX TODO
             %   - needs more tests
             %   - needs some docs
-            %   - the rewrite function gets the request — maybe it should get the post-_rewrite path?
             case couch_query_servers:rewrite(Req, _Db, DDoc) of
                 undefined ->
                     couch_httpd:send_error(Req, 404, <<"rewrite_error">>,

--- a/src/couchdb/couch_query_servers.erl
+++ b/src/couchdb/couch_query_servers.erl
@@ -20,6 +20,7 @@
 -export([reduce/3, rereduce/3,validate_doc_update/5]).
 -export([filter_docs/5]).
 -export([filter_view/3]).
+-export([rewrite/3]).
 
 -export([with_ddoc_proc/2, proc_prompt/2, ddoc_prompt/3, ddoc_proc_prompt/3, json_doc/1]).
 
@@ -237,6 +238,15 @@ validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
             throw({forbidden, Message});
         {[{<<"unauthorized">>, Message}]} ->
             throw({unauthorized, Message})
+    end.
+
+rewrite(Req, Db, DDoc) ->
+    JsonReq = couch_httpd_external:json_req_obj(Req, Db),
+    case ddoc_prompt(DDoc, [<<"rewrites">>], [JsonReq]) of
+        [<<"error">>] ->
+            undefined;
+        [<<"rew">>, Rewrite] ->
+            Rewrite
     end.
 
 json_doc(nil) -> null;


### PR DESCRIPTION
This pull request implements the ability of using functions for rewriting in addition to the rewriting microlanguage that is currently available. The motivation for doing so comes from a discussion on the users' list in which it turned out that I wasn't the only one who found the microlanguage limited (the latter still works just the same though).

It uses the same "rewrites" ddoc key so that you can't have both. I think that this is a feature: specifying both and having to figure out which takes precedence would be excessive complication IMHO. And it's of course possible to have the function implement the microlanguage if for some reason one wishes to use both simultaneously.

I've provided some docs in the comments — if the patch is accepted and those need to be mirrored (and expanded) somewhere else, simply tell me where is the preferred location. I've also written some tests; I guess that there could be more but it seems clear that it works and doesn't break existing rewrites.

The only change that it makes to the current HTTP interface is that previously if you added a ddoc with a string as the value for "rewrites" you'd get a 400. Now, if that strings is a valid function is just works, and if it's not you get a 500. I doubt that this will break anything.

Some caveats:

• This is essentially my Hello World to Erlang. It's not out of the question that I've written something that looks terrifyingly stupid or woefully more convoluted than it needs to be.

• I've tried to follow the coding conventions that I noticed, apologies if I messed it up here or there.

• The rewrite functions are meant to be cacheable at least for the lifetime of a given ddoc but I haven't added such caching. I don't know how much it would affect performance (though I would expect some). I also don't know whether it should vary on userCtx or not. Either way, I think that it's an optimisation that can be added later.
