### PR TITLE
adds CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,30 +3,58 @@
 to be added...
 
 ## to Documentation
-The documentation lives in the CouchDB source tree. We’ll start by forking and closing the CouchDB GitHub mirror. That will allow us to send the contribution to CouchDB with a pull request.
+The documentation lives in the CouchDB source tree. We’ll start by 
+forking and closing the CouchDB GitHub mirror. That will allow us to 
+send the contribution to CouchDB with a pull request.
 
-If you don’t have a GitHub account yet, it is a good time to get one, they are free. If you don’t want to use GitHub, there are alternate ways to contributing back, that we’ll cover next time.
+If you don’t have a GitHub account yet, it is a good time to get one, 
+they are free. If you don’t want to use GitHub, there are alternate 
+ways to contributing back, that we’ll cover next time.
 
-Go to https://github.com/apache/couchdb and click the “fork” button in the top right. This will create a fork of CouchDB in your GitHub account. Mine is janl, so my fork lives at https://github.com/janl/couchdb. In the header, it tells me me my “GitHub Clone URL”. We need to copy that and start a terminal:
+Go to https://github.com/apache/couchdb and click the “fork” button in 
+the top right. This will create a fork of CouchDB in your GitHub 
+account. Mine is janl, so my fork lives at 
+https://github.com/janl/couchdb. In the header, it tells me me my 
+“GitHub Clone URL”. We need to copy that and start a terminal:
 
-I’m opening the whole CouchDB source tree in my favourite editor. It gives me the usual directory listing:
+I’m opening the whole CouchDB source tree in my favourite editor. It 
+gives me the usual directory listing:
 
-The documentation sources live in src/doc, you can safely ignore all the other files and directories.
+The documentation sources live in src/doc, you can safely ignore all 
+the other files and directories.
 
-First we should determine where we want to document this inside the documentation. We can look through http://docs.couchdb.org/en/latest/ for inspiration. The JSON Structure Reference looks like a fine place to write this up.
+First we should determine where we want to document this inside the 
+documentation. We can look through http://docs.couchdb.org/en/latest/ 
+for inspiration. The JSON Structure Reference looks like a fine place 
+to write this up.
 
-The current state includes mostly tables describing the JSON structure (after all, that’s the title of this chapter), but some prose about the number representation can’t hurt. For future reference, since the topic in the thread includes views and different encoding in views (as opposed to the storage engine), we should remember to make a note in the views documentation as well, but we’ll leave this for later.
+The current state includes mostly tables describing the JSON structure 
+(after all, that’s the title of this chapter), but some prose about the 
+number representation can’t hurt. For future reference, since the topic 
+in the thread includes views and different encoding in views (as 
+opposed to the storage engine), we should remember to make a note in 
+the views documentation as well, but we’ll leave this for later.
 
-Let’s try and find the source file that builds the file http://docs.couchdb.org/en/latest/json-structure.html – we are in luck, under share/docs/src/ we find the file json-structure.rst. That looks promising. .rst stands for ReStructured Text (see http://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html for a markup reference), which is an ascii format for writing documents, documentation in this case. Let’s have a look and open it.
+Let’s try and find the source file that builds the file 
+http://docs.couchdb.org/en/latest/json-structure.html – we are in luck, 
+under share/docs/src/ we find the file json-structure.rst. That looks 
+promising. .rst stands for ReStructured Text (see 
+http://thomas-cokelaer.info/tutorials/sphinx/rest_syntax.html for a 
+markup reference), which is an ascii format for writing documents, 
+documentation in this case. Let’s have a look and open it.
 
-We see ascii tables with some additional formatting, all looking like the final HTML. So far so easy. For now, let’s just add to the bottom of this. We can worry about organising this better later.
+We see ascii tables with some additional formatting, all looking like 
+the final HTML. So far so easy. For now, let’s just add to the bottom 
+of this. We can worry about organising this better later.
 
 We start by adding a new headline:
 ```
 Number Handling
 ===============
 ```
-Now we paste in the rest of the main email of the thread. It is mostly text, but it includes some code listings. Let’s mark them up. We’ll turn:
+Now we paste in the rest of the main email of the thread. It is mostly 
+text, but it includes some code listings. Let’s mark them up. We’ll 
+turn:
 ```
 ejson:encode(ejson:decode(<<"1.1">>)).
 <<"1.1000000000000000888">>
@@ -66,20 +94,26 @@ Spidermonkey::
 ```
 And then follow all the other ones.
 
-I cleaned up the text a little but to make it sound more like a documentation entry as opposed to a post on a mailing list.
+I cleaned up the text a little but to make it sound more like a 
+documentation entry as opposed to a post on a mailing list.
 
-The next step would be to validate that we got all the markup right. I’ll leave this for later. For now we’ll contribute our change back to CouchDB.
+The next step would be to validate that we got all the markup right. 
+I’ll leave this for later. For now we’ll contribute our change back to 
+CouchDB.
 
-First, we commit our changes:
+First, we commit our changes: 
 ```
-$ > git commit -am 'document number encoding'
-[master a84b2cf] document number encoding
+$ > git commit -am 'document number encoding' 
+[master a84b2cf] 
+document number encoding 
 1 file changed, 199 insertions(+)
 ```
-Then we push the commit to our CouchDB fork:
+Then we push the commit to our CouchDB fork: 
 ```
 $ git push origin master
 ```
-Next, we go back to our GitHub page https://github.com/janl/couchdb and click the “Pull Request button”. Fill in the description with something useful and hit the “Send Pull Request” button.
+Next, we go back to our GitHub page https://github.com/janl/couchdb 
+and click the “Pull Request button”. Fill in the description with 
+something useful and hit the “Send Pull Request” button.
 
 And we’re done!


### PR DESCRIPTION
1st draft commit of @janl's docs contributions content
(http://docs.couchdb.org/en/latest/contributing.html)
as a github project contribution guideline, as per
(https://github.com/blog/1184-contributing-guidelines)

---

:+1: 
The **upside** to maintaining a [bonafide CONTRIBUTING policy file](https://github.com/blog/1184-contributing-guidelines) here in the root of the project tree, is that it becomes easily discoverable by folks who arrive at `apache/couchdb` project on github to open issues and submit pull requests... the policy is revealed thusly above both the "create new issue" and "create new pull request" forms:
![Screen Shot 2013-02-21 at 10 56 57 AM](https://f.cloud.github.com/assets/194904/181156/bc9c6332-7c47-11e2-9f35-fa319020e5fe.png)

:-1: 
The **downside** is dual-maintenance - keeping this `CONTRIBUTING.md` policy file in sync with the same content in the [`share/doc/src/contributing.rst`](https://github.com/apache/couchdb/blob/master/share/doc/src/contributing.rst) file (plus whereever the source code contribution guidelines are?).

Unless someone knows of a clever way to reconcile that to NOT be dual-maintenance.
