### PR TITLE
COUCHDB-259 allow content_type of attachments to be changed via stub

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Apache CouchDB CHANGES
 # HTTP Interface:
 #
 #  * Fixed bug with CORS and replication (COUCHDB-1689).
+#  * Allow update of content_type in attachments (COUCHDB-259).
 #
 # Test Suite:
 #

--- a/share/doc/src/api/documents.rst
+++ b/share/doc/src/api/documents.rst
@@ -650,6 +650,55 @@ The JSON returned will include the updated revision number:
 For information on batched writes, which can provide improved
 performance, see :ref:`api-batch-writes`.
 
+Inline Attachments
+------------------
+
+It is possible to store attachments inline, along with the main
+JSON structure. Attachments go into a special _attachments attribute
+of the document. They are encoded in a JSON structure that holds
+the name, the content_type and the base64 encoded data of an
+attachment.
+
+Creating a document with an attachment: 
+
+.. code-block:: javascript
+
+    {
+      "_id":"attachment_doc",
+      "_attachments":
+      {
+        "foo.txt":
+        {
+          "content_type":"text/plain",
+          "data": "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        }
+      }
+    }
+
+While metatdata for the attachment (length, MD5-sum, etc.) is
+maintained by the server, it is possible to change the content_type
+field without sending the attachment data. This is useful for cases
+when the supplied content type cannot be trusted (i.e. direct uploads
+via browser).
+
+To change the content type field, PUT the document along with a stub
+attachment structure and the updated content type field:
+
+.. code-block:: javascript
+
+    {
+      "_id":"attachment_doc",
+      "_attachments":
+      {
+        "foo.txt":
+        {
+          "stub": true,
+          "content_type":"text/x-markdown"
+        }
+      }
+    }
+
+
 .. _api-del-doc:
 
 ``DELETE /db/doc``

--- a/src/couchdb/couch_doc.erl
+++ b/src/couchdb/couch_doc.erl
@@ -423,11 +423,14 @@ merge_stubs(#doc{id = Id}, nil) ->
 merge_stubs(#doc{id=Id,atts=MemBins}=StubsDoc, #doc{atts=DiskBins}) ->
     BinDict = dict:from_list([{Name, Att} || #att{name=Name}=Att <- DiskBins]),
     MergedBins = lists:map(
-        fun(#att{name=Name, data=stub, revpos=StubRevPos}) ->
+        fun(#att{name=Name, data=stub, revpos=StubRevPos, type=Type}) ->
             case dict:find(Name, BinDict) of
             {ok, #att{revpos=DiskRevPos}=DiskAtt}
                     when DiskRevPos == StubRevPos orelse StubRevPos == nil ->
-                DiskAtt;
+                case Type of
+                _Binary when is_binary(Type) -> DiskAtt#att{type=Type};
+                _Else -> DiskAtt
+                end;
             _ ->
                 throw({missing_stub,
                         <<"id:", Id/binary, ", name:", Name/binary>>})


### PR DESCRIPTION
Patch to allow the content type of attachments to be changed via a document PUT and stub structure. Partially solves COUCHDB-259, but useful anyway. Test included.
