### PR TITLE
COUCHDB-259 allow arbitrary data to be stored along attachments

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ Apache CouchDB CHANGES
 # HTTP Interface:
 #
 #  * Fixed bug with CORS and replication (COUCHDB-1689).
+#  * Allow update of content_type in attachments (COUCHDB-259).
+#  * Allow arbitrary data to be stored in attachments (COUHDB-259).
 #
 # Test Suite:
 #

--- a/share/doc/src/api/documents.rst
+++ b/share/doc/src/api/documents.rst
@@ -650,6 +650,82 @@ The JSON returned will include the updated revision number:
 For information on batched writes, which can provide improved
 performance, see :ref:`api-batch-writes`.
 
+Inline Attachments
+------------------
+
+It is possible to store attachments inline, along with the main
+JSON structure. Attachments go into a special _attachments attribute
+of the document. They are encoded in a JSON structure that holds
+the name, the content_type and the base64 encoded data of an
+attachment.
+
+Creating a document with an attachment: 
+
+.. code-block:: javascript
+
+    {
+      "_id":"attachment_doc",
+      "_attachments":
+      {
+        "foo.txt":
+        {
+          "content_type":"text/plain",
+          "data": "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        }
+      }
+    }
+
+While metatdata for the attachment (length, MD5-sum, etc.) is
+maintained by the server, it is possible to change the content_type
+field without sending the attachment data. This is useful for cases
+when the supplied content type cannot be trusted (i.e. direct uploads
+via browser).
+
+To change the content type field, PUT the document along with a stub
+attachment structure and the updated content type field:
+
+.. code-block:: javascript
+
+    {
+      "_id":"attachment_doc",
+      "_attachments":
+      {
+        "foo.txt":
+        {
+          "stub": true,
+          "content_type":"text/x-markdown"
+        }
+      }
+    }
+
+Additional Arbitrary Data in Attachments
+----------------------------------------
+
+It is possible to store additional arbitrary data inside the _attachments
+attribute (as long as there is no clash with the standard attachment 
+attributes like ``stub``, ``content_type``, ``encoding`` etc.). Deleting
+the attachment also removes associated data, as one would expect.
+
+A typical use case would be to store an ``uploaded_by`` field along with 
+every attachment. Another use case would be to store state data for post-
+processing workers with the attachment.
+
+.. code-block:: javascript
+
+    {
+      "_id":"attachment_doc",
+      "_attachments":
+      {
+        "foo.txt":
+        {
+          "data": "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=",
+          "content_type":"text/plain",
+          "uploaded_by": "Sam Simple",
+          "spell_checked": false
+        }
+      }
+    }
+
 .. _api-del-doc:
 
 ``DELETE /db/doc``

--- a/share/www/script/test/attachment_arbitrary_data.js
+++ b/share/www/script/test/attachment_arbitrary_data.js
@@ -1,0 +1,71 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+couchTests.attachment_arbitrary_data = function(debug) {
+
+  var db = new CouchDB("test_suite_db", {"X-Couch-Full-Commit":"false"});
+  db.deleteDb();
+  db.createDb();
+
+  // test COUCHDB-259 - allow arbitrary data to be stored along with the attachment
+  var bin_doc9 = {
+    _id: "bin_doc9",
+    name: "Don Draper",
+    _attachments:{
+      "foo.txt": {
+        "content_type":"text/plain",
+        "data": "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=",
+        "field1": "I am a simple string.",
+        "field2": 1234,
+        "field3": [1234, "string", null, {"hey":"ho", "tic":"tac"}]
+      },
+      "foo2.txt": {
+        "content_type":"text/plain",
+        "data": "SGV5IHRoZXJlCg=="
+      }
+    }
+  };
+
+  TEquals(true, db.save(bin_doc9).ok);
+  bin_doc9 = db.open("bin_doc9");
+
+  var stub_data9 = bin_doc9._attachments["foo.txt"];
+  TEquals("I am a simple string.", stub_data9.field1);
+  TEquals(1234, stub_data9.field2);
+
+  TEquals(4, stub_data9.field3.length);
+  TEquals(1234, stub_data9.field3[0]);
+  TEquals("string", stub_data9.field3[1]);
+  TEquals(null, stub_data9.field3[2]);
+  TEquals("tac", stub_data9.field3[3].tic);
+
+
+  // update a field via stub structure
+  var oldRev = bin_doc9._rev;
+  stub_data9.field1 = "I am a better string.";
+  delete stub_data9.field2;
+  bin_doc9._attachments["foo.txt"] = stub_data9;
+  TEquals(true, db.save(bin_doc9).ok);
+  bin_doc9 = db.open("bin_doc9");
+  TEquals("I am a better string.", bin_doc9._attachments["foo.txt"].field1);
+  // has the revision changed properly?
+  T(bin_doc9._rev != oldRev);
+  // is the deleted field2 gone?
+  TEquals(undefined, bin_doc9._attachments["foo.txt"].field2);
+
+  // remove the attachment
+  delete bin_doc9._attachments["foo.txt"];
+  TEquals(true, db.save(bin_doc9).ok);
+  bin_doc9 = db.open("bin_doc9");
+  TEquals(undefined, bin_doc9._attachments["foo.txt"]);
+
+};

--- a/share/www/script/test/attachments_multipart.js
+++ b/share/www/script/test/attachments_multipart.js
@@ -30,7 +30,8 @@ couchTests.attachments_multipart= function(debug) {
           "foo.txt": {
             "follows":true,
             "content_type":"application/test",
-            "length":21
+            "length":21,
+            "arbitrary_field": "arbitrary content"
             },
           "bar.txt": {
             "follows":true,
@@ -176,8 +177,11 @@ couchTests.attachments_multipart= function(debug) {
   
   // parse out the multipart
   var sections = parseMultipart(xhr);
-  TEquals("790", xhr.getResponseHeader("Content-Length"),
+  TEquals("828", xhr.getResponseHeader("Content-Length"),
     "Content-Length should be correct");
+
+
+
   T(sections.length == 3);
   // The first section is the json doc. Check it's content-type.
   // Each part carries their own meta data.

--- a/src/couch_replicator/test/04-replication-large-atts.t
+++ b/src/couch_replicator/test/04-replication-large-atts.t
@@ -40,7 +40,8 @@
     md5= <<>>,
     revpos=0,
     data,
-    encoding=identity
+    encoding=identity,
+    body={[]}
 }).
 
 

--- a/src/couch_replicator/test/05-replication-many-leaves.t
+++ b/src/couch_replicator/test/05-replication-many-leaves.t
@@ -40,7 +40,8 @@
     md5= <<>>,
     revpos=0,
     data,
-    encoding=identity
+    encoding=identity,
+    body={[]}
 }).
 
 -define(b2l(B), binary_to_list(B)).

--- a/src/couch_replicator/test/06-doc-missing-stubs.t
+++ b/src/couch_replicator/test/06-doc-missing-stubs.t
@@ -40,7 +40,8 @@
     md5= <<>>,
     revpos=0,
     data,
-    encoding=identity
+    encoding=identity,
+    body={[]}
 }).
 
 -define(b2l(B), binary_to_list(B)).

--- a/src/couchdb/couch_db.hrl
+++ b/src/couchdb/couch_db.hrl
@@ -134,10 +134,11 @@
     md5= <<>>,
     revpos=0,
     data,
-    encoding=identity % currently supported values are:
+    encoding=identity, % currently supported values are:
                       %     identity, gzip
                       % additional values to support in the future:
                       %     deflate, compress
+    body={[]}
     }).
 
 

--- a/src/couchdb/couch_db_updater.erl
+++ b/src/couchdb/couch_db_updater.erl
@@ -826,11 +826,11 @@ copy_doc_attachments(#db{updater_fd = SrcFd} = SrcDb, SrcSp, DestFd) ->
     NewBinInfos = lists:map(
         fun({Name, Type, BinSp, AttLen, RevPos, Md5}) ->
             % 010 UPGRADE CODE
-            {NewBinSp, AttLen, AttLen, Md5, _IdentityMd5} =
+            {NewBinSp, AttLen, AttLen, Md5, _IdentityMd5} = 
                 couch_stream:copy_to_new_stream(SrcFd, BinSp, DestFd),
             {Name, Type, NewBinSp, AttLen, AttLen, RevPos, Md5, identity};
         ({Name, Type, BinSp, AttLen, DiskLen, RevPos, Md5, Enc1}) ->
-            {NewBinSp, AttLen, _, Md5, _IdentityMd5} =
+            {NewBinSp, AttLen, _, Md5, _IdentityMd5} = 
                 couch_stream:copy_to_new_stream(SrcFd, BinSp, DestFd),
             Enc = case Enc1 of
             true ->
@@ -842,9 +842,14 @@ copy_doc_attachments(#db{updater_fd = SrcFd} = SrcDb, SrcSp, DestFd) ->
             _ ->
                 Enc1
             end,
-            {Name, Type, NewBinSp, AttLen, DiskLen, RevPos, Md5, Enc}
+            {Name, Type, NewBinSp, AttLen, DiskLen, RevPos, Md5, Enc};
+        ({Name, Type, BinSp, AttLen, DiskLen, RevPos, Md5, Enc, AttBody}) ->
+            {NewBinSp, AttLen, _, Md5, _IdentityMd5} = 
+                couch_stream:copy_to_new_stream(SrcFd, BinSp, DestFd),
+            {Name, Type, NewBinSp, AttLen, DiskLen, RevPos, Md5, Enc, AttBody}
         end, BinInfos),
     {BodyData, NewBinInfos}.
+
 
 copy_docs(Db, #db{updater_fd = DestFd} = NewDb, InfoBySeq0, Retry) ->
     % COUCHDB-968, make sure we prune duplicates during compaction
@@ -868,7 +873,7 @@ copy_docs(Db, #db{updater_fd = DestFd} = NewDb, InfoBySeq0, Retry) ->
                     {ok, Pos, SummarySize} = couch_file:append_raw_chunk(
                         DestFd, SummaryChunk),
                     TotalLeafSize = lists:foldl(
-                        fun({_, _, _, AttLen, _, _, _, _}, S) -> S + AttLen end,
+                        fun({_, _, _, AttLen, _, _, _, _, _}, S) -> S + AttLen end,
                         SummarySize, AttsInfo),
                     {IsDel, Pos, Seq, TotalLeafSize}
                 end, RevTree)}

--- a/test/etap/030-doc-from-json.t
+++ b/test/etap/030-doc-from-json.t
@@ -18,7 +18,7 @@
 -record(doc, {id= <<"">>, revs={0, []}, body={[]},
             atts=[], deleted=false, meta=[]}).
 -record(att, {name, type, att_len, disk_len, md5= <<>>, revpos=0, data,
-            encoding=identity}).
+            encoding=identity, body={[]}}).
 
 main(_) ->
     test_util:init_code_path(),
@@ -90,7 +90,8 @@ test_from_json_success() ->
                     type = <<"application/awesome">>,
                     att_len = 45,
                     disk_len = 45,
-                    revpos = nil
+                    revpos = nil,
+                    body = {[]}
                 },
                 #att{
                     name = <<"noahs_private_key.gpg">>,
@@ -98,7 +99,8 @@ test_from_json_success() ->
                     type = <<"application/pgp-signature">>,
                     att_len = 18,
                     disk_len = 18,
-                    revpos = 0
+                    revpos = 0,
+                    body = {[]}
                 }
             ]},
             "Attachments are parsed correctly."

--- a/test/etap/031-doc-to-json.t
+++ b/test/etap/031-doc-to-json.t
@@ -18,7 +18,7 @@
 -record(doc, {id= <<"">>, revs={0, []}, body={[]},
             atts=[], deleted=false, meta=[]}).
 -record(att, {name, type, att_len, disk_len, md5= <<>>, revpos=0, data,
-            encoding=identity}).
+            encoding=identity,body={[]}}).
 
 main(_) ->
     test_util:init_code_path(),


### PR DESCRIPTION
Also: Allow content_type to be changed via stub structure as well.

This includes my last pull request (which only allowed the content type to be changed). Tests included as I see fit, but comments welcome.
