### PR TITLE
COUCHDB-1755 notifications should take templates

### DIFF
--- a/src/fauxton/app/modules/fauxton/base.js
+++ b/src/fauxton/app/modules/fauxton/base.js
@@ -99,11 +99,13 @@ function(app, Backbone) {
       this.selector = options.selector;
       this.fade = options.fade === undefined ? true : options.fade;
       this.clear = options.clear;
+      this.data = options.data || "";
       this.template = options.template || "templates/fauxton/notification";
     },
 
     serialize: function() {
       return {
+        data: this.data,
         msg: this.msg,
         type: this.type
       };


### PR DESCRIPTION
Added the option to pass a template for custom notifications as well as data.  Data is serialized so it can be accessed in the custom template.
