### PR TITLE
[couch_doc] revid_to_str: account for the case when the RevId is a list of binaries

### DIFF
--- a/src/couchdb/couch_doc.erl
+++ b/src/couchdb/couch_doc.erl
@@ -55,6 +55,8 @@ to_json_revisions(Options, Start, RevIds) ->
                 {<<"ids">>, [revid_to_str(R) ||R <- RevIds]}]}}]
     end.
 
+revid_to_str([RevId|_]) when size(RevId) =:= 16 ->
+    ?l2b(couch_util:to_hex(RevId));
 revid_to_str(RevId) when size(RevId) =:= 16 ->
     ?l2b(couch_util:to_hex(RevId));
 revid_to_str(RevId) ->


### PR DESCRIPTION
this happens when _bulk_docs is posted with all_or_nothing=true
and validation func for at least one of the docs fails

see https://issues.apache.org/jira/browse/COUCHDB-1772 for details
