### PR TITLE
Service stop was not working as pid file was not cleared.

### DIFF
--- a/bin/couchdb.tpl.in
+++ b/bin/couchdb.tpl.in
@@ -290,6 +290,10 @@ stop_couchdb () {
     PID=`_get_pid`
     STOP_TIMEOUT=60
     if test -n "$PID"; then
+        if test "$1" = "false"; then
+            echo > $PID_FILE
+        fi
+
         if kill -0 $PID 2> /dev/null; then
             if kill -TERM $PID 2> /dev/null; then
                 count=0


### PR DESCRIPTION
Taken changes from 1.2.1 to stop the service. 

/bin/couchdb runs in a loop & checks if pid file not empty it assumes couchdb might have crashed and restarts couch. Latest start script is not clearing pid file.. so it keeps on starting couch server even after running couchdb -d 
