### PR TITLE
Fix for 1799

### DIFF
--- a/src/couchdb/couch_httpd.erl
+++ b/src/couchdb/couch_httpd.erl
@@ -316,7 +316,8 @@ handle_request_int(MochiReq, DefaultFun,
         design_url_handlers = DesignUrlHandlers,
         default_fun = DefaultFun,
         url_handlers = UrlHandlers,
-        user_ctx = erlang:erase(pre_rewrite_user_ctx)
+        user_ctx = erlang:erase(pre_rewrite_user_ctx),
+        auth = erlang:erase(pre_rewrite_auth)
     },
 
     HandlerFun = couch_util:dict_find(HandlerKey, UrlHandlers, DefaultFun),

--- a/src/couchdb/couch_httpd_rewrite.erl
+++ b/src/couchdb/couch_httpd_rewrite.erl
@@ -198,8 +198,11 @@ handle_rewrite_req(#httpd{
                 design_url_handlers = DesignUrlHandlers,
                 default_fun = DefaultFun,
                 url_handlers = UrlHandlers,
-                user_ctx = UserCtx
+                user_ctx = UserCtx,
+               auth = Auth
             } = Req,
+
+            erlang:put(pre_rewrite_auth, Auth),
             erlang:put(pre_rewrite_user_ctx, UserCtx),
             couch_httpd:handle_request_int(MochiReq1, DefaultFun,
                     UrlHandlers, DbUrlHandlers, DesignUrlHandlers)


### PR DESCRIPTION
Save the auth values along with the User context so that if the AuthSession cookie has passed the time left threshold a new Set-Cookie is returned
