### PR TITLE
Restore rev handling for _bulk_docs with all_or_nothing

### DIFF
--- a/src/couchdb/couch_db.erl
+++ b/src/couchdb/couch_db.erl
@@ -756,10 +756,15 @@ update_docs(Db, Docs, Options, interactive_edit) ->
 
     if (AllOrNothing) and (PreCommitFailures /= []) ->
         {aborted,
-         lists:foldl(fun({#doc{id=Id,revs={Pos, RevIds}}, Ref},Acc) ->
+         lists:foldl(fun({#doc{id=Id,revs=Revs}, Ref},Acc) ->
                          case lists:keyfind(Ref,1,PreCommitFailures) of
                          {Ref, Error} ->
-                             [{{Id,{Pos,RevIds}}, Error} | Acc];
+                             case Revs of
+                             {Pos, [RevId|_]} ->
+                                 [{{Id,{Pos, RevId}}, Error} | Acc];
+                             {0, []} ->
+                                 [{{Id,{0, <<>>}}, Error} | Acc]
+                             end;
                          false ->
                              Acc
                          end


### PR DESCRIPTION
Commit 5b1430c120904181313848444dbfcdb60e42568b added this hunk;
-        {aborted, lists:map(
-            fun({{Id,{Pos, [RevId|_]}}, Error}) ->
-                {{Id, {Pos, RevId}}, Error};
-            ({{Id,{0, []}}, Error}) ->
-                {{Id, {0, <<>>}}, Error}
-            end, PreCommitFailures)};
-        {aborted,
-         lists:foldl(fun({#doc{id=Id,revs={Pos, RevIds}}, Ref},Acc) ->
-                         case lists:keyfind(Ref,1,PreCommitFailures) of
-                         {Ref, Error} ->
-                             [{{Id,{Pos,RevIds}}, Error} | Acc];
-                         false ->
-                             Acc
-                         end
-                     end,[],Docs3)};
  +

This causes the full list of revisions to be passed to revid_to_str/1;

revid_to_str(RevId) when size(RevId) =:= 16 ->
    ?l2b(couch_util:to_hex(RevId));
revid_to_str(RevId) ->
    RevId.

This falls through to the second case, which in turn leads to invalid
JSON output when we convert the presumed iolist.

This patch restores the code that takes only the head of the revisions
list when present, and an artificial "0-" when it is not (in the case
that the validation fails for a new document rather than an update).

BugzID: 1772
