### PR TITLE
share/server: use toString instead of toSource

### DIFF
--- a/share/server/filter.js
+++ b/share/server/filter.js
@@ -29,7 +29,7 @@ var Filter = (function() {
       },
       filter_view : function(fun, ddoc, args) {
         // recompile
-        var source = fun.toSource();
+        var source = fun.toSource ? fun.toSource() : '(' + fun.toString() + ')';
         fun = evalcx(source, filter_sandbox);
 
         var results = [];

--- a/share/server/loop.js
+++ b/share/server/loop.js
@@ -44,7 +44,7 @@ function init_filter_sandbox() {
     }
     filter_sandbox.emit = Filter.emit;
   } catch(e) {
-    log(e.toSource());
+    log(e.toSource ? e.toSource() : e.stack);
   }
 };
 
@@ -143,7 +143,7 @@ var Loop = function() {
     } else if (e.name) {
       respond(["error", e.name, e]);
     } else {
-      respond(["error","unnamed_error",e.toSource()]);
+      respond(["error","unnamed_error",e.toSource ? e.toSource() : e.stack]);
     }
   };
   while (line = readline()) {

--- a/share/server/render.js
+++ b/share/server/render.js
@@ -261,7 +261,7 @@ var Render = (function() {
       if (args[0] === null && isDocRequestPath(args[1])) {
         throw(["error", "not_found", "document not found"]);
       } else {
-        renderError(e, fun.toSource());
+        renderError(e, fun.toString());
       }
     }
   };
@@ -281,7 +281,7 @@ var Render = (function() {
         throw(["error", "render_error", "undefined response from update function"]);      
       }
     } catch(e) {
-      renderError(e, fun.toSource());
+      renderError(e, fun.toString());
     }
   };
 
@@ -310,7 +310,7 @@ var Render = (function() {
       }
       blowChunks("end");
     } catch(e) {
-      renderError(e, listFun.toSource());
+      renderError(e, listFun.toString());
     }
   };
 
@@ -318,7 +318,9 @@ var Render = (function() {
     if (e.error && e.reason || e[0] == "error" || e[0] == "fatal") {
       throw(e);
     } else {
-      var logMessage = "function raised error: "+e.toSource()+" \nstacktrace: "+e.stack;
+      var logMessage = "function raised error: " +
+                       (e.toSource ? e.toSource() : e.toString()) + " \n" +
+                       "stacktrace: " + e.stack;
       log(logMessage);
       throw(["error", "render_error", logMessage]);
     }

--- a/share/server/util.js
+++ b/share/server/util.js
@@ -94,7 +94,12 @@ var Couch = {
                   return require(name, newModule);
                 }]);
               } catch(e) { 
-                throw ["error","compilation_error","Module require('"+name+"') raised error "+e.toSource()]; 
+                throw [
+                  "error",
+                  "compilation_error",
+                  "Module require('" +name+ "') raised error " +
+                  (e.toSource ? e.toSource() : e.stack)
+                ];
               }
               ddoc._module_cache[newModule.id] = newModule.exports;
             }
@@ -107,13 +112,17 @@ var Couch = {
         var functionObject = evaluate_function_source(source, eval);
       }
     } catch (err) {
-      throw(["error", "compilation_error", err.toSource() + " (" + source + ")"]);
+      throw([
+        "error",
+        "compilation_error",
+        (err.toSource ? err.toSource() : err.stack) + " (" + source + ")"
+      ]);
     };
     if (typeof(functionObject) == "function") {
       return functionObject;
     } else {
       throw(["error","compilation_error",
-        "Expression does not eval to a function. (" + source.toSource() + ")"]);
+        "Expression does not eval to a function. (" + source.toString() + ")"]);
     };
   },
   recursivelySeal : function(obj) {
@@ -138,7 +147,7 @@ function respond(obj) {
     print(Couch.toJSON(obj));
   } catch(e) {
     log("Error converting object to JSON: " + e.toString());
-    log("error on obj: "+ obj.toSource());
+    log("error on obj: "+ (obj.toSource ? obj.toSource() : obj.toString()));
   }
 };
 

--- a/share/server/views.js
+++ b/share/server/views.js
@@ -63,7 +63,8 @@ var Views = (function() {
       // will kill the OS process. This is not normally what you want.
       throw(err);
     }
-    var message = "function raised exception " + err.toSource();
+    var message = "function raised exception " +
+                  (err.toSource ? err.toSource() : err.stack);
     if (doc) message += " with doc._id " + doc._id;
     log(message);
   };


### PR DESCRIPTION
Object.toSource is [non-standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toSource) and missing in v8 and probably
other javascript VMs. Its better to chop it off now that feel pain later
if we'll decide to move to different javascript engine.

/cc @janl
