### PR TITLE
Typo - no such function couch_index:get_compactor_pid/1

### DIFF
--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -103,7 +103,7 @@ compact(Db, DDoc, Opts) ->
 
 cancel_compaction(Db, DDoc) ->
     {ok, IPid} = couch_index_server:get_index(couch_mrview_index, Db, DDoc),
-    {ok, CPid} = couch_index:get_compactor_pid(IPid),
+    {ok, CPid} = gen_server:call(IPid, get_compactor_pid),
     ok = couch_index_compactor:cancel(CPid),
 
     % Cleanup the compaction file if it exists


### PR DESCRIPTION
This function was removed in 3f2e85799a078c42b0618c04fe0f7f8488a3ab8d so we have to use gen_server:call/2 instead.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
