### PR TITLE
Fix js runner

### DIFF
--- a/test/javascript/run.tpl
+++ b/test/javascript/run.tpl
@@ -56,7 +56,9 @@ process_response() {
     do
         if [ $data = 'restart' ];
         then
-            restart
+            if [ -z $COUCHDB_NO_START ]; then
+                restart
+            fi
         else
             echo "$data"
         fi
@@ -121,6 +123,9 @@ else
     run $TEST_SRC
 fi
 
-stop
+if [ -z $COUCHDB_NO_START ]; then
+    stop
+fi
+
 trap - 0
 exit $RESULT


### PR DESCRIPTION
The Javascript test runner can't run single files and currently can't run tests on an already running CouchDB instance. 
