### PR TITLE
Remove usage of $.browser as it is gone since jQuery 1.9.

### DIFF
--- a/share/www/script/jquery.couch.js
+++ b/share/www/script/jquery.couch.js
@@ -995,7 +995,9 @@
     errorMessage = errorMessage || "Unknown error";
     timeStart = (new Date()).getTime();
     $.ajax($.extend($.extend({
-      type: "GET", dataType: "json", cache : !$.browser.msie,
+      type: "GET",
+      dataType: "json",
+      cache : (navigator.appVersion.indexOf("MSIE") == -1), // disable caching for IE
       beforeSend: function(xhr){
         if(ajaxOptions && ajaxOptions.headers){
           for (var header in ajaxOptions.headers){


### PR DESCRIPTION
IE browser detection is done using plain old JavaScript, so it should work with jQuery >1.9 and >2.0.
