### PR TITLE
Fix the `proxy_authentication_handler` name

### DIFF
--- a/src/couchdb/couch_httpd_auth.erl
+++ b/src/couchdb/couch_httpd_auth.erl
@@ -111,12 +111,16 @@ null_authentication_handler(Req) ->
 %   ecret key is the secret key in couch_httpd_auth section of ini. This token is optional
 %   if value of proxy_use_secret key in couch_httpd_auth section of ini isn't true.
 %
-proxy_authentification_handler(Req) ->
+proxy_authentication_handler(Req) ->
     case proxy_auth_user(Req) of
         nil -> Req;
         Req2 -> Req2
     end.
-    
+
+% keep the old handler name to avoid breaking compatibility with existing configs
+proxy_authentification_handler(Req) ->
+    proxy_authentication_handler(Req).
+
 proxy_auth_user(Req) ->
     XHeaderUserName = couch_config:get("couch_httpd_auth", "x_auth_username",
                                 "X-Auth-CouchDB-UserName"),


### PR DESCRIPTION
I'm sorry, but the docs say `authentication`, not `authentification`.[1] If you do what the docs say, you simply break your Couch: it starts responding with HTTP 500 to every request that is not authenticated by an earlier handler.

According to the Urban Dictionary, "authentification" is "authentication process which is not working".[1] You can't argue with the UD on that! :)

Some people using this handler might actually use the wrong spelling in their configs, so I left the original name as an alias.

[1] http://docs.couchdb.org/en/latest/api/server/authn.html?highlight=authentication#proxy-authentication
[2] http://www.urbandictionary.com/define.php?term=authentification
