### PR TITLE
COUCHDB-1930 - fix - Futon, create New Document and change _id, clicking Save Document will save but sends you to wrong doc

### DIFF
--- a/share/www/script/futon.browse.js
+++ b/share/www/script/futon.browse.js
@@ -1059,7 +1059,7 @@
           success: function(resp) {
             page.isDirty = false;
             location.href = "?" + encodeURIComponent(dbName) +
-              "/" + $.couch.encodeDocId(page.docId);
+              "/" + $.couch.encodeDocId(resp.id);
           }
         });
       }


### PR DESCRIPTION
After saving a document using Futon, it will reload the page to show the changes. However rather than using the page's docId, it should use the id in the response as the user may have change the document's _id.

This is most obvious when you are creating a new document but want to specify an _id instead of using the generated one. After saving Futon would try to load the generated id, which doesn't exist and raises a "missing" error.
