### PR TITLE
Add `include_attachments` boolean query parameter

### DIFF
--- a/share/doc/src/api/database/changes.rst
+++ b/share/doc/src/api/database/changes.rst
@@ -58,6 +58,10 @@
   :query boolean include_docs: Include the associated document with each result.
     If there are conflicts, only the winning revision is returned.
     Default is ``false``.
+  :query boolean attachments: Include the Base64-encoded content of
+    :ref:`attachments <api/doc/attachments>` in the documents that are included
+    if `include_docs` is ``true``. Ignored if `include_docs` isn't ``true``.
+    Default is ``false``.
   :query number last-event-id: Alias of `Last-Event-ID` header.
   :query number limit: Limit number of result rows to the specified value
     (note that using ``0`` here has the same effect as ``1``).
@@ -161,6 +165,13 @@
    listen changes since current seq number.
 .. versionchanged:: 1.3.0 ``eventsource`` feed type added.
 .. versionchanged:: 1.4.0 Support ``Last-Event-ID`` header.
+.. versionchanged:: 1.6.0 added ``attachments`` parameter
+
+.. warning::
+   Using the ``attachments`` parameter to include attachments in the changes
+   feed is not recommended for large attachment sizes. Also note that the
+   Base64-encoding that is therefor used leads to a 33% overhead (i.e. one
+   third) in transfer size for attachments.
 
 
 .. http:post:: /{db}/_changes

--- a/share/doc/src/api/ddoc/views.rst
+++ b/share/doc/src/api/ddoc/views.rst
@@ -40,8 +40,12 @@
   :query boolean group: Group the results using the reduce function to a group
     or single row. Default is ``false``
   :query number group_level: Specify the group level to be used. *Optional*
-  :query boolean include_docs: Include the full content of the documents in
-    the return. Default is ``false``
+  :query boolean include_docs: Include the associated document with each row.
+    Default is ``false``.
+  :query boolean attachments: Include the Base64-encoded content of
+    :ref:`attachments <api/doc/attachments>` in the documents that are included
+    if `include_docs` is ``true``. Ignored if `include_docs` isn't ``true``.
+    Default is ``false``.
   :query boolean inclusive_end: Specifies whether the specified end key should
     be included in the result. Default is ``true``
   :query string key: Return only documents that match the specified key.
@@ -121,6 +125,14 @@
         ],
         "total_rows": 3
     }
+
+.. versionchanged:: 1.6.0 added ``attachments`` parameter
+
+.. warning::
+   Using the ``attachments`` parameter to include attachments in view results
+   is not recommended for large attachment sizes. Also note that the
+   Base64-encoding that is therefor used leads to a 33% overhead (i.e. one
+   third) in transfer size for attachments.
 
 
 .. http:post:: /{db}/_design/{ddoc}/_view/{view}

--- a/share/doc/src/api/document/common.rst
+++ b/share/doc/src/api/document/common.rst
@@ -391,13 +391,17 @@ information objects with next structure:
 
 - **content_type** (*string*): Attachment MIME type
 - **data** (*string*): Base64-encoded content. Available if attachment content
-  requested by using ``attachments=true`` or ``atts_since`` query parameters
+  is requested by using the following query parameters:
+    - ``attachments=true`` when querying a document
+    - ``attachments=true&include_docs=true`` when querying a
+      :ref:`changes feed <api/db/changes>` or a :ref:`view <api/ddoc/view>`
+    - ``atts_since``.
 - **digest** (*string*): Content hash digest.
   It starts with prefix which announce hash type (``md5-``) and continues with
   Base64-encoded hash digest
 - **encoded_length** (*number*): Compressed attachment size in bytes
   Available when query parameter ``att_encoding_info=true`` was specified and
-  ``content_type`` is in :config:option:`list of compressiable types
+  ``content_type`` is in :config:option:`list of compressible types
   <attachments/compressible_types>`
 - **encoding** (*string*): Compression codec. Available when query parameter
   ``att_encoding_info=true`` was specified

--- a/share/www/script/test/attachment_views.js
+++ b/share/www/script/test/attachment_views.js
@@ -19,13 +19,15 @@ couchTests.attachment_views= function(debug) {
 
   // count attachments in a view
 
+  var attachmentData = "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=";
+
   db.bulkSave(makeDocs(0, 10));
 
   db.bulkSave(makeDocs(10, 20, {
     _attachments:{
       "foo.txt": {
         content_type:"text/plain",
-        data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        data: attachmentData
       }
     }
   }));
@@ -34,11 +36,11 @@ couchTests.attachment_views= function(debug) {
     _attachments:{
       "foo.txt": {
         content_type:"text/plain",
-        data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        data: attachmentData
       },
       "bar.txt": {
         content_type:"text/plain",
-        data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        data: attachmentData
       }
     }
   }));
@@ -47,15 +49,15 @@ couchTests.attachment_views= function(debug) {
     _attachments:{
       "foo.txt": {
         content_type:"text/plain",
-        data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        data: attachmentData
       },
       "bar.txt": {
         content_type:"text/plain",
-        data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        data: attachmentData
       },
       "baz.txt": {
         content_type:"text/plain",
-        data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        data: attachmentData
       }
     }
   }));
@@ -95,4 +97,30 @@ couchTests.attachment_views= function(debug) {
   T(result.rows.length == 1);
   T(result.rows[0].value == 20);
 
+  var result = db.query(mapFunction, null, {
+    startkey: 20,
+    endkey: 29,
+    include_docs: true
+  });
+
+  T(result.rows.length == 10);
+  T(result.rows[0].value == 2);
+  T(result.rows[0].doc._attachments['foo.txt'].stub === true);
+  T(result.rows[0].doc._attachments['foo.txt'].data === undefined);
+  T(result.rows[0].doc._attachments['bar.txt'].stub === true);
+  T(result.rows[0].doc._attachments['bar.txt'].data === undefined);
+
+  var result = db.query(mapFunction, null, {
+    startkey: 20,
+    endkey: 29,
+    include_docs: true,
+    attachments: true
+  });
+
+  T(result.rows.length == 10);
+  T(result.rows[0].value == 2);
+  T(result.rows[0].doc._attachments['foo.txt'].data === attachmentData);
+  T(result.rows[0].doc._attachments['foo.txt'].stub === undefined);
+  T(result.rows[0].doc._attachments['bar.txt'].data === attachmentData);
+  T(result.rows[0].doc._attachments['bar.txt'].stub === undefined);
 };

--- a/share/www/script/test/changes.js
+++ b/share/www/script/test/changes.js
@@ -646,6 +646,53 @@ couchTests.changes = function(debug) {
   T(changes[0][1] === "3");
   T(changes[1][1] === "4");
 
+  // COUCHDB-1923
+  T(db.deleteDb());
+  T(db.createDb());
+
+  var attachmentData = "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ=";
+
+  db.bulkSave(makeDocs(20, 30, {
+    _attachments:{
+      "foo.txt": {
+        content_type:"text/plain",
+        data: attachmentData
+      },
+      "bar.txt": {
+        content_type:"text/plain",
+        data: attachmentData
+      }
+    }
+  }));
+
+  var mapFunction = function(doc) {
+    var count = 0;
+
+    for(var idx in doc._attachments) {
+      count = count + 1;
+    }
+
+    emit(parseInt(doc._id), count);
+  };
+
+  var req = CouchDB.request("GET", "/test_suite_db/_changes?include_docs=true");
+  var resp = JSON.parse(req.responseText);
+
+  T(resp.results.length == 10);
+  T(resp.results[0].doc._attachments['foo.txt'].stub === true);
+  T(resp.results[0].doc._attachments['foo.txt'].data === undefined);
+  T(resp.results[0].doc._attachments['bar.txt'].stub === true);
+  T(resp.results[0].doc._attachments['bar.txt'].data === undefined);
+
+  var req = CouchDB.request("GET", "/test_suite_db/_changes?include_docs=true&attachments=true");
+  var resp = JSON.parse(req.responseText);
+
+  T(resp.results.length == 10);
+  T(resp.results[0].doc._attachments['foo.txt'].data === attachmentData);
+  T(resp.results[0].doc._attachments['foo.txt'].stub === undefined);
+  T(resp.results[0].doc._attachments['bar.txt'].data == attachmentData);
+  T(resp.results[0].doc._attachments['bar.txt'].stub === undefined);
+
   // cleanup
   db.deleteDb();
 };

--- a/src/couch_mrview/include/couch_mrview.hrl
+++ b/src/couch_mrview/include/couch_mrview.hrl
@@ -72,6 +72,7 @@
     stale = false,
     inclusive_end = true,
     include_docs = false,
+    attachments = false,
     update_seq=false,
     conflicts,
     callback,

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -348,6 +348,8 @@ parse_qs(Key, Val, Args) ->
             Args#mrargs{inclusive_end=parse_boolean(Val)};
         "include_docs" ->
             Args#mrargs{include_docs=parse_boolean(Val)};
+        "attachments" ->
+            Args#mrargs{attachments=parse_boolean(Val)};
         "update_seq" ->
             Args#mrargs{update_seq=parse_boolean(Val)};
         "conflicts" ->

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -668,24 +668,28 @@ expand_dups([KV | Rest], Acc) ->
 
 maybe_load_doc(_Db, _DI, #mrargs{include_docs=false}) ->
     [];
-maybe_load_doc(Db, #doc_info{}=DI, #mrargs{conflicts=true}) ->
-    doc_row(couch_index_util:load_doc(Db, DI, [conflicts]));
-maybe_load_doc(Db, #doc_info{}=DI, _Args) ->
-    doc_row(couch_index_util:load_doc(Db, DI, [])).
+maybe_load_doc(Db, #doc_info{}=DI, #mrargs{conflicts=true}=MRArgs) ->
+    doc_row(couch_index_util:load_doc(Db, DI, [conflicts]), MRArgs);
+maybe_load_doc(Db, #doc_info{}=DI, MRArgs) ->
+    doc_row(couch_index_util:load_doc(Db, DI, []), MRArgs).
 
 
 maybe_load_doc(_Db, _Id, _Val, #mrargs{include_docs=false}) ->
     [];
-maybe_load_doc(Db, Id, Val, #mrargs{conflicts=true}) ->
-    doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), [conflicts]));
-maybe_load_doc(Db, Id, Val, _Args) ->
-    doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), [])).
+maybe_load_doc(Db, Id, Val, #mrargs{conflicts=true}=MRArgs) ->
+    doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), [conflicts]), MRArgs);
+maybe_load_doc(Db, Id, Val, MRArgs) ->
+    doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), []), MRArgs).
 
 
-doc_row(null) ->
+doc_row(null, _MRArgs) ->
     [{doc, null}];
-doc_row(Doc) ->
-    [{doc, couch_doc:to_json_obj(Doc, [])}].
+doc_row(Doc, MRArgs) ->
+    ToJsonOpts = case MRArgs#mrargs.attachments of
+    true -> [attachments];
+    _ -> []
+    end,
+    [{doc, couch_doc:to_json_obj(Doc, ToJsonOpts)}].
 
 
 docid_rev(Id, {Props}) ->

--- a/src/couchdb/couch_db.hrl
+++ b/src/couchdb/couch_db.hrl
@@ -219,6 +219,7 @@
 
     view_type = nil,
     include_docs = false,
+    attachments = false,
     conflicts = false,
     stale = false,
     multi_get = false,
@@ -269,6 +270,7 @@
     filter_fun,
     filter_args = [],
     include_docs = false,
+    attachments = false,
     conflicts = false,
     db_open_options = []
 }).

--- a/src/couchdb/couch_httpd_db.erl
+++ b/src/couchdb/couch_httpd_db.erl
@@ -1141,6 +1141,8 @@ parse_changes_query(Req, Db) ->
             Args#changes_args{timeout=list_to_integer(Value)};
         {"include_docs", "true"} ->
             Args#changes_args{include_docs=true};
+        {"attachments", "true"} ->
+            Args#changes_args{attachments=true};
         {"conflicts", "true"} ->
             Args#changes_args{conflicts=true};
         {"filter", _} ->

--- a/test/etap/073-changes.t
+++ b/test/etap/073-changes.t
@@ -34,6 +34,7 @@
     filter_fun,
     filter_args = [],
     include_docs = false,
+    attachments = false,
     conflicts = false,
     db_open_options = []
 }).


### PR DESCRIPTION
This adds the boolean query parameter `include_attachments` for
`/{db}/_changes` and `/{db}/_design/{ddoc}/_view/{view}` queries.

If both `include_docs` and `include_attachments` equal `true`, the
Base64-encoded contents of attachments are included with the documents
in changes or view query results.

Closes COUCHDB-1923.
