### PR TITLE
Update authn.rst

### DIFF
--- a/share/doc/src/api/server/authn.rst
+++ b/share/doc/src/api/server/authn.rst
@@ -275,7 +275,7 @@ Proxy Authentication
    .. code-block:: ini
 
       [httpd]
-      authentication_handlers = {couch_httpd_oauth, oauth_authentication_handler}, {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+      authentication_handlers = {couch_httpd_oauth, oauth_authentication_handler}, {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, proxy_authentification_handler}, {couch_httpd_auth, default_authentication_handler}
 
 
 `Proxy authentication` is very useful in case your application already uses


### PR DESCRIPTION
Typo in documentation.
Maybe it's better to rename the function to match the others, wasn't brave enough.
