### PR TITLE
Handle req.status == 201

### DIFF
--- a/share/www/script/jquery.couch.js
+++ b/share/www/script/jquery.couch.js
@@ -1018,7 +1018,7 @@
         if (options.ajaxStart) {
           options.ajaxStart(resp);
         }
-        if (req.status == options.successStatus) {
+        if (req.status == options.successStatus || req.status == 201) {
           if (options.beforeSuccess) options.beforeSuccess(req, resp, reqDuration);
           if (options.success) options.success(resp, reqDuration);
         } else if (options.error) {


### PR DESCRIPTION
The reason for this fix is that without it, bulkSave() returns the following error on line 1029:

```
Uncaught The documents could not be saved: undefined
```

However, in fact my documents are being saved, so the error message is not correct.

But because line 993 above reads:

```
options = $.extend({successStatus: 200}, options);
```

I wonder if there might be a better way to prevent this error message, either in my client code or maybe by making successStatus be an array of acceptable values.
