### PR TITLE
docs: fix naming of figure

### DIFF
--- a/share/doc/src/intro/tour.rst
+++ b/share/doc/src/intro/tour.rst
@@ -260,7 +260,7 @@ finalize creating the hello field. Double-click the hello field's value
 You can experiment with other JSON values; e.g., ``[1, 2, "c"]`` or
 ``{"foo": "bar"}``. Once you've entered your values into the document,
 make a note of its ``_rev`` attribute and click "Save Document." The result
-should look like :ref:`intro/tour-04` document in Futon".
+should look like :ref:`intro/tour-04`.
 
 
 .. _intro/tour-03:


### PR DESCRIPTION
I just noticed that while translating this part of the docs.

Fixing A “hello world” document in Futon document in Futon”.
