### PR TITLE
hid code editor tab when editing a doc

### DIFF
--- a/src/fauxton/app/templates/documents/doc_field_editor_tabs.html
+++ b/src/fauxton/app/templates/documents/doc_field_editor_tabs.html
@@ -12,8 +12,8 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 
-<ul class="nav nav-tabs">
-  <!--<li id="field_editor" class="<%= isSelectedClass('field_editor') %>"><a href="#<%= doc.url('app') %>/field_editor">Doc fields</a></li>-->
+<!--<ul class="nav nav-tabs">
+  <li id="field_editor" class="<%= isSelectedClass('field_editor') %>"><a href="#<%= doc.url('app') %>/field_editor">Doc fields</a></li>
   <li id="code_editor" class="<%= isSelectedClass('code_editor') %>"><a href="#<%= doc.url('app') %>/code_editor"><i class="icon-pencil"> </i> Code editor</a>
   </li>
-</ul>
+</ul>-->


### PR DESCRIPTION
The single tab was sad and lonely. Left all
the JS around, though, for when Feild Editor
decides to rejoin Code Editor.
