### PR TITLE
Document `data_size` in `/db`

### DIFF
--- a/share/doc/src/api/database/common.rst
+++ b/share/doc/src/api/database/common.rst
@@ -61,6 +61,7 @@
   :>json string db_name: The name of the database.
   :>json number disk_format_version: The version of the physical format used
     for the data when it is stored on disk.
+  :>json number data_size: Actual data size in bytes of the database data.
   :>json number disk_size: Size in bytes of the data as stored on the disk.
     Views indexes are not included in the calculation.
   :>json number doc_count: A count of the documents in the specified database.


### PR DESCRIPTION
The value is returned, but was missing in the documentation.
