### PR TITLE
removing HTML comments from JST templates

### DIFF
--- a/src/fauxton/Gruntfile.js
+++ b/src/fauxton/Gruntfile.js
@@ -160,10 +160,19 @@ module.exports = function(grunt) {
     // The concat task depends on this file to exist, so if you decide to
     // remove this, ensure concat is updated accordingly.
     jst: {
-      "dist/debug/templates.js": [
-        "app/templates/**/*.html",
-        "app/addons/**/templates/**/*.html"
-      ]
+      compile: {
+        options: {
+          processContent: function(src) {
+            return src.replace(/<!--[\s\S]*?-->/gm, '');
+          }
+        },
+        files: {
+          "dist/debug/templates.js": [
+            "app/templates/**/*.html",
+            "app/addons/**/templates/**/*.html"
+          ]
+        }
+      }
     },
 
     template: templateSettings,


### PR DESCRIPTION
This lightens templates.js by removing HTML
comments from the templates.

@deathbearbrown @garrentsmith just some scrubbing.
