### PR TITLE
pass emit as an argument

### DIFF
--- a/share/server/views.js
+++ b/share/server/views.js
@@ -68,12 +68,12 @@ var Views = (function() {
     if (doc) message += " with doc._id " + doc._id;
     log(message);
   };
-
+  function emit(key, value) {
+    map_results.push([key, value]);
+  }
   return {
     // view helper functions
-    emit : function(key, value) {
-      map_results.push([key, value]);
-    },
+    emit : emit,
     sum : function(values) {
       var rv = 0;
       for (var i in values) {
@@ -112,7 +112,7 @@ var Views = (function() {
       for (var i = 0; i < State.funs.length; i++) {
         map_results = [];
         try {
-          State.funs[i](doc);
+          State.funs[i](doc, emit);
           buf.push(Couch.toJSON(map_results));
         } catch (err) {
           handleViewError(err, doc);


### PR DESCRIPTION
allow the map function to be passed a second argument, the emit function.  Benefits as I see them
- 100% backwards compatible, emit is still in the execution closure.
- makes it possible to run views in pure JavaScript without having to use eval (e.g. in pouchdb)
- allows emit to be renamed in the case of some sort of collision, the circumstances of which I can't imagine.

I can write tests if this is something worth pursuing, though at the moment I'm having troubling fathoming the ruby wrapped JavaScript testing format. 

Thanks.
