### PR TITLE
Export missing function - couch_httpd:send_error/2

### DIFF
--- a/src/couchdb/couch_httpd.erl
+++ b/src/couchdb/couch_httpd.erl
@@ -27,7 +27,7 @@
 -export([start_chunked_response/3,send_chunk/2,log_request/2]).
 -export([start_response_length/4, start_response/3, send/2]).
 -export([start_json_response/2, start_json_response/3, end_json_response/1]).
--export([send_response/4,send_method_not_allowed/2,send_error/4, send_redirect/2,send_chunked_error/2]).
+-export([send_response/4,send_method_not_allowed/2,send_error/2,send_error/4, send_redirect/2,send_chunked_error/2]).
 -export([send_json/2,send_json/3,send_json/4,last_chunk/1,parse_multipart_request/3]).
 -export([accepted_encodings/1,handle_request_int/5,validate_referer/1,validate_ctype/2]).
 -export([http_1_0_keep_alive/2]).


### PR DESCRIPTION
Hello All!
This function is used by couch_plugins_httpd.erl but unfortunately was not properly exported. So let's export it.

See:
- https://github.com/apache/couchdb/blob/master/src/couch_plugins/src/couch_plugins_httpd.erl#L36
- https://github.com/apache/couchdb/blob/master/src/couchdb/couch_httpd.erl#L30
