### PR TITLE
Adopt to the recent erlang-oauth (1.3+)

### DIFF
--- a/src/couchdb/couch_httpd_oauth.erl
+++ b/src/couchdb/couch_httpd_oauth.erl
@@ -43,6 +43,7 @@ oauth_auth_callback(#httpd{mochi_req = MochiReq} = Req, CbParams) ->
     Method = atom_to_list(MochiReq:get(method)),
     #callback_params{
         consumer = Consumer,
+        token = Token,
         token_secret = TokenSecret,
         url = Url,
         signature = Sig,
@@ -61,7 +62,7 @@ oauth_auth_callback(#httpd{mochi_req = MochiReq} = Req, CbParams) ->
             "Consumer is `~p`, token secret is `~p`~n"
             "Expected signature was `~p`~n",
             [User, Sig, Method, Url, Params, Consumer, TokenSecret,
-                oauth:signature(Method, Url, Params, Consumer, TokenSecret)]),
+                oauth:sign(Method, Url, Params, Consumer, Token, TokenSecret)]),
         Req
     end.
 


### PR DESCRIPTION
Function oauth:signature/5 was removed long before erlang-oauth 1.3 but CouchDB still using this old API. Let's fix it and use oauth:sign/6 instead.

See:
- https://github.com/tim/erlang-oauth/commit/fc5f528 (pre-1.3.x changeset)
- https://github.com/apache/couchdb/blob/master/src/erlang-oauth/oauth.erl#L68
