### PR TITLE
docs: fix highlighting of artwork.jpg

### DIFF
--- a/share/doc/src/intro/api.rst
+++ b/share/doc/src/intro/api.rst
@@ -567,7 +567,7 @@ documents, music, or movie files. Let's make one.
 Attachments get their own URL where you can upload data. Say we want to add
 the album artwork to the ``6e1295ed6c29495e54cc05947f18c8af`` document
 (*"There is Nothing Left to Lose"*), and let's also say the artwork is in a file
-artwork `.jpg` in the current directory::
+`artwork.jpg` in the current directory::
 
   curl -vX PUT http://127.0.0.1:5984/albums/6e1295ed6c29495e54cc05947f18c8af/artwork.jpg?rev=2-2739352689 \
        --data-binary @artwork.jpg -H "Content-Type:image/jpg"


### PR DESCRIPTION
Just noticed that while I was working on the translation to german.

It is rendered here in the second paragraph: http://docs.couchdb.org/en/latest/intro/api.html#attachments
