### PR TITLE
Multipart/related handling improvements

### DIFF
--- a/share/www/script/test/attachments_multipart.js
+++ b/share/www/script/test/attachments_multipart.js
@@ -17,105 +17,119 @@ couchTests.attachments_multipart= function(debug) {
   if (debug) debugger;
   
   // mime multipart
-            
-  var xhr = CouchDB.request("PUT", "/test_suite_db/multipart", {
-    headers: {"Content-Type": "multipart/related;boundary=\"abc123\""},
-    body:
-      "--abc123\r\n" +
-      "content-type: application/json\r\n" +
-      "\r\n" +
-      JSON.stringify({
-        "body":"This is a body.",
-        "_attachments":{
-          "foo.txt": {
-            "follows":true,
-            "content_type":"application/test",
-            "length":21
-            },
-          "bar.txt": {
-            "follows":true,
-            "content_type":"application/test",
-            "length":20
-            },
-          "baz.txt": {
-            "follows":true,
-            "content_type":"text/plain",
-            "length":19
-            }
+  function testMime(docName, includeLength) {
+    var body = {
+      "body":"This is a body.",
+      "_attachments":{
+        "foo.txt": {
+          "follows":true,
+          "content_type":"application/test"
+          },
+        "bar.txt": {
+          "follows":true,
+          "content_type":"application/test"
+          },
+        "baz.txt": {
+          "follows":true,
+          "content_type":"text/plain"
           }
-        }) +
-      "\r\n--abc123\r\n" +
-      "\r\n" +
-      "this is 21 chars long" +
-      "\r\n--abc123\r\n" +
-      "\r\n" +
-      "this is 20 chars lon" +
-      "\r\n--abc123\r\n" +
-      "\r\n" +
-      "this is 19 chars lo" +
-      "\r\n--abc123--epilogue"
-    });
+        }
+      };
+	if (includeLength) {
+	  body._attachments["foo.txt"].length = 21;
+	  body._attachments["bar.txt"].length = 20;
+	  body._attachments["baz.txt"].length = 19;
+	}
+	var method = (docName == "") ? "POST" : "PUT";
+    var xhr = CouchDB.request(method, "/test_suite_db/" + docName, {
+      headers: {"Content-Type": "multipart/related;boundary=\"abc123\""},
+      body:
+        "--abc123\r\n" +
+        "content-type: application/json\r\n" +
+        "\r\n" +
+        JSON.stringify(body) +
+        "\r\n--abc123\r\n" +
+        "\r\n" +
+        "this is 21 chars long" +
+        "\r\n--abc123\r\n" +
+        "\r\n" +
+        "this is 20 chars lon" +
+        "\r\n--abc123\r\n" +
+        "\r\n" +
+        "this is 19 chars lo" +
+        "\r\n--abc123--epilogue"
+      });
+      
+    var result = JSON.parse(xhr.responseText);
     
-  var result = JSON.parse(xhr.responseText);
-  
-  T(result.ok);
-  
-  
+    T(result.ok);
     
-  TEquals(201, xhr.status, "should send 201 Accepted");
+    docName = result.id;
+      
+    TEquals(201, xhr.status, "should send 201 Accepted");
+    
+    xhr = CouchDB.request("GET", "/test_suite_db/" + docName + "/foo.txt");
+    
+    T(xhr.responseText == "this is 21 chars long");
+    
+    xhr = CouchDB.request("GET", "/test_suite_db/" + docName + "/bar.txt");
+    
+    T(xhr.responseText == "this is 20 chars lon");
+    
+    xhr = CouchDB.request("GET", "/test_suite_db/" + docName + "/baz.txt");
+    
+    T(xhr.responseText == "this is 19 chars lo");
+    
+    // now edit an attachment
+    
+    var doc = db.open(docName, {att_encoding_info: true});
+    var firstrev = doc._rev;
+    
+    T(doc._attachments["foo.txt"].stub == true);
+    T(doc._attachments["bar.txt"].stub == true);
+    T(doc._attachments["baz.txt"].stub == true);
+    TEquals("undefined", typeof doc._attachments["foo.txt"].encoding);
+    TEquals("undefined", typeof doc._attachments["bar.txt"].encoding);
+    TEquals("gzip", doc._attachments["baz.txt"].encoding);
+    
+    //lets change attachment bar
+    delete doc._attachments["bar.txt"].stub; // remove stub member (or could set to false)
+    delete doc._attachments["bar.txt"].digest; // remove the digest (it's for the gzip form)
+	if (includeLength) {
+      doc._attachments["bar.txt"].length = 18;
+	}
+    doc._attachments["bar.txt"].follows = true;
+    //lets delete attachment baz:
+    delete doc._attachments["baz.txt"];
+    
+    var xhr = CouchDB.request("PUT", "/test_suite_db/" + docName, {
+      headers: {"Content-Type": "multipart/related;boundary=\"abc123\""},
+      body:
+        "--abc123\r\n" +
+        "content-type: application/json\r\n" +
+        "\r\n" +
+        JSON.stringify(doc) +
+        "\r\n--abc123\r\n" +
+        "\r\n" +
+        "this is 18 chars l" +
+        "\r\n--abc123--"
+      });
+    TEquals(201, xhr.status);
+    
+    xhr = CouchDB.request("GET", "/test_suite_db/" + docName + "/bar.txt");
+    
+    T(xhr.responseText == "this is 18 chars l");
+    
+    xhr = CouchDB.request("GET", "/test_suite_db/" + docName + "/baz.txt");
+    T(xhr.status == 404);
+	return firstrev;
+  }
   
-  xhr = CouchDB.request("GET", "/test_suite_db/multipart/foo.txt");
-  
-  T(xhr.responseText == "this is 21 chars long");
-  
-  xhr = CouchDB.request("GET", "/test_suite_db/multipart/bar.txt");
-  
-  T(xhr.responseText == "this is 20 chars lon");
-  
-  xhr = CouchDB.request("GET", "/test_suite_db/multipart/baz.txt");
-  
-  T(xhr.responseText == "this is 19 chars lo");
-  
-  // now edit an attachment
-  
-  var doc = db.open("multipart", {att_encoding_info: true});
-  var firstrev = doc._rev;
-  
-  T(doc._attachments["foo.txt"].stub == true);
-  T(doc._attachments["bar.txt"].stub == true);
-  T(doc._attachments["baz.txt"].stub == true);
-  TEquals("undefined", typeof doc._attachments["foo.txt"].encoding);
-  TEquals("undefined", typeof doc._attachments["bar.txt"].encoding);
-  TEquals("gzip", doc._attachments["baz.txt"].encoding);
-  
-  //lets change attachment bar
-  delete doc._attachments["bar.txt"].stub; // remove stub member (or could set to false)
-  delete doc._attachments["bar.txt"].digest; // remove the digest (it's for the gzip form)
-  doc._attachments["bar.txt"].length = 18;
-  doc._attachments["bar.txt"].follows = true;
-  //lets delete attachment baz:
-  delete doc._attachments["baz.txt"];
-  
-  var xhr = CouchDB.request("PUT", "/test_suite_db/multipart", {
-    headers: {"Content-Type": "multipart/related;boundary=\"abc123\""},
-    body:
-      "--abc123\r\n" +
-      "content-type: application/json\r\n" +
-      "\r\n" +
-      JSON.stringify(doc) +
-      "\r\n--abc123\r\n" +
-      "\r\n" +
-      "this is 18 chars l" +
-      "\r\n--abc123--"
-    });
-  TEquals(201, xhr.status);
-  
-  xhr = CouchDB.request("GET", "/test_suite_db/multipart/bar.txt");
-  
-  T(xhr.responseText == "this is 18 chars l");
-  
-  xhr = CouchDB.request("GET", "/test_suite_db/multipart/baz.txt");
-  T(xhr.status == 404);
+  // PUT then POST multipart doc with and without attachment lengths
+  var firstrev = testMime("multipart", true);
+  testMime("multipartNoLength", false);
+  testMime("", true);
+  testMime("", false);
   
   // now test receiving multipart docs
   

--- a/src/couchdb/couch_db.erl
+++ b/src/couchdb/couch_db.erl
@@ -927,6 +927,11 @@ flush_att(Fd, #att{data=Data}=Att) when is_binary(Data) ->
         couch_stream:write(OutputStream, Data)
     end);
 
+flush_att(Fd, #att{data=Fun}=Att) when is_function(Fun, 0) ->
+    with_stream(Fd, Att, fun(OutputStream) ->
+        write_to_body_end(OutputStream, Fun)
+    end);
+
 flush_att(Fd, #att{data=Fun,att_len=undefined}=Att) when is_function(Fun) ->
     MaxChunkSize = list_to_integer(
         couch_config:get("couchdb", "attachment_stream_buffer_size", "4096")),
@@ -1038,18 +1043,21 @@ with_stream(Fd, #att{md5=InMd5,type=Type,encoding=Enc}=Att, Fun) ->
         encoding=NewEnc
     }.
 
+write_to_body_end(Stream, F) ->
+    case F() of
+        {body_end, _} ->
+            ok;
+        {bytes, Bin} ->
+            ok = couch_stream:write(Stream, Bin),
+            write_to_body_end(Stream, F)
+    end.
 
 write_streamed_attachment(_Stream, _F, 0) ->
     ok;
 write_streamed_attachment(Stream, F, LenLeft) when LenLeft > 0 ->
-    Bin = read_next_chunk(F, LenLeft),
+    Bin = F(lists:min([LenLeft, 16#2000])),
     ok = couch_stream:write(Stream, Bin),
     write_streamed_attachment(Stream, F, LenLeft - size(Bin)).
-
-read_next_chunk(F, _) when is_function(F, 0) ->
-    F();
-read_next_chunk(F, LenLeft) when is_function(F, 1) ->
-    F(lists:min([LenLeft, 16#2000])).
 
 enum_docs_since_reduce_to_count(Reds) ->
     couch_btree:final_reduce(

--- a/src/couchdb/couch_doc.erl
+++ b/src/couchdb/couch_doc.erl
@@ -581,7 +581,7 @@ doc_from_multi_part_stream(ContentType, DataFun) ->
         % replace with function that reads the data from MIME stream.
         ReadAttachmentDataFun = fun() ->
             Parser ! {get_bytes, Ref, self()},
-            receive {bytes, Ref, Bytes} -> Bytes end
+            receive {Kind, Ref, Bytes} -> {Kind, Bytes} end
         end,
         Atts2 = lists:map(
             fun(#att{data=follows}=A) ->
@@ -623,6 +623,9 @@ mp_parse_atts({body, Bytes}) ->
     end,
     fun mp_parse_atts/1;
 mp_parse_atts(body_end) ->
+    receive {get_bytes, Ref, From} ->
+        From ! {body_end, Ref, <<>>}
+    end,
     fun mp_parse_atts/1.
 
 


### PR DESCRIPTION
Implements the changes proposed in [Jira 1956](https://issues.apache.org/jira/browse/COUCHDB-1956) to allow chunked encoding of multipart/related requests and make attachment lengths optional. Also addresses [Jira 1685](https://issues.apache.org/jira/browse/COUCHDB-1685) to allow POSTing of multipart/related requests. The code for the latter was in [Pull Request 91](https://github.com/apache/couchdb/pull/91) but that ran into build problems so I will close that PR.

I'd be very grateful if members of the group could give the code a thorough review if you have time. To help out with that I will attach some review notes to the [Jira ticket](https://issues.apache.org/jira/browse/COUCHDB-1956) to give an overview of the changes.
