### PR TITLE
fix right hand side scrolling over navigation

### DIFF
--- a/src/fauxton/assets/less/fauxton.less
+++ b/src/fauxton/assets/less/fauxton.less
@@ -302,8 +302,9 @@ a:hover{
   max-width: 1500px;
   .box-shadow(-6px 0 rgba(0, 0, 0, 0.1));
   border-left: 1px solid #999;
-  position: absolute;
+  position: fixed;
   left: @navWidth;
+  right: 0;
   margin-left: 0;
   background-color: @sidebarBG;
   min-width: 600px;


### PR DESCRIPTION
If the right hand content got really wide, then
it could easily be scrolled over the primary
navigation on the left.

Fixed it by fixed positioning it.

@deathbearbrown @garrensmith for youz guyz
