### PR TITLE
Don't use Array.indexOf in IE8

### DIFF
--- a/share/www/script/futon.js
+++ b/share/www/script/futon.js
@@ -240,7 +240,7 @@ function $$(node) {
           if (userCtx.name) {
             $("#userCtx .name").text(userCtx.name).attr({href : $.couch.urlPrefix + "/_utils/document.html?"+encodeURIComponent(r.info.authentication_db)+"/org.couchdb.user%3A"+encodeURIComponent(userCtx.name)});
 
-            if (userCtx.roles.indexOf("_admin") != -1) {
+            if ($.inArray("_admin", userCtx.roles) != -1) {
               $("#userCtx .loggedin").show();
               $("#userCtx .loggedinadmin").show();
               $(".serverAdmin").removeAttr('disabled'); // user is a server admin
@@ -266,7 +266,7 @@ function $$(node) {
                 }); 
               }
             }
-          } else if (userCtx.roles.indexOf("_admin") != -1) {
+          } else if ($.inArray("_admin", userCtx.roles) != -1) {
             $("#userCtx .adminparty").show();
             $(".serverAdmin").removeAttr('disabled');
           } else {


### PR DESCRIPTION
IE8 does not support Array.indexOf. Instead, use jQuery's $.inArray function which calls Array.indexOf if supported.

NB: I have no way of testing this as I did the change on a Windows machine without IE8 and without anything that could compile CouchDB.
