### PR TITLE
Remove client-side password crypto from JS tests

### DIFF
--- a/share/www/script/couch_test_runner.js
+++ b/share/www/script/couch_test_runner.js
@@ -460,9 +460,7 @@ CouchDB.user_prefix = "org.couchdb.user:";
 CouchDB.prepareUserDoc = function(user_doc, new_password) {
   user_doc._id = user_doc._id || CouchDB.user_prefix + user_doc.name;
   if (new_password) {
-    // handle the password crypto
-    user_doc.salt = CouchDB.newUuids(1)[0];
-    user_doc.password_sha = hex_sha1(new_password + user_doc.salt);
+    user_doc.password = new_password;
   }
   user_doc.type = "user";
   if (!user_doc.roles) {

--- a/share/www/script/test/auth_cache.js
+++ b/share/www/script/test/auth_cache.js
@@ -184,11 +184,7 @@ couchTests.auth_cache = function(debug) {
     hits_before = hits_after;
     misses_before = misses_after;
 
-    var new_salt = CouchDB.newUuids(1)[0];
-    var new_passwd = hex_sha1("foobar" + new_salt);
-    fdmanana.salt = new_salt;
-    fdmanana.password_sha = new_passwd;
-
+    fdmanana.password = "foobar";
     T(authDb.save(fdmanana).ok);
 
     // cache was refreshed
@@ -206,11 +202,7 @@ couchTests.auth_cache = function(debug) {
     misses_before = misses_after;
 
     // and yet another update
-    new_salt = CouchDB.newUuids(1)[0];
-    new_passwd = hex_sha1("javascript" + new_salt);
-    fdmanana.salt = new_salt;
-    fdmanana.password_sha = new_passwd;
-
+    fdmanana.password = "javascript";
     T(authDb.save(fdmanana).ok);
 
     // cache was refreshed

--- a/share/www/script/test/cookie_auth.js
+++ b/share/www/script/test/cookie_auth.js
@@ -115,7 +115,7 @@ couchTests.cookie_auth = function(debug) {
 
       // we can't create docs with malformed ids
       var badIdDoc = CouchDB.prepareUserDoc({
-        name: "foo"
+        name: "w00x"
       }, "bar");
 
       badIdDoc._id = "org.apache.couchdb:w00x";
@@ -153,8 +153,8 @@ couchTests.cookie_auth = function(debug) {
         usersDb.deleteDoc(jchrisUserDoc);
         T(false && "Can't delete other users docs. Should have thrown an error.");
       } catch (e) {
-        TEquals("forbidden", e.error);
-        TEquals(403, usersDb.last_req.status);
+        TEquals("not_found", e.error);
+        TEquals(404, usersDb.last_req.status);
       }
 
       // TODO should login() throw an exception here?
@@ -197,8 +197,8 @@ couchTests.cookie_auth = function(debug) {
         usersDb.save(jasonUserDoc);
         T(false && "Can't update someone else's user doc. Should have thrown an error.");
       } catch (e) {
-        T(e.error == "forbidden");
-        T(usersDb.last_req.status == 403);
+        T(e.error == "not_found");
+        T(usersDb.last_req.status == 404);
       }
 
       // test that you can't edit roles unless you are admin
@@ -272,7 +272,6 @@ couchTests.cookie_auth = function(debug) {
 
   var usersDb = new CouchDB("test_suite_users", {"X-Couch-Full-Commit":"false"});
   usersDb.deleteDb();
-  usersDb.createDb();
 
   run_on_modified_server(
     [


### PR DESCRIPTION
This removes client-side password crypto from the JavaScript tests.

In some JavaScript tests, it has been assumed that SHA-1 is used for the
password hash in user docs.  Those tests should, however, not rely on
implementation details of the user authentication hash function, as it
isn't the goal of those tests to check these.  Furthermore, this causes
problems when a password scheme is changed, or a new one is introduced.

This work clears the way for solving COUCHDB-1780 (upgrade users
password hash on login).  It will prevent problems with tests that would
fail because they'd be relying on an old password scheme when a
mechanism for upgrading user docs to a newer password scheme is
introduced.
