### PR TITLE
Revert "fix right hand side scrolling over navigation"

### DIFF
--- a/src/fauxton/assets/less/fauxton.less
+++ b/src/fauxton/assets/less/fauxton.less
@@ -490,9 +490,8 @@ table.databases {
   max-width: 1500px;
   .box-shadow(-6px 0 rgba(0, 0, 0, 0.1));
   border-left: 1px solid #999;
-  position: fixed;
+  position: absolute;
   left: @navWidth;
-  right: 0;
   margin-left: 0;
   padding-left: 0;
   padding-right: 0;


### PR DESCRIPTION
This reverts commit e389a8ba2a79da2669b536ca242b5dfdee4faba3.

This is the commit that broke modals.

Reverting it fixes COUCHDB-2086

Fixing the right hand content overlapping the left
hand navigation will require a bigger fix...

@deathbearbrown @drsm79 @garrensmith reviews welcome. :smile: 
This sadly was not it...
