### PR TITLE
```validate_doc_update``` moved from views to root

### DIFF
--- a/share/doc/src/query-server/javascript.rst
+++ b/share/doc/src/query-server/javascript.rst
@@ -273,12 +273,12 @@ The CommonJS module can be added to a design document, like so:
        "views": {
           "lib": {
              "security": "function user_context(userctx, secobj) { ... }"
-          },
-          "validate_doc_update": "function(newdoc, olddoc, userctx, secobj) {
-            user = require('lib/security').user(userctx, secobj);
-            return user.is_admin();
-          }"
+          }
        },
+       "validate_doc_update": "function(newdoc, olddoc, userctx, secobj) {
+          user = require('lib/security').user(userctx, secobj);
+          return user.is_admin();
+       }"
        "_id": "_design/test"
     }
 


### PR DESCRIPTION
In documentation `validate_doc_update` was located in `views` which was confusing. 
