### PR TITLE
Cancel event propagation on replication swap.

### DIFF
--- a/src/fauxton/app/addons/replication/views.js
+++ b/src/fauxton/app/addons/replication/views.js
@@ -175,7 +175,6 @@ function(app, FauxtonAPI, Components, replication) {
       this.startReplication(formJSON);
     },	
     swapFields: function(e){
-      e.preventDefault();
       //WALL O' VARIABLES
       var $fromSelect = this.$('#from_name'),
           $toSelect = this.$('#to_name'),
@@ -191,6 +190,9 @@ function(app, FauxtonAPI, Components, replication) {
 
       $fromInput.val(toInputVal);
       $toInput.val(fromInputVal);
+
+      // prevent other click handlers from running
+      return false;
     }
   });
 


### PR DESCRIPTION
Fixes COUCHDB-2141. Previous implementation called event.preventDefault() but did not stop upwards propagation - the click event would trigger navigation to the main database panel. jQuery calls event.preventDefault() and event.stopPropagation() when false is returned from an event handler so just do that here.
