### PR TITLE
Fauxton: Fix placeholder for Username

### DIFF
--- a/src/fauxton/app/addons/auth/templates/create_admin.html
+++ b/src/fauxton/app/addons/auth/templates/create_admin.html
@@ -24,7 +24,7 @@ the License.
     configuration.
   </p>
   <form id="create-admin-form">
-    <input id="username" type="text" name="name" placeholder= "Username:" size="24">
+    <input id="username" type="text" name="name" placeholder="Username" size="24">
     <br/>
     <input id="password" type="password" name="password" placeholder= "Password" size="24">
     <p class="help-block">Non-admin users have read and write access to all databases, which

--- a/src/fauxton/app/addons/auth/templates/login.html
+++ b/src/fauxton/app/addons/auth/templates/login.html
@@ -16,7 +16,7 @@ the License.
     <p class="help-block">
       Login to CouchDB with your name and password.
     </p>
-    <input id="username" type="text" name="name" placeholder= "Username:" size="24">
+    <input id="username" type="text" name="name" placeholder="Username" size="24">
     <br/>
     <input id="password" type="password" name="password" placeholder= "Password" size="24">
     <br/>


### PR DESCRIPTION
The one for Password has no `:` so removing them makes the view
more consistent (and looks maybe better)

![bildschirmfoto 2014-03-05 um 22 20 39](https://f.cloud.github.com/assets/298166/2338672/14b25c7e-a4ac-11e3-93d3-6dac32bac33e.png)
