### PR TITLE
Store the initial collection parameters to allow a safe reset to the first page (COUCHDB-2187)

### DIFF
--- a/src/fauxton/app/addons/documents/resources.js
+++ b/src/fauxton/app/addons/documents/resources.js
@@ -358,7 +358,23 @@ function(app, FauxtonAPI) {
 
   });
 
-  Documents.AllDocs = FauxtonAPI.Collection.extend({
+  var DefaultParametersMixin = function() {
+    // keep this variable private
+    var defaultParams;
+
+    return {
+      saveDefaultParameters: function() {
+        // store the default parameters so we can reset to the first page
+        defaultParams = _.clone(this.params);
+      },
+
+      restoreDefaultParameters: function() {
+        this.params = _.clone(defaultParams);
+      }
+    };
+  };
+
+  Documents.AllDocs = FauxtonAPI.Collection.extend(_.extend({}, DefaultParametersMixin(), {
     model: Documents.Doc,
     isAllDocs: true,
     documentation: function(){
@@ -367,12 +383,15 @@ function(app, FauxtonAPI) {
     initialize: function(_models, options) {
       this.database = options.database;
       this.params = _.clone(options.params);
+
       this.on("remove",this.decrementTotalRows , this);
       this.perPageLimit = options.perPageLimit || 20;
 
       if (!this.params.limit) {
-        this.params.limit = this.perPageLimit; 
+        this.params.limit = this.perPageLimit;
       }
+
+      this.saveDefaultParameters();
     },
 
     url: function(context, params) {
@@ -459,9 +478,9 @@ function(app, FauxtonAPI) {
         };
       });
     }
-  });
+  }));
 
-  Documents.IndexCollection = FauxtonAPI.Collection.extend({
+  Documents.IndexCollection = FauxtonAPI.Collection.extend(_.extend({}, DefaultParametersMixin(), {
     model: Documents.ViewRow,
     documentation: function(){
       return "docs";
@@ -469,6 +488,7 @@ function(app, FauxtonAPI) {
     initialize: function(_models, options) {
       this.database = options.database;
       this.params = _.extend({limit: 20, reduce: false}, options.params);
+
       this.idxType = "_view";
       this.view = options.view;
       this.design = options.design.replace('_design/','');
@@ -476,9 +496,10 @@ function(app, FauxtonAPI) {
       this.perPageLimit = options.perPageLimit || 20;
 
       if (!this.params.limit) {
-        this.params.limit = this.perPageLimit; 
+        this.params.limit = this.perPageLimit;
       }
-
+      
+      this.saveDefaultParameters();
     },
 
     url: function(context, params) {
@@ -618,10 +639,10 @@ function(app, FauxtonAPI) {
       return timeString;
     }
 
-  });
+  }));
 
   
-  Documents.PouchIndexCollection = FauxtonAPI.Collection.extend({
+  Documents.PouchIndexCollection = FauxtonAPI.Collection.extend(_.extend({}, DefaultParametersMixin(), {
     model: Documents.ViewRow,
     documentation: function(){
       return "docs";
@@ -632,7 +653,10 @@ function(app, FauxtonAPI) {
       this.view = options.view;
       this.design = options.design.replace('_design/','');
       this.params = _.extend({limit: 20, reduce: false}, options.params);
+
       this.idxType = "_view";
+
+      this.saveDefaultParameters();
     },
 
     url: function () {
@@ -687,7 +711,7 @@ function(app, FauxtonAPI) {
     allDocs: function(){
       return this.models;
     }
-  });
+  }));
 
 
 

--- a/src/fauxton/app/addons/documents/routes.js
+++ b/src/fauxton/app/addons/documents/routes.js
@@ -377,12 +377,13 @@ function(app, FauxtonAPI, Documents, Databases) {
     },
 
     perPageChange: function (perPage) {
-      var params = app.getParams();
+      // We need to restore the collection parameters to the defaults (1st page)
+      // and update the page size
+      var params = this.documentsView.collection.restoreDefaultParameters();
       this.perPage = perPage;
       this.documentsView.updatePerPage(perPage);
       this.documentsView.forceRender();
-      params.limit = perPage;
-      this.documentsView.collection.params = params;
+      this.documentsView.collection.params.limit = perPage;
       this.setDocPerPageLimit(perPage);
     },
 


### PR DESCRIPTION
When adjusting page size, the desired behaviour is to navigate back to the first page of the collection. This was previously achieved by parsing the browser URL to get the query parameters but that does not capture additional defaults that are set in JavaScript (such as reduce=false for views).

This commit adds 2 new methods to the document collections via a mixin:

saveDefaultParameters()
restoreDefaultParameters()

When each collection is initialized, we save the parameters which represent the initial state - these can then be restored when the page size is changed.

Fixes COUCHDB-2187.
