### PR TITLE
Fix Database search

### DIFF
--- a/src/fauxton/app/addons/databases/views.js
+++ b/src/fauxton/app/addons/databases/views.js
@@ -124,15 +124,18 @@ function(app, Components, FauxtonAPI, Databases) {
     },
 
     afterRender: function() {
-      var that = this;
-      this.dbSearchTypeahead = new Components.DbSearchTypeahead({
-        dbLimit: this.dbLimit,
+      var that = this,
+          AllDBsArray = _.map(this.collection.toJSON(), function(item, key){ 
+            return item.name; 
+          });
+
+      this.dbSearchTypeahead = new Components.Typeahead({
         el: "input.search-autocomplete",
+        source: AllDBsArray,
         onUpdate: function (item) {
           that.switchDatabase(null, item);
         }
       });
-
       this.dbSearchTypeahead.render();
     },
 


### PR DESCRIPTION
Changed the typeahead to not make a call to _all_dbs and instead use the existing fetched collection.
