### PR TITLE
Fix missing file in Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,6 +147,7 @@ FAUXTON_FILES = \
     fauxton/app/addons/databases/resources.js \
     fauxton/app/addons/databases/routes.js \
     fauxton/app/addons/databases/views.js \
+    fauxton/app/addons/databases/tests/resourcesSpec.js \
     fauxton/app/addons/documents/base.js \
     fauxton/app/addons/documents/resources.js \
     fauxton/app/addons/documents/routes.js \


### PR DESCRIPTION
In #181 I have missed to add the test-file to `Makefile.am`. This commit adds the missing file.

I will never remember that, so I created a precommit-githook for me now:

A known issue is that you can have the needed change unstaged, but the test will not fail, but for me it is okay currently.

``` bash
files=$(git diff-index --name-status --cached HEAD | grep -v ^D | cut -c3-)

# initial commit - files is null
if [ -z "$files" ]
then
  files=$(git diff --cached --root --name-status | grep -v ^D | cut -c3-)
fi

if [ -n "$files" ]
then
  echo "running Makefile.am-check..."
  for f in $files
  do
    # return error if not in Makefile.am
    if [ -z "$(grep ${f:4} src/Makefile.am)" ]
    then
    echo ${f:4}
      if [ "${f:4}" != 'Makefile.am' ]
      then
        echo "Error: file not added to Makefile.am"
        exit 1
      fi
    fi
  done
  exit 0
fi
```

PTAL @kxepal 
