### PR TITLE
spell checking my-first-couchdb-plugin's README

### DIFF
--- a/src/my-first-couchdb-plugin/README.md
+++ b/src/my-first-couchdb-plugin/README.md
@@ -8,9 +8,8 @@ A practical guide to developing CouchDB plugins.
 
 To get started, you need to install CouchDB from source, grab the CouchDB sources:
 
-    git clone https://git-wip-us.apache.org/repos/asf/couchdb.git
+    git clone https://github.com/apache/couchdb.git
     cd couchdb
-    git checkout -b 1867-feature-plugin origin/1867-feature-plugins
 
 Follow the instructions in `couchdb/INSTALL.Unix` and `couchdb/DEVELOPERS` to get a development environment going.
 


### PR DESCRIPTION
this pull request only fix spelling mistakes, but there's a part I would like to improve also

the opening note of the plugin README says:

"NOTE: This is incomplete, barely tested, works only with the 1867-feature-plugin branch of Apache CouchDB and expects that you understand some Erlang. This is mostly for early review, but if you are daring, you can learn someting already :)"

the branch name may be outdated since this works on 1.5.0, also the incomplete, barely tested part seems outdated, maybe "this feature is considered alpha/beta/subject to change"?

can you recommend a better warning note?
