### PR TITLE
Fix error message in database permissions

### DIFF
--- a/src/fauxton/app/addons/permissions/views.js
+++ b/src/fauxton/app/addons/permissions/views.js
@@ -148,7 +148,7 @@ function (app, FauxtonAPI, Permissions ) {
         });
       }, function (xhr) {
         FauxtonAPI.addNotification({
-          msg: 'Could not update permissions - reason: ' + xhr.responseText,
+          msg: 'Could not update permissions - reason: ' + xhr.responseJSON.reason,
           type: 'error'
         });
       });


### PR DESCRIPTION
Show the message from the server instead of the whole JSON as text

This fixes:
![bildschirmfoto 2014-03-19 um 20 29 39](https://f.cloud.github.com/assets/298166/2464974/2d7da410-af9d-11e3-87af-c478719b8ec4.png)
