### PR TITLE
Fauxton: make hidden tabs in _changes visible

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -153,6 +153,7 @@ FAUXTON_FILES = \
     fauxton/app/addons/documents/routes.js \
     fauxton/app/addons/documents/tests/resourcesSpec.js \
     fauxton/app/addons/documents/views.js \
+    fauxton/app/addons/documents/assets/less/documents.less \
     fauxton/app/addons/fauxton/base.js \
     fauxton/app/addons/fauxton/components.js \
     fauxton/app/addons/fauxton/resizeColumns.js \

--- a/src/fauxton/assets/less/fauxton.less
+++ b/src/fauxton/assets/less/fauxton.less
@@ -869,3 +869,10 @@ div.spinner {
     }
   }
 }
+
+#tabs {
+  padding-top: 62px;
+  ul {
+    margin-bottom: 0px;
+  }
+}


### PR DESCRIPTION
I found some hidden tabs in the `_changes`-screen I am working on, they are positioned behind the upper header with the breadcrumbs.

I am not sure if we want them, but I made them visible so everybody can have a look.

I find the tabs very useful, but maybe they should be positioned `fixed` so it's always in the screen and not just on scrolldown.

**Merge with caution**: if it is planned that e.g. `Config` will get a fixed header like most views, the padding for tabs makes sense. If not and there would be tabs added, the tabs would have too much space to the top.
- Should we keep the tabs?
- Will all screens get this fixed header?
