### PR TITLE
Remove log level name from the log list & some styling fixes

### DIFF
--- a/src/fauxton/app/addons/logs/assets/less/logs.less
+++ b/src/fauxton/app/addons/logs/assets/less/logs.less
@@ -11,14 +11,26 @@
  *  the License.
  */
 
-#log-sidebar {
-  
-  ul {
-    margin-left: 0px;
-    list-style: none;
+.log {
+  padding: 0 15px;
+
+  #log-sidebar {
+    ul {
+      margin-left: 0px;
+      list-style: none;
+    }
+
+    .remove-filter {
+       opacity: 0.2;
+    }
   }
 
-  .remove-filter {
-     opacity: 0.2;
+  .log-table {
+    width: auto;
+    white-space: nowrap;
+    .args {
+      width: 100%;
+      white-space: normal;
+    }
   }
 }

--- a/src/fauxton/app/addons/logs/templates/dashboard.html
+++ b/src/fauxton/app/addons/logs/templates/dashboard.html
@@ -12,35 +12,33 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 
- <h2> CouchDB Logs </h2>
-  <table class="table table-bordered" >
-  <thead>
-    <tr>
-      <th class="Date">Date</th>
-      <th class="Log Level">Log Value</th>
-      <th class="Pid">Pid</th>
-      <th class="Args">Url</th>
-    </tr>
-  </thead>
+<div class="log">
+  <h2>CouchDB Logs</h2>
+  <table class="table table-bordered log-table">
+    <thead>
+      <tr>
+        <th class="date">Date</th>
+        <th class="pid">Pid</th>
+        <th class="args">Url</th>
+      </tr>
+    </thead>
 
-  <tbody>
-    <% logs.each(function (log) { %>
-    <tr class="<%= log.logLevel() %>">
-      <td>
-        <!-- TODO: better format the date -->
-        <%= log.date() %>
-      </td>
-      <td>
-        <%= log.logLevel() %>
-      </td>
-      <td>
-        <%= log.pid() %>
-      </td>
-      <td>
-        <!-- TODO: split the line, maybe put method in it's own column -->
-        <%= log.args() %>
-      </td>
-    </tr>
-    <% }); %>
-  </tbody>
-</table>
+    <tbody>
+      <% logs.each(function (log) { %>
+      <tr class="<%= log.logLevel() %>">
+        <td>
+          <!-- TODO: better format the date -->
+          <%= log.date() %>
+        </td>
+        <td class="pid">
+          <%= log.pid() %>
+        </td>
+        <td class="args">
+          <!-- TODO: split the line, maybe put method in it's own column -->
+          <%= log.args() %>
+        </td>
+      </tr>
+      <% }); %>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
- Remove the message-level from the view
- small columns (pid, date) get less width
- padding around the view

Closes COUCHDB-2135

**Preview:**
![bildschirmfoto 2014-04-11 um 21 58 32](https://cloud.githubusercontent.com/assets/298166/2684146/e514a15a-c1b3-11e3-997c-a7d8d6b4005a.png)
