### PR TITLE
COUCHDB-2225 Enforce that shared libraries can be built by the system.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,10 @@ AC_DISABLE_STATIC
 AC_PROG_CC
 LT_INIT([win32-dll])
 LT_INIT
+AS_IF([test x"${enable_shared}" = "xno"], [
+  AC_MSG_ERROR([System as configured cannot build shared libraries.])
+])
+
 AC_PROG_LN_S
 
 PKG_PROG_PKG_CONFIG


### PR DESCRIPTION
configure stage should ensure that shared libraries can be built.  
