### PR TITLE
[WIP] Implement a filter for databases - COUCHDB-2125

### DIFF
--- a/src/fauxton/app/addons/activetasks/assets/less/activetasks.less
+++ b/src/fauxton/app/addons/activetasks/assets/less/activetasks.less
@@ -14,3 +14,7 @@
 .active-tasks th {
   cursor: pointer;
 }
+
+#sidenav .task-search-database {
+  margin: 20px;
+}

--- a/src/fauxton/app/addons/activetasks/resources.js
+++ b/src/fauxton/app/addons/activetasks/resources.js
@@ -63,6 +63,10 @@ function (app, Fauxton) {
     }
   });
 
+  Active.Search = Backbone.Model.extend({
+    filterDatabase: null,
+    filterType: "all"
+  });
 
   return Active;
 });

--- a/src/fauxton/app/addons/activetasks/routes.js
+++ b/src/fauxton/app/addons/activetasks/routes.js
@@ -41,15 +41,19 @@ function (app, FauxtonAPI, Activetasks, Views) {
 
     initialize: function () {
       this.allTasks = new Activetasks.AllTasks();
+      this.search = new Activetasks.Search();
     },
 
     defaultView: function () {
       this.setView("#dashboard-content", new Views.View({
         collection: this.allTasks,
-        currentView: "all"
+        currentView: "all",
+        searchModel: this.search
       }));
 
-      this.setView("#sidebar-content", new Views.TabMenu({}));
+      this.setView("#sidebar-content", new Views.TabMenu({
+        searchModel: this.search
+      }));
     }
   });
 

--- a/src/fauxton/app/addons/activetasks/templates/tabs.html
+++ b/src/fauxton/app/addons/activetasks/templates/tabs.html
@@ -17,30 +17,37 @@ the License.
 
 
 <div id="sidenav">
-  <header class="row-fluid">
-    <h3>Filter by: </h3>
-  </header>
-
-  <nav>
-		<ul class="task-tabs nav nav-list">
-		  <% for (var filter in filters) { %>
-		      <li data-type="<%=filter%>">
-			      <a>
-			      		<%=filters[filter]%>
-			      </a>
-		    </li>
-		  <% } %>
-		</ul>
-		<ul class="nav nav-list views">
-			<li class="nav-header">Polling interval</li>
-			<li>
-				<input id="pollingRange" type="range"
-				       min="1"
-				       max="30"
-				       step="1"
-				       value="5"/>
-				<label for="pollingRange"><span>5</span> second(s)</label>
-			</li>
-		</ul>
-  </nav>
+  <section>
+    <header class="row-fluid">
+      <h3>Filter by:</h3>
+    </header>
+    <input class="task-search-database" type="text" name="search" placeholder="Search for databases...">
+  </section>
+  <section>
+    <header class="row-fluid">
+      <h3>Type of Task:</h3>
+    </header>
+    <nav>
+      <ul class="task-tabs nav nav-list">
+        <% for (var filter in filters) { %>
+            <li data-type="<%=filter%>">
+              <a>
+                  <%=filters[filter]%>
+              </a>
+          </li>
+        <% } %>
+      </ul>
+      <ul class="nav nav-list views">
+        <li class="nav-header">Polling interval</li>
+        <li>
+          <input id="pollingRange" type="range"
+                 min="1"
+                 max="30"
+                 step="1"
+                 value="5"/>
+          <label for="pollingRange"><span>5</span> second(s)</label>
+        </li>
+      </ul>
+    </nav>
+  </section>
 </div>

--- a/src/fauxton/app/addons/activetasks/tests/viewsSpec.js
+++ b/src/fauxton/app/addons/activetasks/tests/viewsSpec.js
@@ -19,10 +19,13 @@ define([
       ViewSandbox = testUtils.ViewSandbox;
 
   describe("TabMenu", function () {
-    var tabMenu;
+    var tabMenu, searchModel;
 
     beforeEach(function () {
-      tabMenu = new Views.TabMenu({});
+      searchModel = new Activetasks.Search();
+      tabMenu = new Views.TabMenu({
+        searchModel: searchModel
+      });
     });
 
     describe("on change polling rate", function () {
@@ -70,7 +73,8 @@ define([
 
         mainView = new Views.View({
           collection: new Activetasks.AllTasks(),
-          currentView: "all"
+          currentView: "all",
+          searchModel: searchModel
         });
 
         viewSandbox = new ViewSandbox();
@@ -82,10 +86,15 @@ define([
         viewSandbox.remove();
       });
 
-      it("should set the filter the main-view", function () {
+      it("should set the filter 'type' for the main-view", function () {
         var $rep = tabMenu.$('li[data-type="replication"]');
         $rep.click();
-        assert.equal("replication", mainView.filter);
+        assert.equal("replication", mainView.searchModel.get('filterType'));
+      });
+
+      it("should set the filter 'database' for the main-view", function () {
+        var $rep = tabMenu.$("input").val("registry").trigger("keyup");
+        assert.equal("registry", mainView.searchModel.get('filterDatabase'));
       });
 
       it("should set correct active tab", function () {
@@ -102,7 +111,8 @@ define([
     beforeEach(function () {
       mainView = new Views.View({
         collection: new Activetasks.AllTasks(),
-        currentView: "all"
+        currentView: "all",
+        searchModel: new Activetasks.Search()
       });
 
       viewSandbox = new ViewSandbox();


### PR DESCRIPTION
Please do not merge, but take a look at ebc07d6:

Uses a new model to manage the state of the different search
filters to filter the view.

Nice feature: the filter for the database (upper input) and
the filters for the type (buttons) work nicely together,
so you can filter out all replications for that
database (let's name it registry)  without the compaction,
if you choose replication as type and enter "registry" in the
top input.

Closes COUCHDB-2125

What's missing:
- some :heart: for the design of the input, can take a look at this on my own, but it's not my core competency
- a merge for the refactor which was the base for the feature (another PR, working on it with Garren), after the merge the diff should be just: ebc07d6
