### PR TITLE
Fauxton: fix sorting for tasks on click

### DIFF
--- a/src/fauxton/app/addons/activetasks/resources.js
+++ b/src/fauxton/app/addons/activetasks/resources.js
@@ -23,7 +23,7 @@ function (app, backbone, Fauxton) {
       app.taskSortBy = 'type';
 
   Active.Task = Backbone.Model.extend({
-    initialize: function() { 
+    initialize: function() {
       this.set({"id": this.get('pid')});
     }
   });
@@ -109,7 +109,19 @@ function (app, backbone, Fauxton) {
       this.sort();
     },
     comparator: function(item) {
-      return item.get(app.taskSortBy);
+      var value = app.taskSortBy,
+          values;
+
+      if (value.indexOf(',') !== -1) {
+        values = value.split(',');
+        _.each(values, function (val) {
+          if (item.get(val)) {
+            value = val;
+          }
+        });
+      }
+
+      return item.get(value);
     }
   });
 

--- a/src/fauxton/app/addons/activetasks/templates/table.html
+++ b/src/fauxton/app/addons/activetasks/templates/table.html
@@ -37,7 +37,7 @@ the License.
   <thead>
     <tr>
       <th data-type="type">Type</th>
-      <th data-type="node">Object</th>
+      <th data-type="source,target,database">Object</th>
       <th data-type="started_on">Started on</th>
       <th data-type="updated_on">Last updated on</th>
       <th data-type="pid">PID</th>


### PR DESCRIPTION
there is no node property, but a target, source or database
depending on the task
