### PR TITLE
COUCHDB-2233 - Correct HTML interpolation instances in documents.

### DIFF
--- a/src/fauxton/app/addons/fauxton/templates/api_bar.html
+++ b/src/fauxton/app/addons/fauxton/templates/api_bar.html
@@ -20,11 +20,11 @@ the License.
     <div class="input-prepend input-append">
       <span class="add-on">
         API reference
-        <a href="<%=getDocUrl(documentation)%>" target="_blank">
+        <a href="<%-getDocUrl(documentation)%>" target="_blank">
           <i class="icon-question-sign"></i>
         </a>
       </span>
-      <input type="text" class="input-xxlarge" value="<%= endpoint %>">
-      <a href="<%= endpoint %>" target="_blank" class="btn">Show me</a>
+      <input type="text" class="input-xxlarge" value="<%- endpoint %>">
+      <a href="<%- endpoint %>" target="_blank" class="btn">Show me</a>
     </div>
 </div>

--- a/src/fauxton/app/addons/fauxton/templates/breadcrumbs.html
+++ b/src/fauxton/app/addons/fauxton/templates/breadcrumbs.html
@@ -15,10 +15,10 @@ the License.
 <ul class="breadcrumb">
   <% _.each(_.initial(crumbs), function(crumb) { %>
     <li>
-      <a href="#<%= crumb.link %>"><%= crumb.name %></a>
+      <a href="#<%- crumb.link %>"><%- crumb.name %></a>
       <span class="divider fonticon fonticon-carrot"> </span>
     </li>
   <% }); %>
   <% var last = _.last(crumbs) || {name: ''} %>
-  <li class="active"><%= last.name %></li>
+  <li class="active"><%- last.name %></li>
 </ul>

--- a/src/fauxton/app/addons/fauxton/templates/footer.html
+++ b/src/fauxton/app/addons/fauxton/templates/footer.html
@@ -12,4 +12,4 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 
-Fauxton on <a href="http://couchdb.apache.org/">Apache CouchDB</a><br> v. <%=version%>
+Fauxton on <a href="http://couchdb.apache.org/">Apache CouchDB</a><br> v. <%-version%>

--- a/src/fauxton/app/addons/fauxton/templates/nav_bar.html
+++ b/src/fauxton/app/addons/fauxton/templates/nav_bar.html
@@ -22,10 +22,10 @@ the License.
   <ul id="nav-links" class="nav pull-right">
     <% _.each(navLinks, function(link) { %>
     <% if (link.view) {return;}  %>
-        <li data-nav-name= "<%= link.title %>" >
-          <a href="<%= link.href %>">
-            <i class="<%= link.icon %> fonticon"></i>
-            <%= link.title %>
+        <li data-nav-name= "<%- link.title %>" >
+          <a href="<%- link.href %>">
+            <i class="<%- link.icon %> fonticon"></i>
+            <%- link.title %>
           </a>
         </li>
     <% }); %>
@@ -34,7 +34,7 @@ the License.
   <div id="bottom-nav">
   	<ul id="bottom-nav-links" class="nav">
         <li data-nav-name= "Documentation">
-            <a href="<%=getDocUrl('docs')%>" target="_blank">
+            <a href="<%-getDocUrl('docs')%>" target="_blank">
               <i class="fonticon-bookmark fonticon"></i>
                 Documentation
             </a>
@@ -42,10 +42,10 @@ the License.
 
       <% _.each(bottomNavLinks, function(link) { %>
       <% if (link.view) {return;}  %>
-        <li data-nav-name= "<%= link.title %>">
-            <a href="<%= link.href %>">
-              <i class="<%= link.icon %> fonticon"></i>
-              <%= link.title %>
+        <li data-nav-name= "<%- link.title %>">
+            <a href="<%- link.href %>">
+              <i class="<%- link.icon %> fonticon"></i>
+              <%- link.title %>
             </a>
         </li>
       <% }); %>
@@ -61,10 +61,10 @@ the License.
     <ul id="footer-nav-links" class="nav">
       <% _.each(footerNavLinks, function(link) { %>
       <% if (link.view) {return;}  %>
-        <li data-nav-name= "<%= link.title %>">
-            <a href="<%= link.href %>">
-              <i class="<%= link.icon %> fonticon"></i>
-              <%= link.title %>
+        <li data-nav-name= "<%- link.title %>">
+            <a href="<%- link.href %>">
+              <i class="<%- link.icon %> fonticon"></i>
+              <%- link.title %>
             </a>
         </li>
       <% }); %>

--- a/src/fauxton/app/addons/fauxton/templates/notification.html
+++ b/src/fauxton/app/addons/fauxton/templates/notification.html
@@ -12,7 +12,7 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 
-<div class="alert alert-<%= type %>">
+<div class="alert alert-<%- type %>">
   <button type="button" class="close" data-dismiss="alert">×</button>
-  <%= msg %>
+  <%- msg %>
 </div>

--- a/src/fauxton/app/addons/fauxton/templates/pagination.html
+++ b/src/fauxton/app/addons/fauxton/templates/pagination.html
@@ -15,17 +15,17 @@ the License.
 <div class="pagination pagination-centered">
   <ul>
     <% if (page > 1) { %>
-    <li> <a href="<%= urlFun(page-1) %>">&laquo;</a></li>
+    <li> <a href="<%- urlFun(page-1) %>">&laquo;</a></li>
     <% } else { %>
-      <li class="disabled"> <a href="<%= urlFun(page) %>">&laquo;</a></li>
+      <li class="disabled"> <a href="<%- urlFun(page) %>">&laquo;</a></li>
     <% } %>
     <% _.each(_.range(1, totalPages+1), function(i) { %>
-      <li <% if (page == i) { %>class="active"<% } %>> <a href="<%= urlFun(i) %>"><%= i %></a></li>
+      <li <% if (page == i) { %>class="active"<% } %>> <a href="<%- urlFun(i) %>"><%- i %></a></li>
     <% }) %>
     <% if (page < totalPages) { %>
-      <li><a href="<%= urlFun(page+1) %>">&raquo;</a></li>
+      <li><a href="<%- urlFun(page+1) %>">&raquo;</a></li>
     <% } else { %>
-      <li class="disabled"> <a href="<%= urlFun(page) %>">&raquo;</a></li>
+      <li class="disabled"> <a href="<%- urlFun(page) %>">&raquo;</a></li>
     <% } %>
   </ul>
 </div>


### PR DESCRIPTION
Further updating instances of <%= and to <%- within documents to correctly handle HTML interpolation.

Tested for regression in
- 34.0.1847.131
- Safari 7.0.2
