### PR TITLE
Send a real EventSource event for heartbeat

### DIFF
--- a/share/doc/src/api/database/changes.rst
+++ b/share/doc/src/api/database/changes.rst
@@ -398,6 +398,16 @@ parameter.
 
     }
 
+If you set a heartbeat interval (using the ``heartbeat`` query argument), CouchDB will
+send a ``hearbeat`` event that you can subscribe to with:
+
+.. code-block:: javascript
+
+    source.addEventListener('heartbeat', function () {}, false);
+
+This can be monitored by the client application to restart the EventSource connection if
+needed (i.e. if the TCP connection gets stuck in a half-open state).
+
 .. note::
 
    EventSource connections are subject to cross-origin resource sharing

--- a/share/www/script/test/changes.js
+++ b/share/www/script/test/changes.js
@@ -123,7 +123,7 @@ couchTests.changes = function(debug) {
 
     xhr = CouchDB.newXhr();
 
-    //verify the hearbeat newlines are sent
+    //verify the heartbeat newlines are sent
     xhr.open("GET", CouchDB.proxyUrl("/test_suite_db/_changes?feed=continuous&heartbeat=10&timeout=500"), true);
     xhr.send("");
 
@@ -169,6 +169,25 @@ couchTests.changes = function(debug) {
       T(results[1].seq == 2);
       T(results[1].id == "bar");
       T(results[1].changes[0].rev == docBar._rev);
+    }
+
+    // test that we receive EventSource heartbeat events
+    if (!!window.EventSource) {
+      var source = new EventSource(
+              "/test_suite_db/_changes?feed=eventsource&heartbeat=10");
+
+      var count_heartbeats = 0;
+      source.addEventListener('heartbeat', function () { count_heartbeats = count_heartbeats + 1; } , false);
+
+      waitForSuccess(function() {
+        if (count_heartbeats < 3) {
+          throw "keep waiting";
+        }
+        return true;
+      }, "eventsource-heartbeat");
+
+      T(count_heartbeats >= 3);
+      source.close();
     }
 
     // test longpolling

--- a/src/couchdb/couch_httpd_db.erl
+++ b/src/couchdb/couch_httpd_db.erl
@@ -105,6 +105,8 @@ handle_changes_req2(Req, Db) ->
                 io_lib:format("\n],\n\"last_seq\":~w}\n", [EndSeq])
             ),
             end_json_response(Resp);
+        (timeout, "eventsource") ->
+            send_chunk(Resp, "event: heartbeat\ndata: \n\n");
         (timeout, _) ->
             send_chunk(Resp, "\n")
         end


### PR DESCRIPTION
The EventSource connection can get stuck (in TCP half-open state*) and there's no way
for the client to detect that. This commit changes the way heartbeat is sent, instead of
sending a newline character, it sends an empty event of type heartbeat:

```
event: heartbeat
data:
```

This event doesn't have an id: field, so the client will retain its latest Last-Event-ID state.

This doesn't change the expectations of clients that used EventSource till now, because they
subscribe to the 'message' event type. To get the 'heartbeat' events a client will need to
explicitly subscribe to it:

```
source.addEventListener('heartbeat', function () { /* cancel a timer that would otherwise reconnect the source */ });
```
- this can happen when you suspend your laptop, on flaky internet connection, ADSL reconnect,
  bad wifi signals, bad routers etc. Pretty often in a typical internet usage nowadays.
