### PR TITLE
Fauxton: Configurable escaping of notifications

### DIFF
--- a/src/fauxton/app/addons/compaction/views.js
+++ b/src/fauxton/app/addons/compaction/views.js
@@ -50,6 +50,7 @@ function (app, FauxtonAPI, Compaction) {
         FauxtonAPI.addNotification({
           type: 'success',
           msg: 'Database compaction has started. Visit <a href="#activetasks">Active Tasks</a> to view the compaction progress.',
+          escape: false // beware of possible XSS when the message changes
         });
       }, function (xhr, error, reason) {
         FauxtonAPI.addNotification({
@@ -70,7 +71,8 @@ function (app, FauxtonAPI, Compaction) {
       Compaction.cleanupViews(this.model).then(function () {
         FauxtonAPI.addNotification({
           type: 'success',
-          msg: 'View cleanup has started. Visit <a href="#activetasks">Active Tasks</a> to view progress.'
+          msg: 'View cleanup has started. Visit <a href="#activetasks">Active Tasks</a> to view progress.',
+          escape: false // beware of possible XSS when the message changes
         });
       }, function (xhr, error, reason) {
         FauxtonAPI.addNotification({
@@ -120,7 +122,8 @@ function (app, FauxtonAPI, Compaction) {
       Compaction.compactView(this.database, this.designDoc).then(function () {
         FauxtonAPI.addNotification({
           type: 'success',
-          msg: 'View compaction has started. Visit <a href="#activetasks">Active Tasks</a> to view progress.'
+          msg: 'View compaction has started. Visit <a href="#activetasks">Active Tasks</a> to view progress.',
+          escape: false // beware of possible XSS when the message changes
         });
       }, function (xhr, error, reason) {
         FauxtonAPI.addNotification({

--- a/src/fauxton/app/addons/documents/views.js
+++ b/src/fauxton/app/addons/documents/views.js
@@ -111,8 +111,9 @@ function(app, FauxtonAPI, Components, Documents, Databases, pouchdb,
       this.database.destroy().then(function () {
         FauxtonAPI.navigate('#/_all_dbs');
         FauxtonAPI.addNotification({
-          msg: 'The database <code>' + databaseName + '</code> has been deleted.',
-          clear: true
+          msg: 'The database <code>' + _.escape(databaseName) + '</code> has been deleted.',
+          clear: true,
+          escape: false // beware of possible XSS when the message changes
         });
       }).fail(function (rsp, error, msg) {
         FauxtonAPI.addNotification({
@@ -1596,7 +1597,8 @@ function(app, FauxtonAPI, Components, Documents, Databases, pouchdb,
         msg: "<strong>Warning!</strong> Preview executes the Map/Reduce functions in your browser, and may behave differently from CouchDB.",
         type: "warning",
         selector: ".advanced-options .errors-container",
-        fade: true
+        fade: true,
+        escape: false // beware of possible XSS when the message changes
       });
 
       var promise = FauxtonAPI.Deferred();

--- a/src/fauxton/app/addons/fauxton/base.js
+++ b/src/fauxton/app/addons/fauxton/base.js
@@ -23,7 +23,8 @@ function(app, FauxtonAPI, resizeColumns) {
     options = _.extend({
       msg: "Notification Event Triggered!",
       type: "info",
-      selector: "#global-notifications"
+      selector: "#global-notifications",
+      escape: true
     }, options);
 
     var view = new Fauxton.Notification(options);
@@ -304,7 +305,11 @@ function(app, FauxtonAPI, resizeColumns) {
     fadeTimer: 5000,
 
     initialize: function(options) {
-      this.msg = options.msg;
+      this.htmlToRender = options.msg;
+      // escape always, except the value is false
+      if (options.escape !== false) {
+        this.htmlToRender = _.escape(this.htmlToRender);
+      }
       this.type = options.type || "info";
       this.selector = options.selector;
       this.fade = options.fade === undefined ? true : options.fade;
@@ -316,7 +321,7 @@ function(app, FauxtonAPI, resizeColumns) {
     serialize: function() {
       return {
         data: this.data,
-        msg: this.msg,
+        htmlToRender: this.htmlToRender,
         type: this.type
       };
     },

--- a/src/fauxton/app/addons/fauxton/templates/notification.html
+++ b/src/fauxton/app/addons/fauxton/templates/notification.html
@@ -14,5 +14,5 @@ the License.
 
 <div class="alert alert-<%- type %>">
   <button type="button" class="close" data-dismiss="alert">×</button>
-  <%- msg %>
+  <%= htmlToRender %><!-- every caller has to escape on it's own -->
 </div>

--- a/src/fauxton/app/addons/fauxton/tests/baseSpec.js
+++ b/src/fauxton/app/addons/fauxton/tests/baseSpec.js
@@ -49,7 +49,7 @@ define([
         hooks: [],
         setBreadcrumbs: sinon.spy(),
         apiBar: apiBar,
-        layout: { 
+        layout: {
           setView: function () {}
         }
       };
@@ -75,5 +75,42 @@ define([
 
   });
 
+describe('Fauxton Notifications', function () {
 
+    it('should escape by default', function () {
+      window.fauxton_xss_test_escaped = true;
+      var view = FauxtonAPI.addNotification({
+        msg: '<script>window.fauxton_xss_test_escaped = false;</script>',
+        selector: 'body'
+      });
+      view.$el.remove();
+      assert.ok(window.fauxton_xss_test_escaped);
+      delete window.fauxton_xss_test_escaped;
+    });
+
+    it('should be able to render unescaped', function () {
+      var view = FauxtonAPI.addNotification({
+        msg: '<script>window.fauxton_xss_test_unescaped = true;</script>',
+        selector: 'body',
+        escape: false
+      });
+      view.$el.remove();
+      assert.ok(window.fauxton_xss_test_unescaped);
+      delete window.fauxton_xss_test_unescaped;
+    });
+
+    it('should render escaped if the escape value is not explicitly false,' +
+        'e.g. was forgotten in a direct call', function () {
+
+      window.fauxton_xss_test2_escaped = true;
+      var view = new Base.Notification({
+        msg: '<script>window.fauxton_xss_test2_escaped = false;</script>',
+        selector: 'body'
+      }).render();
+      view.$el.remove();
+      assert.ok(window.fauxton_xss_test2_escaped);
+      delete window.fauxton_xss_test2_escaped;
+    });
+
+  });
 });


### PR DESCRIPTION
Sometimes we are passing static html-links to the notification-
helper. With the new setting `escape: false` the escaping for
the notifications can be disabled.

The default value is that all values are escaped, as long as
no value with `false` is passed for the option escape.
`undefined` and other falsy values will not unescape.

I updated all occurences where we are passing html to the
notifications, and added a comment, that people are careful, when
the passed message changes to e.g. a dynamic content generated
from users.
