### PR TITLE
Fauxton: Fix scrollbar from sidebar on collapsed state in Chrome

### DIFF
--- a/src/fauxton/assets/less/fauxton.less
+++ b/src/fauxton/assets/less/fauxton.less
@@ -335,6 +335,8 @@ table.databases {
 
 /* Fixed side navigation */
 #primary-navbar {
+  /* hack for the scrollbar that shines through from the sidebar */
+  -webkit-transform: translate3d(0, 0, 0);
   height: 100%;
   position: fixed;
   width: @navWidth;


### PR DESCRIPTION
With a collapsed sidebar, in Chrome, the scrollbar was always
visible, even if the z-index of the dashboard was higher.
