### PR TITLE
Fauxton: encode uri component for config url

### DIFF
--- a/src/fauxton/app/addons/config/resources.js
+++ b/src/fauxton/app/addons/config/resources.js
@@ -26,7 +26,7 @@ function (app, FauxtonAPI) {
     documentation: "config",
 
     url: function () {
-      return app.host + '/_config/' + this.get("section") + '/' + this.get("name");
+      return app.host + '/_config/' + this.get("section") + '/' + encodeURIComponent(this.get("name"));
     },
 
     isNew: function () { return false; },
@@ -77,7 +77,7 @@ function (app, FauxtonAPI) {
     }
   });
 
- 
+
 
   return Config;
 });


### PR DESCRIPTION
Another bug @KlausTrainer told me about:

Fixes the "/" in httpd_global_handlers in the config dashboard
