### PR TITLE
Fauxton: use local version of font awesome

### DIFF
--- a/src/fauxton/assets/less/bootstrap/font-awesome/variables.less
+++ b/src/fauxton/assets/less/bootstrap/font-awesome/variables.less
@@ -1,8 +1,8 @@
 // Variables
 // --------------------------
 
-//@FontAwesomePath:    "../../img";
-@FontAwesomePath:    "//netdna.bootstrapcdn.com/font-awesome/3.2.1/font"; // for referencing Bootstrap CDN font files directly
+@FontAwesomePath:    "../../img";
+//@FontAwesomePath:    "//netdna.bootstrapcdn.com/font-awesome/3.2.1/font"; // for referencing Bootstrap CDN font files directly
 @FontAwesomeVersion: "3.2.1";
 @borderColor:        #eee;
 @iconMuted:          #eee;

--- a/src/fauxton/tasks/couchserver.js
+++ b/src/fauxton/tasks/couchserver.js
@@ -56,6 +56,7 @@ module.exports = function (grunt) {
       } else if (!!url.match(/mocha|\/test\/core\/|test\.config/)) {
         filePath = path.join('./test', url.replace('/test/',''));
       } else if (!!url.match(/\.css|img/)) {
+        url = url.replace(/\?.*/, '');
         filePath = path.join(dist_dir,url);
       /*} else if (!!url.match(/\/js\//)) {
         // serve any javascript or files from dist debug dir
@@ -87,7 +88,7 @@ module.exports = function (grunt) {
             res.end(JSON.stringify({error: err.message}));
           })
           .pipe(res);
-      } 
+      }
 
       proxy.proxyRequest(req, res);
     }).listen(port);


### PR DESCRIPTION
We are currently referencing to Font-Awesome on a CDN in the
variables.less, which is basically nice, but some users of
CouchDB are firewalled at work and can just use the local
network.

Additionally offline people without internet can't use Fauxton
if the font is loaded via CDN.

This also removes the cache-buster for imgs (GET-Params with
version) in our routing for the local files of the dev-server
to make it work, in the future we might want to use a real
router module for the long if/else block.

Closes: COUCHDB-2238

@garrensmith @deathbearbrown is there a special reason why we would keep the CDN?
