### PR TITLE
HTTP Interface: Content-Type "application/javascript" for JSONP

### DIFF
--- a/src/couchdb/couch_httpd.erl
+++ b/src/couchdb/couch_httpd.erl
@@ -963,7 +963,7 @@ negotiate_content_type(Req) ->
     case get(jsonp) of
         no_jsonp -> negotiate_content_type1(Req);
         [] -> negotiate_content_type1(Req);
-        _Callback -> "text/javascript"
+        _Callback -> "application/javascript"
     end.
 
 negotiate_content_type1(#httpd{mochi_req=MochiReq}) ->


### PR DESCRIPTION
This changes the content type to application/javascript for
JSONP responses, which is marked as obsolete in rfc 4329.

The upcoming 2.0 release is a great opportunity to include this
small breaking, but breaking change for clients.

Closes COUCHDB-2026
