### PR TITLE
Fauxton: fix scrollbar-issue - COUCHDB-2234

### DIFF
--- a/src/fauxton/app/addons/fauxton/resizeColumns.js
+++ b/src/fauxton/app/addons/fauxton/resizeColumns.js
@@ -29,12 +29,16 @@ function(FauxtonAPI) {
 
   Resize.prototype = {
     getPrimaryNavWidth: function(){
-      var primaryNavWidth  = $('body').hasClass('closeMenu')? 64:224;
+      var primaryNavWidth  = $('body').hasClass('closeMenu') ? 64 : 220;
       return primaryNavWidth;
     },
     getPanelWidth: function(){
-      var sidebarWidth = $('#sidebar-content').length > 0 ? $('#sidebar-content').width(): 0;
-      return (this.getPrimaryNavWidth() + sidebarWidth);
+      var sidebarWidth = $('#sidebar-content').length > 0 ? $('#sidebar-content').outerWidth() : 0,
+          borders = parseInt($('#dashboard').css('border-left-width'), 10) +
+                    parseInt($('#dashboard-content').css('border-left-width'), 10) +
+                    parseInt($('#dashboard-content').css('border-right-width'), 10);
+
+      return (this.getPrimaryNavWidth() + sidebarWidth + borders);
     },
     initialize: function(){
      // $(window).off('resize');
@@ -64,12 +68,10 @@ function(FauxtonAPI) {
         smallWidthConstraint = ($('#sidebar-content').length > 0)? 470:800,
         panelWidth;
 
-        if( combinedWidth > smallWidthConstraint  && combinedWidth < 1400){
+        if (combinedWidth > smallWidthConstraint) {
           panelWidth = window.innerWidth - this.getPanelWidth();
         } else if (combinedWidth < smallWidthConstraint){
           panelWidth = smallWidthConstraint;
-        } else if(combinedWidth > 1400){
-          panelWidth = 1400;
         }
 
         $('.window-resizeable').innerWidth(panelWidth);

--- a/src/fauxton/app/addons/fauxton/templates/api_bar.html
+++ b/src/fauxton/app/addons/fauxton/templates/api_bar.html
@@ -16,6 +16,7 @@ the License.
   API URL
   <i class="fonticon-plus icon"></i>
 </button>
+<div class="clearfix"></div>
 <div class="api-navbar" style="display: none">
     <div class="input-prepend input-append">
       <span class="add-on">

--- a/src/fauxton/app/addons/fauxton/templates/breadcrumbs.html
+++ b/src/fauxton/app/addons/fauxton/templates/breadcrumbs.html
@@ -12,7 +12,7 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 
-<ul class="breadcrumb">
+<ul class="breadcrumb pull-left">
   <% _.each(_.initial(crumbs), function(crumb) { %>
     <li>
       <a href="#<%- crumb.link %>"><%- crumb.name %></a>

--- a/src/fauxton/assets/less/fauxton.less
+++ b/src/fauxton/assets/less/fauxton.less
@@ -530,7 +530,6 @@ table.databases {
 
 
 #dashboard {
-  max-width: 1500px;
   .box-shadow(-6px 0 rgba(0, 0, 0, 0.1));
   border-left: 1px solid #999;
   position: absolute;
@@ -547,7 +546,7 @@ table.databases {
   &.one-pane{
     min-width: 800px;
     margin-top: 0;
-    overflow: auto;
+    overflow-x: hidden;
   }
 }
 
@@ -619,8 +618,8 @@ table.databases {
 }
 
 #breadcrumbs {
-   padding: 15px 20px;
    .breadcrumb {
+    margin: 15px 20px;
     margin-bottom: 0;
     background-color: transparent;
     padding: 0;
@@ -872,12 +871,12 @@ div.spinner {
 
 #api-navbar{
   position: relative;
+  padding-right: 5px;
 }
 
 .api-url-btn {
-  position: absolute;
-  right: 15px;
-  top: -50px;
+  margin-top: 5px;
+  margin-bottom: 5px;
   .icon {
     font-size: 11px;
   }
@@ -885,7 +884,7 @@ div.spinner {
 
 .api-navbar {
   border-top: 1px solid @red;
-  padding: 20px 20px 15px;
+  padding: 20px;
   .input-append.input-prepend {
     margin-bottom: 0px;
     .add-on {


### PR DESCRIPTION
This is a sliceoff from #225 where I try to fix the issue with the scrollbars.
- Try to honor borders in calculating the width
- Adjust magic numbers to new widths of the left area
- Refactor the header/api-url section
- Removing the maximum widths of 1400px and 1500px, which caused
  vertical scrollbars to appear at 1400px (which is on top of the
  page content, some hundred pixels away from the left side on
  large screens) on a system like windows

COUCHDB-2234
