### PR TITLE
Fauxton: Update breadcrumb on duplicate doc

### DIFF
--- a/src/fauxton/app/addons/documents/routes.js
+++ b/src/fauxton/app/addons/documents/routes.js
@@ -71,6 +71,7 @@ function(app, FauxtonAPI, Documents, Databases) {
       var doc = this.doc,
       docView = this.docView,
       database = this.database;
+      this.docID = newId;
 
       doc.copy(newId).then(function () {
         doc.set({_id: newId});


### PR DESCRIPTION
Small fix that makes sure the breadcrumb is updated with the new doc id
when a document is duplicated.
