### PR TITLE
Fauxton: Fix show me api link

### DIFF
--- a/src/fauxton/app/addons/fauxton/templates/api_bar.html
+++ b/src/fauxton/app/addons/fauxton/templates/api_bar.html
@@ -25,6 +25,6 @@ the License.
         </a>
       </span>
       <input type="text" class="input-xxlarge" value="<%- endpoint %>">
-      <a href="<%- endpoint %>" target="_blank" class="btn">Show me</a>
+      <a data-bypass="true" href="<%- endpoint %>" target="_blank" class="btn">Show me</a>
     </div>
 </div>


### PR DESCRIPTION
- use data-bypass attribute to circumvent backbone routing
