### PR TITLE
fix attachment view to bypass backbone processing

### DIFF
--- a/src/fauxton/app/addons/documents/templates/code_editor.html
+++ b/src/fauxton/app/addons/documents/templates/code_editor.html
@@ -31,7 +31,7 @@ the License.
       <ul class="dropdown-menu">
         <%_.each(attachments, function (att) { %>
         <li>
-        <a href="<%- att.url %>" target="_blank"> <strong> <%- att.fileName %> </strong> -
+        <a href="<%- att.url %>" target="_blank" data-bypass="true"> <strong> <%- att.fileName %> </strong> -
           <span> <%- att.contentType %>, <%- formatSize(att.size)%> </span>
         </a>
         </li>


### PR DESCRIPTION
What did apply to the API URL a few days before also applies to viewing attachments: a data-bypass="true" needs to be added to the link pointing to an attachment. then it opens in a new window. Otherwise, an invalid URL to fauxton is constructed that goes nowhere. Test: add an attachment and try to view it
