### PR TITLE
Fauxton: Create fx roles

### DIFF
--- a/src/fauxton/app/addons/auth/resources.js
+++ b/src/fauxton/app/addons/auth/resources.js
@@ -101,6 +101,10 @@ function (app, FauxtonAPI, CouchdbSession) {
       var user = this.user();
 
       if (user && user.roles) {
+        if (user.roles.indexOf('fx_loggedIn') === -1) {
+          user.roles.push('fx_loggedIn');
+        }
+
         return user.roles;
       }
 

--- a/src/fauxton/app/addons/auth/routes.js
+++ b/src/fauxton/app/addons/auth/routes.js
@@ -71,7 +71,7 @@ function(app, FauxtonAPI, Auth) {
     routes: {
       'changePassword': {
         route: 'changePassword',
-        roles: ['_admin', '_reader', '_replicator']
+        roles: ['fx_loggedIn']
       },
       'addAdmin': {
         roles: ['_admin'],


### PR DESCRIPTION
Fauxton auth works by checking what roles a user has and then decide if
they have access to a specific route. The only problem is a regular user
might get created but not have any roles. Unlike an admin user who get
assigned all the roles on creation.

The idea behind this is that certain routes should require a user to be
logged in but not necessary have any roles eg. #changePassword route.

This allows for a standard fauxton role that all logged in users get given so that
we can check via the roles if they are logged
