### PR TITLE
fixed Accept header typo

### DIFF
--- a/share/doc/src/intro/api.rst
+++ b/share/doc/src/intro/api.rst
@@ -281,7 +281,7 @@ browsers will display the JSON as text.
   .. _JSONView: http://jsonview.com/
 
 Do you remember the :header:`Accept` request header and how it is set to 
-``\*/\* -> */*`` to express interest in any MIME type? If you send ``Accept:
+``*/*`` to express interest in any MIME type? If you send ``Accept:
 application/json`` in your request, CouchDB knows that you can deal with a pure 
 JSON response with the proper :header:`Content-Type` header and will 
 use it instead of :mimetype:`text/plain`.


### PR DESCRIPTION
I can't figure out why the documentation says that the Accept header is set to `\*/\* -> */*`. Especially since the example above (the verbose cURL output) clearly shows that the Accept header is `*/*`.

This PR simply fixes the header value in the documentation.
