### PR TITLE
fix cancel button in duplicate docs

### DIFF
--- a/src/fauxton/app/addons/documents/templates/duplicate_doc_modal.html
+++ b/src/fauxton/app/addons/documents/templates/duplicate_doc_modal.html
@@ -28,7 +28,7 @@ the License.
 
   </div>
   <div class="modal-footer">
-    <button data-dismiss="modal" class="btn cancel-button"><i class="icon fonticon-circle-x"></i> Cancel</button>
+    <button data-dismiss="modal" class="btn"><i class="icon fonticon-circle-x"></i> Cancel</button>
     <button id="duplicate-btn" class="btn btn-success save"><i class="fonticon-circle-check"></i> Clone</button>
   </div>
 </div>


### PR DESCRIPTION
Issue: click "Clone document" in single-doc view, then click cancel. You'll get back to all documents. Reason: cancel-button is also the style of "go back to all docs" - and both functions bind. Looking at "upload attachment" reveals: the cancel-button style is not needed. So I removed it which successfully fixes cancel in "Clone documents" also
