### PR TITLE
Use deps whitelist and exclude everything else

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -41,21 +41,40 @@
     {profile, embedded},
     {excl_sys_filters, ["^bin/.*", "^erts.*/bin/(dialyzer|typer)"]},
     {excl_archive_filters, [".*"]},
+    {incl_cond, exclude},
 
-    % It's sufficient to list 'chttpd' here, as reltool will pull in all
-    % dependencies.  But we'll be explicit and list everything actively
-    % developed in this repository.
+    %% stdlib
+    {app, asn1, [{incl_cond, include}]},
+    {app, compiler, [{incl_cond, include}]},
+    {app, crypto, [{incl_cond, include}]},
+    {app, inets, [{incl_cond, include}]},
+    {app, kernel, [{incl_cond, include}]},
+    {app, os_mon, [{incl_cond, include}]},
+    {app, public_key, [{incl_cond, include}]},
+    {app, runtime_tools, [{incl_cond, include}]},
+    {app, sasl, [{incl_cond, include}]},
+    {app, ssl, [{incl_cond, include}]},
+    {app, stdlib, [{incl_cond, include}]},
+    {app, syntax_tools, [{incl_cond, include}]},
+    {app, xmerl, [{incl_cond, include}]},
+
+    %% couchdb
     {app, chttpd, [{incl_cond, include}]},
     {app, config, [{incl_cond, include}]},
     {app, couch, [{incl_cond, include}]},
+    {app, couch_log, [{incl_cond, include}]},
     {app, couch_replicator, [{incl_cond, include}]},
     {app, ddoc_cache, [{incl_cond, include}]},
     {app, ets_lru, [{incl_cond, include}]},
     {app, fabric, [{incl_cond, include}]},
+    {app, goldrush, [{incl_cond, include}]},
+    {app, ibrowse, [{incl_cond, include}]},
+    {app, lager, [{incl_cond, include}]},
     {app, mem3, [{incl_cond, include}]},
+    {app, mochiweb, [{incl_cond, include}]},
+    {app, oauth, [{incl_cond, include}]},
     {app, rexi, [{incl_cond, include}]},
-    {app, snappy, [{incl_cond, include}]},
-    {app, couch_log, [{incl_cond, include}]}
+    {app, snappy, [{incl_cond, include}]}
 ]}.
 
 {overlay_vars, "couchdb.config"}.


### PR DESCRIPTION
Otherwise this causes include conflict issues with other Erlang 
applications which were installed system-wide by system package manager.
