### PR TITLE
Fauxton: Upgrade node-http-proxy

### DIFF
--- a/src/fauxton/Gruntfile.js
+++ b/src/fauxton/Gruntfile.js
@@ -124,14 +124,7 @@ module.exports = function(grunt) {
       dist: './dist/debug/',
       port: 8000,
       proxy: {
-        target: {
-          host: 'localhost',
-          port: 5984,
-          https: false
-        },
-        // This sets the Host header in the proxy so that you can use external
-        // CouchDB instances and not have the Host set to 'localhost'
-        changeOrigin: true
+        target: "http://localhost:5984/"
       }
     };
 

--- a/src/fauxton/package.json
+++ b/src/fauxton/package.json
@@ -27,7 +27,7 @@
     "underscore": "~1.4.2",
     "url": "~0.7.9",
     "urls": "~0.0.3",
-    "http-proxy": "~0.10.2",
+    "http-proxy": "~1.1.4",
     "send": "~0.1.1",
     "grunt-mocha-phantomjs": "~0.3.0"
   },


### PR DESCRIPTION
Some modifications have to be made because the API changed when the module reached v1.0
