### PR TITLE
Allow passing directories as the config sources

### DIFF
--- a/src/couchdb/couch_app.erl
+++ b/src/couchdb/couch_app.erl
@@ -15,6 +15,7 @@
 -behaviour(application).
 
 -include("couch_db.hrl").
+-include_lib("kernel/include/file.hrl").
 
 -export([start/2, stop/1]).
 
@@ -37,7 +38,17 @@ get_ini_files(Default) ->
     {ok, [[]]} ->
         Default;
     {ok, [Values]} ->
-        Values
+        lists:foldl(
+		fun (V, AccIn) ->
+			  case file:read_file_info(V) of
+				  {ok, #file_info{type = regular}} -> AccIn ++ [V];
+				  {ok, #file_info{type = directory}} -> AccIn ++ filelib:wildcard(V ++ "/*.ini");
+				  _ -> AccIn
+			  end
+		end,
+		[],
+		Values
+	)
     end.
 
 start_apps([]) ->

--- a/src/couchdb/couch_app.erl
+++ b/src/couchdb/couch_app.erl
@@ -42,7 +42,7 @@ get_ini_files(Default) ->
 		fun (V, AccIn) ->
 			  case file:read_file_info(V) of
 				  {ok, #file_info{type = regular}} -> AccIn ++ [V];
-				  {ok, #file_info{type = directory}} -> AccIn ++ filelib:wildcard(V ++ "/*.ini");
+				  {ok, #file_info{type = directory}} -> AccIn ++ filelib:wildcard(filename:join([V,"*.ini"]));
 				  _ -> AccIn
 			  end
 		end,


### PR DESCRIPTION
We should allow passing the entire directories as the config sources. In
this case CouchDB will traverse the given directories and load every
*.ini file found.

E.g.

"... -couch_ini /etc/couchdb/default.d/ /etc/couchdb/local.d/ /path/to/extra/couchdb/default.ini /path/to/extra/couchdb/local.ini ..."

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>