### PR TITLE
Add systemd notification support

### DIFF
--- a/src/couchdb/couch_server_sup.erl
+++ b/src/couchdb/couch_server_sup.erl
@@ -106,6 +106,7 @@ start_server(IniFiles) ->
 
     Ip = couch_config:get("httpd", "bind_address"),
     io:format("Apache CouchDB has started. Time to relax.~n"),
+    {module, sd_notify} == code:load_file(sd_notify) andalso sd_notify:sd_notify(0, "READY=1"),
     Uris = [get_uri(Name, Ip) || Name <- [couch_httpd, https]],
     [begin
         case Uri of


### PR DESCRIPTION
This patch adds a very basic systemd notification support (it doesn't harm systems where systemd isn't available).

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
