### PR TITLE
make CI build faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 before_install:
    - sudo apt-get -y update
    - sudo apt-get -y install libicu-dev libmozjs-dev pkg-config help2man
-   - sudo apt-get -y install libtool automake autoconf autoconf-archive
-   - sudo apt-get -y install texlive-latex-base texlive-latex-recommended
-   - sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended texinfo
-   - sudo apt-get -y install python-pygments python-docutils python-sphinx
+                             libtool automake autoconf autoconf-archive
+                             texlive-latex-base texlive-latex-recommended
+                             texlive-latex-extra texlive-fonts-recommended texinfo
+                             python-pygments python-docutils python-sphinx
 before_script: ./configure
 script:
    - make check


### PR DESCRIPTION
no need to let apt-get repeat to `read package list`, `build dependency tree` and `read state info` for 5 times
