### PR TITLE
Enable CSP support for /_utils per default

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -80,9 +80,9 @@ iterations = 10 ; iterations for password hashing
 ; comma-separated list of public fields, 404 if empty
 ; public_fields =
 
-; Experimental CSP (Content Security Policy) Support for _utils
+; CSP (Content Security Policy) Support for _utils
 [csp]
-enable = false
+enable = true
 ; header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
 
 [cors]


### PR DESCRIPTION
With the new 2.0 release Futon, which had too much inline-
JavaScript etc., is not used any more. Fauxton is able to work
with our default CSP settings.
