### PR TITLE
Clarify docker instructions

### DIFF
--- a/DEVELOPERS
+++ b/DEVELOPERS
@@ -146,9 +146,9 @@ Testing a cluster
 -----------------
 
 We use Docker (https://docker.io) to safely run a local three node
-cluster.
+cluster all inside a single docker container.
 
-Assuming you have Docker installed and running;
+Assuming you have Docker installed and running:
 
     make docker-image
 


### PR DESCRIPTION
When I first ran 'make docker-start' I thought I had a corrupt environment because only one docker container was started whereas I was expecting three docker containers to be started each containing a single CouchDB node.
