### PR TITLE
Backport Accept check from chttpd

### DIFF
--- a/src/couchdb/couch_httpd.erl
+++ b/src/couchdb/couch_httpd.erl
@@ -879,29 +879,35 @@ error_headers(#httpd{mochi_req=MochiReq}=Req, Code, ErrorStr, ReasonStr) ->
                             % send the browser popup header no matter what if we are require_valid_user
                             {Code, [{"WWW-Authenticate", "Basic realm=\"server\""}]};
                         _False ->
-                            case MochiReq:accepts_content_type("application/json") of
-                            true ->
+                            % if the accept header matches html, then do the redirect. else proceed as usual.
+                            Accepts = case MochiReq:get_header_value("Accept") of
+                            undefined ->
+                                % According to the HTTP 1.1 spec, if the Accept
+                                % header is missing, it means the client accepts
+                                % all media types.
+                                "html";
+                            Else ->
+                                Else
+                            end,
+                            case re:run(Accepts, "\\bhtml\\b",
+                                [{capture, none}, caseless]) of
+                            nomatch ->
                                 {Code, []};
-                            false ->
-                                case MochiReq:accepts_content_type("text/html") of
-                                true ->
-                                    % Redirect to the path the user requested, not
-                                    % the one that is used internally.
-                                    UrlReturnRaw = case MochiReq:get_header_value("x-couchdb-vhost-path") of
-                                    undefined ->
-                                        MochiReq:get(path);
-                                    VHostPath ->
-                                        VHostPath
-                                    end,
-                                    RedirectLocation = lists:flatten([
-                                        AuthRedirect,
-                                        "?return=", couch_util:url_encode(UrlReturnRaw),
-                                        "&reason=", couch_util:url_encode(ReasonStr)
-                                    ]),
-                                    {302, [{"Location", absolute_uri(Req, RedirectLocation)}]};
-                                false ->
-                                    {Code, []}
-                                end
+                            match ->
+                                % Redirect to the path the user requested, not
+                                % the one that is used internally.
+                                UrlReturnRaw = case MochiReq:get_header_value("x-couchdb-vhost-path") of
+                                undefined ->
+                                    MochiReq:get(path);
+                                VHostPath ->
+                                    VHostPath
+                                end,
+                                RedirectLocation = lists:flatten([
+                                    AuthRedirect,
+                                    "?return=", couch_util:url_encode(UrlReturnRaw),
+                                    "&reason=", couch_util:url_encode(ReasonStr)
+                                ]),
+                                {302, [{"Location", absolute_uri(Req, RedirectLocation)}]}
                             end
                         end
                     end;


### PR DESCRIPTION
Backport "Accept check" from chttpd to correctly handle when browser
try to access a database when they aren't logged in or need to change their login

This fixes so many bugs that have been littering the bug system for years.

The problem was that browsers over promise and we were using that to check
if it was json or html. I have another patch that is only 4 lines added and two
changed but since it was changed in chttpd I thought merging that was the best
thing.

Also if this patch doesn't get accepted I have an other solution in a form of allowing
rewrite to change headers.
