### PR TITLE
Separate out Fauxton compilation from core CouchDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-all:  compile
+all:  config.erl couch fauxton
 
 config.erl:
 	@echo "Apache CouchDB has not been configured."
@@ -18,7 +18,7 @@ config.erl:
 	@echo
 	@false
 
-compile: config.erl fauxton
+couch:
 	@rebar compile
 	@cp src/couch/priv/couchjs bin/
 


### PR DESCRIPTION
This separates compilation of core CouchDB from compilation of Fauxton. I'm not attached to the name `compile-core`, and it might also be worth changing the target `fauxton` to `compile-fauxton`.