### PR TITLE
Add config variable for get_proc_timeout

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -23,6 +23,8 @@ file_compression = snappy
 ; and/or more OS page cache hits, but they can also increase overall response
 ; time for writes when there are many attachment write requests in parallel.
 attachment_stream_buffer_size = 4096
+; Maximum time to wait when getting an os process
+get_proc_timeout = 60000
 
 [cluster]
 q=8


### PR DESCRIPTION
This commit adds the couchdb/get_proc_timeout config variable to
default.ini. This is used by couch_query_servers when getting
a reference to an external process. Previously this value was
always infinity which meant that if anything went wrong in the
gen_server call to get_proc the process would hang around
indefinitely.

COUCHDB-2425