### PR TITLE
build: do not require a globally installed grunt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ fauxton: share/www
 
 share/www:
 	@echo "Building Fauxton"
-	@cd src/fauxton && npm install && grunt couchdb
+	@cd src/fauxton && npm install && ./node_modules/grunt-cli/bin/grunt couchdb


### PR DESCRIPTION
fix build for folks that don't have grunt installed globally,
using the version that gets shipped with Fauxton

ping @andywenk @garrensmith