### PR TITLE
Consume JSON body even when its content is ignored

### DIFF
--- a/src/couchdb/couch_httpd_db.erl
+++ b/src/couchdb/couch_httpd_db.erl
@@ -159,6 +159,7 @@ handle_compact_req(#httpd{method='POST'}=Req, Db) ->
         [_DbName, <<"_compact">>] ->
             ok = couch_db:check_is_admin(Db),
             couch_httpd:validate_ctype(Req, "application/json"),
+            _ = couch_httpd:body(Req),
             {ok, _} = couch_db:start_compact(Db),
             send_json(Req, 202, {[{ok, true}]});
         [_DbName, <<"_compact">>, DesignName | _] ->
@@ -261,6 +262,7 @@ db_req(#httpd{path_parts=[_DbName]}=Req, _Db) ->
 
 db_req(#httpd{method='POST',path_parts=[_,<<"_ensure_full_commit">>]}=Req, Db) ->
     couch_httpd:validate_ctype(Req, "application/json"),
+    _ = couch_httpd:body(Req),
     UpdateSeq = couch_db:get_update_seq(Db),
     CommittedSeq = couch_db:get_committed_update_seq(Db),
     {ok, StartTime} =


### PR DESCRIPTION
"_ensure_full_commit" and "_compact" require that the content-type be set to "application/json". However, when some content is provided (such as "{}" in order to send a valid JSON external representation
for the empty object), CouchDB needs to ensure that this content is read from the incoming HTTP request.

Fixes COUCHDB-2583