### PR TITLE
add tests for downloading docs/views

### DIFF
--- a/test/javascript/tests/http.js
+++ b/test/javascript/tests/http.js
@@ -76,4 +76,37 @@ couchTests.http = function(debug) {
   TEquals(CouchDB.protocol + host + "/test_suite_db/docidtestpost%250A",
     xhr.getResponseHeader("Location"),
     "should work with newlines in document names");
+
+  // COUCHDB-2433: download views with Content-Disposition: attachment
+  xhr = CouchDB.request("POST", "/test_suite_db/", {
+    body: JSON.stringify({"_id": "doc_i_want_to_download"}),
+    headers: {"Content-Type": "application/json"}
+  });
+  xhr = CouchDB.request("GET", "/test_suite_db/doc_i_want_to_download?download=true", {
+    headers: {"Content-Type": "application/json"}
+  });
+  TEquals("attachment", xhr.getResponseHeader("Content-Disposition"),
+    "sends the right Content-Disposition header");
+  xhr = CouchDB.request("GET", "/test_suite_db/doc_i_want_to_download", {
+    headers: {"Content-Type": "application/json"}
+  });
+  TEquals(null, xhr.getResponseHeader("Content-Disposition"),
+    "does not send the Content-Disposition header");
+
+  xhr = CouchDB.request("POST", "/test_suite_db/", {
+    body: JSON.stringify({"_id": "_design/foo"}),
+    headers: {"Content-Type": "application/json"}
+  });
+  xhr = CouchDB.request("GET", "/test_suite_db/doc_i_want_to_download?download=true", {
+    headers: {"Content-Type": "application/json"}
+  });
+  TEquals("attachment", xhr.getResponseHeader("Content-Disposition"),
+    "sends the right Content-Disposition header for design docs");
+  xhr = CouchDB.request("GET", "/test_suite_db/doc_i_want_to_download", {
+    headers: {"Content-Type": "application/json"}
+  });
+  TEquals(null, xhr.getResponseHeader("Content-Disposition"),
+    "does not send the Content-Disposition header");
+
+
 }


### PR DESCRIPTION
allow downloading docs/views

enables downloading of views using a browser, e.g. via a button
in Fauxton.

api: http://localhost:5984/mydb/_design/foobar?download=true

PRs:
https://github.com/apache/couchdb-couch/pull/42
https://github.com/apache/couchdb/pull/310
https://github.com/apache/couchdb-chttpd/pull/30

COUCHDB-2433