### PR TITLE
Provide test data files for JS tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ eunit: couch
 	@rebar -r eunit skip_deps=meck,mochiweb,lager,snappy,couch_replicator,fabric,folsom
 
 javascript: all
+	@mkdir -p share/www/script/test
+	@cp test/javascript/tests/lorem*.txt share/www/script/test/
 	@dev/run -q test/javascript/run
 
 fauxton: share/www


### PR DESCRIPTION
the attachments.js needs some files in place under _utils. In Futon times, they were just here. Now we have to provide them. When running attachments.js without having the files in place, at least one comparison test will fail (because Couch returns "Not found" instead of the test data). 