### PR TITLE
installs npm while building the docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,12 @@ RUN apt-get --no-install-recommends -y install \
     git \
     libicu-dev \
     libmozjs185-dev \
-    python
+    python \
+    nodejs-legacy
+
+RUN curl -L --insecure -O https://www.npmjs.org/install.sh \
+    && npm_install=2.8.4 /bin/bash install.sh
+
 
 # Build rebar
 RUN useradd -m rebar


### PR DESCRIPTION
Building the docker image fails with
```
/bin/sh: 1: npm: not found
make: *** [share/www] Error 127
``` 
because `npm` is used in the Makefile and therefor is a dependency for building a docker image.

This change installs npm while building the image according to https://github.com/joyent/node/wiki/Backports.debian.org#install-node-and-npm