### PR TITLE
Fix documentation to add package libkjsapi4

### DIFF
--- a/INSTALL.Unix
+++ b/INSTALL.Unix
@@ -72,6 +72,7 @@ You can install the dependencies by running:
     sudo apt-get install libcurl4-openssl-dev
     sudo apt-get install pkg-config
     sudo apt-get install rebar
+    sudo apt-get install libkjsapi4
 
 There are lots of Erlang packages. If there is a problem with your
 install, try a different mix. There is more information on the


### PR DESCRIPTION
The current documentation doesn't ask to install package
libkjsapi4 as a dependency, which causes the following problem:

 Compiling /home/ubuntu/Devel/couchdb/src/couch/priv/couch_js/http.c
 /home/ubuntu/Devel/couchdb/src/couch/priv/couch_js/http.c:18:19: fatal error: jsapi.h: No such file or directory
  #include <jsapi.h>
                   ^
 compilation terminated.
 ERROR: compile failed while processing /home/ubuntu/Devel/couchdb/src/couch: rebar_abort
 Makefile:22: recipe for target 'couch' failed
 make: *** [couch] Error 1

This patch just fix the documentation and adds the package as a
dependency.