### PR TITLE
build: support OTP-18.0

### DIFF
--- a/INSTALL.Unix
+++ b/INSTALL.Unix
@@ -39,7 +39,7 @@ Dependencies
 
 You should have the following installed:
 
- * Erlang OTP (>=R14B01, =<R17) (http://erlang.org/)
+ * Erlang OTP (>=R14B01, =<R18) (http://erlang.org/)
  * ICU                          (http://icu-project.org/)
  * OpenSSL                      (http://www.openssl.org/)
  * Mozilla SpiderMonkey (1.8.5) (http://www.mozilla.org/js/spidermonkey/)

--- a/INSTALL.Windows
+++ b/INSTALL.Windows
@@ -29,7 +29,7 @@ Dependencies
 
 You will need the following installed:
 
- * Erlang OTP (>=14B01, <R17)    (http://erlang.org/)
+ * Erlang OTP (>=14B01, <R18)    (http://erlang.org/)
  * ICU        (>=4.*)            (http://icu-project.org/)
  * OpenSSL    (>=0.9.8r)         (http://www.openssl.org/)
  * Mozilla SpiderMonkey (=1.8.5) (http://www.mozilla.org/js/spidermonkey/)

--- a/configure.ac
+++ b/configure.ac
@@ -411,7 +411,7 @@ esac
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking Erlang version compatibility" >&5
 $as_echo_n "checking Erlang version compatibility... " >&6; }
-erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 17 (erts-6.0)"
+erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 18 (erts-7.0)"
 
 version="`${ERL} -version 2>&1 | ${SED} 's/[[^0-9]]/ /g'` 0 0 0"
 major_version=`echo $version | ${AWK} "{print \\$1}"`
@@ -419,7 +419,7 @@ minor_version=`echo $version | ${AWK} "{print \\$2}"`
 patch_version=`echo $version | ${AWK} "{print \\$3}"`
 echo -n "detected Erlang version: $major_version.$minor_version.$patch_version..."
 
-if test $major_version -lt 5 -o $major_version -gt 6; then
+if test $major_version -lt 5 -o $major_version -gt 7; then
     as_fn_error $? "$erlang_version_error major_version does not match" "$LINENO" 5
 fi
 
@@ -438,9 +438,9 @@ otp_release="`\
 AC_SUBST(otp_release)
 
 AM_CONDITIONAL([USE_OTP_NIFS],
-    [can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17)")])
+    [can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17|18)")])
 AM_CONDITIONAL([USE_EJSON_COMPARE_NIF],
-    [can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17)")])
+    [can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17|18)")])
 
 has_crypto=`\
     ${ERL} -eval "\

--- a/share/doc/src/install/unix.rst
+++ b/share/doc/src/install/unix.rst
@@ -52,7 +52,7 @@ Dependencies
 
 You should have the following installed:
 
-* `Erlang OTP (>=R14B01, =<R17) <http://erlang.org/>`_
+* `Erlang OTP (>=R14B01, =<R18) <http://erlang.org/>`_
 * `ICU                          <http://icu-project.org/>`_
 * `OpenSSL                      <http://www.openssl.org/>`_
 * `Mozilla SpiderMonkey (1.8.5) <http://www.mozilla.org/js/spidermonkey/>`_

--- a/share/doc/src/install/windows.rst
+++ b/share/doc/src/install/windows.rst
@@ -90,7 +90,7 @@ Dependencies
 
 You should have the following installed:
 
-* `Erlang OTP (>=14B01, <R17)    <http://erlang.org/>`_
+* `Erlang OTP (>=14B01, <R18)    <http://erlang.org/>`_
 * `ICU        (>=4.*)            <http://icu-project.org/>`_
 * `OpenSSL    (>0.9.8r)          <http://www.openssl.org/>`_
 * `Mozilla SpiderMonkey (=1.8.5) <http://www.mozilla.org/js/spidermonkey/>`_


### PR DESCRIPTION
Support OTP-18.0.

configure & make checks LGTM, would be nice if somebody can check a linux?

- OSX Yosemite 14.4.0 https://gist.github.com/dch/14fd8f57fd806d94a1de
- FreeBSD 10.1 amd64 https://gist.github.com/dch/2387359cd6c21b9f4de9

A few more warnings appear as expected, crypto & time stuff.

```
erlang:now/0 as we know
calendar:local_time_to_universal_time/1 -> calendar:local_time_to_universal_time_dst/1
crypto:sha_mac/2 -> crypto:hmac/3
crypto:sha/1 -> crypto:hash/2
crypto:md5_init/0 -> crypto:hash_init/1
crypto:md5_update/0 -> crypto:hash_update/1
crypto:md5_final/0 -> crypto:hash_final/1
```
