### PR TITLE
Ensure PK uniqueness when merging updates from multiple clients

### DIFF
--- a/INSTALL.Unix
+++ b/INSTALL.Unix
@@ -39,7 +39,7 @@ Dependencies
 
 You should have the following installed:
 
- * Erlang OTP (>=R14B01, =<R17) (http://erlang.org/)
+ * Erlang OTP (>=R14B01, =<R18) (http://erlang.org/)
  * ICU                          (http://icu-project.org/)
  * OpenSSL                      (http://www.openssl.org/)
  * Mozilla SpiderMonkey (1.8.5) (http://www.mozilla.org/js/spidermonkey/)

--- a/INSTALL.Windows
+++ b/INSTALL.Windows
@@ -29,7 +29,7 @@ Dependencies
 
 You will need the following installed:
 
- * Erlang OTP (>=14B01, <R17)    (http://erlang.org/)
+ * Erlang OTP (>=14B01, <R18)    (http://erlang.org/)
  * ICU        (>=4.*)            (http://icu-project.org/)
  * OpenSSL    (>=0.9.8r)         (http://www.openssl.org/)
  * Mozilla SpiderMonkey (=1.8.5) (http://www.mozilla.org/js/spidermonkey/)

--- a/configure.ac
+++ b/configure.ac
@@ -411,7 +411,7 @@ esac
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking Erlang version compatibility" >&5
 $as_echo_n "checking Erlang version compatibility... " >&6; }
-erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 17 (erts-6.0)"
+erlang_version_error="The installed Erlang version must be >= R14B (erts-5.8.1) and =< 18 (erts-7.0)"
 
 version="`${ERL} -version 2>&1 | ${SED} 's/[[^0-9]]/ /g'` 0 0 0"
 major_version=`echo $version | ${AWK} "{print \\$1}"`
@@ -419,7 +419,7 @@ minor_version=`echo $version | ${AWK} "{print \\$2}"`
 patch_version=`echo $version | ${AWK} "{print \\$3}"`
 echo -n "detected Erlang version: $major_version.$minor_version.$patch_version..."
 
-if test $major_version -lt 5 -o $major_version -gt 6; then
+if test $major_version -lt 5 -o $major_version -gt 7; then
     as_fn_error $? "$erlang_version_error major_version does not match" "$LINENO" 5
 fi
 
@@ -438,9 +438,9 @@ otp_release="`\
 AC_SUBST(otp_release)
 
 AM_CONDITIONAL([USE_OTP_NIFS],
-    [can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17)")])
+    [can_use_nifs=$(echo $otp_release | grep -E "^(R14B|R15|R16|17|18)")])
 AM_CONDITIONAL([USE_EJSON_COMPARE_NIF],
-    [can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17)")])
+    [can_use_ejson=$(echo $otp_release | grep -E "^(R14B03|R15|R16|17|18)")])
 
 has_crypto=`\
     ${ERL} -eval "\

--- a/share/doc/src/config/http.rst
+++ b/share/doc/src/config/http.rst
@@ -329,9 +329,12 @@ Secure Socket Level Options
 
   .. config:option:: cacert_file :: CA Certificate file
 
-    Path to file containing PEM encoded CA certificates (trusted certificates
-    used for verifying a peer certificate). May be omitted if you do not want
-    to verify the peer::
+    The path to a file containing PEM encoded CA certificates. The CA
+    certificates are used to build the server certificate chain, and for client
+    authentication. Also the CAs are used in the list of acceptable client CAs
+    passed to the client when a certificate is requested. May be omitted if
+    there is no need to verify the client and if there are not any intermediate
+    CAs for the server certificate::
 
       [ssl]
       cacert_file = /etc/ssl/certs/ca-certificates.crt

--- a/share/doc/src/couchapp/views/intro.rst
+++ b/share/doc/src/couchapp/views/intro.rst
@@ -470,8 +470,8 @@ Consider the map result are:
 
 .. code-block:: javascript
 
-  "afrikan", 1
-  "afrikan", 1
+  "afrikaans", 1
+  "afrikaans", 1
   "chinese", 1
   "chinese", 1
   "chinese", 1
@@ -560,8 +560,8 @@ want to get a list of all the unique labels in our view:
 
 .. code-block:: javascript
 
-  "abc", "afrikan"
-  "cef", "afrikan"
+  "abc", "afrikaans"
+  "cef", "afrikaans"
   "fhi", "chinese"
   "hkl", "chinese"
   "ino", "chinese"

--- a/share/doc/src/install/unix.rst
+++ b/share/doc/src/install/unix.rst
@@ -52,7 +52,7 @@ Dependencies
 
 You should have the following installed:
 
-* `Erlang OTP (>=R14B01, =<R17) <http://erlang.org/>`_
+* `Erlang OTP (>=R14B01, =<R18) <http://erlang.org/>`_
 * `ICU                          <http://icu-project.org/>`_
 * `OpenSSL                      <http://www.openssl.org/>`_
 * `Mozilla SpiderMonkey (1.8.5) <http://www.mozilla.org/js/spidermonkey/>`_

--- a/share/doc/src/install/windows.rst
+++ b/share/doc/src/install/windows.rst
@@ -90,7 +90,7 @@ Dependencies
 
 You should have the following installed:
 
-* `Erlang OTP (>=14B01, <R17)    <http://erlang.org/>`_
+* `Erlang OTP (>=14B01, <R18)    <http://erlang.org/>`_
 * `ICU        (>=4.*)            <http://icu-project.org/>`_
 * `OpenSSL    (>0.9.8r)          <http://www.openssl.org/>`_
 * `Mozilla SpiderMonkey (=1.8.5) <http://www.mozilla.org/js/spidermonkey/>`_

--- a/src/couchdb/couch_db.erl
+++ b/src/couchdb/couch_db.erl
@@ -517,7 +517,8 @@ prep_and_validate_update(Db, #doc{id=Id,revs={RevStart, Revs}}=Doc,
 
 prep_and_validate_updates(_Db, [], [], _AllowConflict, AccPrepped,
         AccFatalErrors) ->
-   {AccPrepped, AccFatalErrors};
+   AccPrepped2 = lists:reverse(lists:map(fun lists:reverse/1, AccPrepped)),
+   {AccPrepped2, AccFatalErrors};
 prep_and_validate_updates(Db, [DocBucket|RestBuckets], [not_found|RestLookups],
         AllowConflict, AccPrepped, AccErrors) ->
     {PreppedBucket, AccErrors3} = lists:foldl(
@@ -543,7 +544,7 @@ prep_and_validate_updates(Db, [DocBucket|RestBuckets], [not_found|RestLookups],
         {[], AccErrors}, DocBucket),
 
     prep_and_validate_updates(Db, RestBuckets, RestLookups, AllowConflict,
-            [lists:reverse(PreppedBucket) | AccPrepped], AccErrors3);
+            [PreppedBucket | AccPrepped], AccErrors3);
 prep_and_validate_updates(Db, [DocBucket|RestBuckets],
         [{ok, #full_doc_info{rev_tree=OldRevTree}=OldFullDocInfo}|RestLookups],
         AllowConflict, AccPrepped, AccErrors) ->
@@ -579,7 +580,8 @@ update_docs(Db, Docs, Options) ->
 prep_and_validate_replicated_updates(_Db, [], [], AccPrepped, AccErrors) ->
     Errors2 = [{{Id, {Pos, Rev}}, Error} ||
             {#doc{id=Id,revs={Pos,[Rev|_]}}, Error} <- AccErrors],
-    {lists:reverse(AccPrepped), lists:reverse(Errors2)};
+    AccPrepped2 = lists:reverse(lists:map(fun lists:reverse/1, AccPrepped)),
+    {AccPrepped2, lists:reverse(Errors2)};
 prep_and_validate_replicated_updates(Db, [Bucket|RestBuckets], [OldInfo|RestOldInfo], AccPrepped, AccErrors) ->
     case OldInfo of
     not_found ->


### PR DESCRIPTION
We had been implicily assuming that clients send us sorted groups, but unsurprisingly that's not always the case. The PR here fixes a case where we broke the sorting, and adds an additional sort inside the `couch_db_updater` server loop since the consequences of screwing this up are so severe.

See [COUCHDB-2735](https://issues.apache.org/jira/browse/COUCHDB-2735).