### PR TITLE
Install and use own rebar if it missed or has bad version

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -64,7 +64,7 @@ You can install the dependencies by running:
     sudo apt-get install build-essential erlang-base-hipe \
         erlang-dev erlang-manpages erlang-eunit erlang-nox \
         libicu-dev libmozjs185-dev libcurl4-openssl-dev \
-        pkg-config rebar
+        pkg-config
 
 There are lots of Erlang packages. If there is a problem with your
 install, try a different mix. There is more information on the
@@ -90,7 +90,7 @@ You can install the dependencies by running:
 
     sudo yum install autoconf autoconf-archive automake \
         curl-devel erlang-asn1 erlang-erts erlang-eunit \
-        erlang-os_mon erlang-xmerl erlang-rebar help2man \
+        erlang-os_mon erlang-xmerl help2man \
         js-devel libicu-devel libtool perl-Test-Harness
 
 While CouchDB builds against the default js-devel-1.7.0 included in
@@ -108,7 +108,7 @@ the Command Line Tools:
 You can then install the other dependencies by running:
 
     brew install autoconf autoconf-archive automake libtool \
-        erlang icu4c spidermonkey curl pkg-config rebar
+        erlang icu4c spidermonkey curl pkg-config
 
 You will need Homebrew installed to use the `brew` command.
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 
 include version.mk
 
+REBAR?=$(shell echo `pwd`/bin/rebar)
 IN_RELEASE = $(shell if [ ! -d .git ]; then echo true; fi)
 COUCHDB_VERSION_SUFFIX = $(shell if [ -d .git ]; then echo '-`git rev-parse --short --verify HEAD`'; fi)
 COUCHDB_VERSION = $(vsn_major).$(vsn_minor).$(vsn_patch)$(COUCHDB_VERSION_SUFFIX)
@@ -27,11 +28,11 @@ config.erl:
 	@false
 
 couch: config.erl
-	@rebar compile
+	@${REBAR} compile
 	@cp src/couch/priv/couchjs bin/
 
 clean:
-	@rebar -r clean
+	@${REBAR} -r clean
 	@rm -f bin/couchjs
 	@rm -rf src/*/ebin
 	@rm -rf src/*/.rebar
@@ -83,7 +84,7 @@ devclean:
 install: all
 	@echo "Installing CouchDB into $(DESTDIR)/$(install_dir)..." | sed -e 's,///,/,'
 	@rm -rf rel/couchdb
-	@rebar generate # make full erlang release
+	@${REBAR} generate # make full erlang release
 
 	@mkdir -p $(DESTDIR)/$(install_dir)
 	@cp -R rel/couchdb/* $(DESTDIR)/$(install_dir)
@@ -155,8 +156,8 @@ docker-stop:
 
 eunit: export BUILDDIR = $(shell pwd)
 eunit: couch
-	@rebar setup_eunit
-	@rebar -r eunit skip_deps=meck,mochiweb,lager,snappy,folsom
+	@${REBAR} setup_eunit
+	@${REBAR} -r eunit skip_deps=meck,mochiweb,lager,snappy,folsom
 
 javascript: all
 	# TODO: Fix tests to look for these files in their new path

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -12,11 +12,7 @@ If you're unsure what this means, ignore this document.
 Dependencies
 ------------
 
-You will need the following installed:
-
- * Rebar (>=2.5.0)        (https://github.com/rebar/rebar)
-
-You may also need:
+You may need:
 
  * Sphinx                 (http://sphinx.pocoo.org/)
  * LaTex                  (http://www.latex-project.org/)

--- a/configure
+++ b/configure
@@ -66,6 +66,7 @@ Options:
   --disable-fauxton           do not build Fauxton
   --disable-docs              do not build any documentation or manpages
   --skip-deps                 do not update erlang dependencies
+  --rebar=PATH                use rebar by specified path (version >=2.6.0 && <3.0 required)
 
 
   Installation directories:
@@ -126,6 +127,22 @@ parse_opts() {
                 SKIP_DEPS=1
                 shift
                 continue
+                ;;
+
+            --rebar)
+                if [ -x "$2" ]; then
+                    version=`$2 --version 2> /dev/null | grep -o "2\.[6-9]\.[0-9]"`
+                    if [ $? -ne 0 ]; then
+                        printf 'Rebar >=2.6.0 and <3.0.0 required' >&2
+                        exit 1
+                    fi
+                    eval REBAR=$2
+                    shift 2
+                    continue
+                else
+                    printf 'ERROR: "--rebar" requires valid path to executable.\n' >&2
+                    exit 1
+                fi
                 ;;
 
             --user|-u)
@@ -632,8 +649,24 @@ cat > $rootdir/config.erl << EOF
 EOF
 
 
+function install_local_rebar(){
+  if [ ! -x "${rootdir}/bin/rebar" ]; then
+      git clone --depth 1 --branch 2.6.0 https://git-wip-us.apache.org/repos/asf/couchdb-rebar.git ${rootdir}/src/rebar
+      make -C ${rootdir}/src/rebar
+      mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar
+      make -C ${rootdir}/src/rebar clean
+  fi
+}
+
+
+if [ -z "${REBAR}" ]; then
+    install_local_rebar
+    REBAR=${rootdir}/bin/rebar
+fi
+
+
 # only update dependencies, when we are not in a release tarball
 if [ -d .git  -a $SKIP_DEPS -ne 1 ]; then
   echo "==> updating dependencies"
-  rebar get-deps update-deps
+  ${REBAR} get-deps update-deps
 fi


### PR DESCRIPTION
It's quite common issue when popular distributives ships rebar 2.0.0, which is heavily outdated and cannot build CouchDB. That means that we cannot recommend people to `apt-get install rebar` in general case. 

This PR adds a trick, that if rebar is missed or has bad version, configure script clones our rebar fork, builds rebar and uses it instead without disturbing user about. If system provides rebar of suitable version then things goes on as before.

cc @janl @micah 