### PR TITLE
Define OTP_VSN/OTP_RELEASE/HAS_CALLBACKS macro

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -15,6 +15,18 @@
 ConfigureEnv = filename:join(filename:dirname(SCRIPT), "config.erl"),
 os:putenv("COUCHDB_CONFIG", ConfigureEnv).
 
+OTP_VSN = erlang:system_info(compat_rel),
+
+Features = lists:filter(fun({_K, Flag}) -> Flag end, [
+    {'HAS_CALLBACKS', OTP_VSN > 14}
+]),
+
+Properties = Features ++ [
+    {'OTP_VSN', OTP_VSN},
+    {'OTP_RELEASE', erlang:system_info(otp_release)}
+],
+
+Defines = [{d, Key, Value}|| {Key, Value} <- Properties],
 
 DepDescs = [
 {b64url,           "b64url",           "319fc604235ab1fde37047b38a432450161db750"},
@@ -75,7 +87,7 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, ["rel"]},
     {lib_dirs, ["src/"]},
-    {erl_opts, [debug_info]},
+    {erl_opts, [debug_info | Defines]},
     {eunit_opts, [verbose]},
     {plugins, [eunit_plugin]},
     {post_hooks, [{compile, "escript support/build_js.escript"}]}


### PR DESCRIPTION
We define HAS_CALLBACKS feature macro in order to make `dialyzer`
happy. OTP releases prior to 15 require defining `behaviour_info` instead
of a `callback` attribute. New macro could be used to make conditional
compilation as follows:

```
    -ifdef(HAS_CALLBACKS).
        -callback app() -> atom().
    -else.
        -export([behaviour_info/1]).
        behaviour_info(callbacks) ->
            [
                {app, 0}
            ];
        behaviour_info(_) ->
            undefined.
    -endif.
```
The same approach could be used to eliminate the cost of `erlang:function_exported` in `couch_crypto.erl`.