### PR TITLE
COUCHDB-769: Store attachments in the external storage

### DIFF
--- a/configure
+++ b/configure
@@ -652,7 +652,7 @@ EOF
 install_local_rebar() {
     if [ ! -x "${rootdir}/bin/rebar" ]; then
         if [ ! -d "${rootdir}/src/rebar" ]; then
-            git clone --depth 1 --branch 2.6.0 https://git-wip-us.apache.org/repos/asf/couchdb-rebar.git ${rootdir}/src/rebar
+            git clone --depth 1 --branch hack/2.0 https://git-wip-us.apache.org/repos/asf/couchdb-rebar.git ${rootdir}/src/rebar
         fi
         make -C ${rootdir}/src/rebar
         mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar

--- a/rel/overlay/etc/local.ini
+++ b/rel/overlay/etc/local.ini
@@ -109,9 +109,12 @@
 ;username = tester
 ; Password for authentication
 ;password = testing
+
+[ext_store]
+; ID of the active backend store. Only one store allowed at any given time.
+active_store = swift
 ; Externalize attachments may be switched off completely.
 attachments_offload = false
-
 
 ; To create an admin account uncomment the '[admins]' section below and add a
 ; line in the format 'username = password'. When you next start CouchDB, it

--- a/rel/overlay/etc/local.ini
+++ b/rel/overlay/etc/local.ini
@@ -98,6 +98,21 @@
 [update_notification]
 ;unique notifier name=/full/path/to/exe -with "cmd line arg"
 
+[swift]
+; Authentication URL to Swift or Keystone
+;auth_url = <AUTH_URL>
+; Authentication model: tempauth,keystone
+;auth_model = tempauth
+; Swift account or Keystone tenant that user belongs to
+;account_tenant = test
+; Username for authentication
+;username = tester
+; Password for authentication
+;password = testing
+; Externalize attachments may be switched off completely.
+attachments_offload = false
+
+
 ; To create an admin account uncomment the '[admins]' section below and add a
 ; line in the format 'username = password'. When you next start CouchDB, it
 ; will change the password to a hash (so that your passwords don't linger


### PR DESCRIPTION
Initial implementation that allows CouchDB to store attachments outside of the database file.
This implementation supports OpenStack Swift and SoftLayer Object store.
