### PR TITLE
Improvements to eunit tests stability checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
    - ./run-tests.sh
 language: erlang
 otp_release:
+   - 18.1
    - 18.0
    - 17.5
    - R16B03-1

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ eunit: export BUILDDIR = $(shell pwd)
 eunit: export ERL_AFLAGS = -config $(shell pwd)/rel/files/eunit.config
 eunit: couch
 	@${REBAR} setup_eunit
-	@${REBAR} -r eunit skip_deps=meck,mochiweb,lager,snappy,folsom,proper
+	@${REBAR} -r eunit skip_deps=meck,mochiweb,lager,snappy,folsom,proper $(EUNIT_OPTS)
 
 javascript: all
 	# TODO: Fix tests to look for these files in their new path


### PR DESCRIPTION
 * Add 18.1 to travis builds to have a total of 4 test runs

 * Add EUNIT_OPTS variable for to pass options to eunit tests.
   For example:

    $ make eunit EUNIT_OPTS='apps=couch_replicator'