### PR TITLE
Change the eunit template cluster_port to 0

### DIFF
--- a/setup_eunit.template
+++ b/setup_eunit.template
@@ -1,6 +1,6 @@
 {variables, [
     {package_author_name, "The Apache Software Foundation"},
-    {cluster_port, 5984},
+    {cluster_port, 0},
     {backend_port, 5986},
     {node_name, "-name couchdbtest@127.0.0.1"},
 


### PR DESCRIPTION
so it will listen on a random, unused port during testing

This makes is possible to "make eunit" when a dev cluster is running on the same machine without a port collision

COUCHDB-2871