### PR TITLE
Use only unix line feeds (LF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Use only Unix line feeds (LF)
+
+# Use automatic conversion by default
+* text=auto
+
+# Text files that must end with LF
+*.args     text eol=lf
+*.cfg      text eol=lf
+*.config   text eol=lf
+*.css      text eol=lf
+*.erl      text eol=lf
+*.es       text eol=lf
+*.escript  text eol=lf
+*.html     text eol=lf
+*.in       text eol=lf
+*.ini      text eol=lf
+*.js       text eol=lf
+*.json     text eol=lf
+*.md       text eol=lf
+*.mk       text eol=lf
+*.ps1      text eol=lf
+*.py       text eol=lf
+*.rb       text eol=lf
+*.rst      text eol=lf
+*.script   text eol=lf
+*.sh       text eol=lf
+*.skip     text eol=lf
+*.template text eol=lf
+*.yml      text eol=lf


### PR DESCRIPTION
Hello everyone.

I really appreciate the project, great work!

When cloning the project to my local machine I noticed that one JS file is using CRLF while the rest of the project use LF.

This PR is a purpose to maintain a pattern and includes a `.gitattributes` file that helps keeping that pattern among contributors.

This is my first PR to the project. Please take a look and let me know if I got something wrong.

Thank you.
