### PR TITLE
Fix version checking for python pygments. 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -642,7 +642,8 @@ python 2> /dev/null << EOF
 import sys
 import pygments
 
-if float(pygments.__version__) >= 1.5:
+pygments_version = pygments.__version__.split('.')
+if int(pygments_version[0]) >= 1 and int(pygments_version[1]) > 5:
     sys.exit(0)
 else:
     sys.exit(1)


### PR DESCRIPTION
Current method only works for versions numbers with only one decimal point. This version splits the version numbers on '.' and compares the elements converted to ints