### PR TITLE
debian: don't suggest installing *-hipe

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -61,7 +61,7 @@ Debian-based Systems
 
 You can install the dependencies by running:
 
-    sudo apt-get install build-essential erlang-base-hipe \
+    sudo apt-get install build-essential \
         erlang-dev erlang-manpages erlang-eunit erlang-nox \
         libicu-dev libmozjs185-dev libcurl4-openssl-dev \
         pkg-config


### PR DESCRIPTION
On IRC I was advised by @wohali not to use the `hipe` variant of erlang. Yet, `INSTALL.Unix` tells one to do so. This fixes it.

On Debian `erlang-nox` depends on `erlang-base`, that's why it should be sufficient to install `erlang-nox`.