### PR TITLE
Fix a broken path in Windows

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -178,6 +178,7 @@ def setup_configs(ctx):
             # Erlang always wants UNIX-style paths
             env["data_dir"] = env["data_dir"].replace("\\", "/")
             env["view_index_dir"] = env["view_index_dir"].replace("\\", "/")
+            env["prefix"] = env["prefix"].replace("\\", "/")
         write_config(ctx, node, env)
 
 


### PR DESCRIPTION
The dev/run file needs one more path to have backslashes replaced by forward slashes under Windows.