### PR TITLE
Support sharing test helpers

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -82,6 +82,8 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, ["rel"]},
     {lib_dirs, ["src/"]},
+    {src_dirs, ["src", "test/helpers"]},
+    {i, ["test/include"]},
     {erl_opts, [debug_info]},
     {eunit_opts, [verbose]},
     {plugins, [eunit_plugin]},


### PR DESCRIPTION
It is tedious to share test_helpers between different applications.
We used to place test helpers modules in the `src` directory of the
application but this pollutes the `src` and gets deployed into
production.
In order to solve this problem we add support for following directories
in every application:

 - test/helpers - a place where you put *.erl files with helper modules
 - test/include - a place for *.hrl files you want to share