### PR TITLE
scrap make install, build full couch into rel/couchdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,10 +227,10 @@ dist: all
 	@echo "Done: apache-couchdb-$(COUCHDB_VERSION).tar.gz"
 
 
-.PHONY: install
-# target: install - Install CouchDB :-)
+.PHONY: build
+# target: build - Build CouchDB!
 -include install.mk
-install: all
+build: all
 	@echo "Installing CouchDB into rel/couchdb/ ..."
 	@rm -rf rel/couchdb
 	@$(REBAR) generate > /dev/null 2>&1 # make full erlang release
@@ -259,8 +259,19 @@ endif
 
 	@echo "... done"
 	@echo
-	@echo "    You can now copy the rel/couchdb/ directory anywhere on your system."
+	@echo "    You can now copy the rel/couchdb directory anywhere on your system."
 	@echo "    Start CouchDB with ./bin/couchdb from within that directory."
+	@echo
+
+.PHONY: install
+# target: install- install CouchDB :)
+install:
+	@echo
+	@echo "Notice: There is no 'make install' command for CouchDB 2.0 yet."
+	@echo
+	@echo "    To install CouchDB into your system, copy the rel/couchdb"
+	@echo "    to your desired installation location. For example:"
+	@echo "    cp -r rel/couchdb /usr/local/lib"
 	@echo
 
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ fauxton: share/www
 check: all
 	@$(MAKE) eunit
 	@$(MAKE) javascript
-	@$(MAKE) build-test
+#	@$(MAKE) build-test
 
 
 .PHONY: eunit

--- a/Makefile
+++ b/Makefile
@@ -231,53 +231,37 @@ dist: all
 # target: install - Install CouchDB :-)
 -include install.mk
 install: all
-	@echo "Installing CouchDB into $(DESTDIR)/$(install_dir)..." | sed -e 's,///,/,'
+	@echo "Installing CouchDB into rel/couchdb/ ..."
 	@rm -rf rel/couchdb
-	@$(REBAR) generate # make full erlang release
-
-	@mkdir -p $(DESTDIR)/$(install_dir)
-	@cp -R rel/couchdb/* $(DESTDIR)/$(install_dir)
-
-	@mkdir -p $(DESTDIR)/$(database_dir)
-	@chown $(user) $(DESTDIR)/$(database_dir)
-
-	@mkdir -p $(DESTDIR)/$(view_index_dir)
-	@chown $(user) $(DESTDIR)/$(view_index_dir)
-
-	@mkdir -p $(DESTDIR)/`dirname $(log_file)`
-	@touch $(DESTDIR)/$(log_file)
-	@chown $(user) $(DESTDIR)/$(log_file)
-
-	@mkdir -p $(DESTDIR)/$(bin_dir)
-	@cp rel/couchdb/bin/couchdb $(DESTDIR)/$(bin_dir)
-
-	@mkdir -p $(DESTDIR)/$(libexec_dir)
-	@cp rel/couchdb/bin/couchjs $(DESTDIR)/$(libexec_dir)
-
-	@mkdir -p $(DESTDIR)/$(sysconf_dir)
-	@mkdir -p $(DESTDIR)/$(sysconf_dir)/default.d
-	@mkdir -p $(DESTDIR)/$(sysconf_dir)/local.d
-	@cp rel/couchdb/etc/default.ini rel/couchdb/etc/local.ini $(DESTDIR)/$(sysconf_dir)
+	@$(REBAR) generate > /dev/null 2>&1 # make full erlang release
 
 ifeq ($(with_fauxton), 1)
-	@mkdir -p $(DESTDIR)/$(data_dir)
-	@cp -R share/server share/www $(DESTDIR)/$(data_dir)
+	@mkdir -p rel/couchdb/share/
+	@cp -R share/www rel/couchdb/share/
 endif
 
 ifeq ($(with_docs), 1)
-	@mkdir -p $(DESTDIR)/$(doc_dir)
-	@mkdir -p $(DESTDIR)/$(html_dir)
-	@mkdir -p $(DESTDIR)/$(pdf_dir)
-	@mkdir -p $(DESTDIR)/$(man_dir)
-	@mkdir -p $(DESTDIR)/$(info_dir)
-	@cp -R share/docs/html $(DESTDIR)/$(html_dir)/html
-	@cp share/docs/pdf/CouchDB.pdf $(DESTDIR)/$(pdf_dir)/CouchDB.pdf
-	@cp share/docs/info/CouchDB.info $(DESTDIR)/$(info_dir)/CouchDB.info
-	@cp share/docs/man/apachecouchdb.1 $(DESTDIR)/$(man_dir)/couchdb.1
+ifeq ($(IN_RELEASE), true)
+	@mkdir -p rel/couchdb/share/www/docs/
+	@mkdir -p rel/couchdb/share/docs/
+	@cp -R share/docs/html/* rel/couchdb/share/www/docs/
+	@cp share/docs/pdf/CouchDB.pdf rel/couchdb/share/docs/CouchDB.pdf
+	@cp share/docs/man/apachecouchdb.1 rel/couchdb/share/docs/couchdb.1
+	@cp share/docs/info/CouchDB.info rel/couchdb/share/docs/CouchDB.info
+else
+	@mkdir -p rel/couchdb/share/docs/
+	@cp -R src/docs/build/html/ rel/couchdb/share/www/docs
+	@cp src/docs/build/latex/CouchDB.pdf rel/couchdb/share/docs/CouchDB.pdf
+	@cp src/docs/build/man/apachecouchdb.1 rel/couchdb/share/docs/couchdb.1
+	@cp src/docs/build/texinfo/CouchDB.info rel/couchdb/share/docs/CouchDB.info
+endif
 endif
 
-	@echo "...done"
-
+	@echo "... done"
+	@echo
+	@echo "    You can now copy the rel/couchdb/ directory anywhere on your system."
+	@echo "    Start CouchDB with ./bin/couchdb from within that directory."
+	@echo
 
 ################################################################################
 # Cleaning

--- a/configure
+++ b/configure
@@ -11,40 +11,22 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# next steps:
+# try running this, figure out what to do with the vars in the generated files
+# in the bottom
+
 # cd into this script’s directory
 rootdir="$(cd "${0%/*}" 2>/dev/null; echo "$PWD")"
 basename=`basename $0`
 
 PACKAGE_AUTHOR_NAME="The Apache Software Foundation"
 
-TEST=0
+# TEST=0
 WITH_CURL="false"
 WITH_FAUXTON=1
 WITH_DOCS=1
 SKIP_DEPS=0
 
-PREFIX=
-DEFAULT_PREFIX=/usr/local
-EXEC_PREFIX=
-BINDIR=
-LIBEXECDIR=
-SYSCONFDIR=
-DATAROOTDIR=
-DATADIR=
-LOCALSTATEDIR=
-RUNSTATEDIR=
-LIBDIR=
-
-INFODIR=
-MANDIR=
-DOCDIR=
-
-HTMLDIR=
-PDFDIR=
-
-DATABASEDIR=
-VIEWDIR=
-LOGDIR=
 COUCHDB_USER=`whoami`
 
 display_help () {
@@ -58,36 +40,36 @@ Options:
 
   -h | --help                 display a short help message and exit
   -u | --user USER            set the username to run as (defaults to $COUCHDB_USER)
-  --prefix=DIRECTORY          set the installation prefix (defaults to $DEFAULT_PREFIX)
-  --databasedir DIRECTORY     specify the data directory (defaults to /var/lib/couchdb)
-  --viewindexdir DIRECTORY    specify the view directory (defaults to /var/lib/couchdb)
-  --logdir DIRECTORY          specify the log file (defaults to /var/log/couchdb.log)
+  # --prefix=DIRECTORY          set the installation prefix (defaults to $DEFAULT_PREFIX)
+  # --databasedir DIRECTORY     specify the data directory (defaults to /var/lib/couchdb)
+  # --viewindexdir DIRECTORY    specify the view directory (defaults to /var/lib/couchdb)
+  # --logdir DIRECTORY          specify the log file (defaults to /var/log/couchdb.log)
   -c | --with-curl            request that couchjs is linked to cURL (default false)
   --disable-fauxton           do not build Fauxton
   --disable-docs              do not build any documentation or manpages
   --skip-deps                 do not update erlang dependencies
   --rebar=PATH                use rebar by specified path (version >=2.6.0 && <3.0 required)
-
-
-  Installation directories:
-    --prefix=PREFIX         install architecture-independent files in PREFIX
-                            [/usr/local]
-    --exec-prefix=EPREFIX   install architecture-dependent files in EPREFIX
-                            [PREFIX]
-
-  Fine tuning of the installation directories:
-    --bindir=DIR            user executables [EPREFIX/bin]
-    --libexecdir=DIR        program executables [EPREFIX/libexec]
-    --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
-    --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-    --libdir=DIR            object code libraries [EPREFIX/lib]
-    --datarootdir=DIR       read-only arch.-independent data root [PREFIX/share]
-    --datadir=DIR           read-only architecture-independent data [DATAROOTDIR]
-    --infodir=DIR           info documentation [DATAROOTDIR/info]
-    --mandir=DIR            man documentation [DATAROOTDIR/man]
-    --docdir=DIR            documentation root [DATAROOTDIR/doc/apache-couchdb]
-    --htmldir=DIR           html documentation [DOCDIR]
-    --pdfdir=DIR            pdf documentation [DOCDIR]
+  #
+  #
+  # Installation directories:
+  #   --prefix=PREFIX         install architecture-independent files in PREFIX
+  #                           [/usr/local]
+  #   --exec-prefix=EPREFIX   install architecture-dependent files in EPREFIX
+  #                           [PREFIX]
+  #
+  # Fine tuning of the installation directories:
+  #   --bindir=DIR            user executables [EPREFIX/bin]
+  #   --libexecdir=DIR        program executables [EPREFIX/libexec]
+  #   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
+  #   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  #   --libdir=DIR            object code libraries [EPREFIX/lib]
+  #   --datarootdir=DIR       read-only arch.-independent data root [PREFIX/share]
+  #   --datadir=DIR           read-only architecture-independent data [DATAROOTDIR]
+  #   --infodir=DIR           info documentation [DATAROOTDIR/info]
+  #   --mandir=DIR            man documentation [DATAROOTDIR/man]
+  #   --docdir=DIR            documentation root [DATAROOTDIR/doc/apache-couchdb]
+  #   --htmldir=DIR           html documentation [DOCDIR]
+  #   --pdfdir=DIR            pdf documentation [DOCDIR]
 EOF
 }
 
@@ -97,12 +79,6 @@ parse_opts() {
             -h|--help)
                 display_help
                 exit
-                ;;
-
-            --test)
-                TEST=1
-                shift
-                continue
                 ;;
 
             --with-curl|-c)
@@ -162,331 +138,6 @@ parse_opts() {
                 printf 'ERROR: "--user" requires a non-empty argument.\n' >&2
                 exit 1
                 ;;
-
-            --prefix)
-                if [ -n "$2" ]; then
-                    eval PREFIX=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--prefix" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --prefix=?*)
-                eval PREFIX=${1#*=}
-                ;;
-            --prefix=)
-                printf 'ERROR: "--prefix" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --exec-prefix)
-                if [ -n "$2" ]; then
-                    eval EXEC_PREFIX=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--exec-prefix" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --exec-prefix=?*)
-                eval EXEC_PREFIX=${1#*=}
-                ;;
-            --exec-prefix=)
-                printf 'ERROR: "--exec-prefix" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --bindir)
-                if [ -n "$2" ]; then
-                    eval BINDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--bindir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --bindir=?*)
-                eval BINDIR=${1#*=}
-                ;;
-            --bindir=)
-                printf 'ERROR: "--bindir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --libexecdir)
-                if [ -n "$2" ]; then
-                    eval LIBEXECDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--libexecdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --libexecdir=?*)
-                eval LIBEXECDIR=${1#*=}
-                ;;
-            --libexecdir=)
-                printf 'ERROR: "--libexecdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --sysconfdir)
-                if [ -n "$2" ]; then
-                    eval SYSCONFDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--sysconfdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --sysconfdir=?*)
-                eval SYSCONFDIR=${1#*=}
-                ;;
-            --sysconfdir=)
-                printf 'ERROR: "--sysconfdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --datarootdir)
-                if [ -n "$2" ]; then
-                    eval DATAROOTDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--datarootdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --datarootdir=?*)
-                eval DATAROOTDIR=${1#*=}
-                ;;
-            --datarootdir=)
-                printf 'ERROR: "--datarootdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --datadir)
-                if [ -n "$2" ]; then
-                    eval DATADIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--datadir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --datadir=?*)
-                eval DATADIR=${1#*=}
-                ;;
-            --datadir=)
-                printf 'ERROR: "--datadir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --localstatedir)
-                if [ -n "$2" ]; then
-                    eval LOCALSTATEDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--localstatedir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --localstatedir=?*)
-                eval LOCALSTATEDIR=${1#*=}
-                ;;
-            --localstatedir=)
-                printf 'ERROR: "--localstatedir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --runstatedir)
-                if [ -n "$2" ]; then
-                    eval RUNSTATEDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--runstatedir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --runstatedir=?*)
-                eval RUNSTATEDIR=${1#*=}
-                ;;
-            --runstatedir=)
-                printf 'ERROR: "--runstatedir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --docdir)
-                if [ -n "$2" ]; then
-                    eval DOCDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--docdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --docdir=?*)
-                eval DOCDIR=${1#*=}
-                ;;
-            --docdir=)
-                printf 'ERROR: "--docdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --mandir)
-                if [ -n "$2" ]; then
-                    eval MANDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--mandir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --mandir=?*)
-                eval MANDIR=${1#*=}
-                ;;
-            --mandir=)
-                printf 'ERROR: "--mandir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --infodir)
-                if [ -n "$2" ]; then
-                    eval INFODIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--infodir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --infodir=?*)
-                eval INFODIR=${1#*=}
-                ;;
-            --infodir=)
-                printf 'ERROR: "--infodir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --libdir)
-                if [ -n "$2" ]; then
-                    eval LIBDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--libdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --libdir=?*)
-                eval LIBDIR=${1#*=}
-                ;;
-            --libdir=)
-                printf 'ERROR: "--libdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --databasedir)
-                if [ -n "$2" ]; then
-                    eval DATABASEDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--databasedir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --databasedir=?*)
-                eval DATABASEDIR=${1#*=}
-                ;;
-            --databasedir=)
-                printf 'ERROR: "--databasedir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --viewindexdir)
-                if [ -n "$2" ]; then
-                    eval VIEWDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--viewindexdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --viewindexdir=?*)
-                eval VIEWDIR=${1#*=}
-                ;;
-            --viewindexdir=)
-                printf 'ERROR: "--viewindexdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --logdir)
-                if [ -n "$2" ]; then
-                    eval LOGDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--logdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --logdir=?*)
-                eval LOGDIR=${1#*=}
-                ;;
-            --logdir=)
-                printf 'ERROR: "--logdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --htmldir)
-                if [ -n "$2" ]; then
-                    eval HTMLDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--htmldir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --htmldir=?*)
-                eval HTMLDIR=${1#*=}
-                ;;
-            --htmldir=)
-                printf 'ERROR: "--htmldir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
-            --pdfdir)
-                if [ -n "$2" ]; then
-                    eval PDFDIR=$2
-                    shift 2
-                    continue
-                else
-                    printf 'ERROR: "--pdfdir" requires a non-empty argument.\n' >&2
-                    exit 1
-                fi
-                ;;
-            --pdfdir=?*)
-                eval PDFDIR=${1#*=}
-                ;;
-            --pdfdir=)
-                printf 'ERROR: "--pdfdir" requires a non-empty argument.\n' >&2
-                exit 1
-                ;;
-
             --) # End of options
                 shift
                 break
@@ -500,80 +151,9 @@ parse_opts() {
         esac
         shift
     done
-
-    # defaults
-    if test -z "$PREFIX"; then
-        PREFIX="$DEFAULT_PREFIX";
-    fi
-    if test -z "$EXEC_PREFIX"; then
-        EXEC_PREFIX="$PREFIX";
-    fi
-    if test -z "$BINDIR"; then
-        BINDIR="$EXEC_PREFIX/bin";
-    fi
-    if test -z "$LIBEXECDIR"; then
-        LIBEXECDIR="$EXEC_PREFIX/libexec";
-    fi
-    if test -z "$SYSCONFDIR"; then
-        SYSCONFDIR="$PREFIX/etc";
-    fi
-    if test -z "$DATAROOTDIR"; then
-        DATAROOTDIR="$PREFIX/share";
-    fi
-    if test -z "$DATADIR"; then
-        DATADIR="$DATAROOTDIR";
-    fi
-    if test -z "$LOCALSTATEDIR"; then
-        LOCALSTATEDIR="$PREFIX/var";
-    fi
-    if test -z "$RUNSTATEDIR"; then
-        RUNSTATEDIR="$LOCALSTATEDIR/run";
-    fi
-    if test -z "$DOCDIR"; then
-        DOCDIR="$DATAROOTDIR/doc/apache-couchdb";
-    fi
-    if test -z "$INFODIR"; then
-        INFODIR="$DATAROOTDIR/info";
-    fi
-    if test -z "$MANDIR"; then
-        MANDIR="$DATAROOTDIR/man";
-    fi
-    if test -z "$LIBDIR"; then
-        LIBDIR="$EXEC_PREFIX/lib";
-    fi
-    if test -z "$DATABASEDIR"; then
-        DATABASEDIR="$LOCALSTATEDIR/lib/couchdb";
-    fi
-    if test -z "$VIEWDIR"; then
-        VIEWDIR="$LOCALSTATEDIR/lib/couchdb";
-    fi
-    if test -z "$LOGDIR"; then
-        LOGDIR="$LOCALSTATEDIR/log";
-    fi
-    if test -z "$HTMLDIR"; then
-        HTMLDIR="$DOCDIR/html";
-    fi
-    if test -z "$PDFDIR"; then
-        PDFDIR="$DOCDIR/pdf";
-    fi
 }
 
 parse_opts $@
-
-# We use this for testing this script
-# The test script lives in test/build/test-configure.sh
-if [ "$TEST" = "1" ]; then
-    echo $PREFIX $EXEC_PREFIX $BINDIR $LIBEXECDIR $SYSCONFDIR $DATAROOTDIR \
-         $DATADIR $LOCALSTATEDIR $RUNSTATEDIR $DOCDIR $LIBDIR $DATABASEDIR \
-         $VIEWDIR $LOGDIR $MANDIR $INFODIR $HTMLDIR $PDFDIR
-    exit 0
-fi
-
-# Translate ./configure variables to CouchDB variables
-
-INSTALLDIR=$LIBDIR/couchdb
-LOG_FILE=$LOGDIR/couch.log
-
 
 echo "==> configuring couchdb in rel/couchdb.config"
 cat > rel/couchdb.config << EOF
@@ -592,13 +172,13 @@ cat > rel/couchdb.config << EOF
 % The contents of this file are auto-generated by configure
 %
 {package_author_name, "$PACKAGE_AUTHOR_NAME"}.
-{prefix, "$INSTALLDIR"}.
-{data_dir, "$DATABASEDIR"}.
-{view_index_dir, "$VIEWDIR"}.
+{prefix, "."}.
+{data_dir, "./data"}.
+{view_index_dir, "./data"}.
 {log_file, "$LOG_FILE"}.
-{fauxton_root, "$DATAROOTDIR/couchdb/www"}.
+{fauxton_root, "./share/www"}.
 {user, "$COUCHDB_USER"}.
-{node_name, "-name couchdb"}.
+{node_name, "-name couchdb@localhost"}.
 {cluster_port, 5984}.
 {backend_port, 5986}.
 EOF
@@ -619,22 +199,6 @@ cat > install.mk << EOF
 # The contents of this file are auto-generated by configure
 #
 package_author_name = $PACKAGE_AUTHOR_NAME
-install_dir = $INSTALLDIR
-
-bin_dir = $BINDIR
-libexec_dir = $LIBEXECDIR/couchdb
-doc_dir = $DOCDIR/couchdb
-sysconf_dir = $SYSCONFDIR/couchdb
-data_dir = $DATADIR/couchdb
-
-database_dir = $DATABASEDIR
-view_index_dir = $VIEWDIR
-log_file = $LOG_FILE
-
-html_dir = $HTMLDIR
-pdf_dir = $PDFDIR
-man_dir = $MANDIR
-info_dir = $INFODIR
 
 with_fauxton = $WITH_FAUXTON
 with_docs = $WITH_DOCS

--- a/rel/overlay/bin/couchdb
+++ b/rel/overlay/bin/couchdb
@@ -13,7 +13,8 @@
 # the License.
 
 COUCHDB_BIN_DIR=$(cd ${0%/*} && pwd)
-ERTS_BIN_DIR=$COUCHDB_BIN_DIR/../lib/couchdb/
+ERTS_BIN_DIR=$COUCHDB_BIN_DIR/../
+cd $COUCHDB_BIN_DIR/../
 
 export ROOTDIR=${ERTS_BIN_DIR%/*}
 


### PR DESCRIPTION
As per dev@ discussion, this PR removes the more familiar behaviour of `make install` and creates a location independent directory `./rel/couchdb` that can be moved to anywhere on the system.

This is a first draft, exact naming of make targets and messages TBD. cc @rnewson @kxepal @davisp 

I noticed this issue when building Fauxton:

 `grunt couchdb` installs `index.html` into `share/www/index.html`, and it tries to load js files from `./dashboard.assets/js/` but these are installed into `share/www/js/`

Either `index.html` needs to not include the `dashboard.assets` path, or we need to install into that.

I tried to fix it, but fauxton master doesn’t have the subsequent copy lines, just the one for `index.html`, so I’m not sure what to do. cc @garrensmith @robertkowalski 