### PR TITLE
Upgrade fauxton to 1.1.2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -44,7 +44,7 @@ DepDescs = [
 {ddoc_cache,       "ddoc-cache",       "c762e90a33ce3cda19ef142dd1120f1087ecd876"},
 {ets_lru,          "ets-lru",          "c05488c8b1d7ec1c3554a828e0c9bf2888932ed6"},
 {fabric,           "fabric",           "1be5506e39baa3b4c7b3d64daf8032a5580b38ba"},
-{fauxton,          "fauxton",          {tag, "v1.1.1"}, [raw]},
+{fauxton,          "fauxton",          {tag, "v1.1.2"}, [raw]},
 {folsom,           "folsom",           "a5c95dec18227c977029fbd3b638966d98f17003"},
 {global_changes,   "global-changes",   "e55de37ece29b6cbc0af540370d2425159338bf9"},
 {goldrush,         "goldrush",         {tag, "0.1.6"}},


### PR DESCRIPTION
This adds the fix that fauxton will be correctly built with CouchDB