### PR TITLE
Set default_security for the tests to everyone

### DIFF
--- a/rel/files/eunit.ini
+++ b/rel/files/eunit.ini
@@ -18,6 +18,7 @@
 [couchdb]
 ; time to relax!
 uuid = 74696d6520746f2072656c617821
+default_security = everyone
 
 [httpd]
 port = 0


### PR DESCRIPTION
This sets default security for the eunit tests to "everyone" to allow them pass again