### PR TITLE
Updated package requirements for build on Ubuntu 16.04

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -63,8 +63,8 @@ You can install the dependencies by running:
 
     sudo apt-get install build-essential erlang-base \
         erlang-dev erlang-manpages erlang-eunit erlang-nox \
-        libicu-dev libmozjs185-dev libcurl4-openssl-dev \
-        pkg-config
+        erlang-reltool libicu-dev libmozjs185-dev libcurl4-openssl-dev \
+        pkg-config rebar
 
 There are lots of Erlang packages. If there is a problem with your
 install, try a different mix. There is more information on the


### PR DESCRIPTION
Building from master requires 2 additional packages that where not enlisted.
