### PR TITLE
Use UNIX-style paths for view servers on Windows

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -174,7 +174,7 @@ def setup_configs(ctx):
             "fauxton_root": "src/fauxton/dist/release",
             "uuid": "fake_uuid_for_dev"
         }
-        if os.name == 'nt':
+        if os.sep == '\\':
             # Erlang always wants UNIX-style paths
             env["data_dir"] = env["data_dir"].replace("\\", "/")
             env["view_index_dir"] = env["view_index_dir"].replace("\\", "/")
@@ -237,7 +237,7 @@ def boot_haproxy(ctx):
 def hack_default_ini(ctx, node, content):
     # Replace log file
     logfile = os.path.join(ctx['devdir'], "logs", "%s.log" % node)
-    if os.name == 'nt':
+    if os.sep == '\\':
         # Erlang always wants UNIX-style paths
         logfile = logfile.replace("\\", "/")
     repl = "file = %s" % logfile
@@ -249,13 +249,13 @@ def hack_default_ini(ctx, node, content):
     coffeejs = os.path.join(ctx['rootdir'], "share", "server", "main-coffee.js")
 
     repl = "javascript = %s %s" % (couchjs, mainjs)
-    if os.name == 'nt':
+    if os.sep == '\\':
         # Erlang always wants UNIX-style paths
         repl = repl.replace("\\", "/")
     contents = re.sub("(?m)^javascript.*$", repl, contents)
 
     repl = "coffeescript = %s %s" % (couchjs, coffeejs)
-    if os.name == 'nt':
+    if os.sep == '\\':
         # Erlang always wants UNIX-style paths
         repl = repl.replace("\\", "/")
     contents = re.sub("(?m)^coffeescript.*$", repl, contents)
@@ -388,7 +388,7 @@ def boot_node(ctx, node):
     ]
     logfname = os.path.join(ctx['devdir'], "logs", "%s.log" % node)
     log = open(logfname, "wb")
-    if os.name == 'nt':
+    if os.sep == '\\':
         # Erlang always wants UNIX-style paths
         cmd = [x.replace("\\", "/") for x in cmd]
     return sp.Popen(cmd, stdin=sp.PIPE, stdout=log, stderr=sp.STDOUT, env=env)

--- a/dev/run
+++ b/dev/run
@@ -19,8 +19,10 @@ import functools
 import glob
 import inspect
 import json
+import ntpath
 import optparse
 import os
+import posixpath
 import re
 import subprocess as sp
 import sys
@@ -41,6 +43,12 @@ try:
 except ImportError:
     import http.client as httpclient
 
+
+def toposixpath(path):
+    if os.sep == ntpath.sep:
+        return path.replace(ntpath.sep, posixpath.sep)
+    else:
+        return path
 
 def log(msg):
     def decorator(func):
@@ -162,23 +170,18 @@ def setup_configs(ctx):
     for idx, node in enumerate(ctx['nodes']):
         cluster_port, backend_port = get_ports(idx + ctx['node_number'])
         env = {
-            "prefix": ctx['rootdir'],
+            "prefix": toposixpath(ctx['rootdir']),
             "package_author_name": "The Apache Software Foundation",
-            "data_dir": ensure_dir_exists(ctx['devdir'],
-                                          "lib", node, "data"),
-            "view_index_dir": ensure_dir_exists(ctx['devdir'],
-                                                "lib", node, "data"),
+            "data_dir": toposixpath(ensure_dir_exists(ctx['devdir'],
+                                          "lib", node, "data")),
+            "view_index_dir": toposixpath(ensure_dir_exists(ctx['devdir'],
+                                                "lib", node, "data")),
             "node_name": "-name %s@127.0.0.1" % node,
             "cluster_port": cluster_port,
             "backend_port": backend_port,
             "fauxton_root": "src/fauxton/dist/release",
             "uuid": "fake_uuid_for_dev"
         }
-        if os.sep == '\\':
-            # Erlang always wants UNIX-style paths
-            env["data_dir"] = env["data_dir"].replace("\\", "/")
-            env["view_index_dir"] = env["view_index_dir"].replace("\\", "/")
-            env["prefix"] = env["prefix"].replace("\\", "/")
         write_config(ctx, node, env)
 
 
@@ -236,10 +239,7 @@ def boot_haproxy(ctx):
 
 def hack_default_ini(ctx, node, content):
     # Replace log file
-    logfile = os.path.join(ctx['devdir'], "logs", "%s.log" % node)
-    if os.sep == '\\':
-        # Erlang always wants UNIX-style paths
-        logfile = logfile.replace("\\", "/")
+    logfile = toposixpath(os.path.join(ctx['devdir'], "logs", "%s.log" % node))
     repl = "file = %s" % logfile
     contents = re.sub("(?m)^file.*$", repl, content)
 
@@ -248,16 +248,10 @@ def hack_default_ini(ctx, node, content):
     mainjs = os.path.join(ctx['rootdir'], "share", "server", "main.js")
     coffeejs = os.path.join(ctx['rootdir'], "share", "server", "main-coffee.js")
 
-    repl = "javascript = %s %s" % (couchjs, mainjs)
-    if os.sep == '\\':
-        # Erlang always wants UNIX-style paths
-        repl = repl.replace("\\", "/")
+    repl = toposixpath("javascript = %s %s" % (couchjs, mainjs))
     contents = re.sub("(?m)^javascript.*$", repl, contents)
 
-    repl = "coffeescript = %s %s" % (couchjs, coffeejs)
-    if os.sep == '\\':
-        # Erlang always wants UNIX-style paths
-        repl = repl.replace("\\", "/")
+    repl = toposixpath("coffeescript = %s %s" % (couchjs, coffeejs))
     contents = re.sub("(?m)^coffeescript.*$", repl, contents)
 
     return contents
@@ -388,9 +382,7 @@ def boot_node(ctx, node):
     ]
     logfname = os.path.join(ctx['devdir'], "logs", "%s.log" % node)
     log = open(logfname, "wb")
-    if os.sep == '\\':
-        # Erlang always wants UNIX-style paths
-        cmd = [x.replace("\\", "/") for x in cmd]
+    cmd = [toposixpath(x) for x in cmd]
     return sp.Popen(cmd, stdin=sp.PIPE, stdout=log, stderr=sp.STDOUT, env=env)
 
 

--- a/dev/run
+++ b/dev/run
@@ -249,9 +249,15 @@ def hack_default_ini(ctx, node, content):
     coffeejs = os.path.join(ctx['rootdir'], "share", "server", "main-coffee.js")
 
     repl = "javascript = %s %s" % (couchjs, mainjs)
+    if os.name == 'nt':
+        # Erlang always wants UNIX-style paths
+        repl = repl.replace("\\", "/")
     contents = re.sub("(?m)^javascript.*$", repl, contents)
 
     repl = "coffeescript = %s %s" % (couchjs, coffeejs)
+    if os.name == 'nt':
+        # Erlang always wants UNIX-style paths
+        repl = repl.replace("\\", "/")
     contents = re.sub("(?m)^coffeescript.*$", repl, contents)
 
     return contents


### PR DESCRIPTION
This is the source of my recent failure as documented on dev@couchdb.a.o.

Addresses COUCHDB-3040 but does not completely fix or close it.