### PR TITLE
Clean up ./dev/run output

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -359,6 +359,7 @@ def check_node_alive(url):
             error = exc
             time.sleep(1)
         else:
+            error = None
             break
     if error is not None:
         raise error


### PR DESCRIPTION
If connection succeeds eventually, don't report spurious error when retrying.

Turns `./dev/run` output from this:

```
[ * ] Check node at http://127.0.0.1:15984/ ... failed: [Errno socket error] [Errno 111] Connection refused
[ * ] Check node at http://127.0.0.1:25984/ ... ok
[ * ] Check node at http://127.0.0.1:35984/ ... ok
[ * ] Check node at http://127.0.0.1:15984/ ... ok
```

to this:

```
[ * ] Check node at http://127.0.0.1:15984/ ... ok
[ * ] Check node at http://127.0.0.1:25984/ ... ok
[ * ] Check node at http://127.0.0.1:35984/ ... ok
```

Cleaner and a bit less scary for new developers.