### PR TITLE
Change default to log to a file, not stderr

### DIFF
--- a/configure
+++ b/configure
@@ -22,6 +22,7 @@ basename=`basename $0`
 PACKAGE_AUTHOR_NAME="The Apache Software Foundation"
 
 # TEST=0
+LOG_FILE="./var/log/couchdb.log"
 WITH_CURL="false"
 WITH_FAUXTON=1
 WITH_DOCS=1
@@ -43,7 +44,7 @@ Options:
   # --prefix=DIRECTORY          set the installation prefix (defaults to $DEFAULT_PREFIX)
   # --databasedir DIRECTORY     specify the data directory (defaults to /var/lib/couchdb)
   # --viewindexdir DIRECTORY    specify the view directory (defaults to /var/lib/couchdb)
-  # --logdir DIRECTORY          specify the log file (defaults to /var/log/couchdb.log)
+  --logfile FILENAME          specify the log file (defaults to ./var/log/couchdb.log)
   -c | --with-curl            request that couchjs is linked to cURL (default false)
   --disable-fauxton           do not build Fauxton
   --disable-docs              do not build any documentation or manpages
@@ -138,12 +139,29 @@ parse_opts() {
                 printf 'ERROR: "--user" requires a non-empty argument.\n' >&2
                 exit 1
                 ;;
+            --logfile)
+                if [ -n "$2" ]; then
+                    eval LOG_FILE=$2
+                    shift 2
+                    continue
+                else
+                    printf 'ERROR: "--logfile" requires a non-empty argument.\n' >&2
+                    exit 1
+                fi
+                ;;
+            --logfile=?*)
+                eval LOG_FILE=${1#*=}
+                ;;
+            --logfile=)
+                printf 'ERROR: "--logfile" requires a non-empty argument.\n' >&2
+                exit 1
+                ;;
             --) # End of options
                 shift
                 break
                 ;;
             -?*)
-                echo "WARNING: Unkonwn option '$1', ignoring" >&2
+                echo "WARNING: Unknown option '$1', ignoring" >&2
                 shift
                 ;;
             *) # Done

--- a/configure.ps1
+++ b/configure.ps1
@@ -136,7 +136,7 @@ $CouchDBConfig = @"
 {prefix, "."}.
 {data_dir, "./data"}.
 {view_index_dir, "./data"}.
-{log_file, ""}.
+{log_file, "./var/log/couchdb.log"}.
 {fauxton_root, "./share/www"}.
 {user, "$CouchDBUser"}.
 {node_name, "-name couchdb@localhost"}.

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -402,7 +402,8 @@ min_file_size = 131072
 ; here if you want to implement your own
 ; writer. See couch_log_writer.erl for
 ; more information on the (simple) API.
-writer = stderr
+writer = file
+file = {{log_file}}
 
 ; Options for the file writer
 ; file = /path/to/couch.log


### PR DESCRIPTION
Presently our default is to log only to stderr. This is both a deviation
from couchdb 1.x behaviour as well as unexpected for a service of
couchdb's stature. This PR defaults output in the 'make release' to
./var/log/couchdb.log.
