### PR TITLE
Update default/local ini files with new settings

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -30,12 +30,18 @@ attachment_stream_buffer_size = 4096
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
 default_security = admin_local
+; btree_chunk_size = 1279
+; maintenance_mode = false
+; stem_interactive_updates = true
+; update_lru_on_read = true
+; uri_file =
 
 [cluster]
 q=8
 r=2
 w=2
 n=3
+; placement = metro-dc-a:2,metro-dc-b:1
 
 [chttpd]
 port = {{cluster_port}}
@@ -76,13 +82,59 @@ allow_jsonp = false
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
 socket_options = [{recbuf, 262144}, {sndbuf, 262144}]
-log_max_chunk_size = 1000000
 enable_cors = false
 ; CouchDB can optionally enforce a maximum uri length;
 ; max_uri_length = 8000
+; changes_timeout = 60000
+; config_whitelist = 
+; max_uri_length = 
+; rewrite_limit = 100
+; x_forwarded_host = X-Forwarded-Host
+; x_forwarded_proto = X-Forwarded-Proto
+; x_forwarded_ssl = X-Forwarded-Ssl
+
+; [httpd_design_handlers]
+; _view = 
+
+; [ioq]
+; concurrency = 10
+; ratio = 0.01
 
 [ssl]
 port = 6984
+
+; [chttpd_auth]
+; authentication_db = _users
+
+; [chttpd_auth_cache]
+; max_lifetime = 600000
+; max_objects = 
+; max_size = 104857600
+
+; [mem3]
+; nodes_db = _nodes
+; shard_cache_size = 25000
+; shards_db = _dbs
+; sync_concurrency = 10
+
+; [fabric]
+; all_docs_concurrency = 10
+; changes_duration = 
+; shard_timeout_factor = 2
+; uuid_prefix_len = 7
+
+; [rexi]
+; buffer_count = 2000
+; server_per_node = false
+
+; [global_changes]
+; max_event_delay = 25
+; max_write_delay = 25
+; update_db = true
+
+; [view_updater]
+; min_writer_items = 100
+; min_writer_size = 16777216
 
 [couch_httpd_auth]
 authentication_db = _users
@@ -94,9 +146,12 @@ allow_persistent_cookies = false ; set to true to allow persistent cookies
 iterations = 10 ; iterations for password hashing
 ; min_iterations = 1
 ; max_iterations = 1000000000
-
+; password_scheme = pbkdf2
+; proxy_use_secret = false
 ; comma-separated list of public fields, 404 if empty
 ; public_fields =
+; secret = 
+; users_db_public = false
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]
@@ -162,8 +217,11 @@ query = {mango_native_proc, start_link, []}
 ; If you think you're hitting reduce_limit with a "good" reduce function,
 ; please let us know on the mailing list so we can fine tune the heuristic.
 [query_server_config]
+; commit_freq = 5
 reduce_limit = true
 os_process_limit = 25
+; os_process_idle_limit = 300
+; os_process_soft_limit = 100
 
 [daemons]
 index_server={couch_index_server, start_link, []}
@@ -233,6 +291,9 @@ _view_changes = {couch_mrview_http, handle_view_changes_req}
 ; alive if it exits.
 ; [os_daemons]
 ; some_daemon_name = /path/to/script -with args
+; [os_daemon_settings]
+; max_retries = 3
+; retry_time = 5
 
 
 [uuids]
@@ -253,12 +314,6 @@ algorithm = sequential
 utc_id_suffix =
 # Maximum number of UUIDs retrievable from /_uuids in a single request
 max_count = 1000
-
-[stats]
-; rate is in milliseconds
-rate = 1000
-; sample intervals are in seconds
-samples = [0, 60, 300, 900]
 
 [attachments]
 compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
@@ -283,8 +338,14 @@ http_connections = 20
 ; Even for very fast/reliable networks it might need to be increased if a remote
 ; database is too busy.
 connection_timeout = 30000
+; Request timeout
+;request_timeout = infinity
 ; If a request fails, the replicator will retry it up to N times.
 retries_per_request = 10
+; Use checkpoints
+;use_checkpoints = true
+; Checkpoint interval
+;checkpoint_interval = 30000
 ; Some socket options that might boost performance in some scenarios:
 ;       {nodelay, boolean()}
 ;       {sndbuf, integer()}
@@ -393,19 +454,38 @@ min_file_size = 131072
 ;_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
 
 [log]
-; CouchDB logging backend
-; Currently supported only two: stderr and lager
-backend = lager
+; Set the log writer to use
+; Current writers include:
+;   stderr
+;   file
+;   syslog
+; You can also specify a full module name
+; here if you want to implement your own
+; writer. See couch_log_writer.erl for
+; more information on the (simple) API.
+writer = stderr
+
+; Options for the file writer
+; file = /path/to/couch.log
+; write_buffer = size_in_bytes
+; write_delay = time_in_milliseconds
+
+; Options for the syslog writer
+; syslog_host = remote host
+; syslog_port = 514
+; syslog_appid = couchdb
+; syslog_facility = local2
+
 ; Possible logging levels (sorted by level):
 ;     none
-;     emergency
+;     emergency, emerg
 ;     alert
-;     critical
-;     error
-;     warning
+;     critical, crit
+;     error, err
+;     warning, warn
 ;     notice
 ;     info
 ;     debug
 ; Each controls how verbose logging will be. Higher level mean less log output.
-; none level turns logging off, except for crashes.
+; none level turns logging off
 level = info

--- a/rel/overlay/etc/local.ini
+++ b/rel/overlay/etc/local.ini
@@ -6,6 +6,7 @@
 
 [couchdb]
 ;max_document_size = 4294967296 ; bytes
+;os_process_timeout = 5000
 
 [couch_peruser]
 ; If enabled, couch_peruser ensures that a private per-user database
@@ -17,7 +18,7 @@
 ; deleted as well.
 ;delete_dbs = true
 
-[httpd]
+[chttpd]
 ;port = 5984
 ;bind_address = 127.0.0.1
 ; Options for the MochiWeb HTTP server.
@@ -25,6 +26,10 @@
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, 262144}, {sndbuf, 262144}, {nodelay, true}]
 
+[httpd]
+; NOTE that this only configures the "backend" node-local port, not the
+; "frontend" clustered port. You probably don't want to change anything in
+; this section.
 ; Uncomment next line to trigger basic-auth popup on unauthorized requests.
 ;WWW-Authenticate = Basic realm="administrator"
 


### PR DESCRIPTION
A comprehensive grep was run across the source code looking for
references to config:get* functions. This was used to remove any
config settings that no longer are used, and to add new defaults
set in the code explicitly to the ini files. Any newly added lines
were added only as *comments*.

One key change: local.ini still had the [httpd] block for port and
host bindings. As this applies to the "backend" binding and port
now, this section was renamed [chttpd] to ensure new users of 2.0
don't accidentally put their backend port on e.g. port 80.

Fixes COUCHDB-2623.