### PR TITLE
README.rst, README-DEV.rst: Code should be in double backquotes

### DIFF
--- a/README-DEV.rst
+++ b/README-DEV.rst
@@ -36,7 +36,7 @@ However, you do not need them if:
 * You don't care about building the documentation
 
 If you intend to build Fauxton, you will also need to install its
-dependencies. After running ./configure to download all of the
+dependencies. After running ``./configure`` to download all of the
 dependent repositories, you can read about required dependencies in
 `src/fauxton/readme.md`. Typically, installing npm and node.js are
 sufficient to enable a Fauxton build.
@@ -118,13 +118,13 @@ If you intend to run the test suites::
 
     ./configure -c
 
-If you want to build it into different destination than `/usr/local`.:
+If you want to build it into different destination than `/usr/local`.::
 
     ./configure --prefix=/<your directory path>
 
-If you don't want to build Fauxton or documentation specify ``--disable-fauxton``
-and/or ``--disable-docs`` arguments for `configure` to ignore their build and
-avoid any issues with their dependencies.
+If you don't want to build Fauxton or documentation specify
+``--disable-fauxton`` and/or ``--disable-docs`` arguments for ``configure`` to
+ignore their build and avoid any issues with their dependencies.
 
 See ``./configure --help`` for more information.
 

--- a/README.rst
+++ b/README.rst
@@ -56,17 +56,17 @@ Getting started with developing
 For more detail, read the README-DEV.rst file in this directory.
 
 Basically you just have to install the needed dependencies which are
-documented in the install docs and then run `./configure && make`.
+documented in the install docs and then run ``./configure && make``.
 
-You don't need to run `make install` after compiling, just use
-`./dev/run` to spin up three nodes. You can add haproxy as a caching
-layer in front of this cluster by running `./dev/run --with-haproxy
---haproxy=/path/to/haproxy` . You will now have a local cluster
-listening on port `5984`.
+You don't need to run ``make install`` after compiling, just use
+``./dev/run`` to spin up three nodes. You can add haproxy as a caching
+layer in front of this cluster by running ``./dev/run --with-haproxy
+--haproxy=/path/to/haproxy`` . You will now have a local cluster
+listening on port 5984.
 
 For Fauxton developers fixing the admin-party does not work via the button in
-Fauxton. To fix the admin party you have to run `./dev/run` with the `admin`
-flag, e.g. `./dev/run --admin=username:password`. If you want to have an
+Fauxton. To fix the admin party you have to run ``./dev/run`` with the ``admin``
+flag, e.g. ``./dev/run --admin=username:password``. If you want to have an
 admin-party, just omit the flag.
 
 Cryptographic Software Notice


### PR DESCRIPTION
Minor fixes to make sure the README and README-DEV files use proper ReST formatting. This improves the readability of these files *a lot* when they are viewed via the github website.

There was no content changed, just minor format changes.