### PR TITLE
Bump dependencies

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -23,12 +23,12 @@ os:putenv("COUCHDB_APPS_CONFIG_DIR", filename:join([COUCHDB_ROOT, "rel/apps"])).
 
 DepDescs = [
 %% must be compiled first as it has a custom behavior
-{couch_epi,        "couch-epi",        "f6ad55d804ac741b59fe37dd092787113847661c"},
+{couch_epi,        "couch-epi",        "60e7f808513b2611eb412cf641d6e7132dda2a30"},
 {config,           "config",           "f62d553b337ce975edb0fb68772d22bdd3bf6490"},
 %% keep these sorted
 {b64url,           "b64url",           "6895652d80f95cdf04efb14625abed868998f174"},
 {couch_log,        "couch-log",        "ad803f66dbd1900b67543259142875a6d03503ce"},
-{chttpd,           "chttpd",           "3dcdb6a2eb97241dce62615319a52affb9e792ed"},
+{chttpd,           "chttpd",           "d6282b03e8c0632d1378a637187eb760af90869c"},
 {couch,            "couch",            "1659fda5dd1808f55946a637fc26c73913b57e96"},
 {couch_index,      "couch-index",      "f0a6854e578469612937a766632fdcdc52ee9c65"},
 {couch_mrview,     "couch-mrview",     "5899436ae7b8d7198bfcbef48475d8c6dd4d9dd9"},
@@ -38,10 +38,10 @@ DepDescs = [
 {couch_stats,      "couch-stats",      "7895d4d3f509ed24f09b6d1a0bd0e06af34551dc"},
 {couch_peruser,    "peruser",          "4eea9571171a5b41d832da32204a1122a01f4b0e"},
 {couch_tests,       "erlang-tests",    "37b3bfeb4b1a48a592456e67991362e155ed81e0"},
-{docs,             "documentation",    "52a2879faac8cdb315a21c4f3a153a934b9bfebb", [raw]},
+{docs,             "documentation",    "2993ccb86f9ec685a183807a54f044d42fb18592", [raw]},
 {ddoc_cache,       "ddoc-cache",       "c762e90a33ce3cda19ef142dd1120f1087ecd876"},
 {ets_lru,          "ets-lru",          "c05488c8b1d7ec1c3554a828e0c9bf2888932ed6"},
-{fabric,           "fabric",           "7cfabb5543de52639d226f509897e9b418327fcb"},
+{fabric,           "fabric",           "205064aa549361f83faa94370c7b70e834f2ed2e"},
 {fauxton,          "fauxton",          {tag, "v1.1.9"}, [raw]},
 {folsom,           "folsom",           "a5c95dec18227c977029fbd3b638966d98f17003"},
 {global_changes,   "global-changes",   "f6e4c5629a7d996d284e4489f1897c057823f846"},
@@ -50,7 +50,7 @@ DepDescs = [
 {jiffy,            "jiffy",            "d3c00e19d8fa20c21758402231247602190988d3"},
 {khash,            "khash",            "7c6a9cd9776b5c6f063ccafedfa984b00877b019"},
 {mango,            "mango",            "50066bc841be578fc1cc2ed8f404392c71d853e5"},
-{mem3,             "mem3",             "252467cb4a27637090b5f9006483f5b7ab551699"},
+{mem3,             "mem3",             "c3c5429180de14a2b139f7741c934143ef73988c"},
 {mochiweb,         "mochiweb",         "bd6ae7cbb371666a1f68115056f7b30d13765782"},
 {oauth,            "oauth",            "099057a98e41f3aff91e77e3cf496d6c6fd901df"},
 {rexi,             "rexi",             "a327b7dbeb2b0050f7ca9072047bf8ef2d282833"},


### PR DESCRIPTION
## List of updates 

    docs: 52a287..2993cc
     * Spelling error fix: fauxuton to fauxton

    chttpd: 3dcdb6..d6282b
     * Merge remote branch 'cloudant:71810-handle-errors-terms-from-fabric'
     * Handle error terms from fabric ([COUCHDB-3195](https://issues.apache.org/jira/browse/COUCHDB-3195))
     * Merge remote branch 'cloudant:78077-pass-user_ctx_to_filter'
     * Include user_ctx in db open options

    mem3: 252467..c3c542
     * Merge remote branch 'cloudant:79066-port-chunkified-replicate_batch'
     * Chunk missing revisions before attempting to save on target

    couch_epi: f6ad55..60e7f8
     * Merge remote branch 'DeadZen:patch-1'
     * Update README.md

    fabric: 7cfabb..205064
     * Merge remote branch 'cloudant:77984-fixup'
     * Use upgraded #mrargs{} instead of old one
     * Merge remote branch 'cloudant:fix-typespecs'
     * Add `{error, Reason}` to typespecs
     * Merge remote branch 'cloudant:77984-upgrade-mrargs-record-phase2'
     * Revert "Revert "Merge remote-tracking branch 'banjiewen/stale-stable-update'""
     * Upgrade #mrargs{} record
     * Merge remote branch 'cloudant:77984-upgrade-mrargs-record-phase1'
     * Compatibility clause for the record upgrade
     * Revert "Merge remote-tracking branch 'banjiewen/stale-stable-update'"
     * Merge remote-tracking branch 'cloudant/3232-all-docs-ctx' ([COUCHDB-3232](https://issues.apache.org/jira/browse/COUCHDB-3232))
     * Merge branch 'COUCHDB-3234-open-shard-timeout-counter' ([COUCHDB-3234-open-shard-timeout-counter'](https://issues.apache.org/jira/browse/COUCHDB-3234-open-shard-timeout-counter'))
     * Track open_shard timeouts with a counter ([COUCHDB-3234](https://issues.apache.org/jira/browse/COUCHDB-3234))
     * Pass user_ctx down to
     fabric_rpc ([COUCHDB-3232](https://issues.apache.org/jira/browse/COUCHDB-3232))