### PR TITLE
Provides access to check disk usage by calling the df command

### DIFF
--- a/configure
+++ b/configure
@@ -210,10 +210,10 @@ apps:
     couchdb:
         daemon: simple
         command: snap_run
-        plugs: [network-bind, browser-support]
+        plugs: [network-bind, browser-support, mount-observe]
     run:
         command: snap_run
-        plugs: [network-bind, browser-support]
+        plugs: [network-bind, browser-support, mount-observe]
 parts:
     couchdb: 
         plugin: dump


### PR DESCRIPTION
The AppArmor rules provided by the mount-observe interface have been expanded to cover /bin/df