### PR TITLE
Support pass command line arguments to couchdb when it is called by bash script

### DIFF
--- a/rel/overlay/bin/couchdb
+++ b/rel/overlay/bin/couchdb
@@ -28,4 +28,4 @@ export PROGNAME=`echo $0 | sed 's/.*\///'`
 
 exec "$BINDIR/erlexec" -boot "$ROOTDIR/releases/$APP_VSN/couchdb" \
      -args_file "$ROOTDIR/etc/vm.args" \
-     -config "$ROOTDIR/releases/$APP_VSN/sys.config"
+     -config "$ROOTDIR/releases/$APP_VSN/sys.config" "$@"


### PR DESCRIPTION
couchdb accepts command line arguments like -pidfile and -couch_ini, but they are ignored by bin/couchdb, this patch fixes it.