### PR TITLE
Remove PDF, TeX/LaTeX and texinfo from the build chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,13 +219,9 @@ dist: all
 	@cp -r share/www apache-couchdb-$(COUCHDB_VERSION)/share/
 	@mkdir -p apache-couchdb-$(COUCHDB_VERSION)/share/docs/html
 	@cp -r src/docs/build/html apache-couchdb-$(COUCHDB_VERSION)/share/docs/
-	@mkdir -p apache-couchdb-$(COUCHDB_VERSION)/share/docs/pdf
-	@cp src/docs/build/latex/CouchDB.pdf apache-couchdb-$(COUCHDB_VERSION)/share/docs/pdf/
 
 	@mkdir -p apache-couchdb-$(COUCHDB_VERSION)/share/docs/man
 	@cp src/docs/build/man/apachecouchdb.1 apache-couchdb-$(COUCHDB_VERSION)/share/docs/man/
-	@mkdir -p apache-couchdb-$(COUCHDB_VERSION)/share/docs/info
-	@cp src/docs/build/texinfo/CouchDB.info apache-couchdb-$(COUCHDB_VERSION)/share/docs/info/
 
 	@tar czf apache-couchdb-$(COUCHDB_VERSION).tar.gz apache-couchdb-$(COUCHDB_VERSION)
 	@echo "Done: apache-couchdb-$(COUCHDB_VERSION).tar.gz"
@@ -249,15 +245,11 @@ ifeq ($(IN_RELEASE), true)
 	@mkdir -p rel/couchdb/share/www/docs/
 	@mkdir -p rel/couchdb/share/docs/
 	@cp -R share/docs/html/* rel/couchdb/share/www/docs/
-	@cp share/docs/pdf/CouchDB.pdf rel/couchdb/share/docs/CouchDB.pdf
 	@cp share/docs/man/apachecouchdb.1 rel/couchdb/share/docs/couchdb.1
-	@cp share/docs/info/CouchDB.info rel/couchdb/share/docs/CouchDB.info
 else
 	@mkdir -p rel/couchdb/share/docs/
 	@cp -R src/docs/build/html/ rel/couchdb/share/www/docs
-	@cp src/docs/build/latex/CouchDB.pdf rel/couchdb/share/docs/CouchDB.pdf
 	@cp src/docs/build/man/apachecouchdb.1 rel/couchdb/share/docs/couchdb.1
-	@cp src/docs/build/texinfo/CouchDB.info rel/couchdb/share/docs/CouchDB.info
 endif
 endif
 
@@ -331,9 +323,7 @@ uninstall:
 	@rm -rf $(DESTDIR)/$(data_dir)
 	@rm -rf $(DESTDIR)/$(doc_dir)
 	@rm -rf $(DESTDIR)/$(html_dir)
-	@rm -rf $(DESTDIR)/$(pdf_dir)
 	@rm -rf $(DESTDIR)/$(man_dir)
-	@rm -rf $(DESTDIR)/$(info_dir)
 
 .PHONY: rc
 rc:

--- a/Makefile.win
+++ b/Makefile.win
@@ -170,13 +170,9 @@ dist: all
 	@copy -r share\www apache-couchdb-$(COUCHDB_VERSION)\share
 	@mkdir apache-couchdb-$(COUCHDB_VERSION)\share\docs\html
 	@copy -r src\docs\build\html apache-couchdb-$(COUCHDB_VERSION)\share\docs
-	@mkdir apache-couchdb-$(COUCHDB_VERSION)\share\docs\pdf
-	@copy src\docs\build\latex\CouchDB.pdf apache-couchdb-$(COUCHDB_VERSION)\share\docs\pdf
 
 	@mkdir apache-couchdb-$(COUCHDB_VERSION)\share\docs\man
 	@copy src\docs\build\man\apachecouchdb.1 apache-couchdb-$(COUCHDB_VERSION)\share\docs\man
-	@mkdir apache-couchdb-$(COUCHDB_VERSION)\share\docs\info
-	@copy src\docs\build\texinfo\CouchDB.info apache-couchdb-$(COUCHDB_VERSION)\share\docs\info
 
 	@tar czf apache-couchdb-$(COUCHDB_VERSION).tar.gz apache-couchdb-$(COUCHDB_VERSION)
 	@echo "Done: apache-couchdb-$(COUCHDB_VERSION).tar.gz"
@@ -202,11 +198,9 @@ ifeq ($(with_docs), 1)
 ifeq ($(IN_RELEASE), true)
 	@xcopy share\docs\html rel\couchdb\share\www\docs /E /I
 	@copy share\docs\man\apachecouchdb.1 rel\couchdb\share\docs\couchdb.1
-	-@copy share\docs\info\CouchDB.info rel\couchdb\share\docs\CouchDB.info
 else
 	@xcopy src\docs\build\html rel\couchdb\share\www\docs /E /I
 	@copy src\docs\build\man\apachecouchdb.1 rel\couchdb\share\docs\couchdb.1
-	-@copy src\docs\build\texinfo\CouchDB.info rel\couchdb\share\docs\CouchDB.info
 endif
 endif
 
@@ -284,9 +278,7 @@ uninstall:
 	-@rmdir /s/q $(DESTDIR)\$(data_dir)
 	-@rmdir /s/q $(DESTDIR)\$(doc_dir)
 	-@rmdir /s/q $(DESTDIR)\$(html_dir)
-	-@rmdir /s/q $(DESTDIR)\$(pdf_dir)
 	-@rmdir /s/q $(DESTDIR)\$(man_dir)
-	-@rmdir /s/q $(DESTDIR)\$(info_dir)
 
 
 ################################################################################
@@ -307,7 +299,7 @@ config.erl:
 src\docs\build:
 	@echo Building docs...
 ifeq ($(with_docs), 1)
-	@cd src\docs && make.bat html && make.bat texinfo && make.bat man
+	@cd src\docs && make.bat html && make.bat man
 endif
 
 

--- a/README-DEV.rst
+++ b/README-DEV.rst
@@ -15,8 +15,6 @@ Dependencies
 You may need:
 
 * `Sphinx                 <http://sphinx.pocoo.org/>`_
-* `LaTex                  <http://www.latex-project.org/>`_
-* `GNU Texinfo            <http://www.gnu.org/software/texinfo/>`_
 * `GNU help2man           <http://www.gnu.org/software/help2man/>`_
 * `GnuPG                  <http://www.gnupg.org/>`_
 * `md5sum                 <http://www.microbrew.org/tools/md5sha1sum/>`_
@@ -52,18 +50,14 @@ Debian-based (inc. Ubuntu) Systems
 
 ::
 
-    sudo apt-get install help2man python-sphinx \
-        texlive-latex-base texlive-latex-recommended \
-        texlive-latex-extra texlive-fonts-recommended texinfo gnupg \
-        nodejs npm
+    sudo apt-get install help2man python-sphinx gnupg nodejs npm
 
 Gentoo-based Systems
 ~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-    sudo emerge texinfo gnupg coreutils pkgconfig help2man
-    sudo USE=latex emerge sphinx
+    sudo emerge gnupg coreutils pkgconfig help2man sphinx
 
 RedHat-based (Fedora, Centos, RHEL) Systems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,8 +65,7 @@ RedHat-based (Fedora, Centos, RHEL) Systems
 ::
 
     sudo yum install help2man python-sphinx python-docutils \
-        python-pygments texlive-latex texlive-latex-fonts texinfo gnupg \
-        nodejs npm
+        python-pygments gnupg nodejs npm
 
 Mac OS X
 ~~~~~~~~
@@ -96,15 +89,12 @@ Now, install the required Python packages::
     sudo pip install docutils
     sudo pip install pygments
 
-Download `MacTeX <http://www.tug.org/mactex/>`_ and follow the instructions 
-to get a working LaTeX install on your system.
-
 FreeBSD
 ~~~~~~~
 
 ::
 
-    pkg install help2man texinfo gnupg py27-sphinx texlive-full tex-formats node
+    pkg install help2man gnupg py27-sphinx node
 
 Windows
 ~~~~~~~

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,10 +15,10 @@ Vagrant::Config.run do |config|
   if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/default/*/id").empty?
     # install build-essential
     pkg_cmd = "apt-get update -qq; apt-get install -q -y build-essential git " \
-        "autoconf autoconf-archive gnu-standards help2man texinfo; "
+        "autoconf autoconf-archive gnu-standards help2man; "
 
     # Install erlang
-    pkg_cmd << "apt-get install -q -y erlang-base-hipe erlang-dev " \
+    pkg_cmd << "apt-get install -q -y erlang-base erlang-dev " \
         "erlang-manpages erlang-eunit erlang-nox erlang-xmerl erlang-inets; "
 
     # couchdb developper dependencies
@@ -26,7 +26,7 @@ Vagrant::Config.run do |config|
         "curl libcurl4-gnutls-dev libtool; "
 
     # doc dependencies
-    pkg_cmd << "apt-get install -q -y help2man texinfo python-sphinx python-pip; " \
+    pkg_cmd << "apt-get install -q -y help2man python-sphinx python-pip; " \
         "pip install -U pygments; "
 
     config.vm.provision :shell, :inline => pkg_cmd

--- a/build-aux/sphinx-build
+++ b/build-aux/sphinx-build
@@ -25,39 +25,6 @@ WARNING: 'sphinx-build' is needed, and is missing on your system.
 EOF
 fi
 
-if test "$2" = "texinfo"; then
-    if test -z "`which makeinfo`"; then
-        missing=yes
-        cat << EOF
-WARNING: 'makeinfo' is needed, and is missing on your system.
-         You might have modified some files without having the
-         proper tools for further handling them.
-EOF
-    fi
-    if test "$missing" != "yes"; then
-        sphinx-build $*
-    else
-        mkdir -p texinfo
-        echo "info:" > texinfo/Makefile
-    fi
-fi
-
-if test "$2" = "latex"; then
-    if test -z "`which pdflatex`"; then
-        missing=yes
-        cat << EOF
-WARNING: 'pdflatex' is needed, and is missing on your system.
-         You might have modified some files without having the
-         proper tools for further handling them.
-EOF
-    fi
-    if test "$missing" != "yes"; then
-        sphinx-build $*
-    else
-        mkdir -p latex
-        echo "all-pdf:" > latex/Makefile
-    fi
-fi
 if test "$2" = "html"; then
     if test "$missing" != "yes"; then
         sphinx-build $*

--- a/configure.ps1
+++ b/configure.ps1
@@ -29,11 +29,9 @@
   -ViewindexDir DIR         specify the view directory [LOCALSTATEDIR\lib]
   -LogDir DIR               specify the log directory [LOCALSTATEDIR\log]
   -DataDir DIR              read-only architecture-independent data [DATAROOTDIR]
-  -InfoDir DIR              info documentation [DATAROOTDIR\info]
   -ManDir DIR               man documentation [DATAROOTDIR\man]
   -DocDir DIR               documentation root [DATAROOTDIR\doc\apache-couchdb]
   -HTMLDir DIR              html documentation [DOCDIR\html]
-  -PDFDir DIR               pdf documentation [DOCDIR\pdf]
 .LINK
     http://couchdb.apache.org/
 #>
@@ -81,16 +79,12 @@ Param(
     [ValidateNotNullOrEmpty()]
     [string]$DataDir = "$DataRootDir", # read-only arch.-independent data (default $DataRootDir)
     [ValidateNotNullOrEmpty()]
-    [string]$InfoDir = "$DataRootDir\info", # info documentation (default $DataRootDir\info)
-    [ValidateNotNullOrEmpty()]
     [string]$ManDir = "$DataRootDir\man", # man documentation (default $DataRootDir\man)
     [ValidateNotNullOrEmpty()]
 
     [string]$DocDir = "$DataRootDir\doc\apache-couchdb", # man documentation (default $DataRootDir\doc\apache-couchdb)
     [ValidateNotNullOrEmpty()]
     [string]$HTMLDir = "$DocDir\html", # html documentation (default $DocDir\html)
-    [ValidateNotNullOrEmpty()]
-    [string]$PDFDir = "$DocDir\pdf" # pdf documentation (default $DocDir\pdf)
 )
 
 
@@ -103,7 +97,7 @@ Push-Location $rootdir
 # The test script lives in test/build/test-configure.sh
 If ($Test) {
     Write-Output @"
-"$Prefix" "$ExecPrefix" "$BinDir" "$LibExecDir" "$SysConfDir" "$DataRootDir" "$DataDir" "$LocalStateDir" "$RunStateDir" "$DocDir" "$LibDir" "$DatabaseDir" "$ViewIndexDir" "$LogDir" "$ManDir" "$InfoDir" "$HTMLDir" "$PDFDir"
+"$Prefix" "$ExecPrefix" "$BinDir" "$LibExecDir" "$SysConfDir" "$DataRootDir" "$DataDir" "$LocalStateDir" "$RunStateDir" "$DocDir" "$LibDir" "$DatabaseDir" "$ViewIndexDir" "$LogDir" "$ManDir" "$HTMLDir"
 "@
     exit 0
 }
@@ -175,9 +169,7 @@ view_index_dir = $ViewIndexDir
 log_file = $LogFile
 
 html_dir = $HTMLDir
-pdf_dir = $PDFDir
 man_dir = $ManDir
-info_dir = $InfoDir
 
 with_fauxton = $BuildFauxton
 with_docs = $BuildDocs

--- a/test/build/test-configure.sh
+++ b/test/build/test-configure.sh
@@ -52,13 +52,13 @@ fi
 CMD="./configure --test "
 
 test_defaults() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
     RESULT=`$CMD`
     assertEquals "test defaults" "$EXPECT" "$RESULT"
 }
 
 test_prefix() {
-    EXPECT="/opt/local /opt/local /opt/local/bin /opt/local/libexec /opt/local/etc /opt/local/share /opt/local/share /opt/local/var /opt/local/var/run /opt/local/share/doc/apache-couchdb /opt/local/lib /opt/local/var/lib/couchdb /opt/local/var/lib/couchdb /opt/local/var/log /opt/local/share/man /opt/local/share/info /opt/local/share/doc/apache-couchdb/html /opt/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/opt/local /opt/local /opt/local/bin /opt/local/libexec /opt/local/etc /opt/local/share /opt/local/share /opt/local/var /opt/local/var/run /opt/local/share/doc/apache-couchdb /opt/local/lib /opt/local/var/lib/couchdb /opt/local/var/lib/couchdb /opt/local/var/log /opt/local/share/man /opt/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --prefix=/opt/local`
     assertEquals "test prefix" "$EXPECT" "$RESULT"
@@ -79,7 +79,7 @@ test_prefix_error() {
 
 
 test_exec_prefix() {
-    EXPECT="/usr/local /opt/local /opt/local/bin /opt/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /opt/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /opt/local /opt/local/bin /opt/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /opt/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --exec-prefix=/opt/local`
     assertEquals "test exec_prefix" "$EXPECT" "$RESULT"
@@ -89,7 +89,7 @@ test_exec_prefix() {
 }
 
 test_exec_prefix_eval() {
-    EXPECT="/horse/local /horse/local /horse/local/bin /horse/local/libexec /horse/local/etc /horse/local/share /horse/local/share /horse/local/var /horse/local/var/run /horse/local/share/doc/apache-couchdb /horse/local/lib /horse/local/var/lib/couchdb /horse/local/var/lib/couchdb /horse/local/var/log /horse/local/share/man /horse/local/share/info /horse/local/share/doc/apache-couchdb/html /horse/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/horse/local /horse/local /horse/local/bin /horse/local/libexec /horse/local/etc /horse/local/share /horse/local/share /horse/local/var /horse/local/var/run /horse/local/share/doc/apache-couchdb /horse/local/lib /horse/local/var/lib/couchdb /horse/local/var/lib/couchdb /horse/local/var/log /horse/local/share/man /horse/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --prefix=/horse/local --exec-prefix=\\${prefix}`
     assertEquals "test exec_prefix" "$EXPECT" "$RESULT"
@@ -109,7 +109,7 @@ test_exec_prefix_error() {
 }
 
 test_bindir() {
-    EXPECT="/usr/local /usr/local /my/funky/bindir /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /my/funky/bindir /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --bindir=/my/funky/bindir`
     assertEquals "test bindir" "$EXPECT" "$RESULT"
@@ -129,7 +129,7 @@ test_bindir_error() {
 }
 
 test_libexecdir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /opt/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /opt/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --libexecdir=/opt/local/libexec`
     assertEquals "test libexecdir" "$EXPECT" "$RESULT"
@@ -149,7 +149,7 @@ test_libexecdir_error() {
 }
 
 test_sysconfdir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /opt/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /opt/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --sysconfdir=/opt/local/etc`
     assertEquals "test sysconfdir" "$EXPECT" "$RESULT"
@@ -169,7 +169,7 @@ test_sysconfdir_error() {
 }
 
 test_datarootdir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /opt/local/share /opt/local/share /usr/local/var /usr/local/var/run /opt/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /opt/local/share/man /opt/local/share/info /opt/local/share/doc/apache-couchdb/html /opt/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /opt/local/share /opt/local/share /usr/local/var /usr/local/var/run /opt/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /opt/local/share/man /opt/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --datarootdir=/opt/local/share`
     assertEquals "test datarootdir" "$EXPECT" "$RESULT"
@@ -189,7 +189,7 @@ test_datarootdir_error() {
 }
 
 test_localstatedir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /horse/local/var /horse/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /horse/local/var/lib/couchdb /horse/local/var/lib/couchdb /horse/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /horse/local/var /horse/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /horse/local/var/lib/couchdb /horse/local/var/lib/couchdb /horse/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --localstatedir=/horse/local/var`
     assertEquals "test localstatedir" "$EXPECT" "$RESULT"
@@ -209,7 +209,7 @@ test_localstatedir_error() {
 }
 
 test_runstatedir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /horse/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /horse/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --runstatedir=/horse/local/var/run`
     assertEquals "test runstatedir" "$EXPECT" "$RESULT"
@@ -229,7 +229,7 @@ test_runstatedir_error() {
 }
 
 test_docdir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /horse/local/share/doc /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /horse/local/share/doc/html /horse/local/share/doc/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /horse/local/share/doc /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /horse/local/share/doc/html"
 
     RESULT=`$CMD --docdir=/horse/local/share/doc`
     assertEquals "test docdir" "$EXPECT" "$RESULT"
@@ -249,7 +249,7 @@ test_docdir_error() {
 }
 
 test_libdir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /horse/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /horse/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --libdir=/horse/local/lib`
     assertEquals "test libdir" "$EXPECT" "$RESULT"
@@ -269,7 +269,7 @@ test_libdir_error() {
 }
 
 test_database_dir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /horse/local/var/lib /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /horse/local/var/lib /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --databasedir=/horse/local/var/lib`
     assertEquals "test databasedir" "$EXPECT" "$RESULT"
@@ -289,7 +289,7 @@ test_database_dir_error() {
 }
 
 test_view_dir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /horse/local/var/lib /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /horse/local/var/lib /usr/local/var/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --viewindexdir=/horse/local/var/lib`
     assertEquals "test viewindexdir" "$EXPECT" "$RESULT"
@@ -309,7 +309,7 @@ test_view_dir_error() {
 }
 
 test_logdir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /horse/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /horse/log /usr/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --logdir=/horse/log`
     assertEquals "test logdir" "$EXPECT" "$RESULT"
@@ -329,7 +329,7 @@ test_logdir_error() {
 }
 
 test_mandir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /horse/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /horse/local/share/man /usr/local/share/doc/apache-couchdb/html"
 
     RESULT=`$CMD --mandir=/horse/local/share/man`
     assertEquals "test mandir" "$EXPECT" "$RESULT"
@@ -348,28 +348,8 @@ test_mandir_error() {
     assertEquals "test mandir error" "$EXPECT" "$RESULT"
 }
 
-test_infodir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /horse/local/share/info /usr/local/share/doc/apache-couchdb/html /usr/local/share/doc/apache-couchdb/pdf"
-
-    RESULT=`$CMD --infodir=/horse/local/share/info`
-    assertEquals "test infodir" "$EXPECT" "$RESULT"
-
-    RESULT=`$CMD --infodir /horse/local/share/info`
-    assertEquals "test infodir" "$EXPECT" "$RESULT"
-}
-
-test_infodir_error() {
-    EXPECT='ERROR: "--infodir" requires a non-empty argument.'
-
-    RESULT=`$CMD --infodir= 2>&1`
-    assertEquals "test infodir error" "$EXPECT" "$RESULT"
-
-    RESULT=`$CMD --infodir 2>&1`
-    assertEquals "test infodir error" "$EXPECT" "$RESULT"
-}
-
 test_htmldir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /horse/local/share/doc/html /usr/local/share/doc/apache-couchdb/pdf"
+    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /horse/local/share/doc/html"
 
     RESULT=`$CMD --htmldir=/horse/local/share/doc/html`
     assertEquals "test htmldir" "$EXPECT" "$RESULT"
@@ -386,26 +366,6 @@ test_htmldir_error() {
 
     RESULT=`$CMD --htmldir 2>&1`
     assertEquals "test htmldir error" "$EXPECT" "$RESULT"
-}
-
-test_pdfdir() {
-    EXPECT="/usr/local /usr/local /usr/local/bin /usr/local/libexec /usr/local/etc /usr/local/share /usr/local/share /usr/local/var /usr/local/var/run /usr/local/share/doc/apache-couchdb /usr/local/lib /usr/local/var/lib/couchdb /usr/local/var/lib/couchdb /usr/local/var/log /usr/local/share/man /usr/local/share/info /usr/local/share/doc/apache-couchdb/html /horse/local/share/doc/pdf"
-
-    RESULT=`$CMD --pdfdir=/horse/local/share/doc/pdf`
-    assertEquals "test pdfdir" "$EXPECT" "$RESULT"
-
-    RESULT=`$CMD --pdfdir /horse/local/share/doc/pdf`
-    assertEquals "test pdfdir" "$EXPECT" "$RESULT"
-}
-
-test_pdfdir_error() {
-    EXPECT='ERROR: "--pdfdir" requires a non-empty argument.'
-
-    RESULT=`$CMD --pdfdir= 2>&1`
-    assertEquals "test pdfdir error" "$EXPECT" "$RESULT"
-
-    RESULT=`$CMD --pdfdir 2>&1`
-    assertEquals "test pdfdir error" "$EXPECT" "$RESULT"
 }
 
 # source the shunit2


### PR DESCRIPTION
As discussed on the mailing list, this removes the PDF and info
builds from the default build.

Depends upon / relates to apache/couchdb-documentation#116 being merged.

Fixes COUCHDB-3329