### PR TITLE
Change snap packaging to build from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ config.erl
 install.mk
 rel/*.config
 rel/dev*
-rel/snap*
 rel/tmpdata
 src/
 /log

--- a/Makefile
+++ b/Makefile
@@ -203,8 +203,8 @@ introspect:
 
 .PHONY: snap
 # target: snap - Build Snap package
-snap: release
-	@cd rel/; snapcraft snap --output ../couchdb_$(COUCHDB_VERSION)_amd64.snap
+snap: 
+	@snapcraft snap
 
 ################################################################################
 # Distributing

--- a/configure
+++ b/configure
@@ -25,7 +25,6 @@ PACKAGE_AUTHOR_NAME="The Apache Software Foundation"
 WITH_CURL="false"
 WITH_FAUXTON=1
 WITH_DOCS=1
-WITH_SNAP=1
 SKIP_DEPS=0
 
 COUCHDB_USER=`whoami`
@@ -47,7 +46,6 @@ Options:
   -c | --with-curl            request that couchjs is linked to cURL (default false)
   --disable-fauxton           do not build Fauxton
   --disable-docs              do not build any documentation or manpages
-  --disable-snap              do not build snap package config
   --skip-deps                 do not update erlang dependencies
   --rebar=PATH                use rebar by specified path (version >=2.6.0 && <3.0 required)
 EOF
@@ -75,12 +73,6 @@ parse_opts() {
 
             --disable-docs)
                 WITH_DOCS=0
-                shift
-                continue
-                ;;
-
-            --disable-snap)
-                WITH_SNAP=0
                 shift
                 continue
                 ;;
@@ -195,86 +187,6 @@ EOF
 cat > $rootdir/config.erl << EOF
 {with_curl, $WITH_CURL}.
 EOF
- 
-if [ "${WITH_SNAP}" -eq "1" ]; then
-echo "==> configuring snapcraft config"
-cat > rel/snapcraft.yaml << EOF
-name: couchdb
-version: $COUCHDB_VERSION
-summary: Document based database
-description: CouchDB is a database that completely embraces the web. Store your data with JSON documents. Access your documents and query your indexes with your web browser, via HTTP. Index, combine, and transform your documents with JavaScript. 
-confinement: strict
-grade: stable
-
-apps:
-    couchdb:
-        daemon: simple
-        command: snap_run
-        plugs: [network-bind, browser-support, mount-observe]
-    run:
-        command: snap_run
-        plugs: [network-bind, browser-support, mount-observe]
-parts:
-    couchdb: 
-        plugin: dump
-        source: .
-        organize:
-            snap.ini: couchdb/etc/snap.ini
-            snap_run: bin/snap_run
-        stage:
-            - couchdb
-            - bin
-        snap:
-            - couchdb
-            - bin
-    erlang:
-        plugin: nil
-        stage-packages:
-            - erlang-base-hipe
-            - erlang-crypto
-            - erlang-eunit
-            - erlang-inets
-            - erlang-os-mon
-            - erlang-public-key
-            - erlang-ssl
-            - erlang-syntax-tools
-            - erlang-tools
-            - erlang-xmerl
-            - libc6
-            - libcurl3
-            - libgcc1
-            - libicu55
-            - libmozjs185-1.0
-            - libstdc++6
-EOF
-
-cat > rel/snap.ini << EOF
-; Snap-specific Configuration Settings
-
-[couchdb]
-database_dir = /var/snap/couchdb/common/data
-view_index_dir = /var/snap/couchdb/common/data
-
-[log]
-writer = file
-file = /var/snap/couchdb/current/couchdb.log
-;level = info
-EOF
-
-cat > rel/snap_run << EOF
-#!/bin/sh
-
-export HOME=$SNAP_DATA
-export ERL_FLAGS="-couch_ini \${SNAP}/couchdb/etc/default.ini \${SNAP}/couchdb/etc/snap.ini \${SNAP_DATA}/local.ini"
-if [ ! -e \${SNAP_DATA}/local.ini ]; then
-    touch \${SNAP_DATA}/local.ini
-fi
-
-exec \${SNAP}/couchdb/bin/couchdb
-EOF
-chmod +x rel/snap_run
-fi
-
 
 install_local_rebar() {
     if [ ! -x "${rootdir}/bin/rebar" ]; then

--- a/snapcfg/snap.ini
+++ b/snapcfg/snap.ini
@@ -1,0 +1,10 @@
+; Snap-specific Configuration Settings
+
+[couchdb]
+database_dir = /var/snap/couchdb/common/data
+view_index_dir = /var/snap/couchdb/common/data
+
+[log]
+writer = file
+file = /var/snap/couchdb/current/couchdb.log
+;level = info

--- a/snapcfg/snap_run
+++ b/snapcfg/snap_run
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export HOME=$SNAP_DATA
+export ERL_FLAGS="-couch_ini ${SNAP}/rel/couchdb/etc/default.ini ${SNAP}/rel/couchdb/etc/snap.ini ${SNAP_DATA}/local.ini"
+if [ ! -e ${SNAP_DATA}/local.ini ]; then
+    touch ${SNAP_DATA}/local.ini
+fi
+
+exec ${SNAP}/rel/couchdb/bin/couchdb

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,81 @@
+name: couchdb
+version: 2.0
+summary: Document based database
+description: CouchDB is a database that completely embraces the web. Store your data with JSON documents. Access your documents and query your indexes with your web browser, via HTTP. Index, combine, and transform your documents with JavaScript. 
+confinement: strict
+grade: stable
+
+apps:
+    server:
+        daemon: simple
+        command: rel/couchdb/bin/snap_run
+        plugs: [network-bind, process-control, mount-observe]
+    couchdb:
+        command: rel/couchdb/bin/snap_run
+        plugs: [network-bind]
+parts:
+    couchdb: 
+        plugin: make
+        source: .
+        prepare: |
+          ./configure --disable-docs
+        build: |
+          make release
+          cp -ra ./rel $SNAPCRAFT_PART_INSTALL
+          cp -ra ./bin $SNAPCRAFT_PART_INSTALL
+        build-packages:
+          - binutils
+          - libc6-dev
+          - gcc
+          - g++
+          - make
+          - erlang-dev
+          - erlang-base-hipe
+          - erlang-reltool
+          - libcurl4-openssl-dev
+          - libmozjs185-dev
+          - libnspr4-dev
+          - libicu-dev
+          - icu-devtools
+          # For erlang/rebar processing
+          - erlang-nox
+          - erlang-os-mon
+          - erlang-syntax-tools
+          # For fauxton
+          - nodejs-dev
+          - nodejs-legacy
+          - npm
+        stage:
+            - rel
+            - bin
+        prime:
+            - rel
+            - bin
+
+    snap-config:
+        plugin: dump
+        source: ./snapcfg/
+        organize:
+            snap.ini: rel/couchdb/etc/snap.ini
+            snap_run: rel/couchdb/bin/snap_run
+
+    erlang:
+        plugin: nil
+        stage-packages:
+            - erlang-base-hipe
+            - erlang-crypto
+            - erlang-eunit
+            - erlang-inets
+            - erlang-os-mon
+            - erlang-public-key
+            - erlang-ssl
+            - erlang-syntax-tools
+            - erlang-tools
+            - erlang-xmerl
+            - libc6
+            - libcurl3
+            - libgcc1
+            - libicu55
+            - libmozjs185-1.0
+            - libstdc++6
+        


### PR DESCRIPTION
<!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

Rather than creating a snap package from pre-build binaries, this allows building the snap package directly from source. Makes it possible to use external build automation such as build.snapcraft.io 

## Testing recommendations

On any Ubuntu 16.04 or newer system, apt install "snapcraft" and then run "snapcraft snap" or "make snap". The resulting .snap file can be installed with "snap install --dangerous *.snap"
