### PR TITLE
Choose index based on fields match

### DIFF
--- a/src/mango/src/mango_cursor_special.erl
+++ b/src/mango/src/mango_cursor_special.erl
@@ -33,7 +33,7 @@ create(Db, Indexes, Selector, Opts) ->
     CatchAll = [{<<"_id">>, {'$gt', null, '$lt', mango_json_max}}],
     FieldRanges = lists:append(CatchAll, InitialRange),
     Composited = mango_cursor_view:composite_indexes(Indexes, FieldRanges),
-    {Index, IndexRanges} = mango_cursor_view:choose_best_index(Db, Composited),
+    {Index, IndexRanges, _Score} = mango_cursor_view:choose_best_index(Db, Composited),
 
     Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
     Skip = couch_util:get_value(skip, Opts, 0),

--- a/src/mango/src/mango_cursor_special.erl
+++ b/src/mango/src/mango_cursor_special.erl
@@ -33,7 +33,7 @@ create(Db, Indexes, Selector, Opts) ->
     CatchAll = [{<<"_id">>, {'$gt', null, '$lt', mango_json_max}}],
     FieldRanges = lists:append(CatchAll, InitialRange),
     Composited = mango_cursor_view:composite_indexes(Indexes, FieldRanges),
-    {Index, IndexRanges, _Score} = mango_cursor_view:choose_best_index(Db, Composited),
+    {Index, IndexRanges} = mango_cursor_view:choose_best_index(Db, Composited),
 
     Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
     Skip = couch_util:get_value(skip, Opts, 0),

--- a/src/mango/test/12-use-correct-index.py
+++ b/src/mango/test/12-use-correct-index.py
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import mango
+import unittest
+
+DOCS = [
+    {
+        "_id": "_design/my-design-doc",
+    },
+    {
+        "_id": "54af50626de419f5109c962f",
+        "user_id": 0,
+        "age": 10,
+        "name": "Jimi",
+        "location": "UK"
+    },
+    {
+        "_id": "54af50622071121b25402dc3",
+        "user_id": 1,
+        "age": 12,
+        "name": "Eddie",
+        "location": "ZAR"
+    },
+    {
+        "_id": "54af50622071121b25402dc6",
+        "user_id": 1,
+        "age": 6,
+        "name": "Harry",
+        "location": "US"
+    },
+    {
+        "_id": "54af50622071121b25402dc9",
+        "name": "Eddie"
+    },
+]
+
+class ChooseCorrectIndexForDocs(mango.DbPerClass):
+    def test_choose_index_with_one_field_in_index(self):
+        self.db.save_docs(DOCS)
+        self.db.create_index(["name", "age", "user_id"], ddoc="aaa")
+        self.db.create_index(["name"], ddoc="zzz")
+        explain = self.db.find({"name": "Eddie"}, explain=True)
+        assert explain["index"]["ddoc"] == '_design/zzz'
+
+    def test_choose_index_with_two(self):
+        self.db.save_docs(DOCS)
+        self.db.create_index(["name", "age", "user_id"], ddoc="aaa")
+        self.db.create_index(["name", "age"], ddoc="bbb")
+        self.db.create_index(["name"], ddoc="zzz")
+        explain = self.db.find({"name": "Eddie", "age":{"$gte": 12}}, explain=True)
+        assert explain["index"]["ddoc"] == '_design/bbb'
+
+    def test_choose_index_alphabetically(self):
+        self.db.save_docs(DOCS)
+        self.db.create_index(["name", "age", "user_id"], ddoc="aaa")
+        self.db.create_index(["name", "age", "location"], ddoc="bbb")
+        self.db.create_index(["name"], ddoc="zzz")
+        explain = self.db.find({"name": "Eddie", "age": {"$gt": 12}}, explain=True)
+        assert explain["index"]["ddoc"] == '_design/aaa'


### PR DESCRIPTION
## Overview

If two indexes can be used, then instead of choosing the index based on
alphabet order of index names, rather choose based on a score. This
score is calculated by determining which index has the least number of
fields

## Testing recommendations

There is a test that proves the issue and passes based on this fix.

## JIRA issue number

https://issues.apache.org/jira/browse/COUCHDB-3357

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [x] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
