### PR TITLE
Use efficient set storage for field names

### DIFF
--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -175,7 +175,7 @@ get_text_entries0(IdxProps, Doc) ->
     Fields = if not DefaultEnabled -> Fields0; true ->
         add_default_text_field(Fields0)
     end,
-    FieldNames = get_field_names(Fields, []),
+    FieldNames = get_field_names(Fields),
     Converted = convert_text_fields(Fields),
     FieldNames ++ Converted.
 
@@ -257,15 +257,11 @@ add_default_text_field([_ | Rest], Acc) ->
 
 
 %% index of all field names
-get_field_names([], FAcc) ->
-    FAcc;
-get_field_names([{Name, _Type, _Value} | Rest], FAcc) ->
-    case lists:member([<<"$fieldnames">>, Name, []], FAcc) of
-        true ->
-            get_field_names(Rest, FAcc);
-        false ->
-            get_field_names(Rest, [[<<"$fieldnames">>, Name, []] | FAcc])
-    end.
+get_field_names(Fields) ->
+    FieldNameSet = lists:foldl(fun({Name, _, _}, Set) ->
+        gb_sets:add([<<"$fieldnames">>, Name, []], Set)
+    end, gb_sets:new(), Fields),
+    gb_sets:to_list(FieldNameSet).
 
 
 convert_text_fields([]) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview
When indexing a set of fields for text search, we also create a special
field called $fieldnames. It contains values for all the fields that
need to be indexed. In order to do that, we need a unique list of the
form [[<<"$fieldnames">>, Name, []] | Rest]. The old code would add an
element to the list, and then check for membership via lists:member/2.
This is inefficient. Some documents can contain a large number of
fields, so we will use gb_sets to create a unique set of fields, and
then extract out the field names.

An alternative is to just use lists:usort/1. For small sets, it would be more efficient,
but if a document is large enough thousands of fields, gb_sets seems to perform
more. The tradeoff is that while gb_set could take longer overall for indexing,
it could reduce the probability of timing out when datasets are extremely large.

## Testing recommendations
There are no usability changes for the user as this is a performance enhancement. A full regression should be sufficient. It requires https://github.com/cloudant-labs/dreyfus to be installed.
 
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users 
     could notice? -->

## JIRA issue number
COUCHDB-3358
<!-- If this is a significant change, please file a JIRA issue at:
     https://issues.apache.org/jira/browse/COUCHDB
     and include the number here and in commit message(s)  -->

## Related Pull Requests

<!-- If your changes affects on multiple components in different 
     repositories please list here links to those pull requests.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
