### PR TITLE
3364 fix view compactor unknown info

### DIFF
--- a/src/couch_index/src/couch_index_compactor.erl
+++ b/src/couch_index/src/couch_index_compactor.erl
@@ -15,7 +15,7 @@
 
 
 %% API
--export([start_link/2, run/2, cancel/1, is_running/1]).
+-export([start_link/2, run/2, cancel/1, is_running/1, get_compacting_pid/1]).
 
 %% gen_server callbacks
 -export([init/1, terminate/2, code_change/3]).
@@ -47,6 +47,8 @@ cancel(Pid) ->
 is_running(Pid) ->
     gen_server:call(Pid, is_running).
 
+get_compacting_pid(Pid) ->
+    gen_server:call(Pid, get_compacting_pid).
 
 init({Index, Module}) ->
     process_flag(trap_exit, true),
@@ -69,6 +71,8 @@ handle_call(cancel, _From, #st{pid=Pid}=State) ->
     unlink(Pid),
     exit(Pid, kill),
     {reply, ok, State#st{pid=undefined}};
+handle_call(get_compacting_pid, _From, #st{pid=Pid}=State) ->
+    {reply, {ok, Pid}, State};
 handle_call(is_running, _From, #st{pid=Pid}=State) when is_pid(Pid) ->
     {reply, true, State};
 handle_call(is_running, _From, State) ->

--- a/src/couch_mrview/src/couch_mrview_compactor.erl
+++ b/src/couch_mrview/src/couch_mrview_compactor.erl
@@ -15,7 +15,7 @@
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch_mrview/include/couch_mrview.hrl").
 
--export([compact/3, swap_compacted/2]).
+-export([compact/3, swap_compacted/2, remove_compacted/1]).
 
 -record(acc, {
    btree = nil,
@@ -292,6 +292,13 @@ swap_compacted(OldState, NewState) ->
     erlang:demonitor(OldState#mrst.fd_monitor, [flush]),
     
     {ok, NewState#mrst{fd_monitor=Ref}}.
+
+
+remove_compacted(#mrst{sig = Sig, db_name = DbName} = State) ->
+    RootDir = couch_index_util:root_dir(),
+    CompactFName = couch_mrview_util:compaction_file(DbName, Sig),
+    ok = couch_file:delete(RootDir, CompactFName),
+    {ok, State}.
 
 
 -ifdef(TEST).

--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -16,7 +16,7 @@
 -export([get/2]).
 -export([init/2, open/2, close/1, reset/1, delete/1]).
 -export([start_update/3, purge/4, process_doc/3, finish_update/1, commit/1]).
--export([compact/3, swap_compacted/2]).
+-export([compact/3, swap_compacted/2, remove_compacted/1]).
 -export([index_file_exists/1]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -182,6 +182,10 @@ compact(Db, State, Opts) ->
 
 swap_compacted(OldState, NewState) ->
     couch_mrview_compactor:swap_compacted(OldState, NewState).
+
+
+remove_compacted(State) ->
+    couch_mrview_compactor:remove_compacted(State).
 
 
 index_file_exists(State) ->

--- a/src/couch_mrview/test/couch_mrview_compact_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_compact_tests.erl
@@ -20,9 +20,11 @@
 
 setup() ->
     {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), map, 1000),
+    ok = meck:new(couch_mrview_compactor, [passthrough]),
     Db.
 
 teardown(Db) ->
+    meck:unload(),
     couch_db:close(Db),
     couch_server:delete(Db#db.name, [?ADMIN_CTX]),
     ok.
@@ -75,28 +77,25 @@ should_swap(Db) ->
 should_remove(Db) ->
     ?_test(begin
         DDoc = <<"_design/bar">>,
-        couch_mrview:query_view(Db, DDoc, <<"baz">>),
-        {ok, Pid} = couch_index_server:get_index(couch_mrview_index, Db, DDoc),
-        ok = couch_index:compact(Pid, []),
-        {ok, CPid} = couch_index:get_compactor_pid(Pid),
-        Info = recon:info(CPid),
-        Ancs = couch_util:get_value('$ancestors',
-            couch_util:get_value(dictionary,
-                couch_util:get_value(meta, Info))),
-        Links = couch_util:get_value(links,
-            couch_util:get_value(signals, Info)),
-        [CompactionPid] = Links -- Ancs,
-        MonRef = erlang:monitor(process, CompactionPid),
-        exit(CompactionPid, crash),
+        {ok, _Results} = couch_mrview:query_view(Db, DDoc, <<"baz">>),
+        {ok, IndexPid} = couch_index_server:get_index(couch_mrview_index, Db, DDoc),
+        ok = couch_index:compact(IndexPid, []),
+        {ok, CompactorPid} = couch_index:get_compactor_pid(IndexPid),
+        {ok, CompactingPid} = couch_index_compactor:get_compacting_pid(CompactorPid),
+        MonRef = erlang:monitor(process, CompactingPid),
+        exit(CompactingPid, crash),
         receive
             {'DOWN', MonRef, process, _, crash} ->
-                ?assert(is_process_alive(Pid)),
-                ?assert(is_process_alive(CPid))
+                meck:wait(couch_mrview_compactor, remove_compacted, '_', 100),
+                ?assertEqual(1, meck:num_calls(
+                    couch_mrview_compactor, remove_compacted, '_', IndexPid)),
+                ?assert(is_process_alive(IndexPid)),
+                ?assert(is_process_alive(CompactorPid))
         after ?TIMEOUT ->
             erlang:error(
-                {assertion_failed,
-                 [{module, ?MODULE}, {line, ?LINE},
-                  {reason, "compaction didn't failed :/"}]})
+                {assertion_failed, [
+                    {module, ?MODULE}, {line, ?LINE},
+                    {reason, "compaction didn't exit :/"}]})
         end
     end).
 


### PR DESCRIPTION
<!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

`couch_index` traps exits, but might get an EXIT message from a crashing mrview_compactor, while it only expects message from its own linked compact process.

This adds a new EXIT info handler to `couch_index_compactor` to prevent the compactor from crashing when a compacting process fails, and also cleans up the view compact file.

## Testing recommendations

We have implemented a new couch_mrview_compact_test `should_remove` which verifies that a crash in the view compacting process doesn't also cause the index or compactor processes to crash. It also ensures `couch_mrview_compactor:remove_compacted/1` is called.

## COUCHDB-3364

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
- [x] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
