### PR TITLE
Fix mango full text detection

### DIFF
--- a/src/mango/rebar.config.script
+++ b/src/mango/rebar.config.script
@@ -10,18 +10,15 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
-DreyfusAppFile  = filename:join(filename:dirname(SCRIPT),
-    "../dreyfus/src/dreyfus.app.src"),
-RenameFile = filename:join(filename:dirname(SCRIPT),
-    "src/mango_cursor_text.erl"),
-CursorFile = filename:join(filename:dirname(SCRIPT),
-    "src/mango_cursor_text.erl.nocompile"),
 
-case filelib:is_regular(DreyfusAppFile) of
-    true ->
-        file:rename(CursorFile, RenameFile);
-    false ->
-        ok
-end,
+HaveDreyfus = code:lib_dir(dreyfus) /= {error, bad_name}.
 
-CONFIG.
+if not HaveDreyfus -> CONFIG; true ->
+    CurrOpts = case lists:keyfind(erl_opts, 1, CONFIG) of
+        {erl_opts, Opts} -> Opts;
+        false -> []
+    end,
+    NewOpts = [{d, 'HAVE_DREYFUS'} | CurrOpts],
+    lists:keystore(erl_opts, 1, CONFIG, {erl_opts, NewOpts})
+end.
+

--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -26,6 +26,19 @@
 -include("mango_cursor.hrl").
 
 
+-ifdef(HAVE_DREYFUS).
+-define(CURSOR_MODULES, [
+    mango_cursor_view,
+    mango_cursor_text,
+    mango_cursor_special
+]).
+-else.
+-define(CURSOR_MODULES, [
+    mango_cursor_view,
+    mango_cursor_special
+]).
+-endif.
+
 -define(SUPERVISOR, mango_cursor_sup).
 
 
@@ -113,12 +126,6 @@ group_indexes_by_type(Indexes) ->
     % used to service this query. This is so that we
     % don't suddenly switch indexes for existing client
     % queries.
-    CursorModules = case module_loaded(dreyfus_index) of
-        true ->
-            [mango_cursor_view, mango_cursor_text, mango_cursor_special];
-        false ->
-            [mango_cursor_view, mango_cursor_special]
-    end,
     lists:flatmap(fun(CMod) ->
         case dict:find(CMod, IdxDict) of
             {ok, CModIndexes} ->
@@ -126,4 +133,4 @@ group_indexes_by_type(Indexes) ->
             error ->
                 []
         end
-    end, CursorModules).
+    end, ?CURSOR_MODULES).

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -12,6 +12,8 @@
 
 -module(mango_cursor_text).
 
+-ifdef(HAVE_DREYFUS).
+
 -export([
     create/4,
     explain/1,
@@ -304,3 +306,5 @@ get_json_docs(DbName, Hits) ->
                 {Sort, not_found}
         end
     end, Hits).
+
+-endif.


### PR DESCRIPTION
The check for whether full text support in mango is available was broken
in that the mango_cursor_text module is only compiled if dreyfus exists
while the check to use the module was a runtime check. Thus is a user
were to add dreyfus after mango had been compiled it would have led to a
runtime error when we attempted to use a module that didn't exist.

This changes the check to a compile time check in both places. And now
that its a compile time define we can remove the need to rename source
files around which causes problems with source control seeing that file
change depending on local configuration.

COUCHDB-3378
