### PR TITLE
Fix mem3_sync_event_listener unit test

### DIFF
--- a/src/mem3/src/mem3_sync_event_listener.erl
+++ b/src/mem3/src/mem3_sync_event_listener.erl
@@ -223,7 +223,7 @@ setup() ->
 
     ok = meck:new(config_notifier, [passthrough]),
     ok = meck:expect(config_notifier, handle_event, [
-        {[{'_', '_', "error", '_'}, '_'], meck:raise(throw, raised_error)},
+        {[{'_', '_', '_', "error", '_'}, '_'], meck:raise(throw, raised_error)},
         {['_', '_'], meck:passthrough()}
     ]),
 


### PR DESCRIPTION
The `should_restart_listener` test was failing because the pattern
supplied to meck was wrong. The argument to
`config_notifier:handle_event/2` is of the pattern `{config_change,
Section, Key, Value, Persist}` but the test was only matching a
four-tuple which I assume was missing the `config_change` atom in the
argument.

COUCHDB-3380
