### PR TITLE
Avoid creation of document if deleting attachment on non-existent doc

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1236,6 +1236,10 @@ db_attachment_req(#httpd{method=Method, user_ctx=Ctx}=Req, Db, DocId, FileNamePa
 
     Doc = case extract_header_rev(Req, chttpd:qs_value(Req, "rev")) of
         missing_rev -> % make the new doc
+            if Method =/= 'DELETE' -> ok; true ->
+                % check for the existence of the doc to handle the 404 case.
+                couch_doc_open(Db, DocId, nil, [])
+            end,
             couch_doc:validate_docid(DocId),
             #doc{id=DocId};
         Rev ->

--- a/src/couch/src/couch_httpd_db.erl
+++ b/src/couch/src/couch_httpd_db.erl
@@ -1013,6 +1013,10 @@ db_attachment_req(#httpd{method=Method,mochi_req=MochiReq}=Req, Db, DocId, FileN
 
     Doc = case extract_header_rev(Req, couch_httpd:qs_value(Req, "rev")) of
         missing_rev -> % make the new doc
+            if Method =/= 'DELETE' -> ok; true ->
+                % check for the existence of the doc to handle the 404 case.
+                couch_doc_open(Db, DocId, nil, [])
+            end,
             couch_doc:validate_docid(DocId),
             #doc{id=DocId};
         Rev ->


### PR DESCRIPTION
 <!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Prior to the change in this PR, one new document was unexpectedly created after a request is issued to delete attachment on non-existent document. This PR is aimed to address this to return 404 (Not Found) instead of creating new document. 

## Testing recommendations
The newly introduced test case `should_return_404_for_delete_att_on_notadoc` covers the steps to test the change in this PR. In addition, two additional test cases `should_return_409_for_del_att_without_rev` and `should_return_200_for_del_att_with_rev` are introduced to make sure that there is no regression.
```
======================== EUnit ========================
chttpd db tests
  chttpd_db_test:71: should_return_ok_true_on_bulk_update...[0.107 s] ok
  chttpd_db_test:86: should_accept_live_as_an_alias_for_continuous...[0.054 s] ok
  chttpd_db_test:107: should_return_404_for_delete_att_on_notadoc...[0.005 s] ok
  chttpd_db_test:129: should_return_409_for_del_att_without_rev...[0.052 s] ok
  chttpd_db_test:155: should_return_200_for_del_att_with_rev...[0.078 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 1.563 s]
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users 
     could notice? -->

## JIRA issue number
COUCHDB-3362
<!-- If this is a significant change, please file a JIRA issue at:
     https://issues.apache.org/jira/browse/COUCHDB
     and include the number here and in commit message(s)  -->

## Related Pull Requests
N/A
<!-- If your changes affects on multiple components in different 
     repositories please list here links to those pull requests.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [] Documentation reflects the changes;
- [X] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.

No documentation change since the changed behavior is aligned with statement in document http://docs.couchdb.org/en/2.0.0/api/document/attachments.html#delete--db-docid-attname
