### PR TITLE
Document that Fauxton requires npm

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -64,7 +64,7 @@ You can install the dependencies by running:
 
     sudo apt-get --no-install-recommends -y install \
         build-essential pkg-config erlang erlang-reltool \
-        libicu-dev libmozjs185-dev libcurl4-openssl-dev
+        libicu-dev libmozjs185-dev libcurl4-openssl-dev npm
 
 Be sure to update the version numbers to match your system's available
 packages.


### PR DESCRIPTION
Fixes this build failure on Ubuntu 16.04:

```
$ make release
[snip...]
==> couchdb (compile)
Building Fauxton
/bin/sh: npm: command not found
Makefile:366: recipe for target 'share/www' failed
make: *** [share/www] Error 127
```