### PR TITLE
Re-enable attachment replication tests

### DIFF
--- a/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
+++ b/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
@@ -57,11 +57,8 @@ reduce_max_request_size_test_() ->
              || Pair <- Pairs]
             ++ [{Pair, fun should_replicate_one/2}
              || Pair <- Pairs]
-            % Test below fails currently because of:
-            %  https://issues.apache.org/jira/browse/COUCHDB-3174
-            % Once that is fixed, can re-enable it
-            % ++ [{Pair, fun should_replicate_one_with_attachment/2}
-            %  || Pair <- Pairs]
+            ++ [{Pair, fun should_replicate_one_with_attachment/2}
+             || Pair <- Pairs]
         }
     }.
 


### PR DESCRIPTION

<!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

These tests were disabled because they weren't passing, but the underlying issue has since been fixed. 

This commit re-enables the tests.

## COUCHDB-3174

<!-- If this is a significant change, please file a JIRA issue at:
     https://issues.apache.org/jira/browse/COUCHDB
     and include the number here and in commit message(s)  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
- [x] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
