### PR TITLE
Revert add sys dbs to lru

### DIFF
--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -61,7 +61,12 @@ init({DbName, Filepath, Fd, Options}) ->
         end
     end,
     Db = init_db(DbName, Filepath, Fd, Header, Options),
-    couch_stats_process_tracker:track([couchdb, open_databases]),
+    case lists:member(sys_db, Options) of
+        false ->
+            couch_stats_process_tracker:track([couchdb, open_databases]);
+        true ->
+            ok
+    end,
     % we don't load validation funs here because the fabric query is liable to
     % race conditions.  Instead see couch_db:validate_doc_update, which loads
     % them lazily

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -359,7 +359,7 @@ handle_call({open_result, _T0, DbName, Error}, {FromPid, _Tag}, Server) ->
         [] ->
             % db was deleted during async open
             {reply, ok, Server};
-        [#db{fd=ReqType, compactor_pid=Froms}] ->
+        [#db{fd=ReqType, compactor_pid=Froms}=Db] ->
             [gen_server:reply(From, Error) || From <- Froms],
             couch_log:info("open_result error ~p for ~s", [Error, DbName]),
             true = ets:delete(couch_dbs, DbName),
@@ -378,9 +378,13 @@ handle_call({open, DbName, Options}, From, Server) ->
         DbNameList = binary_to_list(DbName),
         case check_dbname(Server, DbNameList) of
         ok ->
-            {ok, Server2} = maybe_close_lru_db(Server),
-            Filepath = get_full_filename(Server, DbNameList),
-            {noreply, open_async(Server2, From, DbName, Filepath, Options)};
+            case maybe_close_lru_db(Server) of
+            {ok, Server2} ->
+                Filepath = get_full_filename(Server, DbNameList),
+                {noreply, open_async(Server2, From, DbName, Filepath, Options)};
+            CloseError ->
+                {reply, CloseError, Server}
+            end;
         Error ->
             {reply, Error, Server}
         end;
@@ -402,9 +406,13 @@ handle_call({create, DbName, Options}, From, Server) ->
     ok ->
         case ets:lookup(couch_dbs, DbName) of
         [] ->
-            {ok, Server2} = maybe_close_lru_db(Server),
-            {noreply, open_async(Server2, From, DbName, Filepath,
-                [create | Options])};
+            case maybe_close_lru_db(Server) of
+            {ok, Server2} ->
+                {noreply, open_async(Server2, From, DbName, Filepath,
+                        [create | Options])};
+            CloseError ->
+                {reply, CloseError, Server}
+            end;
         [#db{fd=open}=Db] ->
             % We're trying to create a database while someone is in
             % the middle of trying to open it. We allow one creator
@@ -428,14 +436,14 @@ handle_call({delete, DbName, Options}, _From, Server) ->
         Server2 =
         case ets:lookup(couch_dbs, DbName) of
         [] -> Server;
-        [#db{main_pid=Pid, compactor_pid=Froms}] when is_list(Froms) ->
+        [#db{main_pid=Pid, compactor_pid=Froms} = Db] when is_list(Froms) ->
             % icky hack of field values - compactor_pid used to store clients
             true = ets:delete(couch_dbs, DbName),
             true = ets:delete(couch_dbs_pid_to_name, Pid),
             exit(Pid, kill),
             [gen_server:reply(F, not_found) || F <- Froms],
             db_closed(Server);
-        [#db{main_pid=Pid}] ->
+        [#db{main_pid=Pid} = Db] ->
             true = ets:delete(couch_dbs, DbName),
             true = ets:delete(couch_dbs_pid_to_name, Pid),
             exit(Pid, kill),
@@ -494,7 +502,7 @@ handle_info({'EXIT', _Pid, config_change}, Server) ->
 handle_info({'EXIT', Pid, Reason}, Server) ->
     case ets:lookup(couch_dbs_pid_to_name, Pid) of
     [{Pid, DbName}] ->
-        [#db{compactor_pid=Froms}] = ets:lookup(couch_dbs, DbName),
+        [#db{compactor_pid=Froms}=Db] = ets:lookup(couch_dbs, DbName),
         if Reason /= snappy_nif_not_loaded -> ok; true ->
             Msg = io_lib:format("To open the database `~s`, Apache CouchDB "
                 "must be built with Erlang OTP R13B04 or higher.", [DbName]),

--- a/src/couch/test/couchdb_views_tests.erl
+++ b/src/couch/test/couchdb_views_tests.erl
@@ -372,6 +372,7 @@ couchdb_1283() ->
         MonRef = erlang:monitor(process, CPid),
         Writer3 = spawn_writer(Db3#db.name),
         ?assert(is_process_alive(Writer3)),
+        ?assertEqual({error, all_dbs_active}, get_writer_status(Writer3)),
 
         ?assert(is_process_alive(Writer1)),
         ?assert(is_process_alive(Writer2)),
@@ -390,6 +391,7 @@ couchdb_1283() ->
                   {reason, "Failure compacting view group"}]})
         end,
 
+        ?assertEqual(ok, writer_try_again(Writer3)),
         ?assertEqual(ok, get_writer_status(Writer3)),
 
         ?assert(is_process_alive(Writer1)),


### PR DESCRIPTION
## Overview

This would revert following commits:
 - https://github.com/apache/couchdb/commit/92c25a98666e59ca497fa5732a81e771ff52e07d: Add sys_dbs to the LRU  
 - https://github.com/apache/couchdb/commit/2d984b59ed6886a179fd500efe9780a0d0ad62e3: fix compiler and dialyzer warnings

Turns out this commits exhibit bad behavior causing `couch_server` message queue backup in the case when there are many `_replicator` databases in the system.

## Testing recommendations

This brings the old version of the code which known to be working. Therefore the risk is minimal. Running test suite should suffice.

## JIRA issue number

It is related to [COUCHDB-3325](https://issues.apache.org/jira/browse/COUCHDB-3325)

## Related Pull Requests

None

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
