### PR TITLE
Test changes_listener dies on mem3_shards shutdown

### DIFF
--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -23,6 +23,7 @@
 -export([for_db/1, for_db/2, for_docid/2, for_docid/3, get/3, local/1, fold/2]).
 -export([for_shard_name/1]).
 -export([set_max_size/1]).
+-export([get_changes_pid/0]).
 
 -record(st, {
     max_size = 25000,
@@ -169,6 +170,9 @@ fold(Fun, Acc) ->
 set_max_size(Size) when is_integer(Size), Size > 0 ->
     gen_server:call(?MODULE, {set_max_size, Size}).
 
+get_changes_pid() ->
+    gen_server:call(?MODULE, get_changes_pid).
+
 handle_config_change("mem3", "shard_cache_size", SizeList, _, _) ->
     Size = list_to_integer(SizeList),
     {ok, gen_server:call(?MODULE, {set_max_size, Size}, infinity)};
@@ -219,6 +223,8 @@ handle_call(shard_db_changed, _From, St) ->
     {reply, ok, St};
 handle_call({set_write_timeout, Timeout}, _From, St) ->
     {reply, ok, St#st{write_timeout = Timeout}};
+handle_call(get_changes_pid, _From, St) ->
+    {reply, {ok, St#st.changes_pid}, St};
 handle_call(_Call, _From, St) ->
     {noreply, St}.
 


### PR DESCRIPTION
<!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

This adds a test to ensure that the changes_listener process exits when
the mem3_shards process is shut down.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users 
     could notice? -->

N/A

## JIRA issue number

COUCHDB-3398

<!-- If this is a significant change, please file a JIRA issue at:
     https://issues.apache.org/jira/browse/COUCHDB
     and include the number here and in commit message(s)  -->

## Related Pull Requests

<!-- If your changes affects on multiple components in different 
     repositories please list here links to those pull requests.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are tests;
- [x] Documentation reflects the changes;
- [x] It's not necessary to update [rebar.config.script] (https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
