### PR TITLE
Disabling replication startup jitter in Windows makefile

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -100,7 +100,7 @@ else
 	@copy test\javascript\tests\lorem*.txt src\fauxton\dist\release\test
 endif
 	-@rmdir /s/q dev\lib
-	@python dev\run -n 1 -q --with-admin-party-please python test\javascript\run $(suites)
+	@python dev\run -n 1 -q --with-admin-party-please -c startup_jitter=0 python test\javascript\run $(suites)
 
 
 .PHONY: check-qs


### PR DESCRIPTION
### Overview

A similar change has already been made to *nix Makefile already.

This is for the Javascript integration test suite to not timeout
when running in Travis. We don't run Windows tests in Travis but
this should speed things a bit, and it's nice to keep both in
sync.

Jira: COUCHDB-3324

### Testing recommendations

Javascript replication test suite should run faster than before this change.

### Related Pull Requests

https://github.com/apache/couchdb/pull/470

### Checklist

This needs manual testing from someone with access to Windows machine
