### PR TITLE
Fix error on race condition in mem3 startup

### DIFF
--- a/src/mem3/src/mem3_util.erl
+++ b/src/mem3/src/mem3_util.erl
@@ -214,11 +214,12 @@ shard_info(DbName) ->
 ensure_exists(DbName) when is_list(DbName) ->
     ensure_exists(list_to_binary(DbName));
 ensure_exists(DbName) ->
-    case couch_db:open(DbName, [nologifmissing, sys_db | [?ADMIN_CTX]]) of
+    Options = [nologifmissing, sys_db, {create_if_missing, true}, ?ADMIN_CTX],
+    case couch_db:open(DbName, Options) of
     {ok, Db} ->
         {ok, Db};
-    _ ->
-        couch_server:create(DbName, [?ADMIN_CTX])
+    file_exists ->
+        couch_db:open(DbName, [sys_db, ?ADMIN_CTX])
     end.
 
 


### PR DESCRIPTION
During mem3 startup, 2 paths attempt to call `couch_server:create/2` on
`_dbs`:

```
gen_server:init_it/6
  -> mem3_shards:init/1
    -> mem3_shards:get_update_seq/0
      -> couch_server:create/2
```

and

```
mem3_sync:initial_sync/1
  -> mem3_shards:fold/2
    -> couch_server:create/2
```

Normally, the first path completes before the second. If the second path
finishes first, the first path fails because it does not expect a
`file_exists` response.

This patch simply retries mem3_util:ensure_exists/1 once if it gets back
a `file_exists` response. Any failures past this point are not handled.

Fixes COUCHDB-3402.

/cc @davisp @nickva 