### PR TITLE
Fix `badarg` when querying replicator's _scheduler/docs endpoint

### DIFF
--- a/src/couch_replicator/src/couch_replicator.erl
+++ b/src/couch_replicator/src/couch_replicator.erl
@@ -189,7 +189,7 @@ active_doc(DbName, DocId) ->
             {ok, DocInfo} ->
                 {ok, DocInfo};
             {error, not_found} ->
-                active_doc_rpc(DbName, DocId, Nodes -- Owner)
+                active_doc_rpc(DbName, DocId, Nodes -- [Owner])
         end
     catch
         % Might be a local database


### PR DESCRIPTION
Jira: COUCHDB-3324
