### PR TITLE
Switch to using Travis containerised builds, update Erlang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,54 @@
-before_install:
-   - sudo apt-get -y update
-   - sudo apt-get -y install libicu-dev libmozjs185-dev pkg-config help2man libcurl4-openssl-dev
-   - sudo apt-get -y install libtool automake autoconf autoconf-archive
-   - sudo apt-get -y install shunit2
-before_script: ./configure -c --disable-docs --disable-fauxton
-script:
-   - make check
 language: erlang
+sudo: false
+
+os: linux
 otp_release:
-   - 18.1
-   - 18.0
+   - 19.3
+   - 18.3
    - 17.5
    - R16B03-1
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - curl
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libmozjs185-dev
+    - pkg-config
+    - help2man
+    - shunit2
+
 git:
   depth: 10
-cache: apt
+
+# Enable this block if you want to build docs & fauxton too
+#cache:
+#  - pip
+#node_js:
+#  - 6
+#install:
+#  - pip install sphinx
+#before_script:
+#  - ./configure -c
+
+# Then comment this section out
+before_script:
+  - ./configure -c --disable-docs --disable-fauxton
+
+script:
+   - make check
+
+# Re-enable once test suite is reliable
+#notifications:
+#  email: false
+#  irc:
+#    channels:
+#      "irc.freenode.org#couchdb-dev"
+#  on_success: change
+#  on_failure: always
+#  use_notice: true
+#  skip_join: true
+#  template:
+#    - %{repository_slug}/%{branch}: %{message} %{build_url}"


### PR DESCRIPTION
## Overview

Travis has 2 build environments: containerised and VM based.  Right now
`sudo:false` selects containers, while `sudo:required` selects the VM
based. Container-based builds guarantee 2 CPU cores and boot faster.
We've been using the latter because we needed a bunch of
`apt-get install` commands. But Travis added native (non-sudo) support
to install packages in containers, and we didn't notice.

This PR switches us to `sudo:false` and uses the new `apt` block to
install required packages.

The PR also updates our Erlang build matrix, using the latest minor
release of each major version we support, and prepares us to enable
IRC notifications to `#couchdb-dev` once the test suite is reliable
again (currently disabled.)

## Testing recommendations
Check the Travis build results on this PR. It is passing.
