### PR TITLE
Hibernate couch_stream after each write

### DIFF
--- a/src/couch/src/couch_stream.erl
+++ b/src/couch/src/couch_stream.erl
@@ -259,7 +259,7 @@ handle_call({write, Bin}, _From, Stream) ->
                         buffer_len=0,
                         md5=Md5_2,
                         identity_md5=IdenMd5_2,
-                        identity_len=IdenLen + BinSize}};
+                        identity_len=IdenLen + BinSize}, hibernate};
     true ->
         {reply, ok, Stream#stream{
                         buffer_list=[Bin|Buffer],


### PR DESCRIPTION
In COUCHDB-1946 Adam Kocoloski investigated a memory explosion resulting
from replication of databases with large attachments (npm fullfat). He
was able to stabilize memory usage to a much lower level by hibernating
couch_stream after each write. While this increases CPU utilization when
writing attachments, it should help reduce memory utilization.

This patch is the single change that affected a ~70% reduction in
memory.

No alteration to the spawn of couch_stream to change the fullsweep_after
setting has been made, in part because this can be adjusted at the erl
command line if desired (-erl ERL_FULLSWEEP_AFTER 0).

## Testing recommendations

Replicate a database with a lot of attachments and observe memory usage with and without this patch.

## JIRA issue number

COUCHDB-1946

