### PR TITLE
Return false for empty list

### DIFF
--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -461,7 +461,7 @@ match({[{<<"$elemMatch">>, _Arg}]}, _Value, _Cmp) ->
 
 % Matches when all elements in values match the
 % sub-selector Arg.
-match({[{<<"$allMatch">>, Arg}]}, Values, Cmp) when is_list(Values) ->
+match({[{<<"$allMatch">>, Arg}]}, Values, Cmp) when is_list(Values), length(Values) > 0 ->
     try
         lists:foreach(fun(V) ->
             case match(Arg, V, Cmp) of

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -20,7 +20,6 @@ class OperatorTests(mango.UserDocsTests):
                 "manager": True,
                 "favorites": {"$all": ["Lisp", "Python"]}
             })
-        print docs
         assert len(docs) == 4
         assert docs[0]["user_id"] == 2
         assert docs[1]["user_id"] == 12
@@ -59,7 +58,6 @@ class OperatorTests(mango.UserDocsTests):
                 "bam": True
             }}
         })
-        print docs
         assert len(docs) == 1
         assert docs[0]["user_id"] == "b"
 
@@ -94,7 +92,6 @@ class OperatorTests(mango.UserDocsTests):
         ]
         self.db.save_docs(amdocs, w=3)
         docs = self.db.find({
-            "_id": {"$gt": None},
             "bang": {"$allMatch": {
                 "foo": {"$mod": [2,1]},
                 "bar": {"$mod": [2,0]}
@@ -102,6 +99,21 @@ class OperatorTests(mango.UserDocsTests):
         })
         assert len(docs) == 1
         assert docs[0]["user_id"] == "a"
+    
+    def test_empty_all_match(self):
+        amdocs = [
+            {
+                "bad_doc": "a",
+                "emptybang": []
+            }
+        ]
+        self.db.save_docs(amdocs, w=3)
+        docs = self.db.find({
+            "emptybang": {"$allMatch": {
+                "foo": {"$eq": 2}
+            }}
+        })
+        assert len(docs) == 0
 
     def test_in_operator_array(self):
         docs = self.db.find({


### PR DESCRIPTION
## Overview

Currently if we have a document like this:
```
doc = {
  name: 'Garren',
  activities: []
};

```

and then create a selector like this:

```
find({selector: {
   activities: {
      $allMatch: {
        ['fishing', 'golf']
     }
   }
});
```
CouchDB mango will return the above document. This doesn't seem correct since it doesn't actually match the `$allMatch` selector. This PR changes that so that an empty document is false.

## Testing recommendations
There is an additional test added to the Mango tests to prove this works.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
