### PR TITLE
Add Compaction Logging

### DIFF
--- a/src/couch_mrview/src/couch_mrview_compactor.erl
+++ b/src/couch_mrview/src/couch_mrview_compactor.erl
@@ -275,8 +275,12 @@ update_task(VID, #acc{changes=Changes, total_changes=Total}=Acc, ChangesInc) ->
 
 swap_compacted(OldState, NewState) ->
     #mrst{
+        fd = Fd
+    } = OldState,
+    #mrst{
         sig=Sig,
-        db_name=DbName
+        db_name=DbName,
+        fd=NewFd
     } = NewState,
 
     link(NewState#mrst.fd),
@@ -285,6 +289,11 @@ swap_compacted(OldState, NewState) ->
     RootDir = couch_index_util:root_dir(),
     IndexFName = couch_mrview_util:index_file(DbName, Sig),
     CompactFName = couch_mrview_util:compaction_file(DbName, Sig),
+
+    {ok, Pre} = couch_file:bytes(Fd),
+    {ok, Post} = couch_file:bytes(NewFd),
+    couch_log:notice("Compaction swap for view ~s ~p ~p", [IndexFName,
+        Pre, Post]),
     ok = couch_file:delete(RootDir, IndexFName),
     ok = file:rename(CompactFName, IndexFName),
 


### PR DESCRIPTION
To predict future compaction results, we log pre-compaction and
post-compaction file sizes. These log results will be used as data
points for regression analysis.

COUCHDB-3417

<!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

Users sometimes want to know the results of compaction and how much disk space will be freed up. Unfortunately, using simply data size and disk size to calculate this prediction is misleading due to conflicts and attachments. This approach logs disk size pre and post compaction for db and view shard files. The hope is that with enough data points, users can run regression analysis to heuristically determine a compaction result.

## Testing recommendations

To see the output, one can connect to a node and run compaction on db or view to see the log result. 
  ```{ok, Db} = couch_db:open(<<"shards/00000000-1fffffff/mydb.1494471596">>, []).```
  ```couch_db:start_compact(Db).```

## JIRA issue number
   COUCHDB-3417
<!-- If this is a significant change, please file a JIRA issue at:
     https://issues.apache.org/jira/browse/COUCHDB
     and include the number here and in commit message(s)  -->

## Related Pull Requests

<!-- If your changes affects on multiple components in different 
     repositories please list here links to those pull requests.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
