### PR TITLE
chore: increase timeout for pausing writer COUCHDB-3384

### DIFF
--- a/src/couch_replicator/test/couch_replicator_compact_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_compact_tests.erl
@@ -24,7 +24,7 @@
 -define(ATTFILE, filename:join([?FIXTURESDIR, "logo.png"])).
 -define(DELAY, 100).
 -define(TIMEOUT, 30000).
--define(TIMEOUT_WRITER, 9000).
+-define(TIMEOUT_WRITER, 18000).
 -define(TIMEOUT_EUNIT, ?TIMEOUT div 1000 + 70).
 
 setup() ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

Double the timeout for pausing the source writer.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## JIRA issue number

<!-- If this is a significant change, please file a JIRA issue at:
     and include the number here and in commit message(s)  -->

     https://issues.apache.org/jira/browse/COUCHDB-3384

****
## Related Pull Requests

<!-- If your changes affects on multiple components in different
     repositories please list here links to those pull requests.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
