### PR TITLE
Fix  _local_docs end-point

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1288,7 +1288,7 @@ enum_docs(Db, <<"_local">>, InFun, InAcc, Options) ->
     FoldFun = pipe([fun skip_deleted/4], InFun),
     {ok, _LastReduce, OutAcc} = couch_btree:fold(
         Db#db.local_tree, FoldFun, InAcc, Options),
-    {ok, 0, OutAcc};
+    {ok, null, OutAcc};
 enum_docs(Db, NS, InFun, InAcc, Options0) ->
     FoldFun = pipe([
         fun skip_deleted/4,

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -380,6 +380,8 @@ view_cb({meta, Meta}, #vacc{meta_sent=false, row_sent=false}=Acc) ->
         Offset -> [io_lib:format("\"offset\":~p", [Offset])]
     end ++ case couch_util:get_value(update_seq, Meta) of
         undefined -> [];
+        null ->
+            ["\"update_seq\":null"];
         UpdateSeq when is_integer(UpdateSeq) ->
             [io_lib:format("\"update_seq\":~B", [UpdateSeq])];
         UpdateSeq when is_binary(UpdateSeq) ->

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -345,8 +345,7 @@ get_row_count(#mrview{btree=Bt}) ->
     {ok, Count}.
 
 
-all_docs_reduce_to_count(Reductions0) ->
-    Reductions = maybe_convert_reductions(Reductions0),
+all_docs_reduce_to_count(Reductions) ->
     Reduce = fun couch_db_updater:btree_by_id_reduce/2,
     {Count, _, _} = couch_btree:final_reduce(Reduce, Reductions),
     Count.
@@ -864,16 +863,6 @@ maybe_load_doc(Db, Id, Val, #mrargs{conflicts=true, doc_options=Opts}) ->
     doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), [conflicts]), Opts);
 maybe_load_doc(Db, Id, Val, #mrargs{doc_options=Opts}) ->
     doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), []), Opts).
-
-
-maybe_convert_reductions({KVs0, UserReductions}) ->
-    KVs = lists:map(fun maybe_convert_kv/1, KVs0),
-    {KVs, UserReductions}.
-
-maybe_convert_kv({<<"_local/", _/binary>> = DocId, _}) ->
-    #full_doc_info{id = DocId};
-maybe_convert_kv(DocInfo) ->
-    DocInfo.
 
 
 doc_row(null, _Opts) ->

--- a/src/couch_mrview/test/couch_mrview_local_docs_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_local_docs_tests.erl
@@ -43,7 +43,8 @@ all_docs_test_() ->
                     fun should_query_with_range/1,
                     fun should_query_with_range_rev/1,
                     fun should_query_with_limit_and_skip/1,
-                    fun should_query_with_include_docs/1
+                    fun should_query_with_include_docs/1,
+                    fun should_query_with_update_seq/1
                 ]
             }
         }
@@ -53,7 +54,7 @@ all_docs_test_() ->
 should_query(Db) ->
     Result = run_query(Db, []),
     Expect = {ok, [
-        {meta, [{total, 10}, {offset, 0}]},
+        {meta, [{total, null}, {offset, null}]},
         mk_row(1),
         mk_row(10),
         mk_row(2),
@@ -73,7 +74,7 @@ should_query_with_range(Db) ->
         {end_key, <<"_local/5">>}
     ]),
     Expect = {ok, [
-        {meta, [{total, 10}, {offset, 3}]},
+        {meta, [{total, null}, {offset, null}]},
         mk_row(3),
         mk_row(4),
         mk_row(5)
@@ -87,7 +88,7 @@ should_query_with_range_rev(Db) ->
         {inclusive_end, true}
     ]),
     Expect = {ok, [
-        {meta, [{total, 10}, {offset, 4}]},
+        {meta, [{total, null}, {offset, null}]},
         mk_row(5),
         mk_row(4),
         mk_row(3)
@@ -101,7 +102,7 @@ should_query_with_limit_and_skip(Db) ->
         {skip, 3}
     ]),
     Expect = {ok, [
-        {meta, [{total, 10}, {offset, 5}]},
+        {meta, [{total, null}, {offset, null}]},
         mk_row(5),
         mk_row(6),
         mk_row(7)
@@ -117,11 +118,22 @@ should_query_with_include_docs(Db) ->
     {row, Doc0} = mk_row(8),
     Doc = Doc0 ++ [{doc, {[{<<"val">>, 8}]}}],
     Expect = {ok, [
-        {meta, [{total, 10}, {offset, 8}]},
+        {meta, [{total, null}, {offset, null}]},
         {row, Doc}
     ]},
     ?_assertEqual(Expect, Result).
 
+should_query_with_update_seq(Db) ->
+    Result = run_query(Db, [
+        {start_key, <<"_local/2">>},
+        {limit, 1},
+        {update_seq, true}
+    ]),
+    Expect = {ok, [
+        {meta, [{total, null}, {offset, null}, {update_seq, null}]},
+        mk_row(2)
+    ]},
+    ?_assertEqual(Expect, Result).
 
 mk_row(IntId) ->
     Id = list_to_binary(io_lib:format("_local/~b", [IntId])),


### PR DESCRIPTION
## Overview

This is a second attempt to fix `_local_docs` end-point. The [previous one](https://github.com/apache/couchdb/pull/488) didn't work on big enough btree_local, because local btree doesn't have reduction fun, so reuse of `couch_db_updater:btree_by_id_reduce/2` was crashing on a bad match as soon as btree_local was getting kp_node. Also using full fold to calculate `total_rows` value turned out to be resource expensive when a database have significant number of local documents.

This fix avoids calculating of `total_rows` and `offset` instead always setting them to `null` and also setting to `null` `update_seq` when requested, since it doesn't have meaning in context of local documents.

A fabric module `fabric_view_all_docs.erl` was copied and modified as `fabric_view_local_docs.erl`, because re-using it for processing of both types of the documents was getting rather convoluted.

## Testing recommendations

Unit tests for all invoked dependencies could be run as `make eunit apps=chttpd,fabric,couch_mrview`. There are updated suite `couch_mrview_local_docs_tests` in `couch_mrview`.

From HTTP perspective end-point `/{db}/_local_docs` supports all the query parameters of `/{db}/_all_docs` with the difference that `offset`, 'total_rows` and `update_seq` always return `null`.

## JIRA issue number

COUCHDB-3337

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
