### PR TITLE
Fix link to SpiderMonkey in INSTALL.Unix.md

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -39,7 +39,7 @@ You should have the following installed:
  * Erlang OTP (>=R16B03-1, =<19.x) (http://erlang.org/)
  * ICU                          (http://icu-project.org/)
  * OpenSSL                      (http://www.openssl.org/)
- * Mozilla SpiderMonkey (1.8.5) (http://www.mozilla.org/js/spidermonkey/)
+ * Mozilla SpiderMonkey (1.8.5) (https://developer.mozilla.org/en/docs/Mozilla/Projects/SpiderMonkey/Releases/1.8.5)
  * GNU Make                     (http://www.gnu.org/software/make/)
  * GNU Compiler Collection      (http://gcc.gnu.org/)
  * libcurl                      (http://curl.haxx.se/libcurl/)


### PR DESCRIPTION
## Overview

This updates a link to SpiderMonkey release page in INSTALL.Unix.md.

## Testing recommendations

Link in INSTALL.Unix.md "Dependencies" section to "Mozilla SpiderMonkey (1.8.5)" should point to existing page for SpiderMonkey release 1.8.5

## Issue number

This closes #530 

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
