### PR TITLE
Expose replicator scheduler feature in the API

### DIFF
--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -209,6 +209,7 @@ restart_job(JobId) ->
 %% gen_server functions
 
 init(_) ->
+    config:enable_feature('scheduler'),
     EtsOpts = [named_table, {keypos, #job.id}, {read_concurrency, true},
         {write_concurrency, true}],
     ?MODULE = ets:new(?MODULE, EtsOpts),


### PR DESCRIPTION
That was the intent all along, just forgot to enable before the merge.

## Testing recommendations

Start a 3 node dev cluster.  Query any of the node's top level API:
```
http http://adm:pass@localhost:15984

{
    "couchdb": "Welcome",
    "features": [
        "scheduler"
    ],
    "vendor": {
        "name": "The Apache Software Foundation"
    },
    "version": "2.1.0-a9ad3429e"
}
```


- [x] Code is written and works correctly;
- [x] Changes are covered by tests: there is a features tests in chttpd
- [ ] Documentation reflects the changes: will make a separate PR for docs repo
