### PR TITLE
Close idle dbs

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -33,6 +33,7 @@
 -export([find_in_binary/2]).
 -export([callback_exists/3, validate_callback_exists/3]).
 -export([with_proc/4]).
+-export([process_dict_get/2, process_dict_get/3]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -597,4 +598,22 @@ with_proc(M, F, A, Timeout) ->
     after Timeout ->
         erlang:demonitor(Ref, [flush]),
         {error, timeout}
+    end.
+
+
+process_dict_get(Pid, Key) ->
+    process_dict_get(Pid, Key, undefined).
+
+
+process_dict_get(Pid, Key, DefaultValue) ->
+    case process_info(Pid, dictionary) of
+        {dictionary, Dict} ->
+            case lists:keyfind(Key, 1, Dict) of
+                false ->
+                    DefaultValue;
+                {Key, Value} ->
+                    Value
+            end;
+        undefined ->
+            DefaultValue
     end.


### PR DESCRIPTION
Previously idle dbs, especially sys dbs like _replicator once opened
once for scanning would stay open forever. In a large cluster with many
_replicator shards that can add up to a significant overhead, mostly in terms
of number of active processes.

Add a mechanism to close dbs which have an idle db updater. Before hibernation
was used to limit the memory pressure, however that is often not enough.

Some databases are only read periodically so their updater would time
out. To prevent that from happening keep the last read timestamp in
the couch file process dictionary. Idle check then avoid closing dbs
which have been recently read from.

(Original idea for using timeouts in gen_server replies belongs to
Paul Davis)

COUCHDB-3323

Related to previous PR from before monorepo merge:
 
 https://github.com/apache/couchdb-couch/pull/236

