### PR TITLE
Make sure we cache admin pass prior to test run

### DIFF
--- a/src/chttpd/test/chttpd_db_doc_size_tests.erl
+++ b/src/chttpd/test/chttpd_db_doc_size_tests.erl
@@ -26,7 +26,8 @@
 
 
 setup() ->
-    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
     ok = config:set("couchdb", "max_document_size", "50"),
     TmpDb = ?tempdb(),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),

--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -22,7 +22,8 @@
 -define(FIXTURE_TXT, ?ABS_PATH(?FILE)).
 
 setup() ->
-    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
     TmpDb = ?tempdb(),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),

--- a/src/chttpd/test/chttpd_open_revs_error_test.erl
+++ b/src/chttpd/test/chttpd_open_revs_error_test.erl
@@ -23,7 +23,8 @@
     "multipart/form-data;boundary=\"bound\""}).
 
 setup() ->
-    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
     TmpDb = ?tempdb(),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),

--- a/src/chttpd/test/chttpd_welcome_test.erl
+++ b/src/chttpd/test/chttpd_welcome_test.erl
@@ -22,7 +22,8 @@
 
 
 setup() ->
-    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),
     Url = lists:concat(["http://", Addr, ":", Port, "/"]),

--- a/src/couch/test/couch_db_mpr_tests.erl
+++ b/src/couch/test/couch_db_mpr_tests.erl
@@ -27,7 +27,8 @@
 
 
 setup() ->
-    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
     TmpDb = ?tempdb(),
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(couch_httpd, port),

--- a/src/couch/test/couchdb_auth_tests.erl
+++ b/src/couch/test/couchdb_auth_tests.erl
@@ -16,7 +16,8 @@
 
 
 setup(PortType) ->
-    ok = config:set("admins", "rocko", "artischocko", false),
+    Hashed = couch_passwords:hash_admin_password("artischocko"),
+    ok = config:set("admins", "rocko", binary_to_list(Hashed), _Persist=false),
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
     lists:concat(["http://", Addr, ":", port(PortType), "/_session"]).
 
@@ -51,7 +52,8 @@ make_test_cases(Mod, Funs) ->
 should_return_username_on_post_to_session(_PortType, Url) ->
     ?_assertEqual(<<"rocko">>,
         begin
-            ok = config:set("admins", "rocko", "artischocko", false),
+            Hashed = couch_passwords:hash_admin_password(<<"artischocko">>),
+            ok = config:set("admins", "rocko", binary_to_list(Hashed), false),
             {ok, _, _, Body} = test_request:post(Url, [{"Content-Type", "application/json"}],
                 "{\"name\":\"rocko\", \"password\":\"artischocko\"}"),
             {Json} = jiffy:decode(Body),

--- a/src/couch/test/couchdb_mrview_cors_tests.erl
+++ b/src/couch/test/couchdb_mrview_cors_tests.erl
@@ -31,7 +31,8 @@
 
 start() ->
     Ctx = test_util:start_couch([chttpd]),
-    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
     ok = config:set("httpd", "enable_cors", "true", false),
     ok = config:set("vhosts", "example.com", "/", false),
     Ctx.

--- a/src/couch/test/couchdb_mrview_tests.erl
+++ b/src/couch/test/couchdb_mrview_tests.erl
@@ -42,7 +42,8 @@
 
 start() ->
     Ctx = test_util:start_couch([chttpd]),
-    ok = config:set("admins", ?USER, ?PASS, _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
     Ctx.
 
 setup(PortType) ->

--- a/src/couch/test/global_changes_tests.erl
+++ b/src/couch/test/global_changes_tests.erl
@@ -144,7 +144,8 @@ decode_response(BinBody, ToDecode) ->
     [couch_util:get_value(Key, Body) || Key <- ToDecode].
 
 add_admin(User, Pass) ->
-    config:set("admins", User, Pass, false).
+    Hashed = couch_passwords:hash_admin_password(Pass),
+    config:set("admins", User, ?b2l(Hashed), _Persist=false).
 
 delete_admin(User) ->
     config:delete("admins", User, false).

--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -20,7 +20,8 @@
 
 setup_all() ->
     TestCtx = test_util:start_couch([chttpd]),
-    config:set("admins", ?ADMIN_USERNAME, ?ADMIN_PASSWORD),
+    Hashed = couch_passwords:hash_admin_password(?ADMIN_PASSWORD),
+    ok = config:set("admins", ?ADMIN_USERNAME, ?b2l(Hashed), _Persist=false),
     TestCtx.
 
 teardown_all(TestCtx) ->


### PR DESCRIPTION
## Overview

couch_server is responsible for calling hash_admin_passwords whenever
"admin" section of config changes. However as you can see it from
[here](https://github.com/apache/couchdb/blob/master/src/couch/src/couch_server.erl#L219)
the call is asynchronous. This means that our test cases might fail when
we try to use admin user while admin password is not yet hashed.

## Testing recommendations

make eunit

## Checklist

- [ ] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
