### PR TITLE
Allow configuration of max doc IDs for optimised code path in changes filter

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -35,6 +35,10 @@ default_security = admin_local
 ; stem_interactive_updates = true
 ; update_lru_on_read = true
 ; uri_file =
+; The speed of processing the _changes feed with doc_ids filter can be
+; influenced directly with this setting - increase for faster processing at the
+; expense of more memory usage.
+changes_doc_ids_optimization_threshold = 100
 
 [cluster]
 q=8


### PR DESCRIPTION
## Overview

With certain data sets, performance of the `_changes` feed with the `doc_ids` filter falls off a cliff when the number of supplied `doc_ids` exceeds 100.

This change allows configuration of the poor performance threshold:

### Previous default
```
[changes]
max_doc_ids = 100
```

### Always perform poorly
```
[changes]
max_doc_ids = 0
```

### Perform poorly when more than 10000 doc IDs are supplied
```
[changes]
max_doc_ids = 10000
```

## Testing recommendations

Get a big dataset, and compare the performance of `_changes` requests with the `doc_ids` filter when:
```
[changes]
max_doc_ids = 0
```
and
```
[changes]
max_doc_ids = 100
```
with 100 or less doc_ids.

## Jira issue number

Fixes: https://issues.apache.org/jira/browse/COUCHDB-3425
Related: https://issues.apache.org/jira/browse/COUCHDB-1288

## Related Pull Requests

Just this one.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
