### PR TITLE
Send a better error when opening a db without authorisation

### DIFF
--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -80,6 +80,8 @@ db_open(#httpdb{} = Db1, _Options, Create) ->
             send_req(Db, [{method, put}],
                 fun(401, _, _) ->
                     throw({unauthorized, ?l2b(db_uri(Db))});
+                (403, _, _) ->
+                    throw({forbidden, ?l2b(db_uri(Db))});
                 (_, _, _) ->
                     ok
                 end)
@@ -100,6 +102,8 @@ db_open(#httpdb{} = Db1, _Options, Create) ->
                  throw({db_not_found, ?l2b(db_uri(Db))});
             (401, _, _) ->
                 throw({unauthorized, ?l2b(db_uri(Db))});
+            (403, _, _) ->
+                throw({forbidden, ?l2b(db_uri(Db))});
             (_, _, _) ->
                 throw({db_not_found, ?l2b(db_uri(Db))})
             end)


### PR DESCRIPTION
COUCHDB-3426

## Overview

Send a better error message when the replicator attempts to open a database it is not authorised to open.

## Testing recommendations

Create a user, create a database, change the security object of the database to exclude the user, then ask the replicator to replicate to that database as the user. You should see a 'forbidden' message in _scheduler/jobs instead of the misleading db_not_found message we currently send.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
