### PR TITLE
Jenkinsfile for multibranch pipeline build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,306 @@
+#!groovy
+/*
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/
+pipeline {
+  /* no top-level agent; agents must be declared for each stage */
+  agent none
+
+  environment {
+    COUCHAUTH = credentials('couchdb_vm2_couchdb')
+    recipient = 'notifications@couchdb.apache.org'
+  }
+
+  stages {
+    stage('Build') {
+      agent {
+        docker {
+          /* This image has the oldest Erlang we support, 16B03 */
+          image 'couchdbdev/ubuntu-14.04-erlang-default'
+          /* We need the jenkins user mapped inside of the image */
+          args '-v /etc/passwd:/etc/passwd -v /etc/group:/etc/group'
+        }
+      }
+      steps {
+        timeout(time: 15, unit: "MINUTES") {
+          /* npm config cache below is required because /home/jenkins doesn't
+             ACTUALLY exist in the image */
+          /* sh 'git clone --depth 10 https://github.com/apache/couchdb .' */
+          sh '''
+              export npm_config_cache=$(mktemp -d)
+              ./configure --with-curl
+              make dist
+          '''
+          stash includes: 'apache-couchdb-*.tar.gz', name: 'tarball'
+          archiveArtifacts artifacts: 'apache-couchdb-*.tar.gz', fingerprint: true
+          deleteDir()
+        }
+      }
+    }
+
+    /* TODO rework this once JENKINS-41334 is released
+       https://issues.jenkins-ci.org/browse/JENKINS-41334 */
+    /* The builddir stuff is to prevent all 10 builds from live syncing
+       their build results to each other during the build. Moving the
+       build outside of the workdir should speed up the build process too,
+       though it does mean we pollute /tmp whenever a build fails. */
+    stage('Test') {
+      steps {
+        parallel(centos6erlang183: {
+          node(label: 'ubuntu') {
+            timeout(time: 45, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/centos-6-erlang-18.3'
+              withDockerContainer(image: 'couchdbdev/centos-6-erlang-18.3', args: '-e LD_LIBRARY_PATH=/usr/local/bin --user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        centos7erlangdefault: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/centos-7-erlang-default'
+              withDockerContainer(image: 'couchdbdev/centos-7-erlang-default', args: '-e LD_LIBRARY_PATH=/usr/local/bin --user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        centos7erlang183: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/centos-7-erlang-18.3'
+              withDockerContainer(image: 'couchdbdev/centos-7-erlang-18.3', args: '-e LD_LIBRARY_PATH=/usr/local/bin --user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        ubuntu1204erlang183: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/ubuntu-12.04-erlang-18.3'
+              withDockerContainer(image: 'couchdbdev/ubuntu-12.04-erlang-18.3', args: '--user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        ubuntu1404erlangdefault: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/ubuntu-14.04-erlang-default'
+              withDockerContainer(image: 'couchdbdev/ubuntu-14.04-erlang-default', args: '--user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        ubuntu1404erlang183: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/ubuntu-14.04-erlang-18.3'
+              withDockerContainer(image: 'couchdbdev/ubuntu-14.04-erlang-18.3', args: '--user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        ubuntu1604erlangdefault: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/ubuntu-16.04-erlang-default'
+              withDockerContainer(image: 'couchdbdev/ubuntu-16.04-erlang-default', args: '--user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        ubuntu1604erlang183: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/ubuntu-16.04-erlang-18.3'
+              withDockerContainer(image: 'couchdbdev/ubuntu-16.04-erlang-18.3', args: '--user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        debian8erlangdefault: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/debian-8-erlang-default'
+              withDockerContainer(image: 'couchdbdev/debian-8-erlang-default', args: '--user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        },
+        debian8erlang183: {
+          node(label: 'ubuntu') {
+            timeout(time: 30, unit: "MINUTES") {
+              sh 'rm *.tar.gz || true'
+              unstash 'tarball'
+              sh 'docker pull couchdbdev/debian-8-erlang-18.3'
+              withDockerContainer(image: 'couchdbdev/debian-8-erlang-18.3', args: '--user 0:0') {
+                sh '''
+                  cwd=$(pwd)
+                  builddir=$(mktemp -d)
+                  cd $builddir
+                  tar -xf $cwd/apache-couchdb-*.tar.gz
+                  cd apache-couchdb-*
+                  ./configure --with-curl
+                  make all
+                  make check || (build-aux/logfile-uploader.py && false)
+                '''
+              } // withDocker
+            } // timeout
+          } // node
+        }
+        ) // parallel
+      } // steps
+    } // stage
+
+    stage('Publish') {
+      when {
+        branch '*(master|2.0.x|2.1.x)'
+      }
+      agent any
+      steps {
+        /* Push it somewhere useful other than Jenkins, maybe? */
+        /* echo 'Publishing tarball...'
+        unstash 'tarball' */
+        echo 'Triggering Debian .deb builds...'
+        echo 'Triggering Ubuntu .deb builds...'
+        echo 'Triggering Ubuntu snap builds...'
+        echo 'Triggering CentOS .rpm builds...'
+        echo 'Cleaning workspace...'
+        sh 'rm -rf * .[a-zA-Z]*'
+      }
+    }
+  }
+
+  post {
+    success {
+      mail to: "${env.recipient}",
+        subject: "[Jenkins] SUCCESS: ${currentBuild.fullDisplayName}",
+        replyTo: "${env.recipient}",
+        body: "Yay, we passed. ${env.BUILD_URL}"
+    }
+    failure {
+      mail to: "${env.recipient}",
+        subject: "[Jenkins] FAILURE: ${currentBuild.fullDisplayName}",
+        replyTo: "${env.recipient}",
+        body: "Boo, we failed. ${env.BUILD_URL}"
+    }
+  }
+}

--- a/build-aux/logfile-uploader.py
+++ b/build-aux/logfile-uploader.py
@@ -59,9 +59,8 @@ def build_ci_doc():
         doc['builder'] = 'jenkins'
         doc['build_id'] = os.environ['BUILD_NUMBER']
         doc['url'] = os.environ['BUILD_URL']
-        doc['branch'] = os.environ['GIT_BRANCH']
-        doc['commit'] = os.environ['GIT_COMMIT']
-        doc['repo'] = os.environ['GIT_URL']
+        doc['branch'] = os.environ['BRANCH_NAME']
+        doc['repo'] = 'https://github.com/apache/couchdb'
     else:
         doc['builder'] = 'manual'
         # TODO: shell out to get correct repo, commit, branch info?


### PR DESCRIPTION
## Overview

Our Jenkins setup has been using the traditional Jenkins definition, with a job driven by a shell script sitting in the apache/couchdb-ci repository, and a further script baked into each Docker image. To maintain the build process, ~8GB of new images have to be pushed to Docker Hub, which isn't practical or scalable.

We also now have requests to have Jenkins securely drive our binary deployment process, by triggering .deb/.rpm/Docker/snap builds. With a classic Jenkins job, we have to use dependent/downstream builds to trigger this behaviour, requiring more manual setup in the Jenkins web UI that is difficult to maintain.

This PR adds a Jenkinsfile that uses the new declarative pipeline syntax introduced to Jenkins in February 2017.  It's similar to a .travis.yml file but with additional functionality for a multi-stage pipeline, and extra functionality provided by various Jenkins plugins. For instance, the build automatically archives a `make dist` tarball to Jenkins with each build.

A new *multibranch* pipeline job has been defined in Jenkins pointing to our repository. Only minimal configuration was required:

* Generic credentials were provided for a GitHub API key to poll the couchdb repository for branches and changes.
* `couchdb-vm2.a.o` CouchDB credentials were specified for the logfile uploader.
* The job is set to only build these origin branches: `master 2.1.x jenkins-pipeline`. No PRs (merged or unmerged, forked or not) are being built at this time due to the heavyweight nature of our Jenkins build - let's leave those to Travis.
* The job is set up to keep only the last 10 build result logfiles and archived artefacts.

Minor changes were also required to the logfile uploader due to changes in the environment variables available in the multibranch pipeline build.

## Testing recommendations
The job is live in Jenkins already. You can see the [list of branches](https://builds.apache.org/blue/organizations/jenkins/CouchDB/branches/) that have run, as well as a [list of recent activity](https://builds.apache.org/blue/organizations/jenkins/CouchDB/activity).

Across 4 runs on this branch, we have 1 success and 3 failures. The failures are of 3 sorts:
* `docker pull` sometimes hangs on a Jenkins node ([bug here](https://github.com/moby/moby/issues/12823))
* `couchjs` still segfaults under Jenkins, most often on CentOS 6/7, but at least once in these 4 runs on Debian 8.
* There is one failure due to an eunit context teardown. This is an odd new failure type. The logs were successfully uploaded to `couchdb-vm2.a.o` for further analysis, just as they should have been.

Note that because I have renamed the job, some of the Blue Ocean links to logfiles don't show up. You can use the Jenkins classic view to access these logs (click the Exit icon at the top left to get there.)

One final change to the email address for notifications (currently just to me) will be made and squashed before I push this assuming +1. Emails will go to notifications@couchdb.a.o unless otherwise requested.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;