### PR TITLE
Fix compatibility with master local document revisions

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -594,26 +594,25 @@ seq_tree_reduce(rereduce, Reds) ->
     lists:sum(Reds).
 
 
-local_tree_split(#doc{} = Doc) ->
+local_tree_split(#doc{revs = {0, [Rev]}} = Doc) when is_binary(Rev) ->
     #doc{
         id = Id,
-        revs = {0, [Rev]},
+        body = BodyData
+    } = Doc,
+    {Id, {binary_to_integer(Rev), BodyData}};
+
+local_tree_split(#doc{revs = {0, [Rev]}} = Doc) when is_integer(Rev) ->
+    #doc{
+        id = Id,
         body = BodyData
     } = Doc,
     {Id, {Rev, BodyData}}.
 
 
-local_tree_join(Id, {Rev, BodyData}) when is_binary(Rev) ->
-    #doc{
-        id = Id,
-        revs = {0, [Rev]},
-        body = BodyData
-    };
-
 local_tree_join(Id, {Rev, BodyData}) when is_integer(Rev) ->
     #doc{
         id = Id,
-        revs = {0, [list_to_binary(integer_to_list(Rev))]},
+        revs = {0, [integer_to_binary(Rev)]},
         body = BodyData
     }.
 

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -645,17 +645,17 @@ update_local_doc_revs(Docs) ->
         } = NewDoc,
         case PrevRevs of
             [RevStr | _] ->
-                PrevRev = list_to_integer(?b2l(RevStr));
+                PrevRev = binary_to_integer(RevStr);
             [] ->
                 PrevRev = 0
         end,
         NewRev = case Delete of
             false ->
-                ?l2b(integer_to_list(PrevRev + 1));
+                PrevRev + 1;
             true  ->
-                <<"0">>
+                0
         end,
-        send_result(Client, NewDoc, {ok, {0, NewRev}}),
+        send_result(Client, NewDoc, {ok, {0, integer_to_binary(NewRev)}}),
         NewDoc#doc{
             revs = {0, [NewRev]}
         }

--- a/src/couch/src/test_engine_util.erl
+++ b/src/couch/src/test_engine_util.erl
@@ -161,13 +161,13 @@ gen_local_write(Engine, St, {Action, {DocId, Body}}) ->
         [#doc{revs = {0, []}}] ->
             0;
         [#doc{revs = {0, [RevStr | _]}}] ->
-            list_to_integer(binary_to_list(RevStr))
+            binary_to_integer(RevStr)
     end,
     {RevId, Deleted} = case Action of
         Action when Action == create; Action == update ->
-            {list_to_binary(integer_to_list(PrevRev + 1)), false};
+            {PrevRev + 1, false};
         delete ->
-            {<<"0">>, true}
+            {0, true}
     end,
     #doc{
         id = DocId,


### PR DESCRIPTION
Previously local doc revisions were integers. Keep them that way to allow
downgrading back to previous CouchDB version.

This was issue was discovered by @eiri 
