### PR TITLE
Fix broken eunit test in changes_since_test_ test suite

### DIFF
--- a/src/couch_mrview/src/couch_mrview_test_util.erl
+++ b/src/couch_mrview/src/couch_mrview_test_util.erl
@@ -49,26 +49,27 @@ make_docs(local, Count) ->
 make_docs(_, Count) ->
     [doc(I) || I <- lists:seq(1, Count)].
 
-ddoc(changes) ->
+ddoc({changes, Opts}) ->
+    ViewOpts = case Opts of
+        seq_indexed ->
+            [{<<"seq_indexed">>, true}];
+        keyseq_indexed ->
+            [{<<"keyseq_indexed">>, true}];
+        seq_indexed_keyseq_indexed ->
+            [
+                {<<"seq_indexed">>, true},
+                {<<"keyseq_indexed">>, true}
+            ]
+    end,
     couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/bar">>},
-        {<<"options">>, {[
-            {<<"seq_indexed">>, true}
-        ]}},
+        {<<"options">>, {ViewOpts}},
         {<<"views">>, {[
             {<<"baz">>, {[
-                {<<"map">>, <<"function(doc) {emit(doc.val, doc.val);}">>}
-            ]}},
-            {<<"bing">>, {[
-                {<<"map">>, <<"function(doc) {}">>}
-            ]}},
-            {<<"zing">>, {[
-                {<<"map">>, <<
-                    "function(doc) {\n"
-                    "  if(doc.foo !== undefined)\n"
-                    "    emit(doc.foo, 0);\n"
-                    "}"
-                >>}
+                {
+                    <<"map">>,
+                    <<"function(doc) {emit(doc.val.toString(), doc.val);}">>
+                }
             ]}}
         ]}}
     ]});

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -343,7 +343,7 @@ get_view_changes_count(View) ->
             {ok, 0};
         {#btree{}, nil} ->
             couch_btree:fold_reduce(SBtree, CountFun, 0, []);
-        {nil, #btree{}} ->
+        {_, #btree{}} ->
             couch_btree:fold_reduce(KSBtree, CountFun, 0, [])
     end,
     case {SBtree, KSBtree} of
@@ -813,9 +813,9 @@ changes_expand_dups([{{[Key, Seq], DocId}, {dups, Vals}} | Rest], Acc) ->
 changes_expand_dups([{{Seq, Key}, {DocId, {dups, Vals}}} | Rest], Acc) ->
     Expanded = [{{Seq, Key, DocId}, Val} || Val <- Vals],
     changes_expand_dups(Rest, Expanded ++ Acc);
-changes_expand_dups([{{[Key, Seq], DocId}, Val} | Rest], Acc) ->
+changes_expand_dups([{{[Key, Seq], DocId}, {Val, _}} | Rest], Acc) ->
     changes_expand_dups(Rest, [{{Seq, Key, DocId}, Val} | Acc]);
-changes_expand_dups([{{Seq, Key}, {DocId, Val}} | Rest], Acc) ->
+changes_expand_dups([{{Seq, Key}, {DocId, Val, _}} | Rest], Acc) ->
     changes_expand_dups(Rest, [{{Seq, Key, DocId}, Val} | Acc]).
 
 maybe_load_doc(_Db, _DI, #mrargs{include_docs=false}) ->


### PR DESCRIPTION
 <!-- Thank you for your contribution!
     
     Please file this form by replacing markdown commentary
     tags with the text. If section needs in no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model 
     of code collaboration. Positive feedback provides by +1 from committers
     while negative by -1. The -1 also means veto and need to be addressed
     to find the consensus. Once there are no objections, PR could be merged.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Prior to the change in this PR, most test cases in two test suites `changes_since_test_` and `changes_index_test_` failed to execute. They were disabled. Considering different scope and historical reason, this PR is aimed to address failure from `changes_since_test_` test suites. The test suite `changes_index_test_` will be another story.

The change not only includes test code, but also includes minor change of couch_mrview_util.erl to satisfy required pattern matches.

## Testing recommendations
```
======================== EUnit ========================
module 'couch_mrview_changes_since_tests'
  changes_since tests
    couch_mrview_changes_since_tests:109: test_basic...ok
    couch_mrview_changes_since_tests:132: test_basic_since...ok
    couch_mrview_changes_since_tests:145: test_basic_count...ok
    couch_mrview_changes_since_tests:154: test_basic_count_since...ok
    couch_mrview_changes_since_tests:164: test_compact...ok
    couch_mrview_changes_since_tests:164: test_compact...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 0.666 s]
  changes_since_range tests
    couch_mrview_changes_since_tests:120: test_range...ok
    couch_mrview_changes_since_tests:141: test_range_since...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 0.236 s]
  changes_since_range_count tests
    couch_mrview_changes_since_tests:150: test_range_count...ok
    couch_mrview_changes_since_tests:159: test_range_count_since...ok
    couch_mrview_changes_since_tests:196: test_remove_key...ok
    couch_mrview_changes_since_tests:197: test_remove_key...ok
    couch_mrview_changes_since_tests:198: test_remove_key...ok
    couch_mrview_changes_since_tests:199: test_remove_key...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 0.423 s]
  [done in 3.173 s]
=======================================================
  All 14 tests passed.
==> rel (eunit)
=======================================================
```
Furthermore, the whole test suites from `couch_mrview` can execute successfully.
```
make check apps=couch_mrview
...
    couch_mrview_all_docs_tests:126: should_query_with_include_docs...ok
    couch_mrview_all_docs_tests:133: should_query_empty_views...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 0.537 s]
  [done in 0.635 s]
=======================================================
  All 129 tests passed.
==> rel (eunit)
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users 
     could notice? -->

## JIRA issue number
COUCHDB-3360 
<!-- If this is a significant change, please file a JIRA issue at:
     https://issues.apache.org/jira/browse/COUCHDB
     and include the number here and in commit message(s)  -->

## Related Pull Requests
N/A
<!-- If your changes affects on multiple components in different 
     repositories please list here links to those pull requests.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [] Documentation reflects the changes;
- [X] I will not forget to update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script)
      with the correct commit hash once this PR get merged.
