### PR TITLE
Allow ddoc_cache to be fully disabled

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -48,7 +48,7 @@ DepDescs = [
 %% Independent Apps
 {config,           "config",           "c5a42b52f28853e511afaa5b35d48770da1159d4"},
 {b64url,           "b64url",           "6895652d80f95cdf04efb14625abed868998f174"},
-{ets_lru,          "ets-lru",          "c05488c8b1d7ec1c3554a828e0c9bf2888932ed6"},
+{ets_lru,          "ets-lru",          "1376e50b82571d98bb2cbd96f27d370b20b9fc24"},
 {khash,            "khash",            "7c6a9cd9776b5c6f063ccafedfa984b00877b019"},
 {snappy,           "snappy",           "a728b960611d0795025de7e9668d06b9926c479d"},
 {setup,            "setup",            "e8d1e32ba3b4f5f3be0e06e5269b12d811f24d52"},

--- a/src/ddoc_cache/src/ddoc_cache_sup.erl
+++ b/src/ddoc_cache/src/ddoc_cache_sup.erl
@@ -48,19 +48,19 @@ init([]) ->
 
 lru_opts() ->
     case application:get_env(ddoc_cache, max_objects) of
-        {ok, MxObjs} when is_integer(MxObjs), MxObjs > 0 ->
+        {ok, MxObjs} when is_integer(MxObjs), MxObjs >= 0 ->
             [{max_objects, MxObjs}];
         _ ->
             []
     end ++
     case application:get_env(ddoc_cache, max_size) of
-        {ok, MxSize} when is_integer(MxSize), MxSize > 0 ->
+        {ok, MxSize} when is_integer(MxSize), MxSize >= 0 ->
             [{max_size, MxSize}];
         _ ->
             []
     end ++
     case application:get_env(ddoc_cache, max_lifetime) of
-        {ok, MxLT} when is_integer(MxLT), MxLT > 0 ->
+        {ok, MxLT} when is_integer(MxLT), MxLT >= 0 ->
             [{max_lifetime, MxLT}];
         _ ->
             []


### PR DESCRIPTION
## Overview
Currently it is impossible to disable the ddoc_cache by specifying `-ddoc_cache max_objects 0` in `vm.args`. This allows such a configuration, paired with a similar change in `ets_lru`.

## Testing recommendations
Add `-ddoc_cache max_objects 0` in `vm.args` and start up couch. It should run correctly.

## GitHub issue number

Related to #559 but does not fix it.

## Related Pull Requests

https://github.com/apache/couchdb-ets-lru/pull/4

## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
