### PR TITLE
monitor index before getting its state #548

### DIFF
--- a/test/javascript/couch.js
+++ b/test/javascript/couch.js
@@ -436,6 +436,7 @@ CouchDB.request = function(method, uri, options) {
   options.headers = typeof(options.headers) == 'object' ? options.headers : {};
   options.headers["Content-Type"] = options.headers["Content-Type"] || options.headers["content-type"] || "application/json";
   options.headers["Accept"] = options.headers["Accept"] || options.headers["accept"] || "application/json";
+  options.headers["Connection"] = options.headers["Connection"] || options.headers["connection"] || "close";
   var req = CouchDB.newXhr();
   uri = CouchDB.proxyUrl(uri);
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Implemented suggestion in #548 

## Checklist

- [x] Code is written and works correctly;

