### PR TITLE
Disable unstable JS _show ETag test

### DIFF
--- a/test/javascript/couch_test_runner.js
+++ b/test/javascript/couch_test_runner.js
@@ -322,7 +322,7 @@ function TEquals(expected, actual, testName) {
 }
 
 function TNotEquals(expected, actual, testName) {
-  T(notEquals(expected, actual), "expected '" + repr(expected) +
+  T(notEquals(expected, actual), "expected != '" + repr(expected) +
     "', got '" + repr(actual) + "'", testName);
 }
 

--- a/test/javascript/tests/show_documents.js
+++ b/test/javascript/tests/show_documents.js
@@ -277,39 +277,6 @@ couchTests.show_documents = function(debug) {
   // status is 200
   T(xhr.status == 200);
 
-  // get new etag and request again
-  etag = xhr.getResponseHeader("etag");
-  xhr = CouchDB.request("GET", "/" + db_name + "/_design/template/_show/just-name/"+docid, {
-    headers: {"if-none-match": etag}
-  });
-  // should be 304
-  T(xhr.status == 304);
-
-  // update design doc (but not function)
-  designDoc.isChanged = true;
-  T(db.save(designDoc).ok);
-
-  xhr = CouchDB.request("GET", "/" + db_name + "/_design/template/_show/just-name/"+docid, {
-    headers: {"if-none-match": etag}
-  });
-  // should not be 304 if we change the doc
-  TNotEquals(304, xhr.status, "changed ddoc");
-
-  // update design doc function
-  designDoc.shows["just-name"] = stringFun(function(doc, req) {
-   return {
-     body : "Just old " + doc.name
-   };
-  });
-  T(db.save(designDoc).ok);
-
-  xhr = CouchDB.request("GET", "/" + db_name + "/_design/template/_show/just-name/"+docid, {
-    headers: {"if-none-match": etag}
-  });
-  // status is 200
-  T(xhr.status == 200);
-
-
   // JS can't set etag
   xhr = CouchDB.request("GET", "/" + db_name + "/_design/template/_show/no-set-etag/"+docid);
   // extract the ETag header values


### PR DESCRIPTION
The full discussion is in #559, but here is a summary.

Through instrumentation of ddoc_cache and ets_lru I suspect that this is
caused by cache eviction happening after the second GET. While I didn't
instrument exactly where the GET occurs it's clear that it's fairly
late, certainly after the PUT 201 is returned, and likely after the
subsequent GET actually reads from ddoc_cache.

After applying a change to allow me to completely disable the ddoc_cache
(-ddoc_cache max_objects 0 in vm.args) I ran the test on a loop
overnight, and the test never failed (>1000 executions). Previously the
test would fail every 20-30 executions.

TL;DR: we can't guarantee immediate ddoc_cache eviction on a ddoc
update, even for a single .couch file on a single node. (For obvious
reasons we definitely can't guarantee this in a cluster configuration.)

I will document this as a backwards compatibility change in 2.0 and
forward with a separate checkin to couchdb-documentation.

Thanks to @rnewson @janl and @davisp for helping track this one down!

This checkin also includes an improvement to the output when a JS test
fails a notEquals assertion.

Closes #559 