### PR TITLE
Don't wrap real error in `badmatch` exception

### DIFF
--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -87,6 +87,8 @@ get_view_index_state(Db, DDoc, ViewName, Args0, RetryCount) ->
         exit:{Reason, _} when Reason == noproc; Reason == normal ->
             timer:sleep(?GET_VIEW_RETRY_DELAY),
             get_view_index_state(Db, DDoc, ViewName, Args0, RetryCount - 1);
+        error:{badmatch, Error} ->
+            throw(Error);
         Error ->
             throw(Error)
     end.


### PR DESCRIPTION
## Overview

A change in apache/couchdb#576 made any unexpected return from functions called in `get_view_index_state/4` to be presented as `badmatch` and hide the real error.

This unwraps the `badmatch` and re-throw it as an original response.

## Testing recommendations

A test suite `make javascript suites=view_errorsjs`should pass.

## Related Pull Requests

Bug introduced in apache/couchdb#576

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
