### PR TITLE
Handle attachments downgrades in a mixed cluster environment

### DIFF
--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -481,6 +481,9 @@ flush(Fd, Att) ->
     flush_data(Fd, fetch(data, Att), Att).
 
 
+flush_data(Fd, {stream, {couch_bt_engine_stream, {OtherFd, StreamPointer}}},
+        Att) ->
+    flush_data(Fd, {OtherFd, StreamPointer}, Att);
 flush_data(Fd, {Fd0, _}, Att) when Fd0 == Fd ->
     % already written to our file, nothing to write
     Att;


### PR DESCRIPTION
Previously attachment uploading from a PSE to non-PSE node would
fail as the attachment streaming API changed between version.

This commit handles downgrading attachment streams from PSE nodes so that
non-PSE nodes can write them.
