### PR TITLE
Properly kill OS daemons during test

### DIFF
--- a/src/couch/test/couchdb_os_daemons_tests.erl
+++ b/src/couch/test/couchdb_os_daemons_tests.erl
@@ -56,9 +56,16 @@ setup(DName) ->
     {Ctx, OsDPid}.
 
 teardown(_, {Ctx, OsDPid}) ->
-    test_util:stop_sync_throw(OsDPid, fun() ->
-        exit(OsDPid, shutdown)
-    end, {timeout, os_daemon_stop}, ?TIMEOUT),
+    try
+        test_util:stop_sync_throw(OsDPid, fun() ->
+            exit(OsDPid, shutdown)
+        end, {timeout, os_daemon_stop}, ?TIMEOUT)
+    catch
+        {timeout, os_daemon_stop} ->
+            Msg = "~nWARNING: OS daemons test stop ~p msec timeout exceeded~n",
+            io:format(standard_error, Msg, [?TIMEOUT]),
+            exit(OsDPid, kill)
+    end,
     test_util:stop(Ctx).
 
 


### PR DESCRIPTION
Even if it clean up fails use `kill` to avoid failing the next set of tests.

Issue: #571

