### PR TITLE
Return 409 when put attachment with nonexistent rev

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -850,6 +850,8 @@ error_info(conflict) ->
     {409, <<"conflict">>, <<"Document update conflict.">>};
 error_info({conflict, _}) ->
     {409, <<"conflict">>, <<"Document update conflict.">>};
+error_info({{not_found, missing}, {_, _}}) ->
+    {409, <<"not_found">>, <<"missing_rev">>};
 error_info({forbidden, Error, Msg}) ->
     {403, Error, Msg};
 error_info({forbidden, Msg}) ->

--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -61,7 +61,8 @@ all_test_() ->
                     fun should_accept_live_as_an_alias_for_continuous/1,
                     fun should_return_404_for_delete_att_on_notadoc/1,
                     fun should_return_409_for_del_att_without_rev/1,
-                    fun should_return_200_for_del_att_with_rev/1
+                    fun should_return_200_for_del_att_with_rev/1,
+                    fun should_return_409_for_put_att_nonexistent_rev/1
                 ]
             }
         }
@@ -168,6 +169,21 @@ should_return_200_for_del_att_with_rev(Url) ->
           []
       ),
       ?assertEqual(200, RC1)
+    end).
+
+
+should_return_409_for_put_att_nonexistent_rev(Url) ->
+    ?_test(begin
+        {ok, RC, _Headers, RespBody} = test_request:put(
+            Url ++ "/should_return_404/file.erl?rev=1-000",
+            [?CONTENT_JSON, ?AUTH],
+            jiffy:encode(attachment_doc())
+        ),
+        ?assertEqual(409, RC),
+        ?assertMatch({[
+            {<<"error">>,<<"not_found">>},
+            {<<"reason">>,<<"missing_rev">>}]},
+            ?JSON_DECODE(RespBody))
     end).
 
 

--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -134,19 +134,10 @@ should_return_404_for_delete_att_on_notadoc(Url) ->
 
 should_return_409_for_del_att_without_rev(Url) ->
     ?_test(begin
-        {ok, Data} = file:read_file(?FIXTURE_TXT),
-        Doc = {[
-            {<<"_attachments">>, {[
-                {<<"file.erl">>, {[
-                    {<<"content_type">>, <<"text/plain">>},
-                    {<<"data">>, base64:encode(Data)}
-                ]}
-            }]}}
-        ]},
         {ok, RC, _, _} = test_request:put(
             Url ++ "/testdoc3",
             [?CONTENT_JSON, ?AUTH],
-            jiffy:encode(Doc)
+            jiffy:encode(attachment_doc())
         ),
         ?assertEqual(201, RC),
 
@@ -158,21 +149,13 @@ should_return_409_for_del_att_without_rev(Url) ->
         ?assertEqual(409, RC1)
     end).
 
+
 should_return_200_for_del_att_with_rev(Url) ->
   ?_test(begin
-      {ok, Data} = file:read_file(?FIXTURE_TXT),
-      Doc = {[
-          {<<"_attachments">>, {[
-              {<<"file.erl">>, {[
-                  {<<"content_type">>, <<"text/plain">>},
-                  {<<"data">>, base64:encode(Data)}
-              ]}
-          }]}}
-      ]},
       {ok, RC, _Headers, RespBody} = test_request:put(
           Url ++ "/testdoc4",
           [?CONTENT_JSON, ?AUTH],
-          jiffy:encode(Doc)
+          jiffy:encode(attachment_doc())
       ),
       ?assertEqual(201, RC),
 
@@ -186,3 +169,15 @@ should_return_200_for_del_att_with_rev(Url) ->
       ),
       ?assertEqual(200, RC1)
     end).
+
+
+attachment_doc() ->
+    {ok, Data} = file:read_file(?FIXTURE_TXT),
+    {[
+        {<<"_attachments">>, {[
+            {<<"file.erl">>, {[
+                {<<"content_type">>, <<"text/plain">>},
+                {<<"data">>, base64:encode(Data)}
+            ]}
+        }]}}
+    ]}.

--- a/test/javascript/tests/attachments.js
+++ b/test/javascript/tests/attachments.js
@@ -116,8 +116,7 @@ couchTests.attachments= function(debug) {
     headers:{"Content-Type":"text/plain;charset=utf-8"},
     body:bin_data
   });
-// TODO: revisit whether 500 makes sense for non-existing revs
-  T(xhr.status == 409 || xhr.status == 500);
+  T(xhr.status == 409);
 
   // with current rev
   var xhr = CouchDB.request("PUT", "/" + db_name + "/bin_doc3/attachment.txt?rev=" + rev, {


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Currently we return a 500 and something like
`{"error":"{not_found,missing}","reason":"{1,<<\"000\">>}"}`
when an attempt is made to put an attachment document with a
non-existent revision.

This changes the behavior to return a 409 and
`{"error":"not_found","reason":"missing_rev"}"`

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Test is included with PR

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
