### PR TITLE
Enable OS process IO logging + upload for Travis and Jenkins tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ cache:
 env:
   global:
     - secure: "UdA/gKIlyuXaW+hUgRx40t1TYjLCGxMqHvM5Uw7UbUH2dqEkgJiLfhZGchS1JVzl8M01VKZUUzS7v2nvRLiHZN1kvaw5kfq31VRoafUah8jfmvqNWZVdLovHl3aw5UX/HRt0RkbWbhdbdknTfh6+YinSZ+Nb54jCErMg9nabXtM="
+    - COUCHDB_IO_LOG_DIR=/tmp/couchjslogs
 
 # Enable this block if you want to build docs & fauxton too
 #node_js:
@@ -45,6 +46,8 @@ env:
 
 # Then comment this section out
 before_script:
+  - rm -rf /tmp/couchjslogs
+  - mkdir -p /tmp/couchjslogs
   - ./configure -c --disable-docs --disable-fauxton
 
 script:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
   environment {
     COUCHAUTH = credentials('couchdb_vm2_couchdb')
     recipient = 'notifications@couchdb.apache.org'
+    COUCHDB_IO_LOG_DIR = '/tmp/couchjslogs'
   }
 
   stages {
@@ -65,6 +66,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/centos-6-erlang-18.3', args: '-e LD_LIBRARY_PATH=/usr/local/bin --user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -86,6 +89,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/centos-7-erlang-default', args: '-e LD_LIBRARY_PATH=/usr/local/bin --user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -107,6 +112,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/centos-7-erlang-18.3', args: '-e LD_LIBRARY_PATH=/usr/local/bin --user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -128,6 +135,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/ubuntu-12.04-erlang-18.3', args: '--user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -149,6 +158,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/ubuntu-14.04-erlang-default', args: '--user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -170,6 +181,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/ubuntu-14.04-erlang-18.3', args: '--user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -191,6 +204,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/ubuntu-16.04-erlang-default', args: '--user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -212,6 +227,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/ubuntu-16.04-erlang-18.3', args: '--user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -233,6 +250,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/debian-8-erlang-default', args: '--user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz
@@ -254,6 +273,8 @@ pipeline {
               withDockerContainer(image: 'couchdbdev/debian-8-erlang-18.3', args: '--user 0:0') {
                 sh '''
                   cwd=$(pwd)
+                  rm -rf /tmp/couchjslogs
+                  mkdir -p /tmp/couchjslogs
                   builddir=$(mktemp -d)
                   cd $builddir
                   tar -xf $cwd/apache-couchdb-*.tar.gz

--- a/build-aux/logfile-uploader.py
+++ b/build-aux/logfile-uploader.py
@@ -41,6 +41,9 @@ def collect_logfiles():
     # JS harness
     for log in glob.glob('dev/logs/node1.log'):
         tb.add(log)
+    # couchjs OS process IO logs
+    for log in glob.glob('/tmp/couchjslogs/*'):
+        tb.add(log)
     tb.close()
 
 def build_ci_doc():


### PR DESCRIPTION
Enabled OS process IO logging by setting `COUCHDB_IO_LOG_DIR=/tmp/couchjslogs`

Both Travis and Jenkins then clear and create that directory before tests run.

Also `logfile-uploader.py` was the modified to upload any log files from that directory.

Issue #551
