### PR TITLE
Use Ejson Body Instead of Compressed Body for External size

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1112,8 +1112,9 @@ prepare_doc_summaries(Db, BucketList) ->
             end,
             SummaryChunk = couch_db_updater:make_doc_summary(Db, {Body, DiskAtts}),
             Meta = Doc#doc.meta,
+            ExternalSize = ?term_size(Body),
             Doc#doc{body = {summary, SummaryChunk, SizeInfo, AttsFd},
-                meta = [{ejson_body, Body} | Meta]}
+                meta = [{ejson_size, ExternalSize} | Meta]}
         end,
         Bucket) || Bucket <- BucketList].
 

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1112,9 +1112,10 @@ prepare_doc_summaries(Db, BucketList) ->
             end,
             SummaryChunk = couch_db_updater:make_doc_summary(Db, {Body, DiskAtts}),
             Meta = Doc#doc.meta,
-            ExternalSize = ?term_size(Body),
-            Doc#doc{body = {summary, SummaryChunk, SizeInfo, AttsFd},
-                meta = [{ejson_size, ExternalSize} | Meta]}
+            Doc#doc{
+                body = {summary, SummaryChunk, SizeInfo, AttsFd},
+                meta = [{ejson_size, ?term_size(Body)} | Meta]
+            }
         end,
         Bucket) || Bucket <- BucketList].
 

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1111,7 +1111,9 @@ prepare_doc_summaries(Db, BucketList) ->
                 nil
             end,
             SummaryChunk = couch_db_updater:make_doc_summary(Db, {Body, DiskAtts}),
-            Doc#doc{body = {summary, SummaryChunk, SizeInfo, AttsFd}}
+            Meta = Doc#doc.meta,
+            Doc#doc{body = {summary, SummaryChunk, SizeInfo, AttsFd},
+                meta = [{ejson_body, Body} | Meta]}
         end,
         Bucket) || Bucket <- BucketList].
 

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -1076,7 +1076,6 @@ check_md5(_, _) -> throw(md5_mismatch).
 
 copy_docs(Db, #db{fd = DestFd} = NewDb, MixedInfos, Retry) ->
     DocInfoIds = [Id || #doc_info{id=Id} <- MixedInfos],
-    Compress = NewDb#db.compression,
     LookupResults = couch_btree:lookup(Db#db.id_tree, DocInfoIds),
     % COUCHDB-968, make sure we prune duplicates during compaction
     NewInfos0 = lists:usort(fun(#full_doc_info{id=A}, #full_doc_info{id=B}) ->

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -677,6 +677,7 @@ flush_trees(#db{fd = Fd} = Db,
             case Value of
             #doc{deleted = IsDeleted, body = {summary, _, _, _} = DocSummary} ->
                 {summary, Summary, AttSizeInfo, AttsFd} = DocSummary,
+                EJsonBody = get_body_from_meta(Value#doc.meta, Summary),
                 % this node value is actually an unwritten document summary,
                 % write to disk.
                 % make sure the Fd in the written bins is the same Fd we are
@@ -695,7 +696,7 @@ flush_trees(#db{fd = Fd} = Db,
                                     " changed. Possibly retrying.", []),
                     throw(retry)
                 end,
-                ExternalSize = ?term_size(Summary),
+                ExternalSize = ?term_size(EJsonBody),
                 {ok, NewSummaryPointer, SummarySize} =
                     couch_file:append_raw_chunk(Fd, Summary),
                 Leaf = #leaf{
@@ -1076,6 +1077,7 @@ check_md5(_, _) -> throw(md5_mismatch).
 
 copy_docs(Db, #db{fd = DestFd} = NewDb, MixedInfos, Retry) ->
     DocInfoIds = [Id || #doc_info{id=Id} <- MixedInfos],
+    Compress = NewDb#db.compression,
     LookupResults = couch_btree:lookup(Db#db.id_tree, DocInfoIds),
     % COUCHDB-968, make sure we prune duplicates during compaction
     NewInfos0 = lists:usort(fun(#full_doc_info{id=A}, #full_doc_info{id=B}) ->
@@ -1086,8 +1088,15 @@ copy_docs(Db, #db{fd = DestFd} = NewDb, MixedInfos, Retry) ->
         {NewRevTree, FinalAcc} = couch_key_tree:mapfold(fun
             (_Rev, #leaf{ptr=Sp}=Leaf, leaf, SizesAcc) ->
                 {Body, AttInfos} = copy_doc_attachments(Db, Sp, DestFd),
+                IsComp = couch_compress:is_compressed(Body, Compress),
+                EJsonBody = case IsComp of
+                    true ->
+                        couch_compress:decompress(Body);
+                    false ->
+                        Body
+                end,
                 SummaryChunk = make_doc_summary(NewDb, {Body, AttInfos}),
-                ExternalSize = ?term_size(SummaryChunk),
+                ExternalSize = ?term_size(EJsonBody),
                 {ok, Pos, SummarySize} = couch_file:append_raw_chunk(
                     DestFd, SummaryChunk),
                 AttSizes = [{element(3,A), element(4,A)} || A <- AttInfos],
@@ -1466,6 +1475,16 @@ make_doc_summary(#db{compression = Comp}, {Body0, Atts0}) ->
     end,
     SummaryBin = ?term_to_bin({Body, Atts}),
     couch_file:assemble_file_chunk(SummaryBin, couch_crypto:hash(md5, SummaryBin)).
+
+
+get_body_from_meta(Meta, Summary) ->
+    case lists:keyfind(ejson_body, 1, Meta) of
+        {ejson_body, Body} ->
+            Body;
+        false ->
+            couch_compress:decompress(Summary)
+    end.
+
 
 default_security_object(<<"shards/", _/binary>>) ->
     case config:get("couchdb", "default_security", "everyone") of

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -1086,6 +1086,8 @@ copy_docs(Db, #db{fd = DestFd} = NewDb, MixedInfos, Retry) ->
         {NewRevTree, FinalAcc} = couch_key_tree:mapfold(fun
             (_Rev, #leaf{ptr=Sp}=Leaf, leaf, SizesAcc) ->
                 {Body, AttInfos} = copy_doc_attachments(Db, Sp, DestFd),
+                % In the future, we should figure out how to do this for
+                % upgrade purposes.
                 EJsonBody = case is_binary(Body) of
                     true ->
                         couch_compress:decompress(Body);

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -1087,8 +1087,7 @@ copy_docs(Db, #db{fd = DestFd} = NewDb, MixedInfos, Retry) ->
         {NewRevTree, FinalAcc} = couch_key_tree:mapfold(fun
             (_Rev, #leaf{ptr=Sp}=Leaf, leaf, SizesAcc) ->
                 {Body, AttInfos} = copy_doc_attachments(Db, Sp, DestFd),
-                IsComp = couch_compress:is_compressed(Body, Compress),
-                EJsonBody = case IsComp of
+                EJsonBody = case is_binary(Body) of
                     true ->
                         couch_compress:decompress(Body);
                     false ->

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -1481,7 +1481,7 @@ get_meta_body_size(Meta, Summary) ->
         {ejson_size, ExternalSize} ->
             ExternalSize;
         false ->
-            couch_compress:decompress(Summary)
+            ?term_size(couch_compress:decompress(Summary))
     end.
 
 

--- a/src/couch/test/couchdb_file_compression_tests.erl
+++ b/src/couch/test/couchdb_file_compression_tests.erl
@@ -150,6 +150,7 @@ compare_compression_methods(DbName) ->
     ?assert(ExternalSizeNone =:= ExternalSizeSnappy),
     ?assert(ExternalSizeNone =:= ExternalSizeDeflate9).
 
+
 populate_db(_Db, NumDocs) when NumDocs =< 0 ->
     ok;
 populate_db(Db, NumDocs) ->

--- a/src/couch/test/couchdb_file_compression_tests.erl
+++ b/src/couch/test/couchdb_file_compression_tests.erl
@@ -111,6 +111,7 @@ should_compare_compression_methods(DbName) ->
 
 compare_compression_methods(DbName) ->
     config:set("couchdb", "file_compression", "none", false),
+    ExternalSizePreCompact = db_external_size(DbName),
     compact_db(DbName),
     compact_view(DbName),
     DbSizeNone = db_disk_size(DbName),
@@ -145,9 +146,9 @@ compare_compression_methods(DbName) ->
 
     ?assert(DbSizeDeflate1 > DbSizeDeflate9),
     ?assert(ViewSizeDeflate1 > ViewSizeDeflate9),
+    ?assert(ExternalSizePreCompact =:= ExternalSizeNone),
     ?assert(ExternalSizeNone =:= ExternalSizeSnappy),
     ?assert(ExternalSizeNone =:= ExternalSizeDeflate9).
-
 
 populate_db(_Db, NumDocs) when NumDocs =< 0 ->
     ok;

--- a/src/couch/test/couchdb_file_compression_tests.erl
+++ b/src/couch/test/couchdb_file_compression_tests.erl
@@ -115,12 +115,14 @@ compare_compression_methods(DbName) ->
     compact_view(DbName),
     DbSizeNone = db_disk_size(DbName),
     ViewSizeNone = view_disk_size(DbName),
+    ExternalSizeNone = db_external_size(DbName),
 
     config:set("couchdb", "file_compression", "snappy", false),
     compact_db(DbName),
     compact_view(DbName),
     DbSizeSnappy = db_disk_size(DbName),
     ViewSizeSnappy = view_disk_size(DbName),
+    ExternalSizeSnappy = db_external_size(DbName),
 
     ?assert(DbSizeNone > DbSizeSnappy),
     ?assert(ViewSizeNone > ViewSizeSnappy),
@@ -139,9 +141,12 @@ compare_compression_methods(DbName) ->
     compact_view(DbName),
     DbSizeDeflate9 = db_disk_size(DbName),
     ViewSizeDeflate9 = view_disk_size(DbName),
+    ExternalSizeDeflate9 = db_external_size(DbName),
 
     ?assert(DbSizeDeflate1 > DbSizeDeflate9),
-    ?assert(ViewSizeDeflate1 > ViewSizeDeflate9).
+    ?assert(ViewSizeDeflate1 > ViewSizeDeflate9),
+    ?assert(ExternalSizeNone =:= ExternalSizeSnappy),
+    ?assert(ExternalSizeNone =:= ExternalSizeDeflate9).
 
 
 populate_db(_Db, NumDocs) when NumDocs =< 0 ->
@@ -186,6 +191,12 @@ db_disk_size(DbName) ->
     ok = couch_db:close(Db),
     active_size(Info).
 
+db_external_size(DbName) ->
+    {ok, Db} = couch_db:open_int(DbName, []),
+    {ok, Info} = couch_db:get_db_info(Db),
+    ok = couch_db:close(Db),
+    external_size(Info).
+
 view_disk_size(DbName) ->
     {ok, Db} = couch_db:open_int(DbName, []),
     {ok, DDoc} = couch_db:open_doc(Db, ?DDOC_ID, [ejson_body]),
@@ -195,6 +206,9 @@ view_disk_size(DbName) ->
 
 active_size(Info) ->
     couch_util:get_nested_json_value({Info}, [sizes, active]).
+
+external_size(Info) ->
+    couch_util:get_nested_json_value({Info}, [sizes, external]).
 
 wait_compaction(DbName, Kind, Line) ->
     WaitFun = fun() ->


### PR DESCRIPTION
## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

In two places where we calculate the ExternalSize of the document body,
we use the Summary which is a compressed version of the doc body. We
change this to use the actual ejson body. In copy_docs we don't have
access to the #doc record so we can't access the meta where we store
the ejson body. Unfortunately, this means we have to decompress the
document body after reading it from disk.


## Testing recommendations

Performance tests were conducted to compare pre-fix External Size values and post-fix External Size Values. Here are the results:
```
Version        Compression    DB Dize      DB External Size

Pre-Fix         snappy            70 MB        46249702       
Pre-Fix         snappy            700 MB      462495533       
Pre-Fix         snappy            2.1 GB        1387486406      
                                        
Post-Fix       snappy            70 MB        83950133    
Post-Fix       snappy            700 MB      839500133        
Post-Fix       snappy            2.1 GB        2518500133         
                                        
Pre-Fix         deflate_6        70 MB        46249702         
Pre-Fix         deflate_6        700 MB      413395945      
Pre-Fix         deflate_6        2.1 GB       994598087         
                                        
Post-Fix       deflate_6        70 MB        83950133   
Post-Fix       deflate_6        700 MB      430495496  
Post-Fix       deflate_6        2.1 GB       1291486342
```
## GitHub issue number
PR is number.

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
