### PR TITLE
Calculate ExternalSize Correctly for Views

### DIFF
--- a/src/couch/test/couchdb_file_compression_tests.erl
+++ b/src/couch/test/couchdb_file_compression_tests.erl
@@ -125,6 +125,7 @@ compare_compression_methods(DbName) ->
     DbSizeNone = db_disk_size(DbName),
     ViewSizeNone = view_disk_size(DbName),
     ExternalSizeNone = db_external_size(DbName),
+    ViewExternalSizeNone = view_external_size(DbName),
 
     config:set("couchdb", "file_compression", "snappy", false),
     compact_db(DbName),
@@ -132,6 +133,7 @@ compare_compression_methods(DbName) ->
     DbSizeSnappy = db_disk_size(DbName),
     ViewSizeSnappy = view_disk_size(DbName),
     ExternalSizeSnappy = db_external_size(DbName),
+    ViewExternalSizeSnappy = view_external_size(DbName),
 
     ?assert(DbSizeNone > DbSizeSnappy),
     ?assert(ViewSizeNone > ViewSizeSnappy),
@@ -151,12 +153,15 @@ compare_compression_methods(DbName) ->
     DbSizeDeflate9 = db_disk_size(DbName),
     ViewSizeDeflate9 = view_disk_size(DbName),
     ExternalSizeDeflate9 = db_external_size(DbName),
+    ViewExternalSizeDeflate9 = view_external_size(DbName),
 
     ?assert(DbSizeDeflate1 > DbSizeDeflate9),
     ?assert(ViewSizeDeflate1 > ViewSizeDeflate9),
     ?assert(ExternalSizePreCompact =:= ExternalSizeNone),
     ?assert(ExternalSizeNone =:= ExternalSizeSnappy),
-    ?assert(ExternalSizeNone =:= ExternalSizeDeflate9).
+    ?assert(ExternalSizeNone =:= ExternalSizeDeflate9),
+    ?assert(ViewExternalSizeNone =:= ViewExternalSizeSnappy),
+    ?assert(ViewExternalSizeNone =:= ViewExternalSizeDeflate9).
 
 
 populate_db(_Db, NumDocs) when NumDocs =< 0 ->
@@ -213,6 +218,13 @@ view_disk_size(DbName) ->
     {ok, Info} = couch_mrview:get_info(Db, DDoc),
     ok = couch_db:close(Db),
     active_size(Info).
+
+view_external_size(DbName) ->
+    {ok, Db} = couch_db:open_int(DbName, []),
+    {ok, DDoc} = couch_db:open_doc(Db, ?DDOC_ID, [ejson_body]),
+    {ok, Info} = couch_mrview:get_info(Db, DDoc),
+    ok = couch_db:close(Db),
+    external_size(Info).
 
 active_size(Info) ->
     couch_util:get_nested_json_value({Info}, [sizes, active]).


### PR DESCRIPTION
## Overview

Previously, we were calculating the ExternalSize for views by summing
up all the nodes in the btree. Furthermore, this was the compressed
size. Now we modify the reduce function to return an ExternalSize for
uncompressed values in the KVList.

## Testing recommendations
Performance tests were run to compare External Size Info pre-fix and post-fix.

```
Version        Compression    DB Dize     View External Size

Pre-Fix         snappy            70 MB        26123231     
Pre-Fix         snappy            700 MB      493542711    
Pre-Fix         snappy            2.1 GB       795168531   
                                        
Post-Fix       snappy            70 MB        81775342
Post-Fix       snappy            700 MB      818752126        
Post-Fix       snappy            2.1 GB       2457701744       
                                        
Pre-Fix         deflate_6        70 MB        26109645         
Pre-Fix         deflate_6        700 MB      249677553     
Pre-Fix         deflate_6        2.1 GB       797076702        
                                        
Post-Fix       deflate_6        70 MB        81775244
Post-Fix       deflate_6        700 MB      818752412
Post-Fix       deflate_6        2.1 GB       2478167958
```
## GitHub issue number
PR is number

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
