### PR TITLE
Annotate important processes

### DIFF
--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -37,6 +37,7 @@
 }).
 
 init({DbName, Filepath, Fd, Options}) ->
+    erlang:put(kind, ?MODULE),
     erlang:put(io_priority, {db_update, DbName}),
     update_idle_limit_from_config(),
     case lists:member(create, Options) of

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -354,6 +354,7 @@ msec_since_last_read(Fd) when is_pid(Fd) ->
 % server functions
 
 init({Filepath, Options, ReturnPid, Ref}) ->
+    erlang:put(kind, ?MODULE),
     OpenOptions = file_open_options(Options),
     Limit = get_pread_limit(),
     IsSys = lists:member(sys_db, Options),

--- a/src/fabric/src/fabric_db_update_listener.erl
+++ b/src/fabric/src/fabric_db_update_listener.erl
@@ -68,6 +68,7 @@ start_update_notifiers(Shards) ->
         dict:append(Node, Name, Acc)
     end, dict:new(), Shards),
     lists:map(fun({Node, DbNames}) ->
+        erlang:put(kind, ?MODULE), %% changes_feed
         Ref = rexi:cast(Node, {?MODULE, start_update_notifier, [DbNames]}),
         #worker{ref=Ref, node=Node}
     end, dict:to_list(EndPointDict)).


### PR DESCRIPTION
Opening for discussion. Let me know if you think it is a bad idea. I'll annotate more processes next week.

Once in a while for busy clusters there is a need to figure out a list of processes which has a big number of messages in their mailbox. Currently it is quite hard to infer the kind of process which has backups. We have to rely on inspecting an initial calls, monitors, links and so on.
The idea is to annotate important processes by storing kind key in the process dictionary.
