### PR TITLE
Ensure replicator _active_tasks entry reports recent pending changes

### DIFF
--- a/src/couch_replicator/src/couch_replicator_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_worker.erl
@@ -219,6 +219,10 @@ queue_fetch_loop(Source, Target, Parent, Cp, ChangesManager) ->
     receive
     {closed, ChangesManager} ->
         ok;
+    {changes, ChangesManager, [], ReportSeq} ->
+        Stats = couch_replicator_stats:new(),
+        ok = gen_server:call(Cp, {report_seq_done, ReportSeq, Stats}, infinity),
+        queue_fetch_loop(Source, Target, Parent, Cp, ChangesManager);
     {changes, ChangesManager, Changes, ReportSeq} ->
         Target2 = open_db(Target),
         {IdRevs, Stats0} = find_missing(Changes, Target2),


### PR DESCRIPTION
Previously there was a race between reporting the source update  sequence
between the the workers and the changes readers. Each one used separate
incrementing timestamp sequences.

In some cases that lead to pending changes being stuck. For example, if changes
reader reported the highest sequence with timestamp 10000, then later workers
reported it with sequences 5000, 5001, 5002, then all those reports would be
ignored and users would see an always lagging pending changes value reported
with timestamp 1000.

The fix is to thread the last_sequence update through the changes queue to
the changes manager, so only its timestamp sequence will be used. This removes
the race condition.