### PR TITLE
Enable compaction daemon by default

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -188,7 +188,8 @@ def setup_configs(ctx):
             "cluster_port": cluster_port,
             "backend_port": backend_port,
             "fauxton_root": fauxton_root,
-            "uuid": "fake_uuid_for_dev"
+            "uuid": "fake_uuid_for_dev",
+            "_default": ""
         }
         write_config(ctx, node, env)
 

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -468,7 +468,7 @@ min_file_size = 131072
 ;    Similar to the preceding example, but a database and its views can be
 ;    compacted in parallel.
 ;
-;_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
+_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}]
 
 [log]
 ; Set the log writer to use

--- a/src/couch/test/couchdb_compaction_daemon_tests.erl
+++ b/src/couch/test/couchdb_compaction_daemon_tests.erl
@@ -23,8 +23,9 @@
 
 start() ->
     Ctx = test_util:start_couch(),
-    config:set("compaction_daemon", "check_interval", "3", false),
-    config:set("compaction_daemon", "min_file_size", "100000", false),
+    ok = config:set("compaction_daemon", "check_interval", "3", false),
+    ok = config:set("compaction_daemon", "min_file_size", "100000", false),
+    ok = config:delete("compactions", "_default", false),
     ok = meck:new(?MODS_TO_MOCK, [passthrough]),
     Ctx.
 


### PR DESCRIPTION
This is the #1 potential user footgun we ship by default. Especially with `_global_changes` coming on the scene, this becomes quite the annoying issue. Pro-users can easily disable it, most users will want to have it enabled.