### PR TITLE
Add stable and update support to Mango

### DIFF
--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -138,10 +138,10 @@ composite_prefix([Col | Rest], Ranges) ->
 
 
 % The query planner
-% First choose the index with the lowest difference between its 
+% First choose the index with the lowest difference between its
 % Prefix and the FieldRanges. If that is equal, then
-% choose the index with the least number of 
-% fields in the index. If we still cannot break the tie, 
+% choose the index with the least number of
+% fields in the index. If we still cannot break the tie,
 % then choose alphabetically based on ddocId.
 % Return the first element's Index and IndexRanges.
 %
@@ -156,13 +156,13 @@ choose_best_index(_DbName, IndexRanges) ->
                 ColsLenA = length(mango_idx:columns(IdxA)),
                 ColsLenB = length(mango_idx:columns(IdxB)),
                 case ColsLenA - ColsLenB of
-                    M when M < 0 -> 
+                    M when M < 0 ->
                         true;
                     M when M == 0 ->
-                        % We have no other way to choose, so at this point 
+                        % We have no other way to choose, so at this point
                         % select the index based on (dbname, ddocid, view_name) triple
                         IdxA =< IdxB;
-                    _ -> 
+                    _ ->
                         false
                 end;
             _ ->
@@ -270,6 +270,22 @@ apply_opts([{sort, Sort} | Rest], Args) ->
             },
             apply_opts(Rest, NewArgs)
     end;
+apply_opts([{stale, ok} | Rest], Args) ->
+    NewArgs = Args#mrargs{
+        stable = true,
+        update = false
+    },
+    apply_opts(Rest, NewArgs);
+apply_opts([{stable, true} | Rest], Args) ->
+    NewArgs = Args#mrargs{
+        stable = true
+    },
+    apply_opts(Rest, NewArgs);
+apply_opts([{update, false} | Rest], Args) ->
+    NewArgs = Args#mrargs{
+        update = false
+    },
+    apply_opts(Rest, NewArgs);
 apply_opts([{_, _} | Rest], Args) ->
     % Ignore unknown options
     apply_opts(Rest, Args).

--- a/src/mango/src/mango_opts.erl
+++ b/src/mango/src/mango_opts.erl
@@ -25,6 +25,7 @@
     is_pos_integer/1,
     is_non_neg_integer/1,
     is_object/1,
+    is_ok_or_false/1,
 
     validate_idx_name/1,
     validate_selector/1,
@@ -127,6 +128,24 @@ validate_find({Props}) ->
             {optional, true},
             {default, false},
             {validator, fun mango_opts:is_boolean/1}
+        ]},
+        {<<"stale">>, [
+            {tag, stale},
+            {optional, true},
+            {default, false},
+            {validator, fun mango_opts:is_ok_or_false/1}
+        ]},
+        {<<"update">>, [
+            {tag, update},
+            {optional, true},
+            {default, true},
+            {validator, fun mango_opts:is_boolean/1}
+        ]},
+        {<<"stable">>, [
+            {tag, stable},
+            {optional, true},
+            {default, false},
+            {validator, fun mango_opts:is_boolean/1}
         ]}
     ],
     validate(Props, Opts).
@@ -197,6 +216,14 @@ is_object({Props}) ->
 is_object(Else) ->
     ?MANGO_ERROR({invalid_object, Else}).
 
+is_ok_or_false(<<"ok">>) ->
+  {ok, ok};
+is_ok_or_false(<<"false">>) -> % convenience
+  {ok, false};
+is_ok_or_false(false) ->
+  {ok, false};
+is_ok_or_false(Else) ->
+  ?MANGO_ERROR({invalid_ok_or_false_value, Else}).
 
 validate_idx_name(auto_name) ->
     {ok, auto_name};

--- a/src/mango/test/13-stable-update-test.py
+++ b/src/mango/test/13-stable-update-test.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import copy
+import mango
+
+DOCS1 = [
+    {
+        "_id": "54af50626de419f5109c962f",
+        "user_id": 0,
+        "age": 10,
+        "name": "Jimi",
+        "location": "UK",
+        "number": 4
+    },
+    {
+        "_id": "54af50622071121b25402dc3",
+        "user_id": 1,
+        "age": 12,
+        "name": "Eddie",
+        "location": "ZAR",
+        "number": 2
+    },
+]
+
+class SupportStableAndUpdate(mango.DbPerClass):
+    def setUp(self):
+        self.db.recreate()
+        self.db.create_index(["name"])
+        self.db.save_docs(copy.deepcopy(DOCS1))
+
+    def test_update_updates_view_when_specified(self):
+        docs = self.db.find({"name": "Eddie"}, update=False)
+        assert len(docs) == 0
+        docs = self.db.find({"name": "Eddie"}, update=True)
+        assert len(docs) == 1

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -155,7 +155,7 @@ class Database(object):
 
     def find(self, selector, limit=25, skip=0, sort=None, fields=None,
                 r=1, conflicts=False, use_index=None, explain=False,
-                bookmark=None, return_raw=False):
+                bookmark=None, return_raw=False, update=True):
         body = {
             "selector": selector,
             "use_index": use_index,
@@ -170,6 +170,8 @@ class Database(object):
             body["fields"] = fields
         if bookmark is not None:
             body["bookmark"] = bookmark
+        if update == False:
+            body["update"] = False
         body = json.dumps(body)
         if explain:
             path = self.path("_explain")


### PR DESCRIPTION
This brings mango inline with views by supporting the new options
`stable` and `update`.

Fixes #621

## Testing recommendations

See the test for an example on how to test. I'm not really sure of a way to test the `stable` option.

## GitHub issue number

#621

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes; (https://github.com/apache/couchdb-documentation/pull/145)
