### PR TITLE
Stop indexing activity on ddoc update

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -846,6 +846,8 @@ error_info({not_found, Reason}) ->
     {404, <<"not_found">>, Reason};
 error_info({filter_fetch_error, Reason}) ->
     {404, <<"not_found">>, Reason};
+error_info(ddoc_updated) ->
+    {404, <<"not_found">>, <<"Design document was updated or deleted.">>};
 error_info({not_acceptable, Reason}) ->
     {406, <<"not_acceptable">>, Reason};
 error_info(conflict) ->

--- a/src/couch_mrview/test/couch_mrview_ddoc_updated_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_ddoc_updated_tests.erl
@@ -1,0 +1,139 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_mrview_ddoc_updated_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(TIMEOUT, 1000).
+
+
+setup() ->
+    Name = ?tempdb(),
+    couch_server:delete(Name, [?ADMIN_CTX]),
+    {ok, Db} = couch_db:create(Name, [?ADMIN_CTX]),
+    DDoc = couch_doc:from_json_obj({[
+        {<<"_id">>, <<"_design/bar">>},
+        {<<"views">>, {[
+            {<<"baz">>, {[
+                {<<"map">>, <<
+                    "function(doc) {\n"
+                    "    var i = 0; while(i<1000){ i++ };\n"
+                    "    emit(doc.val, doc.val);\n"
+                    "}"
+                >>}
+            ]}}
+        ]}}
+    ]}),
+    [Doc1 | Docs999] = couch_mrview_test_util:make_docs(map, 100),
+    {ok, _} = couch_db:update_docs(Db, [DDoc, Doc1], []),
+    {ok, Db2} = couch_db:reopen(Db),
+
+    % run a query with 1 doc to initialize couch_index process
+    CB = fun
+        ({row, _}, Count) -> {ok, Count+1};
+        (_, Count) -> {ok, Count}
+    end,
+    {ok, _} =
+        couch_mrview:query_view(Db2, <<"_design/bar">>, <<"baz">>, [], CB, 0),
+
+    % add more docs
+    {ok, _} = couch_db:update_docs(Db2, Docs999, []),
+    {ok, Db3} = couch_db:reopen(Db2),
+    Db3.
+
+teardown(Db) ->
+    couch_db:close(Db),
+    couch_server:delete(Db#db.name, [?ADMIN_CTX]),
+    ok.
+
+
+ddoc_update_test_() ->
+    {
+        "Check ddoc update actions",
+        {
+            setup,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun check_indexing_stops_on_ddoc_change/1
+                ]
+            }
+        }
+    }.
+
+
+check_indexing_stops_on_ddoc_change(Db) ->
+    ?_test(begin
+        DDocID = <<"_design/bar">>,
+
+        IndexesBefore = get_indexes_by_ddoc(DDocID, 1),
+        ?assertEqual(1, length(IndexesBefore)),
+        AliveBefore = lists:filter(fun erlang:is_process_alive/1, IndexesBefore),
+        ?assertEqual(1, length(AliveBefore)),
+
+        {ok, DDoc} = couch_db:open_doc(Db, DDocID, [ejson_body, ?ADMIN_CTX]),
+        DDocJson2 = couch_doc:from_json_obj({[
+            {<<"_id">>, DDocID},
+            {<<"_deleted">>, true},
+            {<<"_rev">>, couch_doc:rev_to_str(DDoc#doc.revs)}
+        ]}),
+
+        % spawn a process for query
+        Self = self(),
+        QPid = spawn(fun() ->
+            {ok, Result} = couch_mrview:query_view(
+                Db, <<"_design/bar">>, <<"baz">>, []),
+            Self ! {self(), Result}
+        end),
+
+        % while indexing for the query is in progress, delete DDoc
+        {ok, _} = couch_db:update_doc(Db, DDocJson2, []),
+        receive
+            {QPid, Msg} ->
+                ?assertEqual(Msg, ddoc_updated)
+        after ?TIMEOUT ->
+            erlang:error(
+                {assertion_failed, [{module, ?MODULE}, {line, ?LINE},
+                {reason, "test failed"}]})
+        end,
+
+        %% assert that previously running indexes are gone
+        IndexesAfter = get_indexes_by_ddoc(DDocID, 0),
+        ?assertEqual(0, length(IndexesAfter)),
+        AliveAfter = lists:filter(fun erlang:is_process_alive/1, IndexesBefore),
+        ?assertEqual(0, length(AliveAfter))
+    end).
+
+
+get_indexes_by_ddoc(DDocID, N) ->
+    Indexes = test_util:wait(fun() ->
+        Indxs = ets:match_object(
+            couchdb_indexes_by_db, {'$1', {DDocID, '$2'}}),
+        case length(Indxs) == N of
+            true ->
+                Indxs;
+            false ->
+                wait
+        end
+    end),
+    lists:foldl(fun({DbName, {_DDocID, Sig}}, Acc) ->
+        case ets:lookup(couchdb_indexes_by_sig, {DbName, Sig}) of
+            [{_, Pid}] -> [Pid|Acc];
+            _ -> Acc
+        end
+    end, [], Indexes).
+
+

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -314,7 +314,9 @@ view_cb({row, Row}, Acc) ->
 view_cb(complete, Acc) ->
     % Finish view output
     ok = rexi:stream_last(complete),
-    {ok, Acc}.
+    {ok, Acc};
+view_cb(ok, ddoc_updated) ->
+    rexi:reply({ok, ddoc_updated}).
 
 
 reduce_cb({meta, Meta}, Acc) ->
@@ -331,7 +333,9 @@ reduce_cb({row, Row}, Acc) ->
 reduce_cb(complete, Acc) ->
     % Finish view output
     ok = rexi:stream_last(complete),
-    {ok, Acc}.
+    {ok, Acc};
+reduce_cb(ok, ddoc_updated) ->
+    rexi:reply({ok, ddoc_updated}).
 
 
 changes_enumerator(#doc_info{id= <<"_local/", _/binary>>, high_seq=Seq}, Acc) ->

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -132,6 +132,9 @@ handle_stream_start(rexi_STREAM_INIT, {Worker, From}, St) ->
                 {stop, St#stream_acc{workers=Workers1}}
         end
     end;
+handle_stream_start({ok, ddoc_updated}, _, St) ->
+    cleanup(St#stream_acc.workers),
+    {stop, ddoc_updated};
 handle_stream_start(Else, _, _) ->
     exit({invalid_stream_start, Else}).
 


### PR DESCRIPTION
Currently when ddoc is updated, couch_index and couch_index_updater processes
corresponding to the previous version of ddoc will still exist until
all indexing processing initiated by them is done.
When ddoc of a big database is rapidly modified, this puts a lot
of unnecessary strain on database.

With this change, when ddoc is updated:
* all couch_index processes for the previous version of ddoc will be shutdown
* all linked to them couch_index_updater processes will die as well
* all processes waiting for indexing activity to be finished (waiters
    for couch_index:get_status) will receive an immediate reply:
    ddoc_updated. Interactive user requests (view queries) will get response:
    {404, <<"not_found">>, <<"Design document was updated or deleted.">>}

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
When design document is updated, stop couch_index processes for the previous version
of the design doc.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
`make check apps=couch_mrview tests=ddoc_update_test_`

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
