### PR TITLE
Remove yet another invalid test case (ddoc_cache related)

### DIFF
--- a/test/javascript/tests/design_docs.js
+++ b/test/javascript/tests/design_docs.js
@@ -224,22 +224,6 @@ couchTests.design_docs = function(debug) {
     TEquals(200, xhr.status);
     TEquals("One", xhr.responseText);
 
-    // Test that changes to the design doc properly invalidate cached modules:
-
-    // update the designDoc and replace
-    designDoc.whatever.commonjs.circular_one = "exports.name = 'Updated';"
-    T(db.save(designDoc).ok);
-
-    // request circular_require show function again and check the response has
-    // changed
-    xhr = CouchDB.request(
-      "GET",
-      "/" + db_name + "/_design/test/_show/circular_require"
-    );
-    TEquals(200, xhr.status);
-    TEquals("Updated", xhr.responseText);
-
-
     // test module id values are as expected:
     xhr = CouchDB.request("GET", "/" + db_name + "/_design/test/_show/idtest1");
     TEquals(200, xhr.status);


### PR DESCRIPTION
This test case is failing because of late ddoc_cache eviction.
It'd be nice to validate that we correctly invalidate our
cached CommonJS modules, but ddoc_cache makes such a test
infeasible.

See https://github.com/apache/couchdb/commit/85cfc71beb089c7881959c2ac7699b9b35b0f04b#diff-f2fc11abc651cc0b4e99643c85f2a5f6 as well as #559 for more detail.

Closes #632