### PR TITLE
Pass db open options to fabric_view_map

### DIFF
--- a/src/chttpd/src/chttpd_show.erl
+++ b/src/chttpd/src/chttpd_show.erl
@@ -211,7 +211,8 @@ handle_view_list(Req, Db, DDoc, LName, {ViewDesignName, ViewName}, Keys) ->
             <<"_all_docs">> ->
                 fabric:all_docs(Db, Options, CB, Acc, QueryArgs);
             _ ->
-                fabric:query_view(Db, VDoc, ViewName, CB, Acc, QueryArgs)
+                fabric:query_view(Db, Options, VDoc, ViewName,
+                    CB, Acc, QueryArgs)
         end
     end).
 


### PR DESCRIPTION
## Overview

We don't set db open options to `fabric_view_map` and missing `user_ctx` when opening databases. For admin-only database we inject `user_ctx` for after doc check, pulling it from passed accumulator with assumption it is always `#vacc` record. This is incorrect in case of `list` or `mango` queries and breaks fabric abstraction, where it is spec'ed for acc to be type `any()`

This patch allows to pass db open options  and `user_ctx` along with it to `fabric:query_view/7` and modifies chttpd show and view handlers accordingly.

## Testing recommendations

Javascript test suite should pass:
```
make javascript
```

For manual check on admin-only database the following should work:

```
echo '{"name": "demo", "password": "apple", "roles": [], "type": "user"}' | curl -u $CRED http://localhost:15984/_users/org.couchdb.user:demo

...

echo '{"views": {"names": {"map": "function(doc) { emit(doc.name); }"}}, "lists": {"names": "function(head, req) { var row; while (row = getRow()) { send(\"name: \" + row.key + \"\\n\"); } }"}}}' | curl -u $CRED http://localhost:15984/_users/_design/users 
```

Then
```
$ curl -u $CRED http://localhost:15984/_users/_design/users/_view/names?include_docs=true
$ curl  -u $CRED "http://localhost:15984/_users/_design/users/_list/names/names"
```

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
