### PR TITLE
Fix couch_replicator_changes_reader:process_change

### DIFF
--- a/src/couch_replicator/src/couch_replicator_changes_reader.erl
+++ b/src/couch_replicator/src/couch_replicator_changes_reader.erl
@@ -82,7 +82,7 @@ read_changes(Parent, StartSeq, Db, ChangesQueue, Options) ->
     end.
 
 
-process_change(#doc_info{id = <<>>} = DocInfo, {_, Db, _, _, _}) ->
+process_change(#doc_info{id = <<>>} = DocInfo, {_, Db, _, _}) ->
     % Previous CouchDB releases had a bug which allowed a doc with an empty ID
     % to be inserted into databases. Such doc is impossible to GET.
     couch_log:error("Replicator: ignoring document with empty ID in "


### PR DESCRIPTION
## Overview

The size of the tuple was changed in all clauses of process_change but one.
Remove TS argument from `#doc_info{id = <<>>}` clause of process_change.

## Testing recommendations

make eunit 

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
