### PR TITLE
JS test cleanup x3

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -189,7 +189,8 @@ def setup_configs(ctx):
             "backend_port": backend_port,
             "fauxton_root": fauxton_root,
             "uuid": "fake_uuid_for_dev",
-            "_default": ""
+            "_default": "",
+            "compaction_daemon": "{}"
         }
         write_config(ctx, node, env)
 

--- a/test/javascript/tests/config.js
+++ b/test/javascript/tests/config.js
@@ -11,9 +11,6 @@
 // the License.
 
 couchTests.config = function(debug) {
-  var db_name = get_random_db_name();
-  var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
-  db.createDb();
   if (debug) debugger;
 
   // test that /_config returns all the settings

--- a/test/javascript/tests/delayed_commits.js
+++ b/test/javascript/tests/delayed_commits.js
@@ -32,6 +32,9 @@ couchTests.delayed_commits = function(debug) {
       // other updates. If it crashes or is restarted you may lose the most
       // recent commits.
 
+      // restartServer() requires a server to be up 15s before it restarts
+      sleep(15000);
+
       T(db.save({_id:"1",a:2,b:4}).ok);
       T(db.open("1") != null);
 
@@ -41,4 +44,7 @@ couchTests.delayed_commits = function(debug) {
       // note if we waited > 1 sec before the restart, the doc would likely
       // commit.
     });
+
+  // cleanup
+  db.deleteDb();
 };

--- a/test/javascript/tests/proxyauth.js
+++ b/test/javascript/tests/proxyauth.js
@@ -132,4 +132,6 @@ couchTests.proxyauth = function(debug) {
 
   // cleanup
   db.deleteDb();
+  usersDb.deleteDb();
+
 };

--- a/test/javascript/tests/reader_acl.js
+++ b/test/javascript/tests/reader_acl.js
@@ -214,7 +214,12 @@ couchTests.reader_acl = function(debug) {
     testFun  // stick to the essentials and do it all in one
   );
         
-  // cleanup
   usersDb.deleteDb();
+  // have to delete the backside version now too :(
+  var req = CouchDB.newXhr();
+  req.open("DELETE", "http://127.0.0.1:15986/" + users_db_name, false);
+  req.send("");
+  CouchDB.maybeThrowError(req);
+
   secretDb.deleteDb();
 }

--- a/test/javascript/tests/replication.js
+++ b/test/javascript/tests/replication.js
@@ -1715,9 +1715,6 @@ couchTests.replication = function(debug) {
 
   // COUCHDB-885 - push replication of a doc with attachment causes a
   //               conflict in the target.
-  sourceDb = new CouchDB("test_suite_db_a");
-  targetDb = new CouchDB("test_suite_db_b");
-
   populateSourceDb([]);
   populateTargetDb([]);
 

--- a/test/javascript/tests/rev_stemming.js
+++ b/test/javascript/tests/rev_stemming.js
@@ -117,5 +117,7 @@ couchTests.rev_stemming = function(debug) {
     "should return a truncated revision list");
 
   // cleanup
+  db_orig.deleteDb();
   db.deleteDb();
+  dbB.deleteDb();
 };

--- a/test/javascript/tests/rewrite.js
+++ b/test/javascript/tests/rewrite.js
@@ -505,8 +505,7 @@ couchTests.rewrite = function(debug) {
             TEquals(200, xhr.status);
         }
       });
+    // cleanup
+    db.deleteDb();
   }
-
-  // cleanup
-  db.deleteDb();
 }

--- a/test/javascript/tests/rewrite_js.js
+++ b/test/javascript/tests/rewrite_js.js
@@ -336,5 +336,8 @@ couchTests.rewrite = function(debug) {
     var url = "/"+dbName+"/_design/loop/_rewrite/loop";
     var xhr = CouchDB.request("GET", url);
     TEquals(400, xhr.status);
+
+    // cleanup
+    db.deleteDb();
   }
 }

--- a/test/javascript/tests/security_validation.js
+++ b/test/javascript/tests/security_validation.js
@@ -325,4 +325,9 @@ couchTests.security_validation = function(debug) {
     adminDbB.deleteDb();
   }
   authDb.deleteDb();
+  // have to clean up authDb on the backside :(
+  var req = CouchDB.newXhr();
+  req.open("DELETE", "http://127.0.0.1:15986/" + authDb_name, false);
+  req.send("");
+  CouchDB.maybeThrowError(req);
 };

--- a/test/javascript/tests/stats.js
+++ b/test/javascript/tests/stats.js
@@ -11,6 +11,10 @@
 // the License.
 
 couchTests.stats = function(debug) {
+
+  // test has become very flaky - needs complete rewrite
+  return console.log('TODO');
+
   function newDb(doSetup) {
     var db_name = get_random_db_name();
     var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
@@ -44,9 +48,19 @@ couchTests.stats = function(debug) {
     if(funcs.run) funcs.run(db);
     var after = getStat(path);
     if(funcs.test) funcs.test(before, after);
+    db.deleteDb();
   }
 
   if (debug) debugger;
+
+  /* Need to delete _users and _replicator or background activity
+     will mess with the results of this entire suite. */
+  (function() {
+    var users = new CouchDB("_users");
+    users.deleteDb();
+    var replicator = new CouchDB("_replicator");
+    replicator.deleteDb();
+  })();
 
   (function() {
     var db = newDb(false);
@@ -116,6 +130,9 @@ couchTests.stats = function(debug) {
       var post_files = getStat(["couchdb", "open_os_files"]);
       TEquals(pre_dbs, post_dbs, "We have the same number of open dbs.");
       TEquals(pre_files, post_files, "We have the same number of open files.");
+      for (var ctr = 0; ctr < dbs.length; ctr++) {
+        dbs[ctr].deleteDb();
+      }
     };
     
     run_on_modified_server(
@@ -331,4 +348,12 @@ couchTests.stats = function(debug) {
   })();
 
   // cleanup
+  /* Recreate the deleted _users and _replicator dbs */
+  (function() {
+    var users = new CouchDB("_users");
+    users.createDb();
+    var replicator = new CouchDB("_replicator");
+    replicator.createDb();
+  })();
+
 };


### PR DESCRIPTION
## Overview

This PR includes 3 small commits to fix up the JS test suite:

1. Really, truly disable the compaction daemon. (The previous approach wasn't working.)
2. Ensure that every JS test cleans up after itself, removing all old databases before exiting.
3. Disable the flaky `stats.js` test, which needs a complete rewrite to make sense. It was my fault re-enabling it even partially for 2.0. Sorry.

## Testing recommendations

`make javascript` and look for all passes.