### PR TITLE
Disable compaction daemon on eunit run couch startups

### DIFF
--- a/src/couch/src/test_util.erl
+++ b/src/couch/src/test_util.erl
@@ -72,6 +72,7 @@ start_couch(IniFiles, ExtraApps) ->
     load_applications_with_stats(),
     ok = application:set_env(config, ini_files, IniFiles),
     Apps = start_applications(?DEFAULT_APPS ++ ExtraApps),
+    ok = config:delete("compactions", "_default", false),
     #test_context{started = Apps}.
 
 stop_couch() ->


### PR DESCRIPTION
Commit 21f9544 enabled the compaction daemon by default. And commit
3afe3ad disabled the compaction daemon at the start of the compaction
daemon tests. Unfortunately, the compaction daemon remains active during
all the other EUnit tests. This has resulted in some strange behaviour,
especially filling the LRU up and `all_dbs_active` errors during tests
that shouludn't be hitting it otherwise (like
`couchdb_views_tests:couchdb_1283` which monkeys with max_dbs_open ).

I attempted to override the [compactions] _default line in the file
rel/files/eunit.ini but specifying `_default=` or `_default=[]` did not
provide the desired behaviour. (This in and of itself is worrying; how would
someone disable the compaction daemon in `local.ini` now?)

This change disables the _default config as part of
`test_util:start_couch` after startup. This means there is a very brief
period during which the daemon is running, but in empirical testing the
only thing I've seen it manage to do is compact `_dbs` before being
disabled.

Tested with `make soak-eunit` for 3 hours; this seems to eliminate the
`all_dbs_active` error we've been seeing in CI runs since the compaction
daemon was enabled by default.

Now, I realize that this PR is at odds with making sure that all of the
usual things we do in CouchDB work correctly while the compaction daemon
is running in the background, so if you feel strongly about this, don't
hesitate to -1 it.

Noting here that the alternative is that we can try and fix all of the
suddenly failing tests - but with all of the DBs that EUnit creates and
deletes rapidly, the daemon will be working overtime to try and compact
them all. And many EUnit tests don't delete their databases after
they're done (which itself is probably another bug). The LRU is
adversely affected as well, as we see in
`couchdb_views_tests:couchdb_1283`, but
`couch_db_tests:should_create_multiple_dbs` would also be affected.

Other test failures from enabling the compaction daemon: 
* #649 
* #643 

Closes #652