### PR TITLE
Make couch_event_sup:stop/1 synchronous

### DIFF
--- a/src/couch/src/couch_event_sup.erl
+++ b/src/couch/src/couch_event_sup.erl
@@ -48,7 +48,7 @@ start_link(ServerName, EventMgr, EventHandler, Args) ->
     gen_server:start_link(ServerName, couch_event_sup, {EventMgr, EventHandler, Args}, []).
 
 stop(Pid) ->
-    gen_server:cast(Pid, stop).
+    gen_server:call(Pid, stop).
 
 init({EventMgr, EventHandler, Args}) ->
     case gen_event:add_sup_handler(EventMgr, EventHandler, Args) of
@@ -61,11 +61,11 @@ init({EventMgr, EventHandler, Args}) ->
 terminate(_Reason, _State) ->
     ok.
 
-handle_call(_Whatever, _From, State) ->
-    {reply, ok, State}.
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State}.
 
-handle_cast(stop, State) ->
-    {stop, normal, State}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
 
 handle_info({gen_event_EXIT, _Handler, Reason}, State) ->
     {stop, Reason, State}.


### PR DESCRIPTION
Because `stop/1` is asynchronous, and casts a stop message and as result the
client process could end getting killed during termination/cleanup phase if
this sequence of events took place:

1. Client calls `stop(ListerPid).`

2. couch_event_sup casts a `stop` message to couch_event_sup gen_server

3. `stop` message is delayed and client continues executing.

4. Client calls something like application:stop/1`.

5. `application:stop/1` terminates couch_event_sup gen_server.

6. App termination kills client process because it is still linked.

So this make the stop synchrounous by using call instead of cast.

Issue #644


