### PR TITLE
631 fix os proc pool eunit

### DIFF
--- a/src/couch/test/couchdb_os_proc_pool.erl
+++ b/src/couch/test/couchdb_os_proc_pool.erl
@@ -206,6 +206,8 @@ should_reduce_pool_on_idle_os_procs() ->
 
 
 setup_config() ->
+    MFA = "{couch_native_process, start_link, []}",
+    config:set("native_query_servers", "test_lang", MFA, false),
     config:set("query_server_config", "os_process_limit", "3", false),
     config:set("query_server_config", "os_process_soft_limit", "2", false),
     ok = confirm_config("os_process_soft_limit", "2").
@@ -233,7 +235,7 @@ spawn_client() ->
     Parent = self(),
     Ref = make_ref(),
     Pid = spawn(fun() ->
-        Proc = couch_query_servers:get_os_process(<<"javascript">>),
+        Proc = couch_query_servers:get_os_process(<<"test_lang">>),
         loop(Parent, Ref, Proc)
     end),
     {Pid, Ref}.
@@ -243,7 +245,7 @@ spawn_client(DDocId) ->
     Ref = make_ref(),
     Pid = spawn(fun() ->
         DDocKey = {DDocId, <<"1-abcdefgh">>},
-        DDoc = #doc{body={[]}},
+        DDoc = #doc{body={[{<<"language">>, <<"test_lang">>}]}},
         Proc = couch_query_servers:get_ddoc_process(DDoc, DDocKey),
         loop(Parent, Ref, Proc)
     end),


### PR DESCRIPTION
This is a fix for #631. Basically just replacse the couchjs processes with couch_native_proc instances since we're just worried about how the proc manager behaves rather than anything to do with JavaScript.