### PR TITLE
Fix flaky os daemons tests

### DIFF
--- a/src/couch/src/couch_os_daemons.erl
+++ b/src/couch/src/couch_os_daemons.erl
@@ -36,7 +36,6 @@
 }).
 
 -define(PORT_OPTIONS, [stream, {line, 1024}, binary, exit_status, hide]).
--define(TIMEOUT, 5000).
 -define(RELISTEN_DELAY, 5000).
 
 start_link() ->

--- a/src/couch/test/couchdb_os_daemons_tests.erl
+++ b/src/couch/test/couchdb_os_daemons_tests.erl
@@ -52,6 +52,7 @@ setup(DName) ->
     % Set configuration option to be used by configuration_reader_test_
     % This will be used in os_daemon_configer.escript:test_get_cfg2
     config:set("uuids", "algorithm","sequential", false),
+    config:set("os_daemon_settings", "max_retries", "2"),
     ensure_n_daemons_are_alive(1),
     {Ctx, OsDPid}.
 
@@ -181,7 +182,7 @@ should_fail_due_to_lack_of_permissions(DName, _) ->
     ?_test(should_halts(DName, 1000)).
 
 should_die_on_boot(DName, _) ->
-    ?_test(should_halts(DName, 1000)).
+    ?_test(should_halts(DName, 2000)).
 
 should_die_quickly(DName, _) ->
     ?_test(should_halts(DName, 4000)).


### PR DESCRIPTION
 Fix flaky os daemons tests

The "should die" test was close to the edge of timing out. Daemon started up,
slept for 1 second then died. However max_retries is 3 so the whole thing was
happening 3 times in a row. The total wait was 4 seconds, but on slow machines
1 extra second was not enough for the overhead of forking the 3 processes and
other setup stuff.

Set restart times to 2. Hopefully 4 seconds should be enough overhead for 2
restarts.

Also adjust sleep time for the "die quickly" test. 1 second there might not
be enough for both restarts, so made it 2 just to be safe.

Also in a separate commit, remove unused TIMEOUT macro from os daemons module 