### PR TITLE
Make replication ID generation more robust. 

### DIFF
--- a/src/couch_replicator/src/couch_replicator.hrl
+++ b/src/couch_replicator/src/couch_replicator.hrl
@@ -10,7 +10,7 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
--define(REP_ID_VERSION, 3).
+-define(REP_ID_VERSION, 4).
 
 -record(rep, {
     id :: rep_id() | '_' | 'undefined',


### PR DESCRIPTION
Replications checkpoint to _local documents identified by replication ids. If
replication ids change replication tasks will not be able to find their
previous checkpoints and will rewind their change feeds back to 0. For a large
database that could mean reprocessing millions of documents.

Current version of replication id generation algorithm hashes the full url of
the source, target, their headers, including authorization ones as well, and a
few other things. This means when user changes their password and updates their
replication document, replication ids will change and all the checkpoint will
be invalidated.

Also, it is fairly common to upgrade services from http:// to https://.
Replication endpoint URIs then typically just change their schema part
accordingly. However, schema is part of the replication ID calculation, so
replication ids would then change as well.

Introduce a more robust replication id generation algorithm which can handle
some of those issues. The new algorithm:

 1. Excludes source and target URI schema from the replication id calculation.
 As long as the host and other parts stay the same changing the schema will
 have no effect on the replication id.

 2. Ignores inline (specified in the URL) basic authentication passwords.

 3. Ignores basic authentication password even if provided in the
 basic authorization headers.

 4. Is insensitive to switching between providing basic authentication
 credentials inline or in a headers section. However it includes the username
 used in the basic auth in the calculation. It is plausible scenario that
 `http://user1:pass1@a.host.com` is really a different database than
 `http://user2:pass2@@a.host.com`

Issue #688