### PR TITLE
Use test_util:stop_config in mem3_util_test

### DIFF
--- a/src/mem3/test/mem3_util_test.erl
+++ b/src/mem3/test/mem3_util_test.erl
@@ -145,8 +145,8 @@ config_01_setup() ->
     {ok, Pid} = config:start_link([Ini]),
     Pid.
 
-config_teardown(_Pid) ->
-    config:stop().
+config_teardown(Pid) ->
+    test_util:stop_config(Pid).
 
 
 n_val_test_() ->


### PR DESCRIPTION
## Overview

The config:stop is asynchronous which causes test failures with error
like the following

```
{error,{already_started,<0.32662.3>}
```

## Testing recommendations

This is rather hard to test since it is a flaky test. Just make sure that it doesn't make things worse by calling `make eunit apps=mem3 tests=n_val_tes`

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
