### PR TITLE
Remove get_details replicator job gen_server call

### DIFF
--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -215,9 +215,6 @@ do_init(#rep{options = Options, id = {BaseId, Ext}, user_ctx=UserCtx} = Rep) ->
     }.
 
 
-handle_call(get_details, _From, #rep_state{rep_details = Rep} = State) ->
-    {reply, {ok, Rep}, State};
-
 handle_call({add_stats, Stats}, From, State) ->
     gen_server:reply(From, ok),
     NewStats = couch_replicator_utils:sum_stats(State#rep_state.stats, Stats),

--- a/src/couch_replicator/test/couch_replicator_compact_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_compact_tests.erl
@@ -112,7 +112,6 @@ check_active_tasks(RepPid, {BaseId, Ext} = RepId, Src, Tgt) ->
     end,
     FullRepId = ?l2b(BaseId ++ Ext),
     Pid = ?l2b(pid_to_list(RepPid)),
-    ok = wait_for_replicator(RepId),
     RepTasks = wait_for_task_status(),
     ?assertNotEqual(timeout, RepTasks),
     [RepTask] = RepTasks,
@@ -131,20 +130,11 @@ check_active_tasks(RepPid, {BaseId, Ext} = RepId, Src, Tgt) ->
     Pending = couch_util:get_value(changes_pending, RepTask),
     ?assert(is_integer(Pending)).
 
-rep_details(RepId) ->
-    gen_server:call(get_pid(RepId), get_details).
-
 replication_tasks() ->
     lists:filter(fun(P) ->
         couch_util:get_value(type, P) =:= replication
     end, couch_task_status:all()).
 
-wait_for_replicator(RepId) ->
-    %% since replicator started asynchronously
-    %% we need to wait when it would be in couch_task_status
-    %% we query replicator:details to ensure that do_init happen
-    ?assertMatch({ok, _}, rep_details(RepId)),
-    ok.
 
 wait_for_task_status() ->
     test_util:wait(fun() ->


### PR DESCRIPTION
This was used from a test only and it wasn't reliable. Because of replicator
job delays initialization the `State` would be either #rep_state{} or #rep. If
replication job hasn't finished initializing, then state would be #rep{} and a
call like get_details which matches the state with #rep_state{] would fail with
the badmatch error.

As seen in issue #686

So remove `get_details` call and let the test rely on task polling as all other
tests do.