### PR TITLE
Fix cancellation race in replication.js tests

### DIFF
--- a/test/javascript/tests/replication.js
+++ b/test/javascript/tests/replication.js
@@ -1841,7 +1841,7 @@ couchTests.replication = function(debug) {
       headers: {"Content-Type": "application/json"}
   });
   TEquals(200, xhr.status, "Replication cancel request success");
-
+  waitReplicationTaskStop(repId);
   task = getTask(repId);
   TEquals(null, task, "Replication was canceled");
 


### PR DESCRIPTION
Replication cancelation doesn't immediately update active tasks. Instead, use
the new `waitReplicationTaskStop(rep_id)` function to propery wait for the
task status.

Issue #634
