### PR TITLE
Increase timeout of some replication tests

### DIFF
--- a/src/couch_replicator/test/couch_replicator_large_atts_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_large_atts_tests.erl
@@ -24,7 +24,7 @@
 -define(ATT_SIZE_1, 2 * 1024 * 1024).
 -define(ATT_SIZE_2, round(6.6 * 1024 * 1024)).
 -define(DOCS_COUNT, 11).
--define(TIMEOUT_EUNIT, 30).
+-define(TIMEOUT_EUNIT, 120).
 
 
 setup() ->

--- a/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
+++ b/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
@@ -9,7 +9,7 @@
     compare_dbs/3
 ]).
 
--define(TIMEOUT_EUNIT, 60).
+-define(TIMEOUT_EUNIT, 180).
 
 
 setup() ->


### PR DESCRIPTION
Could reproduce issue #633 by limiting disk throughput in a VBox
VM instance to about 5KB. Try to increase the timeouts to let it
handle such apparent slowdowns.

Fixed #633
