### PR TITLE
Increase various eunit test timeouts

### DIFF
--- a/src/couch/test/couch_changes_tests.erl
+++ b/src/couch/test/couch_changes_tests.erl
@@ -15,7 +15,7 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
--define(TIMEOUT, 3000).
+-define(TIMEOUT, 6000).
 -define(TEST_TIMEOUT, 10000).
 
 -record(row, {

--- a/src/couch/test/couchdb_file_compression_tests.erl
+++ b/src/couch/test/couchdb_file_compression_tests.erl
@@ -17,7 +17,7 @@
 
 -define(DDOC_ID, <<"_design/test">>).
 -define(DOCS_COUNT, 5000).
--define(TIMEOUT, 30000).
+-define(TIMEOUT, 60000).
 
 setup() ->
     config:set("couchdb", "file_compression", "none", false),

--- a/src/couch/test/couchdb_os_daemons_tests.erl
+++ b/src/couch/test/couchdb_os_daemons_tests.erl
@@ -38,7 +38,7 @@
 -define(DAEMON_CAN_REBOOT, "os_daemon_can_reboot.sh").
 -define(DAEMON_DIE_ON_BOOT, "os_daemon_die_on_boot.sh").
 -define(DAEMON_DIE_QUICKLY, "os_daemon_die_quickly.sh").
--define(TRIES, 20).
+-define(TRIES, 40).
 -define(TRY_DELAY_MS, 100).
 -define(TIMEOUT, 10000).
 -define(CONFIG_TIMEOUT, 1000).

--- a/src/couch/test/couchdb_update_conflicts_tests.erl
+++ b/src/couch/test/couchdb_update_conflicts_tests.erl
@@ -18,7 +18,7 @@
 -define(i2l(I), integer_to_list(I)).
 -define(DOC_ID, <<"foobar">>).
 -define(NUM_CLIENTS, [100, 500, 1000, 2000, 5000, 10000]).
--define(TIMEOUT, 10000).
+-define(TIMEOUT, 20000).
 
 start() ->
     Ctx = test_util:start_couch(),

--- a/src/couch/test/couchdb_views_tests.erl
+++ b/src/couch/test/couchdb_views_tests.erl
@@ -18,6 +18,7 @@
 
 -define(DELAY, 100).
 -define(TIMEOUT, 1000).
+-define(WAIT_DELAY_COUNT, 40).
 
 setup() ->
     DbName = ?tempdb(),
@@ -565,7 +566,7 @@ compact_db(DbName) ->
     {ok, Db} = couch_db:open_int(DbName, []),
     {ok, _} = couch_db:start_compact(Db),
     ok = couch_db:close(Db),
-    wait_db_compact_done(DbName, 20).
+    wait_db_compact_done(DbName, ?WAIT_DELAY_COUNT).
 
 wait_db_compact_done(_DbName, 0) ->
     erlang:error({assertion_failed,

--- a/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
+++ b/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
@@ -9,7 +9,7 @@
     compare_dbs/3
 ]).
 
--define(TIMEOUT_EUNIT, 180).
+-define(TIMEOUT_EUNIT, 360).
 
 
 setup() ->


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Several eunit tests tend to fail by timing out when run on
travis-ci. This change increases timeouts on the more commonly failing
tests, and improves test robustness.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
