### PR TITLE
Allow replicator application to always update replicator docs

### DIFF
--- a/src/couch_replicator/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator/src/couch_replicator_js_functions.hrl
@@ -53,6 +53,11 @@
         var isReplicator = (userCtx.roles.indexOf('_replicator') >= 0);
         var isAdmin = (userCtx.roles.indexOf('_admin') >= 0);
 
+        if (isReplicator) {
+            // Always let replicator update the replication document
+            return;
+        }
+
         if (newDoc._replication_state === 'failed') {
             // Skip validation in case when we update the document with the
             // failed state. In this case it might be malformed. However,


### PR DESCRIPTION
Previously when updating the document with the error or failed states
the document body will not pass the validation function and will
consequently crash either the scheduler or the doc processor.
