### PR TITLE
couch_epi depends on crypto app

### DIFF
--- a/src/couch_epi/src/couch_epi.app.src.script
+++ b/src/couch_epi/src/couch_epi.app.src.script
@@ -20,7 +20,8 @@ ConfigFile = filename:join([os:getenv("COUCHDB_APPS_CONFIG_DIR"), "couch_epi.con
   {registered, [couch_epi_sup, couch_epi_server]},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  crypto
                  ]},
   {mod, { couch_epi_app, []}},
   {env, AppConfig}


### PR DESCRIPTION
couch_epi calls crypto functions since 9e56cf334c33d4cdb96acbfca9cc9461e2b658aa so should ensure the app is started first.