### PR TITLE
Add [couchdb, httpd_status_codes, 503] metric

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -194,6 +194,10 @@
     {type, counter},
     {desc, <<"number of HTTP 501 Not Implemented responses">>}
 ]}.
+{[couchdb, httpd_status_codes, 503], [
+    {type, counter},
+    {desc, <<"number of HTTP 503 Service unavailable responses">>}
+]}.
 {[couchdb, open_databases], [
     {type, counter},
     {desc,  <<"number of open databases">>}


### PR DESCRIPTION
## Overview

The 503 response was added recently. We need to update the `stats_description.cfg` to include this new return code in order to avoid `"unknown metric: [couchdb,httpd_status_codes,503]"` errors from [here](https://github.com/apache/couchdb/blob/master/src/chttpd/src/chttpd.erl#L1127).



## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
