### PR TITLE
Fix incorrect indexable_fields for $in

### DIFF
--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -307,7 +307,7 @@ indexable_fields(Fields, {op_or, [{op_field, Field0},
         {op_field, {[Name | _], _}} = Field1]}) ->
     case lists:member(<<"[]">>, Name) of
         true ->
-            indexable_fields(Fields, Field1);
+            indexable_fields(Fields, {op_field, Field0});
         false ->
             Fields1 = indexable_fields(Fields, {op_field, Field0}),
             indexable_fields(Fields1, Field1)

--- a/src/mango/test/07-text-custom-field-list-test.py
+++ b/src/mango/test/07-text-custom-field-list-test.py
@@ -64,6 +64,16 @@ class CustomFieldsTest(mango.UserDocsTextTests):
         docs = self.db.find({"favorites": {"$in": vals}})
         assert len(docs) == 10
 
+    def test_in_with_array_not_explicit(self):
+        agelist = [22, 51]
+        statelist = ["New Hampshire"]
+        docs = self.db.find({"age": {"$in": agelist}})
+        docs2 = self.db.find({"location.state": {"$in": statelist}})
+        docs3 = self.db.find({"age": {"$in": statelist}})
+        assert len(docs) == 2
+        assert len(docs2) == 1
+        assert len(docs3) == 0
+
     # This should also throw an error because we only indexed
     # favorites.[] of type string. For the following query to work, the
     # user has to index favorites.[] of type number, and also
@@ -75,16 +85,10 @@ class CustomFieldsTest(mango.UserDocsTextTests):
         except Exception, e:
                 assert e.response.status_code == 400
 
-    # This test differs from the situation where we index everything.
-    # When we index everything the actual number of docs that gets
-    # returned is 5. That's because of the special situation where we
-    # have an array of an array, i.e: [["Lisp"]], because we're indexing
-    # specifically favorites.[] of type string. So it does not count
-    # the example and we only get 4 back.
     def test_nin_with_array(self):
         vals = ["Lisp", "Python"]
         docs = self.db.find({"favorites": {"$nin": vals}})
-        assert len(docs) == 4
+        assert len(docs) == 5
 
     def test_missing(self):
         self.db.find({"location.state": "Nevada"})


### PR DESCRIPTION
## Overview

The function indexable_fields/1 is supposed to remove extraneous fields
created by the mango_selector_text:convert/1 function so that indexes
will not be bypassed during index selection time. This wasn't working
as expected in the case of $in when the user did not explicitly specify
an array at index time. In fact, we had two different results depending
on whether or not users used all_fields or explicilty specified a
field. Before if you only specified {"name" : "age", "type : "number"}
as a field, you could not query for {"age" : {"$in" : [2, 3]}}. You
had to explicitly add {"name" : "age.[]", "type : "number"} to your
list of indexes so the $in would work. This fixes the scenario and now
should work as expected


## Testing recommendations

Automated Tests added
## GitHub issue number

Github Issue is this PR

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
