### PR TITLE
Add a debugging utilities for listing processes

### DIFF
--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -419,6 +419,13 @@ shorten_path(Path) ->
 
 %% Limmitations:
 %%   - The first column has to be specified as {Width, left, Something}
+%% The TableSpec is a list of either:
+%%   - {Value}
+%%   - {Width, Align, Value}
+%% Align is one of the following:
+%%  - left
+%%  - centre
+%%  - right
 print_tree(Tree, TableSpec) ->
     io:format("~s~n", [format(TableSpec)]),
     map_tree(Tree, fun(_, {Id, Props}, Pos) ->

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -466,7 +466,7 @@ random_processes(Acc, Left) ->
         spawn ->
             spawn(fun process_fun/0);
         spawn_link ->
-            spawn(fun process_fun/0)
+            spawn_link(fun process_fun/0)
     end,
     random_processes([Pid | Acc], Left - 1).
 

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -42,7 +42,6 @@ help() ->
         opened_files_contains,
         process_name,
         link_tree,
-        link_tree,
         mapfold,
         map,
         fold,

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -45,8 +45,7 @@ help() ->
         map,
         fold,
         linked_processes_info,
-        print_linked_processes,
-        ps
+        print_linked_processes
     ].
 
 -spec help(Function :: atom()) -> ok.

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -55,7 +55,7 @@ help(opened_files) ->
     --------------
 
     Returns list of currently opened files
-    It iterates through erlang:ports and filter out all ports which are not efile.
+    It iterates through `erlang:ports` and filters out all ports which are not efile.
     It uses `process_info(Pid, dictionary)` to get info about couch_file properties.
     ---
     ", []);
@@ -64,7 +64,7 @@ help(opened_files_by_regexp) ->
     opened_files_by_regexp(FileRegExp)
     ----------------------------------
 
-    Returns list of currently opened files which name matches provided regular expression.
+    Returns list of currently opened files which name match the provided regular expression.
     It iterates through `erlang:ports()` and filter out all ports which are not efile.
     It uses `process_info(Pid, dictionary)` to get info about couch_file properties.
     ---
@@ -74,8 +74,8 @@ help(opened_files_contains) ->
     opened_files_contains(SubString)
     --------------------------------
 
-    Returns list of currently opened files which name contains provided SubString.
-    It iterates through `erlang:ports()` and filter out all ports which are not efile.
+    Returns list of currently opened files whose names contain the provided SubString.
+    It iterates through `erlang:ports()` and filters out all ports which are not efile.
     It uses `process_info(Pid, dictionary)` to get info about couch_file properties.
     ---
     ", []);
@@ -84,7 +84,7 @@ help(process_name) ->
     process_name(Pid)
     -----------------
 
-    Uses heuristics to figure out the best way to name process.
+    Uses heuristics to figure out the process name.
     The heuristic is based on the following information about the process:
     - process_info(Pid, registered_name)
     - '$initial_call' key in process dictionary
@@ -165,7 +165,7 @@ help(linked_processes_info) ->
         linked_processes_info(Pid, Info)
         --------------------------------
 
-        Convinience function which reduces the amount of typing compared to direct
+        Convenience function which reduces the amount of typing compared to direct
         use of link_tree.
           - Pid: initial Pid to start from
           - Info: a list of process_info_item() as documented

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -27,9 +27,9 @@
     process_name/1,
     link_tree/1,
     link_tree/2,
-    mapfold/3,
-    map/2,
-    fold/3,
+    mapfold_tree/3,
+    map_tree/2,
+    fold_tree/3,
     linked_processes_info/2,
     print_linked_processes/1,
     ps/1
@@ -120,9 +120,9 @@ help(link_tree) ->
     can be dangerous in a very busy system.
     ---
     ", []);
-help(mapfold) ->
+help(mapfold_tree) ->
     io:format("
-    mapfold(Tree, Acc, Fun)
+    mapfold_tree(Tree, Acc, Fun)
     -----------------------
 
     Traverses all nodes of the tree. It is a combination of a map and fold.
@@ -136,9 +136,9 @@ help(mapfold) ->
 
     ---
     ", []);
-help(map) ->
+help(map_tree) ->
     io:format("
-    map(Tree, Fun)
+    map_tree(Tree, Fun)
     -----------------------
 
     Traverses all nodes of the tree in order to modify them.
@@ -151,9 +151,9 @@ help(map) ->
 
     ---
     ", []);
-help(fold) ->
+help(fold_tree) ->
     io:format("
-    fold(Tree, Fun)
+    fold_tree(Tree, Fun)
     Traverses all nodes of the tree in order to collect some aggregated information
     about the tree. It calls a user provided callback
     `Fun(Key, Value, Pos) -> NewValue`
@@ -349,22 +349,22 @@ info(Port, Info) when is_port(Port) ->
     Validated = lists:filter(fun(P) -> lists:member(P, ValidProps) end, Info),
     erlang:port_info(Port, lists:usort(Validated)).
 
-mapfold([], Acc, _Fun) ->
+mapfold_tree([], Acc, _Fun) ->
     {[], Acc};
-mapfold([{Pos, {Key, Value0, SubTree0}} | Rest0], Acc0, Fun) ->
+mapfold_tree([{Pos, {Key, Value0, SubTree0}} | Rest0], Acc0, Fun) ->
     {Value1, Acc1} = Fun(Key, Value0, Pos, Acc0),
-    {SubTree1, Acc2} = mapfold(SubTree0, Acc1, Fun),
-    {Rest1, Acc3} = mapfold(Rest0, Acc2, Fun),
+    {SubTree1, Acc2} = mapfold_tree(SubTree0, Acc1, Fun),
+    {Rest1, Acc3} = mapfold_tree(Rest0, Acc2, Fun),
     {[{Pos, {Key, Value1, SubTree1}} | Rest1], Acc3}.
 
-map(Tree, Fun) ->
-    {Result, _} = mapfold(Tree, nil, fun(Key, Value, Pos, Acc) ->
+map_tree(Tree, Fun) ->
+    {Result, _} = mapfold_tree(Tree, nil, fun(Key, Value, Pos, Acc) ->
         {Fun(Key, Value, Pos), Acc}
     end),
     Result.
 
-fold(Tree, Acc, Fun) ->
-    {_, Result} = mapfold(Tree, Acc, fun(Key, Value, Pos, AccIn) ->
+fold_tree(Tree, Acc, Fun) ->
+    {_, Result} = mapfold_tree(Tree, Acc, fun(Key, Value, Pos, AccIn) ->
         {Value, Fun(Key, Value, Pos, AccIn)}
     end),
     Result.
@@ -427,7 +427,7 @@ shorten_path(Path) ->
 %%   - The first column has to be specified as {Width, left, Something}
 print_tree(Tree, TableSpec) ->
     io:format("~s~n", [format(TableSpec)]),
-    map(Tree, fun(_, {Id, Props}, Pos) ->
+    map_tree(Tree, fun(_, {Id, Props}, Pos) ->
         io:format("~s~n", [table_row(Id, Pos * 2, Props, TableSpec)])
     end),
     ok.


### PR DESCRIPTION
## Overview

This adds few useful debug tools.

1. List a cluster of linked processes. This function receives the
initial Pid to start from. The function doesn't recurse to pids
older than initial one.
```
167> couch_debug:print_linked_processes(whereis(couch_index_server)).
name                                         | reductions | message_queue_len |  memory
couch_index_server[<0.288.0>]                |   478240   |         0         |  109696
  couch_index:init/1[<0.3520.22>]            |    4899    |         0         |  109456
    couch_file:init/1[<0.886.22>]            |   11973    |         0         |  67984
      couch_index:init/1[<0.3520.22>]        |    4899    |         0         |  109456
    couch_index_updater:init/1[<0.3550.22>]  |   19671    |         0         |  26408
      couch_index:init/1[<0.3520.22>]        |    4899    |         0         |  109456
    couch_index_compactor:init/1[<0.885.22>] |     25     |         0         |   2704
      couch_index:init/1[<0.3520.22>]        |    4899    |         0         |  109456
    couch_index_server[<0.288.0>]            |   478240   |         0         |  109696
```
2. List couch_index_server children
```
169> couch_debug:ps(couch_index_server).
name                                              | reductions | message_queue_len |    memory    |id
couch_index_server[<0.288.0>]                     |   503398   |         0         |    109696    |
  couch_index:init/1[<0.10447.22>]                |    4700    |         0         |    109456    |
    couch_file:init/1[<0.10462.22>]               |    8514    |         0         |    67984     |46:#Port<0.134945>:/.shards/00000000-1fffffff/thedb-010b3e313347496ab96a4d762aae4e87.1503092951_design/mrview/8f3db710871cdc942f4793936e3de269.view
      couch_index:init/1[<0.10447.22>]            |    4700    |         0         |    109456    |
    couch_index_updater:init/1[<0.10489.22>]      |   12575    |         0         |    34312     |
      couch_index:init/1[<0.10447.22>]            |    4700    |         0         |    109456    |
    couch_index_compactor:init/1[<0.10476.22>]    |     25     |         0         |     2704     |
      couch_index:init/1[<0.10447.22>]            |    4700    |         0         |    109456    |
    couch_index_server[<0.288.0>]                 |   503398   |         0         |    109696    |
  couch_index:init/1[<0.10630.22>]                |    4750    |         0         |    109456    |
    couch_file:init/1[<0.10642.22>]               |    9381    |         0         |    67984     |44:#Port<0.134965>:/.shards/a0000000-bfffffff/thedb-010b3e313347496ab96a4d762aae4e87.1503092951_design/mrview/8f3db710871cdc942f4793936e3de269.view
```

## Testing recommendations

- couch_debug:ps(couch_index_server). 
- couch_debug:print_linked_processes(whereis(couch_index_server)).

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
