### PR TITLE
Use fully qualified call to allow code upgrade

### DIFF
--- a/src/rexi/src/rexi_monitor.erl
+++ b/src/rexi/src/rexi_monitor.erl
@@ -12,6 +12,7 @@
 
 -module(rexi_monitor).
 -export([start/1, stop/1]).
+-export([wait_monitors/1]).
 
 
 %% @doc spawn_links a process which monitors the supplied list of items and
@@ -51,7 +52,7 @@ wait_monitors(Parent) ->
     receive
     {'DOWN', _, process, Pid, Reason} ->
         notify_parent(Parent, Pid, Reason),
-        wait_monitors(Parent);
+        ?MODULE:wait_monitors(Parent);
     {Parent, shutdown} ->
         ok
     end.


### PR DESCRIPTION
## Overview

`rexi_monitor:wait_monitor/1` function is called recursively. This means
that hot code upgrade will not work when we are inside that
function. Use fully qualified call to allow the update of a module.

## Testing recommendations

1. Add `-export([wait_monitors/1]).`
2. Run following snippet
    ```
    Self = self(), spawn(fun() -> rexi_monitor:wait_monitors(Self) end).
    code:soft_purge(rexi_monitor).
    ```
3. Without this change the test ^^ would always return false.
## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
