### PR TITLE
include mrview options in _explain result

### DIFF
--- a/src/mango/test/02-basic-find-test.py
+++ b/src/mango/test/02-basic-find-test.py
@@ -14,7 +14,6 @@
 
 import mango
 
-
 class BasicFindTests(mango.UserDocsTests):
 
     def test_bad_selector(self):
@@ -264,3 +263,15 @@ class BasicFindTests(mango.UserDocsTests):
                 ]
             })
         assert len(docs) == 0
+
+    def test_explain_view_args(self):
+        explain = self.db.find({
+               "age":{"$gt": 0}
+            }, fields=["manager"],
+            explain=True)
+        assert explain["mrargs"]["stable"] == False
+        assert explain["mrargs"]["update"] == True
+        assert explain["mrargs"]["reduce"] == False
+        assert explain["mrargs"]["start_key"] == [0]
+        assert explain["mrargs"]["end_key"] == [{}]
+        assert explain["mrargs"]["include_docs"] == True


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
`_explain` previously returned the options passed in by the user but
not those modified at execution time by Mango. Now we include
index-specific options (mrargs for map/reduce indexes) in the output,
allowing us to see e.g. when include_docs was used.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Manually test by making a request to the `_explain` endpoint from the command line / Fauxton. When a query is fulfilled by a `json` index, you should see an `mrargs` field in the output.

Unit tests should provide good coverage.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
