### PR TITLE
Fix leaking chttpd's security tests config

### DIFF
--- a/src/chttpd/test/chttpd_security_tests.erl
+++ b/src/chttpd/test/chttpd_security_tests.erl
@@ -34,10 +34,11 @@
 
 setup() ->
     Hashed = couch_passwords:hash_admin_password(?PASS),
-    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
+    Persist = false,
+    ok = config:set("admins", ?USER, ?b2l(Hashed), Persist),
     UserDb = ?tempdb(),
     TmpDb = ?tempdb(),
-    ok = config:set("chttpd_auth", "authentication_db", ?b2l(UserDb)),
+    ok = config:set("chttpd_auth", "authentication_db", ?b2l(UserDb), Persist),
 
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),


### PR DESCRIPTION
## Overview

We are setting custom "authentication_db" in `chttpd_security_tests`, but making this change persistent in `eunit.ini` config. As a result the rest of the tests expecting this temporary database to be a proper authentication database and getting background `chttpd_auth_cache` crashes with `database_does_not_exist` exception on attempt to pull `_design/_auth` .

## Testing recommendations

Before:
```bash
$ make clean

$ grep authentication_db tmp/etc/*
grep: tmp/etc/*: No such file or directory

$ make eunit apps=chttpd suites=chttpd_security_tests skip_deps=couch_epi
 ...
   [done in 8.694 s]
=======================================================
  All 8 tests passed.

$ grep authentication_db tmp/etc/*
tmp/etc/default_eunit.ini:; authentication_db = _users
tmp/etc/default_eunit.ini:authentication_db = _users
tmp/etc/eunit.ini:authentication_db = eunit-test-db-1503408726307396
```

After:
```bash
...
$ grep authentication_db tmp/etc/*
tmp/etc/default_eunit.ini:; authentication_db = _users
tmp/etc/default_eunit.ini:authentication_db = _users
```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
