### PR TITLE
Fix chttpd's tests warnings

### DIFF
--- a/src/chttpd/test/chttpd_db_doc_size_tests.erl
+++ b/src/chttpd/test/chttpd_db_doc_size_tests.erl
@@ -58,7 +58,8 @@ all_test_() ->
         "chttpd db max_document_size tests",
         {
             setup,
-            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
             {
                 foreach,
                 fun setup/0, fun teardown/1,
@@ -118,7 +119,7 @@ put_post_doc_attach_inline(Url) ->
     {ok, _, _, ResultBody} = test_request:post(Url,
         [?CONTENT_JSON, ?AUTH], Doc1),
     {Msg} = ?JSON_DECODE(ResultBody),
-       {ok, _, _, ResultBody1} = test_request:post(Url,
+    {ok, _, _, ResultBody1} = test_request:post(Url,
         [?CONTENT_JSON, ?AUTH], Doc2),
     {Msg1} = ?JSON_DECODE(ResultBody1),
 

--- a/src/chttpd/test/chttpd_db_doc_size_tests.erl
+++ b/src/chttpd/test/chttpd_db_doc_size_tests.erl
@@ -118,20 +118,24 @@ put_post_doc_attach_inline(Url) ->
     {ok, _, _, ResultBody} = test_request:post(Url,
         [?CONTENT_JSON, ?AUTH], Doc1),
     {Msg} = ?JSON_DECODE(ResultBody),
-    ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
        {ok, _, _, ResultBody1} = test_request:post(Url,
         [?CONTENT_JSON, ?AUTH], Doc2),
     {Msg1} = ?JSON_DECODE(ResultBody1),
-    ?_assertEqual({<<"error">>, <<"document_too_large">>}, lists:nth(1, Msg1)),
 
     {ok, _, _, ResultBody2} = test_request:put(Url ++ "/" ++ "accept",
         [?CONTENT_JSON, ?AUTH], Doc1),
     {Msg2} = ?JSON_DECODE(ResultBody2),
-    ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg2)),
     {ok, _, _, ResultBody3} = test_request:put(Url ++ "/" ++ "fail",
         [?CONTENT_JSON, ?AUTH], Doc2),
     {Msg3} = ?JSON_DECODE(ResultBody3),
-    ?_assertEqual({<<"error">>, <<"document_too_large">>}, lists:nth(1, Msg3)).
+    [
+        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>},
+            lists:nth(1, Msg1)),
+        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg2)),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>},
+            lists:nth(1, Msg3))
+    ].
 
 put_multi_part_related(Url) ->
     Body1 = "{\"body\":\"This is a body.\",",
@@ -148,11 +152,14 @@ put_multi_part_related(Url) ->
     {ok, _, _, ResultBody} = test_request:put(Url ++ "/" ++ "accept",
         [?CONTENT_MULTI_RELATED, ?AUTH], Doc1),
     {Msg} = ?JSON_DECODE(ResultBody),
-    ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
        {ok, _, _, ResultBody1} = test_request:put(Url ++ "/" ++ "faildoc",
         [?CONTENT_MULTI_RELATED, ?AUTH], Doc2),
     {Msg1} = ?JSON_DECODE(ResultBody1),
-    ?_assertEqual({<<"error">>, <<"document_too_large">>}, lists:nth(1, Msg1)).
+    [
+        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>},
+            lists:nth(1, Msg1))
+    ].
 
 post_multi_part_form(Url) ->
     Port = mochiweb_socket_server:get(chttpd, port),
@@ -171,8 +178,11 @@ post_multi_part_form(Url) ->
     {ok, _, _, ResultBody} = test_request:post(Url ++ "/" ++ "accept",
         [?CONTENT_MULTI_FORM, ?AUTH, Referer], Doc1),
     {Msg} = ?JSON_DECODE(ResultBody),
-    ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
     {ok, _, _, ResultBody1} = test_request:post(Url ++ "/" ++ "fail",
         [?CONTENT_MULTI_FORM, ?AUTH, Referer], Doc2),
     {Msg1} = ?JSON_DECODE(ResultBody1),
-    ?_assertEqual({<<"error">>, <<"document_too_large">>}, lists:nth(1, Msg1)).
+    [
+        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>},
+            lists:nth(1, Msg1))
+    ].

--- a/src/chttpd/test/chttpd_db_doc_size_tests.erl
+++ b/src/chttpd/test/chttpd_db_doc_size_tests.erl
@@ -46,7 +46,7 @@ create_db(Url) ->
     case Status of
         201 -> ok;
         202 -> ok;
-        Else -> io:format(user, "~n HTTP Status Code: ~p~n", [Status])
+        _ -> io:format(user, "~n HTTP Status Code: ~p~n", [Status])
     end,
     ?assert(Status =:= 201 orelse Status =:= 202).
 

--- a/src/chttpd/test/chttpd_db_doc_size_tests.erl
+++ b/src/chttpd/test/chttpd_db_doc_size_tests.erl
@@ -76,26 +76,20 @@ all_test_() ->
     }.
 
 post_single_doc(Url) ->
-    ?_assertEqual({<<"error">>, <<"document_too_large">>},
-        begin
-            NewDoc = "{\"post_single_doc\": \"some_doc\",
-                \"_id\": \"testdoc\", \"should_be\" : \"too_large\"}",
-            {ok, _, _, ResultBody} = test_request:post(Url,
-                [?CONTENT_JSON, ?AUTH], NewDoc),
-            {ErrorMsg} = ?JSON_DECODE(ResultBody),
-            lists:nth(1, ErrorMsg)
-        end).
+    NewDoc = "{\"post_single_doc\": \"some_doc\",
+        \"_id\": \"testdoc\", \"should_be\" : \"too_large\"}",
+    {ok, _, _, ResultBody} = test_request:post(Url,
+        [?CONTENT_JSON, ?AUTH], NewDoc),
+    {[ErrorMsg | _]} = ?JSON_DECODE(ResultBody),
+    ?_assertEqual({<<"error">>, <<"document_too_large">>}, ErrorMsg).
 
 put_single_doc(Url) ->
-    ?_assertEqual({<<"error">>, <<"document_too_large">>},
-        begin
-            NewDoc = "{\"post_single_doc\": \"some_doc\",
-                \"_id\": \"testdoc\", \"should_be\" : \"too_large\"}",
-            {ok, _, _, ResultBody} = test_request:put(Url ++ "/" ++ "testid",
-                [?CONTENT_JSON, ?AUTH], NewDoc),
-            {ErrorMsg} = ?JSON_DECODE(ResultBody),
-            lists:nth(1, ErrorMsg)
-        end).
+    NewDoc = "{\"post_single_doc\": \"some_doc\",
+        \"_id\": \"testdoc\", \"should_be\" : \"too_large\"}",
+    {ok, _, _, ResultBody} = test_request:put(Url ++ "/" ++ "testid",
+        [?CONTENT_JSON, ?AUTH], NewDoc),
+    {[ErrorMsg | _]} = ?JSON_DECODE(ResultBody),
+    ?_assertEqual({<<"error">>, <<"document_too_large">>}, ErrorMsg).
 
 bulk_doc(Url) ->
     NewDoc = "{\"docs\": [{\"doc1\": 1}, {\"errordoc\":
@@ -118,24 +112,22 @@ put_post_doc_attach_inline(Url) ->
 
     {ok, _, _, ResultBody} = test_request:post(Url,
         [?CONTENT_JSON, ?AUTH], Doc1),
-    {Msg} = ?JSON_DECODE(ResultBody),
+    {[Msg | _]} = ?JSON_DECODE(ResultBody),
     {ok, _, _, ResultBody1} = test_request:post(Url,
         [?CONTENT_JSON, ?AUTH], Doc2),
-    {Msg1} = ?JSON_DECODE(ResultBody1),
+    {[Msg1 | _]} = ?JSON_DECODE(ResultBody1),
 
     {ok, _, _, ResultBody2} = test_request:put(Url ++ "/" ++ "accept",
         [?CONTENT_JSON, ?AUTH], Doc1),
-    {Msg2} = ?JSON_DECODE(ResultBody2),
+    {[Msg2 | _]} = ?JSON_DECODE(ResultBody2),
     {ok, _, _, ResultBody3} = test_request:put(Url ++ "/" ++ "fail",
         [?CONTENT_JSON, ?AUTH], Doc2),
-    {Msg3} = ?JSON_DECODE(ResultBody3),
+    {[Msg3 | _]} = ?JSON_DECODE(ResultBody3),
     [
-        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
-        ?_assertEqual({<<"error">>, <<"document_too_large">>},
-            lists:nth(1, Msg1)),
-        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg2)),
-        ?_assertEqual({<<"error">>, <<"document_too_large">>},
-            lists:nth(1, Msg3))
+        ?_assertEqual({<<"ok">>, true}, Msg),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>}, Msg1),
+        ?_assertEqual({<<"ok">>, true}, Msg2),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>}, Msg3)
     ].
 
 put_multi_part_related(Url) ->
@@ -152,14 +144,13 @@ put_multi_part_related(Url) ->
     Doc2 = lists:concat([DocBeg, Body2, DocRest]),
     {ok, _, _, ResultBody} = test_request:put(Url ++ "/" ++ "accept",
         [?CONTENT_MULTI_RELATED, ?AUTH], Doc1),
-    {Msg} = ?JSON_DECODE(ResultBody),
+    {[Msg | _]} = ?JSON_DECODE(ResultBody),
        {ok, _, _, ResultBody1} = test_request:put(Url ++ "/" ++ "faildoc",
         [?CONTENT_MULTI_RELATED, ?AUTH], Doc2),
-    {Msg1} = ?JSON_DECODE(ResultBody1),
+    {[Msg1 | _]} = ?JSON_DECODE(ResultBody1),
     [
-        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
-        ?_assertEqual({<<"error">>, <<"document_too_large">>},
-            lists:nth(1, Msg1))
+        ?_assertEqual({<<"ok">>, true}, Msg),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>}, Msg1)
     ].
 
 post_multi_part_form(Url) ->
@@ -178,12 +169,11 @@ post_multi_part_form(Url) ->
     Doc2 = lists:concat([DocBeg, Body2, DocRest]),
     {ok, _, _, ResultBody} = test_request:post(Url ++ "/" ++ "accept",
         [?CONTENT_MULTI_FORM, ?AUTH, Referer], Doc1),
-    {Msg} = ?JSON_DECODE(ResultBody),
+    {[Msg | _]} = ?JSON_DECODE(ResultBody),
     {ok, _, _, ResultBody1} = test_request:post(Url ++ "/" ++ "fail",
         [?CONTENT_MULTI_FORM, ?AUTH, Referer], Doc2),
-    {Msg1} = ?JSON_DECODE(ResultBody1),
+    {[Msg1 | _]} = ?JSON_DECODE(ResultBody1),
     [
-        ?_assertEqual({<<"ok">>, true}, lists:nth(1, Msg)),
-        ?_assertEqual({<<"error">>, <<"document_too_large">>},
-            lists:nth(1, Msg1))
+        ?_assertEqual({<<"ok">>, true}, Msg),
+        ?_assertEqual({<<"error">>, <<"document_too_large">>}, Msg1)
     ].

--- a/src/chttpd/test/chttpd_open_revs_error_test.erl
+++ b/src/chttpd/test/chttpd_open_revs_error_test.erl
@@ -55,7 +55,8 @@ open_revs_error_test_() ->
         "open revs error tests",
         {
             setup,
-            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
             {
                 foreach,
                 fun setup/0, fun teardown/1,
@@ -74,7 +75,7 @@ should_return_503_error_for_open_revs_get(Url) ->
     mock_open_revs({error, all_workers_died}),
     {ok, Code, _, _} = test_request:get(Url ++
         "/testdoc?rev=" ++ ?b2l(Ref), [?AUTH]),
-     ?_assertEqual(503, Code).
+    ?_assertEqual(503, Code).
 
 should_return_503_error_for_open_revs_post_form(Url) ->
     Port = mochiweb_socket_server:get(chttpd, port),

--- a/src/chttpd/test/chttpd_open_revs_error_test.erl
+++ b/src/chttpd/test/chttpd_open_revs_error_test.erl
@@ -97,7 +97,12 @@ should_return_503_error_for_open_revs_post_form(Url) ->
     mock_open_revs({error, all_workers_died}),
     {ok, Code, _, ResultBody1} = test_request:post(Url ++ "/" ++ "RevDoc",
         [?CONTENT_MULTI_FORM, ?AUTH, Referer], Doc2),
-    ?_assertEqual(503, Code).
+    {Json1} = ?JSON_DECODE(ResultBody1),
+    ErrorMessage = couch_util:get_value(<<"error">>, Json1),
+    [
+        ?_assertEqual(503, Code),
+        ?_assertEqual(<<"service unvailable">>, ErrorMessage)
+    ].
 
 mock_open_revs(RevsResp) ->
     ok = meck:expect(fabric, open_revs, fun(_, _, _, _) -> RevsResp end).


### PR DESCRIPTION
## Overview

Some tests in `chttpd_db_doc_size_tests` and `chttpd_open_revs_error_test` specified incorrectly leading to actual assertions not to be run and the tests throwing warning on first compilation.

This change fixes those tests and doing some general house cleaning.

## Testing recommendations

On `make clean; make eunit apps=chttpd` no warnings should be printed and all the tests should pass.

Before:

```bash
$ make clean

$ make eunit apps=chttpd suites=chttpd_db_doc_size_tests
...
Compiled test/chttpd_db_test.erl
/home/vagrant/git/couchdb/src/chttpd/test/chttpd_db_doc_size_tests.erl:49: Warning: variable 'Else' is unused
/home/vagrant/git/couchdb/src/chttpd/test/chttpd_db_doc_size_tests.erl:121: Warning: a term is constructed, but never used
/home/vagrant/git/couchdb/src/chttpd/test/chttpd_db_doc_size_tests.erl:125: Warning: a term is constructed, but never used
/home/vagrant/git/couchdb/src/chttpd/test/chttpd_db_doc_size_tests.erl:130: Warning: a term is constructed, but never used
/home/vagrant/git/couchdb/src/chttpd/test/chttpd_db_doc_size_tests.erl:151: Warning: a term is constructed, but never used
/home/vagrant/git/couchdb/src/chttpd/test/chttpd_db_doc_size_tests.erl:174: Warning: a term is constructed, but never used.
...
```
## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
