### PR TITLE
Cleanup mango test runner script

### DIFF
--- a/test/build/test-run-couch-for-mango.sh
+++ b/test/build/test-run-couch-for-mango.sh
@@ -15,11 +15,11 @@
 export SERVER_PID=$!
 sleep 10
 curl http://dev:15984
-cd src/mango/ 
+cd src/mango/
 nosetests
 
 EXIT_STATUS=$?
-if [[ ! -z $SERVER_PID ]]; then
+if [ ! -z "$SERVER_PID" ]; then
   kill $SERVER_PID
 fi
 exit $EXIT_STATUS


### PR DESCRIPTION
When tests run on Travis they run on Ubuntu where /bin/sh is dash, so bash
specific syntax will throw errors.

Make script more generic by using [ for tests. Also double quotes as suggested:

http://mywiki.wooledge.org/Bashism

Also remove a trailing whitespace and fix final newline
