### PR TITLE
Add selector support to json indexes

### DIFF
--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -197,6 +197,12 @@ opts() ->
         {<<"fields">>, [
             {tag, fields},
             {validator, fun mango_opts:validate_sort/1}
+        ]},
+        {<<"selector">>, [
+            {tag, selector},
+            {optional, true},
+            {default, {[]}},
+            {validator, fun mango_opts:validate_selector/1}
         ]}
     ].
 

--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -135,19 +135,33 @@ index_doc(#st{indexes=Indexes}, Doc) ->
 
 get_index_entries({IdxProps}, Doc) ->
     {Fields} = couch_util:get_value(<<"fields">>, IdxProps),
-    Values = lists:map(fun({Field, _Dir}) ->
-        case mango_doc:get_field(Doc, Field) of
-            not_found -> not_found;
-            bad_path -> not_found;
-            Else -> Else
-        end
-    end, Fields),
+    Selector = case couch_util:get_value(<<"selector">>, IdxProps) of
+        [] -> {[]};
+        Else -> Else
+    end,
+    Values = get_index_values(Fields, Selector, Doc),
     case lists:member(not_found, Values) of
         true ->
             [];
         false ->
             [[Values, null]]
     end.
+
+
+get_index_values(Fields, Selector, Doc) ->
+    lists:map(fun({Field, _Dir}) ->
+        case mango_doc:get_field(Doc, Field) of
+            not_found -> 
+                not_found;
+            bad_path -> 
+                not_found;
+            Else -> 
+                case should_index(Selector, Doc) of
+                    true -> Else;
+                    false -> not_found
+                end
+        end
+    end, Fields).
 
 
 get_text_entries({IdxProps}, Doc) ->

--- a/src/mango/test/16-json-index-selector.py
+++ b/src/mango/test/16-json-index-selector.py
@@ -1,0 +1,123 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import mango
+import copy
+
+DOCS = [
+    {
+        "_id": "100",
+        "name": "Jimi",
+        "location": "AUS",
+        "user_id": 1,
+        "same": "value"
+    },
+    {
+        "_id": "200",
+        "name": "Eddie",
+        "location": "BRA",
+        "user_id": 2,
+        "same": "value"
+    },
+    {
+        "_id": "300",
+        "name": "Harry",
+        "location": "CAN",
+        "user_id":3,
+        "same": "value"
+    },
+    {
+        "_id": "400",
+        "name": "Eddie",
+        "location": "DEN",
+        "user_id":4,
+        "same": "value"
+    },
+    {
+        "_id": "500",
+        "name": "Jones",
+        "location": "ETH",
+        "user_id":5,
+        "same": "value"
+    },
+    {
+        "_id": "600",
+        "name": "Winnifried",
+        "location": "FRA",
+        "user_id":6,
+        "same": "value"
+    },
+    {
+        "_id": "700",
+        "name": "Marilyn",
+        "location": "GHA",
+        "user_id":7,
+        "same": "value"
+    },
+    {
+        "_id": "800",
+        "name": "Sandra",
+        "location": "ZAR",
+        "user_id":8,
+        "same": "value"
+    },
+]
+
+class IndexSelectorJson(mango.DbPerClass):
+    def setUp(self):
+        self.db.recreate()
+        self.db.save_docs(copy.deepcopy(DOCS))
+
+    def test_saves_selector_in_index(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.create_index(["location"], selector=selector)
+        indexes = self.db.list_indexes()
+        assert indexes[1]["def"]["selector"] == selector
+
+    def test_uses_selector_for_index(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.create_index(["location"], selector=selector, name="Selected")
+        resp = self.db.find({"location":{"$gte": "FRA"}}, explain=True)
+        assert resp["index"]["name"] == "Selected"
+
+    def test_uses_selector_for_index_multiple_fields(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.create_index(["location"], selector=selector, name="Selected")
+        resp = self.db.find({"location":{"$gte": "FRA"}, "user_id": 7}, explain=True)
+        assert resp["index"]["name"] == "Selected"
+
+    def test_uses_selector_for_index_multiple_fields_on_both(self):
+        selector = {"location": {"$gte": "FRA"}, "user_id": 7}
+        self.db.create_index(["location"], selector=selector, name="Selected")
+        resp = self.db.find({"location":{"$gte": "FRA"}, "user_id": 7}, explain=True)
+        assert resp["index"]["name"] == "Selected"
+
+    def test_with_or_selector(self):
+        selector = {"location": {"$gte": "FRA"}, "user_id": 7}
+        self.db.create_index(["location"], selector=selector, name="Selected")
+        self.db.create_index(["location"], name="NotSelected")
+        resp = self.db.find({"$or":[{"location":{"$gte": "FRA"}, "user_id": 7}, {"name": "Sandra"}]}, explain=True)
+        assert resp["index"]["name"] != "Selected"
+
+    def test_does_not_use_selector_index(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.create_index(["location"], selector=selector, name="Selected")
+        resp = self.db.find({"location":{"$eq": "ZAR"}}, explain=True)
+        assert resp["index"]["name"] != "Selected"
+
+    def test_two_indexes_use_index_with_selector(self):
+        selector = {"location": {"$gte": "ZAR"}}
+        self.db.create_index(["location"], selector=selector, name="Selected")
+        self.db.create_index(["location"], name="NotSelected")
+        resp = self.db.find({"location":{"$gte": "ZAR"}}, explain=True)
+        print resp
+        assert resp["index"]["name"] == "Selected"

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -84,7 +84,7 @@ class Database(object):
         r.raise_for_status()
         return r.json()
 
-    def create_index(self, fields, idx_type="json", name=None, ddoc=None):
+    def create_index(self, fields, idx_type="json", name=None, ddoc=None, selector=None):
         body = {
             "index": {
                 "fields": fields
@@ -96,6 +96,8 @@ class Database(object):
             body["name"] = name
         if ddoc is not None:
             body["ddoc"] = ddoc
+        if selector is not None:
+            body["index"]["selector"] = selector
         body = json.dumps(body)
         r = self.sess.post(self.path("_index"), data=body)
         r.raise_for_status()


### PR DESCRIPTION
Adds selector support to json indexes. The selector can be used to filter what documents are
added to the index. When executing a query the index will
only be choosen if the query selector contains the selector defined in
the index or if the index is defined via `use_index`.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
