### PR TITLE
Check all indexed fields are in the selector

### DIFF
--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -23,7 +23,7 @@ class IndexSelectionTests(mango.UserDocsTests):
             user_docs.add_text_indexes(klass.db, {})
 
     def test_basic(self):
-        resp = self.db.find({"name.last": "A last name"}, explain=True)
+        resp = self.db.find({"manager": "A manager"}, explain=True)
         assert resp["index"]["type"] == "json"
 
     def test_with_and(self):


### PR DESCRIPTION
Each mango json index is a filtered index, meaning that it only adds
documents to the index that have all the fields that are defined in the
index. So when selecing an index for a query we need to make sure that
all the fields defined in the index are also in the selector. Otherwise the
query could return incorrect results.

An example:
For documents:
```
{
    name: "Garren",
    location: "South Africa"
},
{
    name: "Ed",
}
```
and with an index: `["name, "location"]. If we have a query like this:

```
selector: {name: {$gte: "E"}}
```
If it uses the above defined index it will only return the first document. Not both of them.
This PR changes it so that it will not use that index and rather use another index if there is or use _all_docs.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
