### PR TITLE
Return reduce overflow errors to the client

### DIFF
--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -440,7 +440,11 @@ row_to_json(error, Row) ->
     % match prior behavior.
     Key = couch_util:get_value(key, Row),
     Val = couch_util:get_value(value, Row),
-    Obj = {[{key, Key}, {error, Val}]},
+    Reason = couch_util:get_value(reason, Row),
+    ReasonProp = if Reason == undefined -> []; true ->
+        [{reason, Reason}]
+    end,
+    Obj = {[{key, Key}, {error, Val}] ++ ReasonProp},
     ?JSON_ENCODE(Obj);
 row_to_json(Id0, Row) ->
     Id = case Id0 of

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -203,8 +203,6 @@ get_shard([#shard{node = Node, name = Name} | Rest], Opts, Timeout, Factor) ->
         rexi_monitor:stop(Mon)
     end.
 
-error_info({{<<"reduce_overflow_error">>, _} = Error, _Stack}) ->
-    Error;
 error_info({{timeout, _} = Error, _Stack}) ->
     Error;
 error_info({{Error, Reason}, Stack}) ->

--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -258,6 +258,8 @@ find_next_key([], _, _, _) ->
 find_next_key([Key|Rest], _, _, _) ->
     {Key, Rest}.
 
+transform_row(#view_row{value={[{reduce_overflow_error, Msg}]}}) ->
+    {row, [{key,null}, {id,error}, {value,reduce_overflow_error}, {reason,Msg}]};
 transform_row(#view_row{key=Key, id=reduced, value=Value}) ->
     {row, [{key,Key}, {value,Value}]};
 transform_row(#view_row{key=Key, id=undefined}) ->

--- a/test/javascript/tests/view_errors.js
+++ b/test/javascript/tests/view_errors.js
@@ -174,9 +174,9 @@ couchTests.view_errors = function(debug) {
       // if the reduce grows to fast, throw an overflow error
       var path = "/" + db_name + "/_design/testbig/_view/reduce_too_big";
       xhr = CouchDB.request("GET", path);
-      T(xhr.status == 500);
+      T(xhr.status == 200);
       result = JSON.parse(xhr.responseText);
-      T(result.error == "reduce_overflow_error");
+      T(result.rows[0].error == "reduce_overflow_error");
 
       try {
           db.query(function() {emit(null, null)}, null, {startkey: 2, endkey:1});


### PR DESCRIPTION
This changes the reduce overflow error to return an error to the client
rather than blowing up the view build. This allows views that have a
single bad reduce to build while not crushing the server's RAM usage.

## Testing recommendations

```make javascript suites=view_errors```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
