### PR TITLE
Implement attachment size limit

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -43,6 +43,8 @@ changes_doc_ids_optimization_threshold = 100
 ; Single documents that exceed this value in a bulk request will receive a
 ; too_large error. The max_http_request_size still takes precedence.
 ;single_max_doc_size = 1048576
+; Maximum attachment size.
+; max_attachment_size = infinity
 
 [cluster]
 q=8

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -897,6 +897,8 @@ error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
 error_info(request_entity_too_large) ->
     {413, <<"too_large">>, <<"the request entity is too large">>};
+error_info({request_entity_too_large, {attachment, AttName}}) ->
+    {413, <<"attachment_too_large">>, AttName};
 error_info({request_entity_too_large, DocID}) ->
     {413, <<"document_too_large">>, DocID};
 error_info({error, security_migration_updates_disabled}) ->

--- a/src/chttpd/test/chttpd_db_attachment_size_tests.erl
+++ b/src/chttpd/test/chttpd_db_attachment_size_tests.erl
@@ -1,0 +1,206 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_db_attachment_size_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(USER, "chttpd_db_att_test_admin").
+-define(PASS, "pass").
+-define(AUTH, {basic_auth, {?USER, ?PASS}}).
+-define(CONTENT_JSON, {"Content-Type", "application/json"}).
+-define(CONTENT_MULTI_RELATED, {"Content-Type",
+    "multipart/related;boundary=\"bound\""}).
+
+
+setup() ->
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
+    ok = config:set("couchdb", "max_attachment_size", "50", _Persist=false),
+    TmpDb = ?tempdb(),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = integer_to_list(mochiweb_socket_server:get(chttpd, port)),
+    Url = "http://" ++ Addr ++ ":" ++ Port ++ "/" ++ ?b2l(TmpDb),
+    create_db(Url),
+    add_doc(Url, "doc1"),
+    Url.
+
+
+teardown(Url) ->
+    delete_db(Url),
+    ok = config:delete("admins", ?USER, _Persist=false),
+    ok = config:delete("couchdb", "max_attachment_size").
+
+
+attachment_size_test_() ->
+    {
+        "chttpd max_attachment_size tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun put_inline/1,
+                    fun put_simple/1,
+                    fun put_simple_chunked/1,
+                    fun put_mp_related/1
+                ]
+            }
+        }
+    }.
+
+
+put_inline(Url) ->
+  ?_test(begin
+      Status = put_inline(Url, "doc2", 50),
+      ?assert(Status =:= 201 orelse Status =:= 202),
+      ?assertEqual(413, put_inline(Url, "doc3", 51))
+  end).
+
+
+put_simple(Url) ->
+    ?_test(begin
+        Headers = [{"Content-Type", "app/binary"}],
+        Rev1 = doc_rev(Url, "doc1"),
+        Data1 = data(50),
+        Status1 = put_req(Url ++ "/doc1/att2?rev=" ++ Rev1, Headers, Data1),
+        ?assert(Status1 =:= 201 orelse Status1 =:= 202),
+        Data2 = data(51),
+        Rev2 = doc_rev(Url, "doc1"),
+        Status2 = put_req(Url ++ "/doc1/att3?rev=" ++ Rev2, Headers, Data2),
+        ?assertEqual(413, Status2)
+    end).
+
+
+put_simple_chunked(Url) ->
+     ?_test(begin
+        Headers = [{"Content-Type", "app/binary"}],
+        Rev1 = doc_rev(Url, "doc1"),
+        DataFun1 = data_stream_fun(50),
+        Status1 = put_req_chunked(Url ++ "/doc1/att2?rev=" ++ Rev1, Headers, DataFun1),
+        ?assert(Status1 =:= 201 orelse Status1 =:= 202),
+        DataFun2 = data_stream_fun(51),
+        Rev2 = doc_rev(Url, "doc1"),
+        Status2 = put_req_chunked(Url ++ "/doc1/att3?rev=" ++ Rev2, Headers, DataFun2),
+        ?assertEqual(413, Status2)
+    end).
+
+
+put_mp_related(Url) ->
+    ?_test(begin
+        Headers = [?CONTENT_MULTI_RELATED],
+        Body1 = mp_body(50),
+        Status1 = put_req(Url ++ "/doc2", Headers, Body1),
+        ?assert(Status1 =:= 201 orelse Status1 =:= 202),
+        Body2 = mp_body(51),
+        Status2 = put_req(Url ++ "/doc3", Headers, Body2),
+        ?assertEqual(413, Status2)
+    end).
+
+
+% Helper functions
+
+create_db(Url) ->
+    Status = put_req(Url, "{}"),
+    ?assert(Status =:= 201 orelse Status =:= 202).
+
+
+add_doc(Url, DocId) ->
+    Status = put_req(Url ++ "/" ++ DocId, "{}"),
+    ?assert(Status =:= 201 orelse Status =:= 202).
+
+
+delete_db(Url) ->
+    {ok, 200, _, _} = test_request:delete(Url, [?AUTH]).
+
+
+put_inline(Url, DocId, Size) ->
+    Doc = "{\"_attachments\": {\"att1\":{"
+        "\"content_type\": \"app/binary\", "
+        "\"data\": \"" ++ data_b64(Size) ++ "\""
+        "}}}",
+    put_req(Url ++ "/" ++ DocId, Doc).
+
+
+mp_body(AttSize) ->
+    AttData = data(AttSize),
+    SizeStr = integer_to_list(AttSize),
+    string:join([
+        "--bound",
+
+        "Content-Type: application/json",
+
+        "",
+
+        "{\"_id\":\"doc2\", \"_attachments\":{\"att\":"
+        "{\"content_type\":\"app/binary\", \"length\":" ++ SizeStr ++ ","
+        "\"follows\":true}}}",
+
+        "--bound",
+
+        "Content-Disposition: attachment; filename=\"att\"",
+
+        "Content-Type: app/binary",
+
+        "",
+
+        AttData,
+
+        "--bound--"
+    ], "\r\n").
+
+
+doc_rev(Url, DocId) ->
+    {200, ResultProps} = get_req(Url ++ "/" ++ DocId),
+    {<<"_rev">>, BinRev} = lists:keyfind(<<"_rev">>, 1, ResultProps),
+    binary_to_list(BinRev).
+
+
+put_req(Url, Body) ->
+    put_req(Url, [], Body).
+
+
+put_req(Url, Headers, Body) ->
+    {ok, Status, _, _} = test_request:put(Url, Headers ++ [?AUTH], Body),
+    Status.
+
+
+put_req_chunked(Url, Headers, Body) ->
+    Opts = [{transfer_encoding, {chunked, 1}}],
+    {ok, Status, _, _} = test_request:put(Url, Headers ++ [?AUTH], Body, Opts),
+    Status.
+
+
+get_req(Url) ->
+    {ok, Status, _, ResultBody} = test_request:get(Url, [?CONTENT_JSON, ?AUTH]),
+    {[_ | _] = ResultProps} = ?JSON_DECODE(ResultBody),
+    {Status, ResultProps}.
+
+% Data streaming generator for ibrowse client. ibrowse will repeatedly call the
+% function with State and it should return {ok, Data, NewState} or eof at end.
+data_stream_fun(Size) ->
+    Fun = fun(0) -> eof; (BytesLeft) ->
+        {ok, <<"x">>, BytesLeft - 1}
+    end,
+    {Fun, Size}.
+
+
+data(Size) ->
+    string:copies("x", Size).
+
+
+data_b64(Size) ->
+    base64:encode_to_string(data(Size)).

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -885,6 +885,10 @@ error_info(file_exists) ->
         "created, the file already exists.">>};
 error_info(request_entity_too_large) ->
     {413, <<"too_large">>, <<"the request entity is too large">>};
+error_info({request_entity_too_large, {attachment, AttName}}) ->
+    {413, <<"attachment_too_large">>, AttName};
+error_info({request_entity_too_large, DocID}) ->
+    {413, <<"document_too_large">>, DocID};
 error_info(request_uri_too_long) ->
     {414, <<"too_long">>, <<"the request uri is too long">>};
 error_info({bad_ctype, Reason}) ->

--- a/src/couch/test/couch_doc_tests.erl
+++ b/src/couch/test/couch_doc_tests.erl
@@ -131,6 +131,7 @@ mock_config_max_document_id_length() ->
     ok = meck:new(config, [passthrough]),
     meck:expect(config, get,
         fun("couchdb", "max_document_id_length", "infinity") -> "1024";
+           ("couchdb", "max_attachment_size", "infinity") -> "infinity";
             (Key, Val, Default) -> meck:passthrough([Key, Val, Default])
         end
     ).

--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -711,10 +711,12 @@ receive_docs(Streamer, UserFun, Ref, UserAcc) ->
     {headers, Ref, Headers} ->
         case header_value("content-type", Headers) of
         {"multipart/related", _} = ContentType ->
+            % Skip document body and attachment size limits validation here
+            % since these should be validated by the replication target
             case couch_doc:doc_from_multi_part_stream(
                 ContentType,
                 fun() -> receive_doc_data(Streamer, Ref) end,
-                Ref) of
+                Ref, _ValidateDocLimits = false) of
             {ok, Doc, WaitFun, Parser} ->
                 case run_user_fun(UserFun, {ok, Doc}, UserAcc, Ref) of
                 {ok, UserAcc2} ->

--- a/src/couch_replicator/test/couch_replicator_attachments_too_large.erl
+++ b/src/couch_replicator/test/couch_replicator_attachments_too_large.erl
@@ -1,0 +1,104 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_replicator_attachments_too_large).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch_replicator/src/couch_replicator.hrl").
+
+
+setup(_) ->
+    Ctx = test_util:start_couch([couch_replicator]),
+    Source = create_db(),
+    create_doc_with_attachment(Source, <<"doc">>, 1000),
+    Target = create_db(),
+    {Ctx, {Source, Target}}.
+
+
+teardown(_, {Ctx, {Source, Target}}) ->
+    delete_db(Source),
+    delete_db(Target),
+    config:delete("couchdb", "max_attachment_size"),
+    ok = test_util:stop_couch(Ctx).
+
+
+attachment_too_large_replication_test_() ->
+    Pairs = [{local, remote}, {remote, local}, {remote, remote}],
+    {
+        "Attachment size too large replication tests",
+        {
+            foreachx,
+            fun setup/1, fun teardown/2,
+            [{Pair, fun should_succeed/2} || Pair <- Pairs] ++
+            [{Pair, fun should_fail/2} || Pair <- Pairs]
+        }
+    }.
+
+
+should_succeed({From, To}, {_Ctx, {Source, Target}}) ->
+    RepObject = {[
+        {<<"source">>, db_url(From, Source)},
+        {<<"target">>, db_url(To, Target)}
+    ]},
+    config:set("couchdb", "max_attachment_size", "1000", _Persist = false),
+    {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
+    ?_assertEqual(ok, couch_replicator_test_helper:compare_dbs(Source, Target)).
+
+
+should_fail({From, To}, {_Ctx, {Source, Target}}) ->
+    RepObject = {[
+        {<<"source">>, db_url(From, Source)},
+        {<<"target">>, db_url(To, Target)}
+    ]},
+    config:set("couchdb", "max_attachment_size", "999", _Persist = false),
+    {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
+    ?_assertError({badmatch, {not_found, missing}},
+        couch_replicator_test_helper:compare_dbs(Source, Target)).
+
+
+create_db() ->
+    DbName = ?tempdb(),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
+    ok = couch_db:close(Db),
+    DbName.
+
+
+create_doc_with_attachment(DbName, DocId, AttSize) ->
+    {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
+    Doc = #doc{id = DocId, atts = att(AttSize)},
+    {ok, _} = couch_db:update_doc(Db, Doc, []),
+    couch_db:close(Db),
+    ok.
+
+
+att(Size) when is_integer(Size), Size >= 1 ->
+    [couch_att:new([
+        {name, <<"att">>},
+        {type, <<"app/binary">>},
+        {att_len, Size},
+        {data, fun(_Bytes) ->
+            << <<"x">> || _ <- lists:seq(1, Size) >>
+        end}
+    ])].
+
+
+delete_db(DbName) ->
+    ok = couch_server:delete(DbName, [?ADMIN_CTX]).
+
+
+db_url(local, DbName) ->
+    DbName;
+db_url(remote, DbName) ->
+    Addr = config:get("httpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(couch_httpd, port),
+    ?l2b(io_lib:format("http://~s:~b/~s", [Addr, Port, DbName])).

--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -96,7 +96,9 @@ handle_message({not_found, no_db_file} = X, Worker, Acc0) ->
     Docs = couch_util:get_value(Worker, GroupedDocs),
     handle_message({ok, [X || _D <- Docs]}, Worker, Acc0);
 handle_message({bad_request, Msg}, _, _) ->
-    throw({bad_request, Msg}).
+    throw({bad_request, Msg});
+handle_message({request_entity_too_large, Entity}, _, _) ->
+    throw({request_entity_too_large, Entity}).
 
 before_doc_update(DbName, Docs, Opts) ->
     case {fabric_util:is_replicator_db(DbName), fabric_util:is_users_db(DbName)} of


### PR DESCRIPTION
Currently CouchDB has configurable single document body size limits, as well as
http request body limits, and this commit implements attachment size limit.

Maximum attachment size can be configured with:

```
[couchdb]

max_attachment_size = Bytes | infinity
```

`infinity` (i.e. no maximum) is the default value it also preserves the current
behavior.

Fixes #769
