### PR TITLE
Query operator tests for multiple index types

### DIFF
--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -11,9 +11,9 @@
 # the License.
 
 import mango
+import unittest
 
-
-class OperatorTests(mango.UserDocsTests):
+class OperatorTests:
 
     def assertUserIds(self, user_ids, docs):
         user_ids_returned = list(d["user_id"] for d in docs)
@@ -198,3 +198,13 @@ class OperatorTests(mango.UserDocsTests):
         self.assertGreater(len(docs), 0)
         for d in docs:
             self.assertNotIn("twitter", d)
+
+
+class OperatorJSONTests(mango.UserDocsTests, OperatorTests):
+    pass
+
+
+@unittest.skipUnless(mango.has_text_service(), "requires text service")
+class OperatorTextTests(mango.UserDocsTextTests, OperatorTests):
+    pass
+

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -208,3 +208,8 @@ class OperatorJSONTests(mango.UserDocsTests, OperatorTests):
 class OperatorTextTests(mango.UserDocsTextTests, OperatorTests):
     pass
 
+
+class OperatorAllDocsTests(mango.UserDocsTestsNoIndexes, OperatorTests):
+    pass
+
+

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -226,6 +226,17 @@ class UserDocsTests(DbPerClass):
         user_docs.setup(klass.db)
 
 
+class UserDocsTestsNoIndexes(DbPerClass):
+
+    @classmethod
+    def setUpClass(klass):
+        super(UserDocsTestsNoIndexes, klass).setUpClass()
+        user_docs.setup(
+                    klass.db,
+                    index_type="_all_docs"
+            )
+
+
 class UserDocsTextTests(DbPerClass):
 
     DEFAULT_FIELD = None

--- a/src/mango/test/user_docs.py
+++ b/src/mango/test/user_docs.py
@@ -83,7 +83,8 @@ def add_view_indexes(db, kwargs):
         ["manager"],
         ["favorites"],
         ["favorites.3"],
-        ["twitter"]
+        ["twitter"],
+        ["ordered"]
     ]
     for idx in indexes:
         assert db.create_index(idx) is True
@@ -310,8 +311,8 @@ DOCS = [
             "Ruby",
             "Erlang"
         ],
-        "exists_field" : "should_exist1"
-
+        "exists_field" : "should_exist1",
+        "ordered": None
     },
     {
         "_id": "6c0afcf1-e57e-421d-a03d-0c0717ebf843",
@@ -333,7 +334,8 @@ DOCS = [
         "email": "jamesmcdaniel@globoil.com",
         "manager": True,
         "favorites": None,
-        "exists_field" : "should_exist2"
+        "exists_field" : "should_exist2",
+        "ordered": False
     },
     {
         "_id": "954272af-d5ed-4039-a5eb-8ed57e9def01",
@@ -361,7 +363,8 @@ DOCS = [
             "Python"
         ],
         "exists_array" : ["should", "exist", "array1"],
-        "complex_field_value" : "+-(){}[]^~&&*||\"\\/?:!"
+        "complex_field_value" : "+-(){}[]^~&&*||\"\\/?:!",
+        "ordered": True
     },
     {
         "_id": "e900001d-bc48-48a6-9b1a-ac9a1f5d1a03",
@@ -386,7 +389,8 @@ DOCS = [
             "Erlang",
             "Erlang"
         ],
-        "exists_array" : ["should", "exist", "array2"]
+        "exists_array" : ["should", "exist", "array2"],
+        "ordered": 9
     },
     {
         "_id": "b06aadcf-cd0f-4ca6-9f7e-2c993e48d4c4",
@@ -414,7 +418,8 @@ DOCS = [
             "C++",
             "C++"
         ],
-        "exists_object" : {"should": "object"}
+        "exists_object" : {"should": "object"},
+        "ordered": 10000
     },
     {
         "_id": "5b61abc1-a3d3-4092-b9d7-ced90e675536",
@@ -440,7 +445,8 @@ DOCS = [
             "Python",
             "Lisp"
         ],
-        "exists_object" : {"another": "object"}
+        "exists_object" : {"another": "object"},
+        "ordered": "a"
     },
     {
         "_id": "b1e70402-8add-4068-af8f-b4f3d0feb049",
@@ -466,7 +472,8 @@ DOCS = [
             "C",
             "Ruby",
             "Ruby"
-        ]
+        ],
+        "ordered": "A"
     },
     {
         "_id": "c78c529f-0b07-4947-90a6-d6b7ca81da62",
@@ -491,7 +498,8 @@ DOCS = [
             "Erlang",
             "Python",
             "Lisp"
-        ]
+        ],
+        "ordered": "aa"
     }
 ]
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Mango operator tests previously only ran against json indexes. This PR ensures they also run against a database with no indexes (i.e. verify "pure" selector behaviour) as well as against json indexes and text indexes (when available). The intention here is to catch any inconsistencies or change in results that might occur due to the index selected (clearly we don't want results to change because a user adds an index!).

Note that text indexes do not currently pass these tests, but are not exercised as part of the CouchDB test suite.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Ensure the test suite runs (CI should handle this).

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
