### PR TITLE
Do not crash when free space cannot be calculated

### DIFF
--- a/src/couch/src/couch_compaction_daemon.erl
+++ b/src/couch/src/couch_compaction_daemon.erl
@@ -509,8 +509,8 @@ free_space(Path) ->
             length(filename:split(PathA)) > length(filename:split(PathB))
         end,
         disksup:get_disk_data()),
-    {ok, Path0} = abs_path(Path),
-    free_space_rec(Path0, DiskData).
+    {ok, AbsPath} = abs_path(Path),
+    free_space_rec(AbsPath, DiskData).
 
 free_space_rec(_Path, []) ->
     undefined;
@@ -525,8 +525,8 @@ free_space_rec(Path, [{MountPoint0, Total, Usage} | Rest]) ->
         end;
     {error, Reason} ->
         couch_log:warning("Compaction daemon - unable to calculate free space"
-                        " for `~s`: `~s`",
-                        [MountPoint0, Reason]),
+            " for `~s`: `~s`",
+            [MountPoint0, Reason]),
         free_space_rec(Path, Rest)
     end.
 
@@ -543,7 +543,6 @@ abs_path(Path0) ->
     {error, Reason} ->
         {error, Reason}
     end.
-
 
 abs_path2(Path0) ->
     Path = filename:absname(Path0),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

If the compaction daemon cannot calculate the free space
for a volume, do not crash CouchDB. Instead, log a warning
that free space could not be calculated and continue.

Compaction of the database is not necessarily prevented -
just that the disk space for this specific volume
won't be taken into account when deciding whether
to automatically compact or not.

This is primarily to cope with edge cases arising from
ERL-343, whereby disksup:get_disk_data() returns invalid
paths for volumes containing whitespace, and impacts Erlang 19.x and 20.x.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

On MacOS, the error can be reproduced under Erlang 19 by creating a mount point with whitespace (e.g. mounting an installer) and forcing the compaction daemon to run.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

#732

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
