### PR TITLE
Fix Mango error handling

### DIFF
--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -21,19 +21,19 @@
 ]).
 
 
-info(mango_cursor, {no_usable_index, no_indexes_defined}) ->
+info(mango_idx, {no_usable_index, no_indexes_defined}) ->
     {
         400,
         <<"no_usable_index">>,
         <<"There are no indexes defined in this database.">>
     };
-info(mango_cursor, {no_usable_index, no_index_matching_name}) ->
+info(mango_idx, {no_usable_index, no_index_matching_name}) ->
     {
         400,
         <<"no_usable_index">>,
         <<"No index matches the index specified with \"use_index\"">>
     };
-info(mango_cursor, {no_usable_index, missing_sort_index}) ->
+info(mango_idx, {no_usable_index, missing_sort_index}) ->
     {
         400,
         <<"no_usable_index">>,

--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -38,13 +38,13 @@ handle_req(#httpd{} = Req, Db0) ->
         handle_req_int(Req, Db)
     catch
         throw:{mango_error, Module, Reason} ->
-            %Stack = erlang:get_stacktrace(),
-            {Code, ErrorStr, ReasonStr} = mango_error:info(Module, Reason),
-            Resp = {[
-                {<<"error">>, ErrorStr},
-                {<<"reason">>, ReasonStr}
-            ]},
-            chttpd:send_json(Req, Code, Resp)
+            case mango_error:info(Module, Reason) of
+            {500, ErrorStr, ReasonStr} ->
+                Stack = erlang:get_stacktrace(),
+                chttpd:send_error(Req, 500, [], ErrorStr, ReasonStr, Stack);
+            {Code, ErrorStr, ReasonStr} ->
+                chttpd:send_error(Req, Code, ErrorStr, ReasonStr)
+            end
     end.
 
 

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -24,14 +24,14 @@ class IndexSelectionTests(mango.UserDocsTests):
 
     def test_basic(self):
         resp = self.db.find({"name.last": "A last name"}, explain=True)
-        assert resp["index"]["type"] == "json"
+        self.assertEqual(resp["index"]["type"], "json")
 
     def test_with_and(self):
         resp = self.db.find({
                 "name.first": "Stephanie",
                 "name.last": "This doesn't have to match anything."
             }, explain=True)
-        assert resp["index"]["type"] == "json"
+        self.assertEqual(resp["index"]["type"], "json")
 
     @unittest.skipUnless(mango.has_text_service(), "requires text service")
     def test_with_text(self):
@@ -40,12 +40,12 @@ class IndexSelectionTests(mango.UserDocsTests):
                 "name.first": "Stephanie",
                 "name.last": "This doesn't have to match anything."
             }, explain=True)
-        assert resp["index"]["type"] == "text"
+        self.assertEqual(resp["index"]["type"], "text")
 
     @unittest.skipUnless(mango.has_text_service(), "requires text service")
     def test_no_view_index(self):
         resp = self.db.find({"name.first": "Ohai!"}, explain=True)
-        assert resp["index"]["type"] == "text"
+        self.assertEqual(resp["index"]["type"], "text")
 
     @unittest.skipUnless(mango.has_text_service(), "requires text service")
     def test_with_or(self):
@@ -55,7 +55,7 @@ class IndexSelectionTests(mango.UserDocsTests):
                     {"name.last": "This doesn't have to match anything."}
                 ]
             }, explain=True)
-        assert resp["index"]["type"] == "text"
+        self.assertEqual(resp["index"]["type"], "text")
 
     def test_use_most_columns(self):
         # ddoc id for the age index
@@ -65,22 +65,22 @@ class IndexSelectionTests(mango.UserDocsTests):
                 "name.last": "Something or other",
                 "age": {"$gt": 1}
             }, explain=True)
-        assert resp["index"]["ddoc"] != "_design/" + ddocid
+        self.assertNotEqual(resp["index"]["ddoc"], "_design/" + ddocid)
 
         resp = self.db.find({
                 "name.first": "Stephanie",
                 "name.last": "Something or other",
                 "age": {"$gt": 1}
             }, use_index=ddocid, explain=True)
-        assert resp["index"]["ddoc"] == ddocid
+        self.assertEqual(resp["index"]["ddoc"], ddocid)
 
-    def test_use_most_columns(self):
+    def test_invalid_use_index(self):
         # ddoc id for the age index
         ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"
         try:
             self.db.find({}, use_index=ddocid)
         except Exception, e:
-            assert e.response.status_code == 400
+            self.assertEqual(e.response.status_code, 400)
         else:
             raise AssertionError("bad find")
 
@@ -149,9 +149,9 @@ class IndexSelectionTests(mango.UserDocsTests):
         }
         self.db.save_doc(design_doc)
         docs= self.db.find({"age" : 48})
-        assert len(docs) == 1
-        assert docs[0]["name"]["first"] == "Stephanie"
-        assert docs[0]["age"] == 48
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["name"]["first"], "Stephanie")
+        self.assertEqual(docs[0]["age"], 48)
 
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
@@ -165,14 +165,14 @@ class MultiTextIndexSelectionTests(mango.UserDocsTests):
 
     def test_view_ok_with_multi_text(self):
         resp = self.db.find({"name.last": "A last name"}, explain=True)
-        assert resp["index"]["type"] == "json"
+        self.assertEqual(resp["index"]["type"], "json")
 
     def test_multi_text_index_is_error(self):
         try:
             self.db.find({"$text": "a query"}, explain=True)
         except Exception, e:
-            assert e.response.status_code == 400
+            self.assertEqual(e.response.status_code, 400)
 
     def test_use_index_works(self):
         resp = self.db.find({"$text": "a query"}, use_index="foo", explain=True)
-        assert resp["index"]["ddoc"] == "_design/foo"
+        self.assertEqual(resp["index"]["ddoc"], "_design/foo")

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -74,6 +74,14 @@ class IndexSelectionTests(mango.UserDocsTests):
             }, use_index=ddocid, explain=True)
         self.assertEqual(resp["index"]["ddoc"], ddocid)
 
+    def test_no_valid_sort_index(self):
+        try:
+            self.db.find({"_id": {"$gt": None}}, sort=["name"], return_raw=True)
+        except Exception, e:
+            self.assertEqual(e.response.status_code, 400)
+        else:
+            raise AssertionError("bad find")
+
     def test_invalid_use_index(self):
         # ddoc id for the age index
         ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"


### PR DESCRIPTION
## Overview

Fixes a regression where a 500 status code was returned when  no index is available to service a _find query because the  sort order does not match any available indexes. This was actually a general issue with _find errors, introduced when index selection moved from `mango_cursor.erl` to `mango_idx.erl` in https://github.com/apache/couchdb-mango/commit/01252f971bef0c8da1d78bf5a7b506b71926ce1b.

In a separate commit, I converted the index selection tests to use `unittest` assertion functions and addressed an issue with a duplicate test name.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Changes covered by unit tests

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
