### PR TITLE
Avoid duplicate index selection in Mango

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -17,13 +17,15 @@
     create/3,
     explain/1,
     execute/3,
-    maybe_filter_indexes/2
+    maybe_filter_indexes/2,
+    maybe_add_warning/3
 ]).
 
 
 -include_lib("couch/include/couch_db.hrl").
 -include("mango.hrl").
 -include("mango_cursor.hrl").
+-include("mango_idx.hrl").
 
 
 -ifdef(HAVE_DREYFUS).
@@ -134,3 +136,14 @@ group_indexes_by_type(Indexes) ->
                 []
         end
     end, ?CURSOR_MODULES).
+
+
+maybe_add_warning(UserFun, #idx{type = IndexType}, UserAcc) ->
+    case IndexType of
+        <<"special">> ->
+            Arg = {add_key, warning, <<"no matching index found, create an index to optimize query time">>},
+            {_Go, UserAcc0} = UserFun(Arg, UserAcc),
+            UserAcc0;
+        _ ->
+            UserAcc
+    end.

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -124,7 +124,8 @@ execute(Cursor, UserFun, UserAcc) ->
             Arg = {add_key, bookmark, JsonBM},
             {_Go, FinalUserAcc} = UserFun(Arg, LastUserAcc),
             FinalUserAcc0 = mango_execution_stats:maybe_add_stats(Opts, UserFun, Stats0, FinalUserAcc),
-            {ok, FinalUserAcc0}
+            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Idx, FinalUserAcc0),
+            {ok, FinalUserAcc1}
     end.
 
 

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -118,7 +118,8 @@ execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFu
                     {_Go, FinalUserAcc} = UserFun(Arg, LastCursor#cursor.user_acc),
                     Stats0 = LastCursor#cursor.execution_stats,
                     FinalUserAcc0 = mango_execution_stats:maybe_add_stats(Opts, UserFun, Stats0, FinalUserAcc),
-                    {ok, FinalUserAcc0};
+                    FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Idx, FinalUserAcc0),
+                    {ok, FinalUserAcc1};
                 {error, Reason} ->
                     {error, Reason}
             end

--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -183,7 +183,7 @@ handle_find_req(#httpd{method='POST'}=Req, Db) ->
     chttpd:validate_ctype(Req, "application/json"),
     {ok, Opts0} = mango_opts:validate_find(chttpd:json_body_obj(Req)),
     {value, {selector, Sel}, Opts} = lists:keytake(selector, 1, Opts0),
-    {ok, Resp0} = start_find_resp(Req, Db, Sel, Opts),
+    {ok, Resp0} = start_find_resp(Req),
     {ok, AccOut} = run_find(Resp0, Db, Sel, Opts),
     end_find_resp(AccOut);
 
@@ -230,18 +230,8 @@ convert_to_design_id(DDocId) ->
     end.
 
 
-start_find_resp(Req, Db, Sel, Opts) ->
-    chttpd:start_delayed_json_response(Req, 200, [], maybe_add_warning(Db, Sel, Opts)).
-
-
-maybe_add_warning(Db, Selector, Opts) ->
-    UsableIndexes = mango_idx:get_usable_indexes(Db, Selector, Opts),
-    case length(UsableIndexes) of
-        0 ->
-            "{\"warning\":\"no matching index found, create an index to optimize query time\",\r\n\"docs\":[";
-        _ ->
-            "{\"docs\":["
-    end.
+start_find_resp(Req) ->
+    chttpd:start_delayed_json_response(Req, 200, [], "{\"docs\":[").
 
 
 end_find_resp(Acc0) ->

--- a/src/mango/test/12-use-correct-index.py
+++ b/src/mango/test/12-use-correct-index.py
@@ -58,42 +58,42 @@ class ChooseCorrectIndexForDocs(mango.DbPerClass):
         self.db.create_index(["name", "age", "user_id"], ddoc="aaa")
         self.db.create_index(["name"], ddoc="zzz")
         explain = self.db.find({"name": "Eddie"}, explain=True)
-        assert explain["index"]["ddoc"] == '_design/zzz'
+        self.assertEqual(explain["index"]["ddoc"], '_design/zzz')
 
     def test_choose_index_with_two(self):
         self.db.create_index(["name", "age", "user_id"], ddoc="aaa")
         self.db.create_index(["name", "age"], ddoc="bbb")
         self.db.create_index(["name"], ddoc="zzz")
         explain = self.db.find({"name": "Eddie", "age":{"$gte": 12}}, explain=True)
-        assert explain["index"]["ddoc"] == '_design/bbb'
+        self.assertEqual(explain["index"]["ddoc"], '_design/bbb')
 
     def test_choose_index_alphabetically(self):
         self.db.create_index(["name", "age", "user_id"], ddoc="aaa")
         self.db.create_index(["name", "age", "location"], ddoc="bbb")
         self.db.create_index(["name"], ddoc="zzz")
         explain = self.db.find({"name": "Eddie", "age": {"$gte": 12}}, explain=True)
-        assert explain["index"]["ddoc"] == '_design/aaa'
+        self.assertEqual(explain["index"]["ddoc"], '_design/aaa')
 
     def test_choose_index_most_accurate(self):
         self.db.create_index(["name", "location", "user_id"], ddoc="aaa")
         self.db.create_index(["name", "age", "user_id"], ddoc="bbb")
         self.db.create_index(["name"], ddoc="zzz")
         explain = self.db.find({"name": "Eddie", "age": {"$gte": 12}}, explain=True)
-        assert explain["index"]["ddoc"] == '_design/bbb'
+        self.assertEqual(explain["index"]["ddoc"], '_design/bbb')
     
     def test_choose_index_most_accurate_in_memory_selector(self):
         self.db.create_index(["name", "location", "user_id"], ddoc="aaa")
         self.db.create_index(["name", "age", "user_id"], ddoc="bbb")
         self.db.create_index(["name"], ddoc="zzz")
         explain = self.db.find({"name": "Eddie", "number": {"$lte": 12}}, explain=True)
-        assert explain["index"]["ddoc"] == '_design/zzz'
+        self.assertEqual(explain["index"]["ddoc"], '_design/zzz')
 
     def test_warn_on_full_db_scan(self):
         selector = {"not_indexed":"foo"}
         explain_resp = self.db.find(selector, explain=True, return_raw=True)
-        assert explain_resp["index"]["type"] == "special"
+        self.assertEqual(explain_resp["index"]["type"], "special")
         resp = self.db.find(selector, return_raw=True)
-        assert resp["warning"] == "no matching index found, create an index to optimize query time"
+        self.assertEqual(resp["warning"], "no matching index found, create an index to optimize query time")
 
     def test_chooses_idxA(self):
         DOCS2 = [
@@ -104,4 +104,4 @@ class ChooseCorrectIndexForDocs(mango.DbPerClass):
         self.db.create_index(["a", "b", "c"])
         self.db.create_index(["a", "d", "e"])
         explain = self.db.find({"a": {"$gt": 0}, "b": {"$gt": 0}, "c": {"$gt": 0}}, explain=True)
-        assert explain["index"]["def"]["fields"] == [{'a': 'asc'}, {'b': 'asc'}, {'c': 'asc'}]
+        self.assertEqual(explain["index"]["def"]["fields"], [{'a': 'asc'}, {'b': 'asc'}, {'c': 'asc'}])

--- a/src/mango/test/12-use-correct-index.py
+++ b/src/mango/test/12-use-correct-index.py
@@ -88,6 +88,13 @@ class ChooseCorrectIndexForDocs(mango.DbPerClass):
         explain = self.db.find({"name": "Eddie", "number": {"$lte": 12}}, explain=True)
         assert explain["index"]["ddoc"] == '_design/zzz'
 
+    def test_warn_on_full_db_scan(self):
+        selector = {"not_indexed":"foo"}
+        explain_resp = self.db.find(selector, explain=True, return_raw=True)
+        assert explain_resp["index"]["type"] == "special"
+        resp = self.db.find(selector, return_raw=True)
+        assert resp["warning"] == "no matching index found, create an index to optimize query time"
+
     def test_chooses_idxA(self):
         DOCS2 = [
             {"a":1, "b":1, "c":1},


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Previously, index selection for a given query was run twice for each request - once to add
a warning in case a full database scan would be performed and then again when the query was executed.

This moves the warning generation so that it occurs at the end of the query processing and we can use the existing index context to decide whether to add a warning or not.

Whilst only a minor optimisation (which also assumes we don't have cached query plans etc), it
at least moves index selection to where one might expect it to happen i.e. during query planning.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Added a unit test to cover that a warning is appropriately generated. The text index tests should also be run manually.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
