### PR TITLE
Don't crash on invalid inline attachments

### DIFF
--- a/test/javascript/tests/attachments.js
+++ b/test/javascript/tests/attachments.js
@@ -33,6 +33,24 @@ couchTests.attachments= function(debug) {
   var save_response = db.save(binAttDoc);
   T(save_response.ok);
 
+  var badAttDoc = {
+    _id: "bad_doc",
+    _attachments: {
+      "foo.txt": {
+        content_type: "text/plain",
+        data: "notBase64Encoded="
+      }
+    }
+  };
+
+  try {
+    db.save(badAttDoc);
+    T(false && "Shouldn't get here!");
+  } catch (e) {
+    TEquals("bad_request", e.error);
+    TEquals("Invalid attachment data for foo.txt", e.message);
+  }
+
   var xhr = CouchDB.request("GET", "/" + db_name + "/bin_doc/foo.txt");
   T(xhr.responseText == "This is a base64 encoded text");
   T(xhr.getResponseHeader("Content-Type") == "application/octet-stream");


### PR DESCRIPTION
## Overview

We trust inline attachment to be base64 encoded, so in case it's not provided or invalidly encoded the upload request crashes with `function_clause`.

The change catches decode attempt and re-throws it as 400 error.

## Testing recommendations

Standard eunit and javascript tests should pass.

## GitHub issue number

Fixes #784 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
