### PR TITLE
Avoid decompressing just to calculate external size

### DIFF
--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -30,12 +30,7 @@
 -define(i2b(V), couch_util:integer_to_boolean(V)).
 -define(b2i(V), couch_util:boolean_to_integer(V)).
 -define(term_to_bin(T), term_to_binary(T, [{minor_version, 1}])).
--define(term_size(T),
-    try
-        erlang:external_size(T)
-    catch _:_ ->
-        byte_size(?term_to_bin(T))
-    end).
+-define(term_size(T), erlang:external_size(T, [{minor_version, 1}])).
 
 -define(DEFAULT_ATTACHMENT_CONTENT_TYPE, <<"application/octet-stream">>).
 

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -1079,14 +1079,13 @@ copy_docs(Db, #db{fd = DestFd} = NewDb, MixedInfos, Retry) ->
                 {Body, AttInfos} = copy_doc_attachments(Db, Sp, DestFd),
                 % In the future, we should figure out how to do this for
                 % upgrade purposes.
-                EJsonBody = case is_binary(Body) of
+                ExternalSize = case is_binary(Body) of
                     true ->
-                        couch_compress:decompress(Body);
+                        couch_compress:uncompressed_size(Body);
                     false ->
-                        Body
+                        ?term_size(Body)
                 end,
                 SummaryChunk = make_doc_summary(NewDb, {Body, AttInfos}),
-                ExternalSize = ?term_size(EJsonBody),
                 {ok, Pos, SummarySize} = couch_file:append_raw_chunk(
                     DestFd, SummaryChunk),
                 AttSizes = [{element(3,A), element(4,A)} || A <- AttInfos],
@@ -1472,7 +1471,7 @@ get_meta_body_size(Meta, Summary) ->
         {ejson_size, ExternalSize} ->
             ExternalSize;
         false ->
-            ?term_size(couch_compress:decompress(Summary))
+            couch_compress:uncompressed_size(Summary)
     end.
 
 

--- a/src/couch/test/couch_compress_tests.erl
+++ b/src/couch/test/couch_compress_tests.erl
@@ -72,3 +72,14 @@ is_compressed_test_() ->
         ?_assertError(invalid_compression,
             couch_compress:is_compressed(?CORRUPT, snappy))
     ].
+
+uncompressed_size_test_() ->
+    [
+        ?_assertEqual(49, couch_compress:uncompressed_size(?NONE)),
+        ?_assertEqual(49, couch_compress:uncompressed_size(?DEFLATE)),
+        ?_assertEqual(49, couch_compress:uncompressed_size(?SNAPPY)),
+        ?_assertEqual(5, couch_compress:uncompressed_size(
+            couch_compress:compress(x, {deflate, 9}))),
+        ?_assertError(invalid_compression,
+            couch_compress:uncompressed_size(?CORRUPT))
+    ].

--- a/src/couch/test/couchdb_file_compression_tests.erl
+++ b/src/couch/test/couchdb_file_compression_tests.erl
@@ -157,7 +157,7 @@ compare_compression_methods(DbName) ->
 
     ?assert(DbSizeDeflate1 > DbSizeDeflate9),
     ?assert(ViewSizeDeflate1 > ViewSizeDeflate9),
-    ?assert(ExternalSizePreCompact =:= ExternalSizeNone),
+    ?assert(ExternalSizePreCompact >= ExternalSizeNone),
     ?assert(ExternalSizeNone =:= ExternalSizeSnappy),
     ?assert(ExternalSizeNone =:= ExternalSizeDeflate9),
     ?assert(ViewExternalSizeNone =:= ViewExternalSizeSnappy),


### PR DESCRIPTION
Use snappy's `uncompressed_length` and external binary format's binary spec to
get uncompressed size.

http://erlang.org/doc/apps/erts/erl_ext_dist.html
