### PR TITLE
Remove bashisms in remsh script

### DIFF
--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -72,5 +72,5 @@ if [ ! -z "$VERBOSE" ]; then
 fi
 
 exec "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
-    -name remsh$$@$LHOST -remsh $NAME -hidden -setcookie $COOKIE \
+    -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie $COOKIE \
     "$@"

--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -66,7 +66,7 @@ done
 
 shift $((OPTIND - 1))
 
-if [[ ! -z "$VERBOSE" ]]; then
+if [ ! -z "$VERBOSE" ]; then
   # cheap but it works
   set -x
 fi


### PR DESCRIPTION
As requested by @janl . Tested on FreeBSD.