### PR TITLE
Update meck to latest version 0.8.8

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -60,11 +60,11 @@ DepDescs = [
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.1.13"}, [raw]},
 %% Third party deps
-{folsom,           "folsom",           {tag, "CouchDB-0.8.1"}},
+{folsom,           "folsom",           {tag, "CouchDB-0.8.2"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-1"}},
 {mochiweb,         "mochiweb",         {tag, "CouchDB-2.12.0-1"}},
-{meck,             "meck",             {tag, "0.8.2"}}
+{meck,             "meck",             {tag, "0.8.8"}}
 
 ],
 

--- a/src/fabric/rebar.config
+++ b/src/fabric/rebar.config
@@ -11,5 +11,5 @@
 % the License.
 
 {deps, [
-    {meck, ".*", {git, "https://github.com/apache/couchdb-meck.git", {tag, "0.8.2"}}}
+    {meck, ".*", {git, "https://github.com/apache/couchdb-meck.git", {tag, "0.8.8"}}}
 ]}.


### PR DESCRIPTION
Folsom depended on 0.8.2 as well so had to update folsom and bump its tag.
