### PR TITLE
Bypass authentication check for /_up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.snap
 *.so
+*.swp
 .DS_Store
 .rebar/
 .eunit/

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -85,6 +85,8 @@ basic_name_pw(Req) ->
 default_authentication_handler(Req) ->
     default_authentication_handler(Req, couch_auth_cache).
 
+default_authentication_handler(#httpd{path_parts=[<<"_up">>]}=Req, _) ->
+    Req#httpd{user_ctx=?ADMIN_USER};
 default_authentication_handler(Req, AuthModule) ->
     case basic_name_pw(Req) of
     {User, Pass} ->


### PR DESCRIPTION
This will allow various automated health check systems to hit /_up
without having to provide a username/password pair when the
chttpd.require_valid_user config setting is true. Apparently, many
of these health check providers do not even allow supplying creds
for such a purpose...

Closes #823