### PR TITLE
Replace deprecated crypto:rand_bytes call

### DIFF
--- a/src/ddoc_cache/test/ddoc_cache_refresh_test.erl
+++ b/src/ddoc_cache/test/ddoc_cache_refresh_test.erl
@@ -158,7 +158,7 @@ check_upgrade_clause({DbName, _}) ->
 
 
 rand_string() ->
-    Bin = crypto:rand_bytes(8),
+    Bin = crypto:strong_rand_bytes(8),
     to_hex(Bin, []).
 
 


### PR DESCRIPTION
Replaced with crypto:strong_rand_bytes

Also fixed a missing newline at the end of file.