### PR TITLE
Fix exists false when field is explicitly defined

### DIFF
--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -329,6 +329,9 @@ indexable_fields(Fields, {op_or, Args}) when is_list(Args) ->
 indexable_fields(Fields, {op_not, {ExistsQuery, Arg}}) when is_tuple(Arg) ->
     Fields0 = indexable_fields(Fields, ExistsQuery),
     indexable_fields(Fields0, Arg);
+% forces "$exists" : false to use _all_docs
+indexable_fields(Fields, {op_not, {ExistsQuery, false}}) ->
+    [];
 
 indexable_fields(Fields, {op_insert, Arg}) when is_binary(Arg) ->
     Fields;


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

When users explicitly defined a text index's fields, and used $exists
with false, we tag false when constructing the query. This led to a
function clause for indexable_fields since we did not account for it.
This fix patches that up, but note that we don't care about the false
value itself since we only care about fields.

## Testing recommendations

New unit tests added to test for this particular operator

## GitHub issue number

This PR is the issue.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
