### PR TITLE
Fix incorrect index selection when sort specified

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -46,7 +46,7 @@
 
 create(Db, Selector0, Opts) ->
     Selector = mango_selector:normalize(Selector0),
-    UsableIndexes = mango_idx:get_usable_indexes(Db, Selector0, Opts),
+    UsableIndexes = mango_idx:get_usable_indexes(Db, Selector, Opts),
 
     {use_index, IndexSpecified} = proplists:lookup(use_index, Opts),
     case {length(UsableIndexes), length(IndexSpecified)} of

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -33,6 +33,12 @@ info(mango_idx, {no_usable_index, no_index_matching_name}) ->
         <<"no_usable_index">>,
         <<"No index matches the index specified with \"use_index\"">>
     };
+info(mango_idx, {no_usable_index, no_usable_index_matching_name}) ->
+    {
+        400,
+        <<"no_usable_index">>,
+        <<"The index specified with \"use_index\" is not usable for the query.">>
+    };
 info(mango_idx, {no_usable_index, missing_sort_index}) ->
     {
         400,

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -33,12 +33,6 @@ info(mango_idx, {no_usable_index, no_index_matching_name}) ->
         <<"no_usable_index">>,
         <<"No index matches the index specified with \"use_index\"">>
     };
-info(mango_idx, {no_usable_index, no_usable_index_matching_name}) ->
-    {
-        400,
-        <<"no_usable_index">>,
-        <<"The index specified with \"use_index\" is not usable for the query.">>
-    };
 info(mango_idx, {no_usable_index, missing_sort_index}) ->
     {
         400,
@@ -49,7 +43,7 @@ info(mango_cursor, {no_usable_index, selector_unsupported}) ->
     {
         400,
         <<"no_usable_index">>,
-        <<"There is no index available for this selector.">>
+        <<"The index specified with \"use_index\" is not usable for the query.">>
     };
 
 info(mango_json_bookmark, {invalid_bookmark, BadBookmark}) ->

--- a/src/mango/src/mango_idx.erl
+++ b/src/mango/src/mango_idx.erl
@@ -20,7 +20,6 @@
 -export([
     list/1,
     recover/1,
-    for_sort/2,
 
     new/2,
     validate_new/2,
@@ -36,7 +35,7 @@
     def/1,
     opts/1,
     columns/1,
-    is_usable/2,
+    is_usable/3,
     start_key/2,
     end_key/2,
     cursor_mod/1,
@@ -57,9 +56,8 @@ list(Db) ->
     {ok, Indexes} = ddoc_cache:open(db_to_name(Db), ?MODULE),
     Indexes.
 
-get_usable_indexes(Db, Selector0, Opts) ->
-    Selector = mango_selector:normalize(Selector0),
 
+get_usable_indexes(Db, Selector, Opts) ->
     ExistingIndexes = mango_idx:list(Db),
     if ExistingIndexes /= [] -> ok; true ->
         ?MANGO_ERROR({no_usable_index, no_indexes_defined})
@@ -70,29 +68,15 @@ get_usable_indexes(Db, Selector0, Opts) ->
         ?MANGO_ERROR({no_usable_index, no_index_matching_name})
     end,
 
-    UsableFilter = fun(I) -> mango_idx:is_usable(I, Selector) end,
+    SortFields = get_sort_fields(Opts),
+    UsableFilter = fun(I) -> is_usable(I, Selector, SortFields) end,
     UsableIndexes0 = lists:filter(UsableFilter, FilteredIndexes),
 
-    UsableIndexes1 = case has_use_index(Opts) of
-        true ->
-            case mango_cursor:maybe_filter_indexes_by_ddoc(UsableIndexes0, Opts) of
-                [] -> ?MANGO_ERROR({no_usable_index, no_usable_index_matching_name});
-                UsableFilteredIndexes -> UsableFilteredIndexes
-            end;
-        false ->
-            UsableIndexes0
-    end,
-
-    % If a sort was specified we have to find an index that
-    % can satisfy the request.
-    case has_sort(Opts) of
-        true ->
-            case mango_idx:for_sort(UsableIndexes1, Opts) of
-                [] -> ?MANGO_ERROR({no_usable_index, missing_sort_index}); 
-                SortIndexes -> SortIndexes
-            end;
-        false ->
-            UsableIndexes1
+    case maybe_filter_by_sort_fields(UsableIndexes0, SortFields) of
+        {ok, SortIndexes} -> 
+            SortIndexes;
+        {error, no_usable_index} -> 
+            ?MANGO_ERROR({no_usable_index, missing_sort_index})
     end.
 
 
@@ -111,47 +95,38 @@ recover(Db) ->
     end, DDocs)}.
 
 
-has_use_index(Opts) ->
+get_sort_fields(Opts) ->
     case lists:keyfind(sort, 1, Opts) of
-        {use_index, _} ->
-            true;
+        {sort, Sort} ->
+            mango_sort:fields(Sort);
         _ ->
-            false
+            []
     end.
 
 
-has_sort(Opts) ->
-    case lists:keyfind(sort, 1, Opts) of
-        {sort, {[]}} ->
-            false;
-        {sort, {SProps}} when is_list(SProps) ->
-            true;
-        _ ->
-            false
-    end.
+maybe_filter_by_sort_fields(Indexes, []) ->
+    {ok, Indexes};
 
-
-for_sort(Indexes, Opts) ->
-    {sort, {SProps}} = lists:keyfind(sort, 1, Opts),
-    for_sort_int(Indexes, {SProps}).
-
-
-for_sort_int(Indexes, Sort) ->
-    Fields = mango_sort:fields(Sort),
+maybe_filter_by_sort_fields(Indexes, SortFields) ->
     FilterFun = fun(Idx) ->
         Cols = mango_idx:columns(Idx),
         case {mango_idx:type(Idx), Cols} of
             {_, all_fields} ->
                 true;
             {<<"text">>, _} ->
-                sets:is_subset(sets:from_list(Fields), sets:from_list(Cols));
+                sets:is_subset(sets:from_list(SortFields), sets:from_list(Cols));
             {<<"json">>, _} ->
-                lists:prefix(Fields, Cols);
+                lists:prefix(SortFields, Cols);
             {<<"special">>, _} ->
-                lists:prefix(Fields, Cols)
+                lists:prefix(SortFields, Cols)
         end
     end,
-    lists:filter(FilterFun, Indexes).
+    case lists:filter(FilterFun, Indexes) of
+        [] ->
+            {error, no_usable_index};
+        FilteredIndexes ->
+            {ok, FilteredIndexes}
+    end.
 
 
 new(Db, Opts) ->
@@ -282,9 +257,9 @@ columns(#idx{}=Idx) ->
     Mod:columns(Idx).
 
 
-is_usable(#idx{}=Idx, Selector) ->
+is_usable(#idx{}=Idx, Selector, SortFields) ->
     Mod = idx_mod(Idx),
-    Mod:is_usable(Idx, Selector).
+    Mod:is_usable(Idx, Selector, SortFields).
 
 
 start_key(#idx{}=Idx, Ranges) ->

--- a/src/mango/src/mango_idx_special.erl
+++ b/src/mango/src/mango_idx_special.erl
@@ -20,7 +20,7 @@
     from_ddoc/1,
     to_json/1,
     columns/1,
-    is_usable/2,
+    is_usable/3,
     start_key/1,
     end_key/1
 ]).
@@ -63,7 +63,7 @@ columns(#idx{def=all_docs}) ->
     [<<"_id">>].
 
 
-is_usable(#idx{def=all_docs}, Selector) ->
+is_usable(#idx{def=all_docs}, Selector, _) ->
     Fields = mango_idx_view:indexable_fields(Selector),
     lists:member(<<"_id">>, Fields).
 

--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -22,7 +22,7 @@
     from_ddoc/1,
     to_json/1,
     columns/1,
-    is_usable/2,
+    is_usable/3,
     get_default_field_options/1
 ]).
 
@@ -125,7 +125,7 @@ columns(Idx) ->
     end.
 
 
-is_usable(Idx, Selector) ->
+is_usable(Idx, Selector, _) ->
     case columns(Idx) of
         all_fields ->
             true;

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -20,7 +20,7 @@
     remove/2,
     from_ddoc/1,
     to_json/1,
-    is_usable/2,
+    is_usable/3,
     columns/1,
     start_key/1,
     end_key/1,
@@ -113,12 +113,17 @@ columns(Idx) ->
     [Key || {Key, _} <- Fields].
 
 
-is_usable(Idx, Selector) ->
-    % This index is usable if all of the columns are 
+is_usable(Idx, Selector, SortFields) ->
+    % This index is usable if all of the columns are
     % restricted by the selector such that they are required to exist
     % and the selector is not a text search (so requires a text index)
     RequiredFields = columns(Idx),
-    mango_selector:has_required_fields(Selector, RequiredFields)
+
+    % sort fields are required to exist in the results so 
+    % we don't need to check the selector for these
+    RequiredFields1 = ordsets:subtract(lists:usort(RequiredFields), lists:usort(SortFields)),
+
+    mango_selector:has_required_fields(Selector, RequiredFields1)
         andalso not is_text_search(Selector).
 
 

--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -609,7 +609,7 @@ has_required_fields([{[{Field, Cond}]} | Rest], RequiredFields) ->
         _ ->
             has_required_fields(Rest, lists:delete(Field, RequiredFields))
     end.
-    
+
 
 %%%%%%%% module tests below %%%%%%%%
 

--- a/src/mango/test/02-basic-find-test.py
+++ b/src/mango/test/02-basic-find-test.py
@@ -222,6 +222,36 @@ class BasicFindTests(mango.UserDocsTests):
         docs2 = list(reversed(sorted(docs1, key=lambda d: d["age"])))
         assert docs1 is not docs2 and docs1 == docs2
 
+    def test_sort_desc_complex(self):
+        docs = self.db.find({
+            "company": {"$lt": "M"},
+            "manager": {"$exists": True},
+            "$or": [
+                {"company": "Dreamia"},
+                {"manager": True}
+            ]
+        }, sort=[{"company":"desc"}])
+        
+        companies_returned = list(d["company"] for d in docs)
+        desc_companies = sorted(companies_returned, reverse=True)
+        self.assertEqual(desc_companies, companies_returned)
+
+    def test_sort_desc_complex_error(self):
+        try:
+            self.db.find({
+            "company": {"$lt": "M"},
+            "$or": [
+                {"company": "Dreamia"},
+                {"manager": True}
+            ]
+        }, sort=[{"company":"desc"}])
+        except Exception as e:
+            self.assertEqual(e.response.status_code, 400)
+            resp = e.response.json()
+            self.assertEqual(resp["error"], "no_usable_index")
+        else:
+            raise AssertionError("expected find error")
+
     def test_fields(self):
         selector = {"age": {"$gt": 0}}
         docs = self.db.find(selector, fields=["user_id", "location.address"])

--- a/src/mango/test/13-users-db-find-test.py
+++ b/src/mango/test/13-users-db-find-test.py
@@ -44,7 +44,7 @@ class UsersDbFindTests(mango.UsersDbTests):
 
     def test_sort(self):
         self.db.create_index(["order", "name"])
-        selector = {"name": {"$gt": "demo01"}}
+        selector = {"name": {"$gt": "demo01"}, "order": {"$exists": True}}
         docs1 = self.db.find(selector, sort=[{"order": "asc"}])
         docs2 = list(sorted(docs1, key=lambda d: d["order"]))
         assert docs1 is not docs2 and docs1 == docs2

--- a/src/mango/test/13-users-db-find-test.py
+++ b/src/mango/test/13-users-db-find-test.py
@@ -44,7 +44,7 @@ class UsersDbFindTests(mango.UsersDbTests):
 
     def test_sort(self):
         self.db.create_index(["order", "name"])
-        selector = {"name": {"$gt": "demo01"}, "order": {"$exists": True}}
+        selector = {"name": {"$gt": "demo01"}}
         docs1 = self.db.find(selector, sort=[{"order": "asc"}])
         docs2 = list(sorted(docs1, key=lambda d: d["order"]))
         assert docs1 is not docs2 and docs1 == docs2


### PR DESCRIPTION
## Overview

Mango has an apparently long-standing bug whereby if an index is deemed valid for sorting a query but is not valid according to mango_idx:is_usable, the query planner would fall back to _all_docs silently, therefore ignoring the sort order specified in the query.

This reverses the index selection logic so that the list of usable indexes is generated prior to filtering them based on the sort order specified in the query.

Similar logic is applied to use_index, allowing us to generate a more specific error message when a user specifies an index which isn't valid for the current
selector.

This fix exposes that the change introduced in https://github.com/apache/couchdb/pull/816 may cause existing queries with sort fields to fail (indeed, several queries in our test suite needed fixing), so we need to consider whether this is a severe enough breaking change to warrant a major version bump.

## Testing recommendations

Run the test suite. Test that you can run Mango queries with sort criteria.

## Related Pull Requests

https://github.com/apache/couchdb/pull/816

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
