### PR TITLE
Correct result count in Mango execution stats

### DIFF
--- a/src/mango/test/15-execution-stats-test.py
+++ b/src/mango/test/15-execution-stats-test.py
@@ -38,6 +38,10 @@ class ExecutionStatsTests(mango.UserDocsTests):
         self.assertEqual(resp["execution_stats"]["results_returned"], 3)
         self.assertGreater(resp["execution_stats"]["execution_time_ms"], 0)
 
+    def test_results_returned_limit(self):
+        resp = self.db.find({"age": {"$lt": 35}}, limit=2, return_raw=True, executionStats=True)
+        self.assertEqual(resp["execution_stats"]["results_returned"], len(resp["docs"]))
+
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class ExecutionStatsTests_Text(mango.UserDocsTextTests):
 


### PR DESCRIPTION
## Overview

Mango execution stats previously incremented the result count
at a point where the final result might be discarded. Instead,
increment the count when we know the result is being included
in the response.

## Testing recommendations

Test Mango queries with a limit and that the results_returned in the execution stats matches the number of rows in the response.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
