### PR TITLE
Bump khash, b64, ioq deps

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -47,12 +47,12 @@ SubDirs = [
 DepDescs = [
 %% Independent Apps
 {config,           "config",           {tag, "1.0.1"}},
-{b64url,           "b64url",           {tag, "1.0.0"}},
+{b64url,           "b64url",           {tag, "1.0.1"}},
 {ets_lru,          "ets-lru",          {tag, "1.0.0"}},
-{khash,            "khash",            {tag, "1.0.0"}},
+{khash,            "khash",            {tag, "1.0.1"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.0"}},
 {setup,            "setup",            {tag, "1.0.1"}},
-{ioq,              "ioq",              {tag, "1.0.0"}},
+{ioq,              "ioq",              {tag, "1.0.1"}},
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},


### PR DESCRIPTION
To fix `random` module compatibility issue
