### PR TITLE
Fix attachments test also 20.0 seems a-ok

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 os: linux
 otp_release:
+   - 20.0
    - 19.3
    - 18.3
    - 17.5

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -85,7 +85,7 @@ MakeDep = fun
 end,
 
 AddConfig = [
-    {require_otp_vsn, "R16B03|R16B03-1|17|18|19"},
+    {require_otp_vsn, "R16B03|R16B03-1|17|18|19|20"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, SubDirs},

--- a/src/couch/test/couchdb_attachments_tests.erl
+++ b/src/couch/test/couchdb_attachments_tests.erl
@@ -758,8 +758,8 @@ create_already_compressed_att(Host, DbName) ->
 gzip(Data) ->
     Z = zlib:open(),
     ok = zlib:deflateInit(Z, ?COMPRESSION_LEVEL, deflated, 16 + 15, 8, default),
-    zlib:deflate(Z, Data),
+    Chunk = zlib:deflate(Z, Data),
     Last = zlib:deflate(Z, [], finish),
     ok = zlib:deflateEnd(Z),
     ok = zlib:close(Z),
-    Last.
+    [Chunk, Last].


### PR DESCRIPTION
The first commit fixes attachments tests to properly account for zlib deflate returning some data before the final chunk.

The second commit enables 20.0 compatibility in rebar.config and also set Travis up to test it.