### PR TITLE
Fix cluster upgrades when deploying ddoc_cache

### DIFF
--- a/src/ddoc_cache/src/ddoc_cache_lru.erl
+++ b/src/ddoc_cache/src/ddoc_cache_lru.erl
@@ -39,6 +39,9 @@
 -include("ddoc_cache.hrl").
 
 
+-define(OPENER, ddoc_cache_opener).
+
+
 -record(st, {
     pids, % pid -> key
     dbs, % dbname -> docid -> key -> pid
@@ -143,11 +146,11 @@ handle_call(Msg, _From, St) ->
 
 
 handle_cast({evict, DbName}, St) ->
-    gen_server:abcast(mem3:nodes(), ?MODULE, {do_evict, DbName}),
+    gen_server:abcast(mem3:nodes(), ?OPENER, {do_evict, DbName}),
     {noreply, St};
 
 handle_cast({refresh, DbName, DDocIds}, St) ->
-    gen_server:abcast(mem3:nodes(), ?MODULE, {do_refresh, DbName, DDocIds}),
+    gen_server:abcast(mem3:nodes(), ?OPENER, {do_evict, DbName, DDocIds}),
     {noreply, St};
 
 handle_cast({do_evict, DbName}, St) ->


### PR DESCRIPTION
## Overview

As it turns out I made a bit of a mistake when I forgot that the old
ddoc_cache implementation had an ets_lru process registered as
ddoc_cache_lru. These cast messages were causing that process to crash.
If a cluster had enough design document activity and enough nodes this
would cause nodes with the old ddoc_cache implementation to reboot the
entire VM. This was a cascading failure due to the ets_lru process
restarting frequently enough that it brought down the entire ddoc_cache
application.

## Testing recommendations

Try a rolling reboot upgrade of a large cluster with significant write load on design documents.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
