### PR TITLE
Update Unix install dependencies (FreeBSD)

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -135,6 +135,11 @@ You can install this by running:
 
     pkg install gmake
 
+You can install the remaining dependencies by running:
+
+    pkg install npm4 help2man openssl icu curl git \
+        autoconf automake libtool node spidermonkey185
+
 ## Installing
 
 Once you have satisfied the dependencies you should run:


### PR DESCRIPTION
Hi,

The documentation for installing CouchDB has several operating systems and their respective commands to install the dependencies, except for FreeBSD. I don't know if it is on purpose or not but given that I just installed CouchDB on a digital ocean droplet, it seemed cheap to update the documentation.

Let me know if any additional test is required.

