### PR TITLE
Add test to show selector works with old design docs

### DIFF
--- a/src/mango/test/16-index-selectors.py
+++ b/src/mango/test/16-index-selectors.py
@@ -73,6 +73,28 @@ DOCS = [
     },
 ]
 
+oldschoolnoselectorddoc = {
+    "_id": "_design/oldschoolnoselector",
+    "language": "query",
+    "views": {
+        "oldschoolnoselector": {
+            "map": {
+                "fields": {
+                    "location": "asc"
+                }
+            },
+            "reduce": "_count",
+            "options": {
+                "def": {
+                    "fields": [
+                        "location"
+                    ]
+                }
+            }
+        }
+    }
+}
+
 oldschoolddoc = {
     "_id": "_design/oldschool",
     "language": "query",
@@ -177,6 +199,14 @@ class IndexSelectorJson(mango.DbPerClass):
         self.db.create_index(["location"], name="NotSelected")
         resp = self.db.find(selector, explain=True)
         self.assertEqual(resp["index"]["name"], "NotSelected")
+
+    def test_old_selector_with_no_selector_still_supported(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.save_doc(oldschoolnoselectorddoc)
+        resp = self.db.find(selector, explain=True, use_index='oldschoolnoselector')
+        self.assertEqual(resp["index"]["name"], "oldschoolnoselector")
+        docs = self.db.find(selector, use_index='oldschoolnoselector')
+        self.assertEqual(len(docs), 3)
 
     def test_old_selector_still_supported(self):
         selector = {"location": {"$gte": "FRA"}}


### PR DESCRIPTION
Add a test to show the parital_filter_selector functionality will work
with design docs that don't have a selector defined in it by default

## Testing recommendations

Mango tests should all pass

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
