### PR TITLE
Mango test configuration

### DIFF
--- a/src/mango/test/README.md
+++ b/src/mango/test/README.md
@@ -15,3 +15,15 @@ To run an individual test suite:
 
 To run the tests with text index support:
     MANGO_TEXT_INDEXES=1 nosetests --nocapture test
+
+
+Test configuration
+==================
+
+The following environment variables can be used to configure the test fixtures:
+
+COUCH_HOST - root url (including port) of the CouchDB instance to run the tests against. Default is "http://127.0.0.1:15984".
+COUCH_USER - CouchDB username (with admin premissions). Default is "testuser"
+COUCH_PASSWORD -  CouchDB password. Default is "testpass"
+COUCH_AUTH_HEADER - Optional Authorization header value. If specified, this is used instead of basic authentication with the username/password variables above.
+MANGO_TEXT_INDEXES - Set to "1" to run the tests only applicable to text indexes

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -66,7 +66,7 @@ class Database(object):
             parts = [parts]
         return "/".join([self.url] + parts)
 
-    def create(self, q=1, n=3):
+    def create(self, q=1, n=1):
         r = self.sess.get(self.url)
         if r.status_code == 404:
             r = self.sess.put(self.url, params={"q":q, "n": n})


### PR DESCRIPTION
## Overview

Previously, the tests hardcoded a target host of `http://127.0.0.1:15984` with username "testuser" and password "testpass". This PR allows the host url and authentication parameters to be configured using environment variables. 

Additionally, we default to n=1 when creating the test databases rather than assuming the target cluster will have a single node.

## Testing recommendations

Run the test suite. Try using a different username / password (following the README) or CouchDB 2.1 host.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
