### PR TITLE
Disable eval() and Function() constructor in JS by default

### DIFF
--- a/src/couch/priv/couch_js/help.h
+++ b/src/couch/priv/couch_js/help.h
@@ -54,7 +54,7 @@ static const char USAGE_TEMPLATE[] =
     "              most SIZE bytes of memory to be allocated\n"
     "  -u FILE     path to a .uri file containing the address\n"
     "              (or addresses) of one or more servers\n"
-    "  --no-eval   Disable runtime code evaluation\n"
+    "  --eval      Enable runtime code evaluation (dangerous!)\n"
     "\n"
     "Report bugs at <%s>.\n";
 

--- a/src/couch/priv/couch_js/main.c
+++ b/src/couch/priv/couch_js/main.c
@@ -353,10 +353,10 @@ static JSBool
 csp_allows(JSContext* cx)
 {
     couch_args *args = (couch_args*)JS_GetContextPrivate(cx);
-    if(args->no_eval) {
-        return JS_FALSE;
-    } else {
+    if(args->eval) {
         return JS_TRUE;
+    } else {
+        return JS_FALSE;
     }
 }
 

--- a/src/couch/priv/couch_js/util.c
+++ b/src/couch/priv/couch_js/util.c
@@ -98,8 +98,8 @@ couch_parse_args(int argc, const char* argv[])
             }
         } else if(strcmp("-u", argv[i]) == 0) {
             args->uri_file = argv[++i];
-        } else if(strcmp("--no-eval", argv[i]) == 0) {
-            args->no_eval = 1;
+        } else if(strcmp("--eval", argv[i]) == 0) {
+            args->eval = 1;
         } else if(strcmp("--", argv[i]) == 0) {
             i++;
             break;

--- a/src/couch/priv/couch_js/util.h
+++ b/src/couch/priv/couch_js/util.h
@@ -16,7 +16,7 @@
 #include <jsapi.h>
 
 typedef struct {
-    int          no_eval;
+    int          eval;
     int          use_http;
     int          use_test_funs;
     int          stack_size;

--- a/test/javascript/run
+++ b/test/javascript/run
@@ -72,7 +72,7 @@ def mkformatter(tests):
 
 def run_couchjs(test, fmt):
     fmt(test)
-    cmd = [COUCHJS, "-H", "-T"] + \
+    cmd = [COUCHJS, "--eval", "-H", "-T"] + \
             ["-u", "test/javascript/couchdb.uri"] + SCRIPTS + [test, RUNNER]
     p = sp.Popen(
         cmd,

--- a/test/javascript/tests/view_sandboxing.js
+++ b/test/javascript/tests/view_sandboxing.js
@@ -148,41 +148,21 @@ couchTests.view_sandboxing = function(debug) {
   // cleanup
   db.deleteDb();
 
-/* TODO: re-enable this test once --no-eval is the default
   // test that runtime code evaluation can be prevented
-  var couchjs_command_xhr = CouchDB.request(
-    "GET", "_node/node1@127.0.0.1/_config/query_servers/javascript");
+  db_name = get_random_db_name();
+  db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
+  db.createDb();
 
-  var couchjs_command = JSON.parse(couchjs_command_xhr.responseText);
-  var couchjs_command_args = couchjs_command.match(/\S+|"(?:\\"|[^"])+"/g);
+  var doc = {integer: 1, string: "1", array: [1, 2, 3]};
+  T(db.save(doc).ok);
 
-  couchjs_command_args.splice(1, 0, "--no-eval");
-  var new_couchjs_command = couchjs_command_args.join(" ");
+  var results = db.query(function(doc) {
+      var glob = emit.constructor('return this')();
+      emit(doc._id, null);
+  });
 
-  run_on_modified_server(
-    [{section: "query_servers",
-      key: "javascript",
-      value: new_couchjs_command}],
-    function () {
-      CouchDB.request("POST", "_reload_query_servers");
-
-      db_name = get_random_db_name();
-      db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
-      db.createDb();
-
-      var doc = {integer: 1, string: "1", array: [1, 2, 3]};
-      T(db.save(doc).ok);
-
-      var results = db.query(function(doc) {
-          var glob = emit.constructor('return this')();
-          emit(doc._id, null);
-      });
-
-      TEquals(0, results.rows.length);
-    });
-*/
+  TEquals(0, results.rows.length);
 
   // cleanup
-  CouchDB.request("POST", "_reload_query_servers");
   db.deleteDb();
 };


### PR DESCRIPTION
This changes the couchjs --no-eval flag to --eval and disables
eval() and Function() constructors by default in couchjs.

As this is a major change to compatibility, it should land in the next feature release, not `2.1.1`.

A documentation PR will come after this lands.
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
