### PR TITLE
Travis: s/20.0/20.1 for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 os: linux
 otp_release:
-   - 20.0
+   - 20.1
    - 19.3
    - 18.3
    - 17.5


### PR DESCRIPTION
Enable Erlang 20.1 for Travis (instead of 20.0)