### PR TITLE
Mango test failures

### DIFF
--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -33,6 +33,11 @@ def get_from_environment(key, default):
     value = os.environ.get(key)
     return value if value is not None else default
 
+# add delay functionality
+def delay(n=5, t=0.2):
+    for i in range(0, n):
+        time.sleep(t)
+
 
 class Database(object):
     def __init__(self, dbname,
@@ -77,9 +82,9 @@ class Database(object):
 
     def recreate(self):
         self.delete()
-        time.sleep(1)
+        delay()
         self.create()
-        time.sleep(1)
+        delay()
 
     def save_doc(self, doc):
         self.save_docs([doc])
@@ -166,13 +171,14 @@ class Database(object):
 
     def delete_index(self, ddocid, name, idx_type="json"):
         path = ["_index", ddocid, idx_type, name]
-        r = self.sess.delete(self.path(path), params={"w": "1"})
+        r = self.sess.delete(self.path(path), params={"w": "3"})
+        delay()
         r.raise_for_status()
 
     def bulk_delete(self, docs):
         body = {
             "docids" : docs,
-            "w": 1
+            "w": 3
         }
         body = json.dumps(body)
         r = self.sess.post(self.path("_index/_bulk_delete"), data=body)

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -122,6 +122,7 @@ class Database(object):
         body = json.dumps(body)
         r = self.sess.post(self.path("_index"), data=body)
         r.raise_for_status()
+
         assert r.json()["id"] is not None
         assert r.json()["name"] is not None
         return r.json()["result"] == "created"
@@ -165,13 +166,13 @@ class Database(object):
 
     def delete_index(self, ddocid, name, idx_type="json"):
         path = ["_index", ddocid, idx_type, name]
-        r = self.sess.delete(self.path(path), params={"w":"3"})
+        r = self.sess.delete(self.path(path), params={"w": 1})
         r.raise_for_status()
 
     def bulk_delete(self, docs):
         body = {
             "docids" : docs,
-            "w": 3
+            "w": 1
         }
         body = json.dumps(body)
         r = self.sess.post(self.path("_index/_bulk_delete"), data=body)

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -166,7 +166,7 @@ class Database(object):
 
     def delete_index(self, ddocid, name, idx_type="json"):
         path = ["_index", ddocid, idx_type, name]
-        r = self.sess.delete(self.path(path), params={"w": 1})
+        r = self.sess.delete(self.path(path), params={"w": "1"})
         r.raise_for_status()
 
     def bulk_delete(self, docs):

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -34,7 +34,7 @@ def get_from_environment(key, default):
     return value if value is not None else default
 
 # add delay functionality
-def delay(n=5, t=0.2):
+def delay(n=5, t=0.5):
     for i in range(0, n):
         time.sleep(t)
 

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -126,6 +126,7 @@ class Database(object):
             body["index"]["partial_filter_selector"] = partial_filter_selector
         body = json.dumps(body)
         r = self.sess.post(self.path("_index"), data=body)
+        delay()
         r.raise_for_status()
 
         assert r.json()["id"] is not None
@@ -157,6 +158,7 @@ class Database(object):
             body["ddoc"] = ddoc
         body = json.dumps(body)
         r = self.sess.post(self.path("_index"), data=body)
+        delay()
         r.raise_for_status()
         return r.json()["result"] == "created"
 
@@ -182,6 +184,7 @@ class Database(object):
         }
         body = json.dumps(body)
         r = self.sess.post(self.path("_index/_bulk_delete"), data=body)
+        delay(n=10)
         return r.json()
 
     def find(self, selector, limit=25, skip=0, sort=None, fields=None,

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -128,7 +128,6 @@ class Database(object):
         r = self.sess.post(self.path("_index"), data=body)
         delay()
         r.raise_for_status()
-
         assert r.json()["id"] is not None
         assert r.json()["name"] is not None
         return r.json()["result"] == "created"


### PR DESCRIPTION
## Overview
Mango tests fail due to flaky tests with index deletion. I cannot recreate locally.
@davisp and @garrensmith
mentioned that it could be due to the latest ddoc_cache changes and suggested
changing r=3 to see if that would help. However, we recently changed tests to use
n=1 as default for all dbs created. I wonder if having w=3 and n=1 could be the reason.
We get a 202 back, but the index isn't deleted in time when we go to retrieve it. So changing
w=3  to w=1 to see if that will help. If not, I may add a wait loop inside delete.

## Testing recommendations
Let's see if it passes travis.

## Related Issues or Pull Requests
https://github.com/apache/couchdb/issues/918

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
