### PR TITLE
Updating verifyinstall URL

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -236,7 +236,7 @@ To check that everything has worked, point your web browser to:
 
 From here you should verify your installation by pointing your web browser to:
 
-    http://localhost:5984/_utils/verify_install.html
+    http://localhost:5984/_utils/#/verifyinstall
 
 ## Running as a Daemon
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

While going to `http://localhost:5984/_utils/verify_install.html` returns `Not found.`, browsing to `http://localhost:5984/_utils/#/verifyinstall` works. Maybe the url is outdated


## Testing recommendations

Follow [INSTALL.Unix.md](https://github.com/apache/couchdb/blob/master/INSTALL.Unix.md) until the "First Run" section and then browse to the <http://localhost:5984/_utils/verify_install.html>

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
