### PR TITLE
Return error 410 on temporary view request

### DIFF
--- a/src/chttpd/src/chttpd_view.erl
+++ b/src/chttpd/src/chttpd_view.erl
@@ -82,7 +82,7 @@ handle_view_req(Req, _Db, _DDoc) ->
 
 handle_temp_view_req(Req, _Db) ->
     Msg = <<"Temporary views are not supported in CouchDB">>,
-    chttpd:send_error(Req, 403, forbidden, Msg).
+    chttpd:send_error(Req, 410, gone, Msg).
 
 
 

--- a/test/javascript/tests/view_errors.js
+++ b/test/javascript/tests/view_errors.js
@@ -185,6 +185,18 @@ couchTests.view_errors = function(debug) {
           T(e.error == "query_parse_error");
           T(e.reason.match(/no rows can match/i));
       }
+
+      // querying a temporary view should give "gone" error message
+      var xhr = CouchDB.request("POST", "/" + db_name + "/_temp_view", {
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({language: "javascript",
+          map : "function(doc){emit(doc.integer)}"
+        })
+      });
+      T(xhr.status == 410);
+      result = JSON.parse(xhr.responseText);
+      T(result.error == "gone");
+      T(result.reason == "Temporary views are not supported in CouchDB");
     // });
 
   // cleanup


### PR DESCRIPTION
## Overview

The request for temporary view is currently returning "403 Forbidden" error, which is implying a permissions issue. Error "410 Gone" seems to fit better.

> [The HTTP 410 Gone client error response code indicates that access to the target resource is no longer available at the origin server and that this condition is likely to be permanent.](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410)

## Testing recommendations

`make javascript suites=view_errors`

## Related Issues or Pull Requests

Related to #932 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
