### PR TITLE
Update jiffy to use dedupe_keys

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -62,7 +62,7 @@ DepDescs = [
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.2"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1"}},
-{jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-1"}},
+{jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-2"}},
 {mochiweb,         "mochiweb",         {tag, "CouchDB-2.12.0-1"}},
 {meck,             "meck",             {tag, "0.8.8"}}
 

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -426,7 +426,7 @@ json_encode(V) ->
 
 json_decode(V) ->
     try
-        jiffy:decode(V)
+        jiffy:decode(V, [dedupe_keys])
     catch
         throw:Error ->
             throw({invalid_json, Error})


### PR DESCRIPTION
## Overview

Update to use new dedupe_keys option in Jiffy.

## Testing recommendations

```make check```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
