### PR TITLE
Mark R15B03 build as flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ otp_release:
 matrix:
   allow_failures:
     - otp_release: R14B04
+    - otp_release: R15B03


### PR DESCRIPTION
It's runs unstable on travis and while 2.x branch no longer supports it, we recommend to use recent Erlang/OTP release as possible to avoid any issues.