### PR TITLE
disable js tests that need the native query server

### DIFF
--- a/share/www/script/test/erlang_views.js
+++ b/share/www/script/test/erlang_views.js
@@ -11,6 +11,7 @@
 // the License.
 
 couchTests.erlang_views = function(debug) {
+  return; // diabled because of https://github.com/apache/couchdb/pull/939
   var db = new CouchDB("test_suite_db", {"X-Couch-Full-Commit":"false"});
   db.deleteDb();
   db.createDb();
@@ -40,7 +41,7 @@ couchTests.erlang_views = function(debug) {
       T(results.total_rows == 1);
       T(results.rows[0].key == 1);
       T(results.rows[0].value == "str1");
-      
+
       // check simple reduction - another doc with same key.
       var doc = {_id: "2", integer: 1, string: "str2"};
       T(db.save(doc).ok);
@@ -99,7 +100,7 @@ couchTests.erlang_views = function(debug) {
       db.deleteDb();
       db.createDb();
       var words = "foo bar abc def baz xxyz".split(/\s+/);
-      
+
       var docs = [];
       for(var i = 0; i < 250; i++) {
         var body = [];
@@ -115,16 +116,16 @@ couchTests.erlang_views = function(debug) {
         });
       }
       T(db.bulkSave(docs).length, 250, "Saved big doc set.");
-      
+
       var mfun = 'fun({Doc}) -> ' +
         'Words = couch_util:get_value(<<"words">>, Doc), ' +
         'lists:foreach(fun({Word}) -> ' +
-            'WordString = couch_util:get_value(<<"word">>, Word), ' + 
-            'Count = couch_util:get_value(<<"count">>, Word), ' + 
+            'WordString = couch_util:get_value(<<"word">>, Word), ' +
+            'Count = couch_util:get_value(<<"count">>, Word), ' +
             'Emit(WordString , Count) ' +
           'end, Words) ' +
         'end.';
-      
+
       var rfun = 'fun(Keys, Values, RR) -> length(Values) end.';
       var results = db.query(mfun, rfun, null, null, "erlang");
       T(results.rows[0].key === null, "Returned a reduced value.");

--- a/share/www/script/test/list_views.js
+++ b/share/www/script/test/list_views.js
@@ -221,7 +221,7 @@ couchTests.list_views = function(debug) {
     headers: {"if-none-match": etag}
   });
   T(xhr.status == 304);
-  
+
   // confirm ETag changes with different POST bodies
   xhr = CouchDB.request("POST", "/test_suite_db/_design/lists/_list/basicBasic/basicView",
     {body: JSON.stringify({keys:[1]})}
@@ -240,7 +240,7 @@ couchTests.list_views = function(debug) {
   TEquals(10, resp.head.total_rows);
   TEquals(0, resp.head.offset);
   TEquals(11, resp.head.update_seq);
-  
+
   T(resp.rows.length == 10);
   TEquals(resp.rows[0], {"id": "0","key": 0,"value": "0"});
 
@@ -414,7 +414,7 @@ couchTests.list_views = function(debug) {
   xhr = CouchDB.request("POST", url, {
     body: '{"keys":[-2,-4,-5,-7]}'
   });
-  
+
   T(xhr.status == 200, "multi key separate docs");
   T(!(/Key: -3/.test(xhr.responseText)));
   T(/Key: -7/.test(xhr.responseText));
@@ -441,11 +441,12 @@ couchTests.list_views = function(debug) {
     }
   };
 
-  run_on_modified_server([{
-    section: "native_query_servers",
-    key: "erlang",
-    value: "{couch_native_process, start_link, []}"
-  }], erlViewTest);
+  // diabled because of https://github.com/apache/couchdb/pull/939
+  // run_on_modified_server([{
+  //   section: "native_query_servers",
+  //   key: "erlang",
+  //   value: "{couch_native_process, start_link, []}"
+  // }], erlViewTest);
 
   // COUCHDB-1113
   var ddoc = {


### PR DESCRIPTION
this didn’t trip up https://github.com/apache/couchdb/pull/939 because it looks like js test fails don’t break the build