### PR TITLE
Do not always return partial_filter_selector

### DIFF
--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -152,6 +152,10 @@ def_to_json([{fields, Fields} | Rest]) ->
     [{<<"fields">>, fields_to_json(Fields)} | def_to_json(Rest)];
 def_to_json([{<<"fields">>, Fields} | Rest]) ->
     [{<<"fields">>, fields_to_json(Fields)} | def_to_json(Rest)];
+% Don't include partial_filter_selector in the json conversion
+% if its the default value
+def_to_json([{<<"partial_filter_selector">>, {[]}} | Rest]) ->
+    def_to_json(Rest);
 def_to_json([{Key, Value} | Rest]) ->
     [{Key, Value} | def_to_json(Rest)].
 

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -120,7 +120,7 @@ is_usable(Idx, Selector, SortFields) ->
     % and the selector is not a text search (so requires a text index)
     RequiredFields = columns(Idx),
 
-    % sort fields are required to exist in the results so
+    % sort fields are required to exist in the results so 
     % we don't need to check the selector for these
     RequiredFields1 = ordsets:subtract(lists:usort(RequiredFields), lists:usort(SortFields)),
 

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -120,7 +120,7 @@ is_usable(Idx, Selector, SortFields) ->
     % and the selector is not a text search (so requires a text index)
     RequiredFields = columns(Idx),
 
-    % sort fields are required to exist in the results so 
+    % sort fields are required to exist in the results so
     % we don't need to check the selector for these
     RequiredFields1 = ordsets:subtract(lists:usort(RequiredFields), lists:usort(SortFields)),
 
@@ -195,6 +195,10 @@ def_to_json([{fields, Fields} | Rest]) ->
     [{<<"fields">>, mango_sort:to_json(Fields)} | def_to_json(Rest)];
 def_to_json([{<<"fields">>, Fields} | Rest]) ->
     [{<<"fields">>, mango_sort:to_json(Fields)} | def_to_json(Rest)];
+% Don't include partial_filter_selector in the json conversion
+% if its the default value
+def_to_json([{<<"partial_filter_selector">>, {[]}} | Rest]) ->
+    def_to_json(Rest);
 def_to_json([{Key, Value} | Rest]) ->
     [{Key, Value} | def_to_json(Rest)].
 

--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -161,6 +161,12 @@ class IndexSelectorJson(mango.DbPerClass):
         indexes = self.db.list_indexes()
         self.assertEqual(indexes[1]["def"]["partial_filter_selector"], selector)
 
+    def test_partial_filter_only_in_return_if_not_default(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.create_index(["location"])
+        index = self.db.list_indexes()[1]
+        self.assertEqual('partial_filter_selector' in index['def'], False)
+
     def test_saves_selector_in_index_throws(self):
         selector = {"location": {"$gte": "FRA"}}
         try:
@@ -265,3 +271,10 @@ class IndexSelectorJson(mango.DbPerClass):
         self.assertEqual(resp["index"]["name"], "oldschooltext")
         docs = self.db.find(selector, use_index='oldschooltext')
         self.assertEqual(len(docs), 3)
+
+    @unittest.skipUnless(mango.has_text_service(), "requires text service")
+    def test_text_partial_filter_only_in_return_if_not_default(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.create_text_index(fields=[{"name":"location"}])
+        index = self.db.list_indexes()[1]
+        self.assertEqual('partial_filter_selector' in index['def'], False)

--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -162,7 +162,6 @@ class IndexSelectorJson(mango.DbPerClass):
         self.assertEqual(indexes[1]["def"]["partial_filter_selector"], selector)
 
     def test_partial_filter_only_in_return_if_not_default(self):
-        selector = {"location": {"$gte": "FRA"}}
         self.db.create_index(["location"])
         index = self.db.list_indexes()[1]
         self.assertEqual('partial_filter_selector' in index['def'], False)
@@ -274,7 +273,6 @@ class IndexSelectorJson(mango.DbPerClass):
 
     @unittest.skipUnless(mango.has_text_service(), "requires text service")
     def test_text_partial_filter_only_in_return_if_not_default(self):
-        selector = {"location": {"$gte": "FRA"}}
         self.db.create_text_index(fields=[{"name":"location"}])
         index = self.db.list_indexes()[1]
         self.assertEqual('partial_filter_selector' in index['def'], False)


### PR DESCRIPTION
For Get / _index only return the partial_filter_selector for an index if
it is set to something other than default



## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
