### PR TITLE
Return error 400 on invalid new_edits value

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -451,7 +451,9 @@ db_req(#httpd{method='POST',path_parts=[_,<<"_bulk_docs">>], user_ctx=Ctx}=Req, 
         {accepted, Errors} ->
             ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
             send_json(Req, 202, ErrorsJson)
-        end
+        end;
+    _ ->
+        throw({bad_request, <<"`new_edits` parameter must be a boolean.">>})
     end;
 
 db_req(#httpd{path_parts=[_,<<"_bulk_docs">>]}=Req, _Db) ->

--- a/test/javascript/tests/bulk_docs.js
+++ b/test/javascript/tests/bulk_docs.js
@@ -110,6 +110,16 @@ couchTests.bulk_docs = function(debug) {
   T(result.error == "bad_request");
   T(result.reason == "POST body must include `docs` parameter.");
 
+  // verify that sending a request with invalid `new_edits` causes error
+  var req = CouchDB.request("POST", "/" + db_name + "/_bulk_docs", {
+    body: JSON.stringify({"docs": [], "new_edits": 0})
+  });
+
+  T(req.status == 400);
+  result = JSON.parse(req.responseText);
+  T(result.error == "bad_request");
+  T(result.reason == "`new_edits` parameter must be a boolean.");
+
   // jira-911
   db.deleteDb();
   // avoid Heisenbugs w/ files remaining - create a new name

--- a/test/javascript/tests/bulk_docs.js
+++ b/test/javascript/tests/bulk_docs.js
@@ -110,6 +110,16 @@ couchTests.bulk_docs = function(debug) {
   T(result.error == "bad_request");
   T(result.reason == "POST body must include `docs` parameter.");
 
+  // verify that sending a request with invalid `docs` causes error
+  var req = CouchDB.request("POST", "/" + db_name + "/_bulk_docs", {
+    body: JSON.stringify({"docs": "foo"})
+  });
+
+  T(req.status == 400);
+  result = JSON.parse(req.responseText);
+  T(result.error == "bad_request");
+  T(result.reason == "`docs` parameter must be an array.");
+
   // verify that sending a request with invalid `new_edits` causes error
   var req = CouchDB.request("POST", "/" + db_name + "/_bulk_docs", {
     body: JSON.stringify({"docs": [], "new_edits": 0})


### PR DESCRIPTION
## Overview

End-point `_bulk_docs` crashes if provided with non-boolean value for `new_edits` parameter.

This patch changes it to return "Bad Request" error instead.

## Testing recommendations

`make javascript suites=bulk_docs`

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
