### PR TITLE
Fix user-specified ddoc name in Mango

### DIFF
--- a/src/mango/src/mango_idx.erl
+++ b/src/mango/src/mango_idx.erl
@@ -333,7 +333,7 @@ get_idx_type(Opts) ->
 
 get_idx_ddoc(Idx, Opts) ->
     case proplists:get_value(ddoc, Opts) of
-        <<"_design/", _Rest>> = Name ->
+        <<"_design/", _Rest/binary>> = Name ->
             Name;
         Name when is_binary(Name) ->
             <<"_design/", Name/binary>>;
@@ -436,5 +436,14 @@ get_partial_filter_selector_with_legacy_selector_test() ->
 get_partial_filter_selector_with_legacy_default_selector_test() ->
     Idx = index(<<"selector">>, []),
     ?assertEqual(undefined, get_partial_filter_selector(Idx)).
+
+
+get_idx_ddoc_name_only_test() ->
+    Opts = [{ddoc, <<"foo">>}],
+    ?assertEqual(<<"_design/foo">>, get_idx_ddoc({}, Opts)).
+
+get_idx_ddoc_design_slash_name_test() ->
+    Opts = [{ddoc, <<"_design/foo">>}],
+    ?assertEqual(<<"_design/foo">>, get_idx_ddoc({}, Opts)).
 
 -endif.


### PR DESCRIPTION
## Overview

When creating a Mango index, we allow the user to specify
a design document name. This can be of the form "_design/foo"
or just "foo", with the expectation that Mango would
automatically add the "_design" prefix.

This fixes a bug whereby if the user specified "_design/foo",
Mango was prefixing this again, creating a design document called
"_design/_design/foo".

## Testing recommendations

Added a couple of new eunit tests to cover this. To test manually, verify that you can create a mango index using the `"ddoc"` field to specify the design document id, with and without a `"_design/"` prefix.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
