### PR TITLE
Mango: generate a warning instead of an error when an user-specified index cannot be used

### DIFF
--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -124,7 +124,7 @@ execute(Cursor, UserFun, UserAcc) ->
             Arg = {add_key, bookmark, JsonBM},
             {_Go, FinalUserAcc} = UserFun(Arg, LastUserAcc),
             FinalUserAcc0 = mango_execution_stats:maybe_add_stats(Opts, UserFun, Stats0, FinalUserAcc),
-            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Idx, FinalUserAcc0),
+            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, FinalUserAcc0),
             {ok, FinalUserAcc1}
     end.
 

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -137,7 +137,7 @@ execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFu
                     {_Go, FinalUserAcc} = UserFun(Arg, LastCursor#cursor.user_acc),
                     Stats0 = LastCursor#cursor.execution_stats,
                     FinalUserAcc0 = mango_execution_stats:maybe_add_stats(Opts, UserFun, Stats0, FinalUserAcc),
-                    FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Idx, FinalUserAcc0),
+                    FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, FinalUserAcc0),
                     {ok, FinalUserAcc1};
                 {error, Reason} ->
                     {error, Reason}

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -21,12 +21,6 @@
 ]).
 
 
-info(mango_idx, {no_usable_index, no_indexes_defined}) ->
-    {
-        400,
-        <<"no_usable_index">>,
-        <<"There are no indexes defined in this database.">>
-    };
 info(mango_idx, {no_usable_index, no_index_matching_name}) ->
     {
         400,

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -21,25 +21,12 @@
 ]).
 
 
-info(mango_idx, {no_usable_index, no_index_matching_name}) ->
-    {
-        400,
-        <<"no_usable_index">>,
-        <<"No index matches the index specified with \"use_index\"">>
-    };
 info(mango_idx, {no_usable_index, missing_sort_index}) ->
     {
         400,
         <<"no_usable_index">>,
         <<"No index exists for this sort, try indexing by the sort fields.">>
     };
-info(mango_cursor, {no_usable_index, selector_unsupported}) ->
-    {
-        400,
-        <<"no_usable_index">>,
-        <<"The index specified with \"use_index\" is not usable for the query.">>
-    };
-
 info(mango_json_bookmark, {invalid_bookmark, BadBookmark}) ->
     {
         400,

--- a/src/mango/src/mango_idx.erl
+++ b/src/mango/src/mango_idx.erl
@@ -59,9 +59,6 @@ list(Db) ->
 
 get_usable_indexes(Db, Selector, Opts) ->
     ExistingIndexes = mango_idx:list(Db),
-    if ExistingIndexes /= [] -> ok; true ->
-        ?MANGO_ERROR({no_usable_index, no_indexes_defined})
-    end,
 
     FilteredIndexes = mango_cursor:maybe_filter_indexes_by_ddoc(ExistingIndexes, Opts),
     if FilteredIndexes /= [] -> ok; true ->

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -46,7 +46,7 @@ class IndexSelectionTests:
                 "name.last": "Something or other",
                 "age": {"$gt": 1}
             }, explain=True)
-        self.assertNotEqual(resp["index"]["ddoc"], ddocid)
+        self.assertNotEqual(resp["index"]["ddoc"], "_design/" + ddocid)
 
         resp = self.db.find({
                 "name.first": "Stephanie",
@@ -107,6 +107,10 @@ class IndexSelectionTests:
         resp = self.db.find(selector, use_index=[ddocid,name], return_raw=True)
         self.assertEqual(resp["warning"], "{0}, {1} was not used because it is not a valid index for this query.".format(ddocid, name))
 
+        # should still return a correct result
+        for d in resp["docs"]:
+            self.assertEqual(d["company"], "Pharmex")
+
     def test_reject_use_index_sort_order(self):
         # index on ["company","manager"] which should not be valid
         # and there is no valid fallback (i.e. an index on ["company"])
@@ -135,6 +139,7 @@ class IndexSelectionTests:
 
         resp = self.db.find(selector, sort=["foo", "bar"], use_index=ddocid_invalid, return_raw=True)
         self.assertEqual(resp["warning"], '{0} was not used because it does not contain a valid index for this query.'.format(ddocid_invalid))    
+        self.assertEqual(len(resp["docs"]), 0)
 
     def test_prefer_use_index_over_optimal_index(self):
         # index on ["company"] even though index on ["company", "manager"] is better

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -46,7 +46,7 @@ class IndexSelectionTests:
                 "name.last": "Something or other",
                 "age": {"$gt": 1}
             }, explain=True)
-        self.assertNotEqual(resp["index"]["ddoc"], "_design/" + ddocid)
+        self.assertNotEqual(resp["index"]["ddoc"], ddocid)
 
         resp = self.db.find({
                 "name.first": "Stephanie",
@@ -66,12 +66,8 @@ class IndexSelectionTests:
     def test_invalid_use_index(self):
         # ddoc id for the age index
         ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"
-        try:
-            self.db.find({}, use_index=ddocid)
-        except Exception as e:
-            self.assertEqual(e.response.status_code, 400)
-        else:
-            raise AssertionError("bad find")
+        r = self.db.find({}, use_index=ddocid, return_raw=True)
+        self.assertEqual(r["warning"], '{0} was not used because it does not contain a valid index for this query.'.format(ddocid))
 
     def test_uses_index_when_no_range_or_equals(self):
         # index on ["manager"] should be valid because
@@ -87,19 +83,18 @@ class IndexSelectionTests:
         resp_explain = self.db.find(selector, explain=True)
         self.assertEqual(resp_explain["index"]["type"], "json")
 
-
     def test_reject_use_index_invalid_fields(self):
         # index on ["company","manager"] which should not be valid
         ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
         selector = {
             "company": "Pharmex"
         }
-        try:
-            self.db.find(selector, use_index=ddocid)
-        except Exception as e:
-            self.assertEqual(e.response.status_code, 400)
-        else:
-            raise AssertionError("did not reject bad use_index")
+        r = self.db.find(selector, use_index=ddocid, return_raw=True)
+        self.assertEqual(r["warning"], '{0} was not used because it does not contain a valid index for this query.'.format(ddocid))
+        
+        # should still return a correct result
+        for d in r["docs"]:
+            self.assertEqual(d["company"], "Pharmex")
 
     def test_reject_use_index_ddoc_and_name_invalid_fields(self):
         # index on ["company","manager"] which should not be valid
@@ -108,41 +103,53 @@ class IndexSelectionTests:
         selector = {
             "company": "Pharmex"
         }
-        try:
-            self.db.find(selector, use_index=[ddocid,name])
-        except Exception as e:
-            self.assertEqual(e.response.status_code, 400)
-        else:
-            raise AssertionError("did not reject bad use_index")
+        
+        resp = self.db.find(selector, use_index=[ddocid,name], return_raw=True)
+        self.assertEqual(resp["warning"], "{0}, {1} was not used because it is not a valid index for this query.".format(ddocid, name))
 
     def test_reject_use_index_sort_order(self):
         # index on ["company","manager"] which should not be valid
+        # and there is no valid fallback (i.e. an index on ["company"])
         ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
         selector = {
-            "company": {"$gt": None},
-            "manager": {"$gt": None}
+            "company": {"$gt": None}
         }
         try:
-            self.db.find(selector, use_index=ddocid, sort=[{"manager":"desc"}])
+            self.db.find(selector, use_index=ddocid, sort=[{"company":"desc"}])
         except Exception as e:
             self.assertEqual(e.response.status_code, 400)
         else:
             raise AssertionError("did not reject bad use_index")
 
-    def test_reject_use_index_ddoc_and_name_sort_order(self):
-        # index on ["company","manager"] which should not be valid
-        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
-        name = "a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+    def test_use_index_fallback_if_valid_sort(self):
+        ddocid_valid = "_design/fallbackfoo"
+        ddocid_invalid = "_design/fallbackfoobar"
+        self.db.create_index(fields=["foo"], ddoc=ddocid_invalid)
+        self.db.create_index(fields=["foo", "bar"], ddoc=ddocid_valid)
         selector = {
-            "company": {"$gt": None},
-            "manager": {"$gt": None}
+            "foo": {"$gt": None}
         }
-        try:
-            self.db.find(selector, use_index=[ddocid,name], sort=[{"manager":"desc"}])
-        except Exception as e:
-            self.assertEqual(e.response.status_code, 400)
-        else:
-            raise AssertionError("did not reject bad use_index")
+
+        resp_explain = self.db.find(selector, sort=["foo", "bar"], use_index=ddocid_invalid, explain=True)
+        self.assertEqual(resp_explain["index"]["ddoc"], ddocid_valid)    
+
+        resp = self.db.find(selector, sort=["foo", "bar"], use_index=ddocid_invalid, return_raw=True)
+        self.assertEqual(resp["warning"], '{0} was not used because it does not contain a valid index for this query.'.format(ddocid_invalid))    
+
+    def test_prefer_use_index_over_optimal_index(self):
+        # index on ["company"] even though index on ["company", "manager"] is better
+        ddocid_preferred = "_design/testsuboptimal"
+        self.db.create_index(fields=["baz"], ddoc=ddocid_preferred)
+        self.db.create_index(fields=["baz", "bar"])
+        selector = {
+            "baz": {"$gt": None},
+            "bar": {"$gt": None}
+        }
+        resp = self.db.find(selector, use_index=ddocid_preferred, return_raw=True)
+        self.assertTrue("warning" not in resp)
+
+        resp_explain = self.db.find(selector, use_index=ddocid_preferred, explain=True)
+        self.assertEqual(resp_explain["index"]["ddoc"], ddocid_preferred)
 
     # This doc will not be saved given the new ddoc validation code
     # in couch_mrview


### PR DESCRIPTION
## Overview

If a user specifies a value for use_index that is not valid for the current query - i.e. it does not meet the coverage requirements of the selector or sort fields - attempt to fall back to a valid index (or database scan) rather than returning a 400 error to the client.

When a fallback occurs, populate the "warning" field in the response (as we already do when a full database scan takes place) to feed back to the user that `use_index` was ignored.

This change is partially as mitigation for #816, which may lead to some previously valid indexes being deemed invalid, and also to make `use_index` less brittle for production applications in general. 

## Testing recommendations

Run the test suite. Run some mango queries with and without `use_index`. Observe that a warning is returned in the JSON and in Fauxton.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
