### PR TITLE
Fix eunit and js testsuites on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -102,7 +102,10 @@ else
 	@copy test\javascript\tests\lorem*.txt src\fauxton\dist\release\test
 endif
 	-@rmdir /s/q dev\lib
-	@python dev\run -n 1 -q --with-admin-party-please -c startup_jitter=0 python test\javascript\run $(suites)
+	@python dev\run -n 1 -q --with-admin-party-please \
+		--enable-erlang-views \
+		-c startup_jitter=0 \
+		python test\javascript\run $(suites)
 
 
 .PHONY: check-qs

--- a/src/couch/include/couch_eunit.hrl
+++ b/src/couch/include/couch_eunit.hrl
@@ -42,7 +42,7 @@
     fun() ->
         A = integer_to_list(couch_util:unique_monotonic_integer()),
         N = node(),
-        FileName = lists:flatten(io_lib:format("~p-~p", [N, A])),
+        FileName = lists:flatten(io_lib:format("~p-~s", [N, A])),
         filename:join([?TEMPDIR, FileName])
     end).
 -define(tempdb,


### PR DESCRIPTION
Commit afb7c8e ported the use of `couch_util:unique_monotonic_integer` for the EUnit test suite instead of `erlang:now`. Unfortunately, this resulted in filenames being generated with double-quotation marks in them (`"`), which are invalid filename characters on Windows. This failed many test suites, including `couch_epi` and `couch_log`.

Fortunately, the fix is a single character in the `io_lib:format` string:

```erlang
24> A = integer_to_list(erlang:unique_integer([monotonic, positive])).
"20"
25> N = node().
nonode@nohost
27> io_lib:format("~p-~s", [N, A]).
["nonode@nohost",45,"20"]
28> lists:flatten(io_lib:format("~p-~s", [N, A])).
"nonode@nohost-20"
29> lists:flatten(io_lib:format("~p-~p", [N, A])).
"nonode@nohost-\"20\""
```

There is also an associated fix to `Makefile.win`, porting over a change I missed in commit 82635ef.