### PR TITLE
Version bump to 2.2.0 for future release

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -12,7 +12,7 @@
 
 {sys, [
     {lib_dirs, ["../src"]},
-    {rel, "couchdb", "2.1.1", [
+    {rel, "couchdb", "2.2.0", [
         %% stdlib
         asn1,
         compiler,

--- a/version.mk
+++ b/version.mk
@@ -1,3 +1,3 @@
 vsn_major=2
-vsn_minor=1
-vsn_patch=1
+vsn_minor=2
+vsn_patch=0


### PR DESCRIPTION
Given PSE work will probably land, we need to bump the minor version number.