### PR TITLE
Fix Mango text index tests

### DIFF
--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -181,15 +181,13 @@ class JSONIndexSelectionTests(mango.UserDocsTests, IndexSelectionTests):
 
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
-class TextIndexSelectionTests(mango.UserDocsTests, IndexSelectionTests):
+class TextIndexSelectionTests(mango.UserDocsTests):
 
     @classmethod
     def setUpClass(klass):
         super(TextIndexSelectionTests, klass).setUpClass()
-
-    def setUp(self):
-        self.db.recreate()
-        user_docs.add_text_indexes(self.db, {})
+        if mango.has_text_service():
+            user_docs.add_text_indexes(klass.db, {})
 
     def test_with_text(self):
         resp = self.db.find({

--- a/src/mango/test/06-basic-text-test.py
+++ b/src/mango/test/06-basic-text-test.py
@@ -450,14 +450,14 @@ class ElemMatchTests(mango.FriendDocsTextTests):
             }
         }
         docs = self.db.find(q)
-        assert len(docs) == 1
-        assert docs[0]["bestfriends"] == ["Wolverine", "Cyclops"]
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["bestfriends"], ["Wolverine", "Cyclops"])
 
         q = {"results": {"$elemMatch": {"$gte": 80, "$lt": 85}}}
 
         docs = self.db.find(q)
-        assert len(docs) == 1
-        assert docs[0]["results"] == [82, 85, 88]
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["results"], [82, 85, 88])
 
     def test_elem_match(self):
         q = {"friends": {
@@ -466,9 +466,9 @@ class ElemMatchTests(mango.FriendDocsTextTests):
             }
         }
         docs = self.db.find(q)
-        assert len(docs) == 2
+        self.assertEqual(len(docs), 2)
         for d in docs:
-            assert d["user_id"] in (0, 1)
+            self.assertIn(d["user_id"], (0, 1))
 
         q = {
             "friends": {
@@ -479,8 +479,8 @@ class ElemMatchTests(mango.FriendDocsTextTests):
             }
         }
         docs = self.db.find(q)
-        assert len(docs) == 1
-        assert docs[0]["user_id"] == 4
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["user_id"], 4)
 
 
         # Check that we can do logic in elemMatch
@@ -490,8 +490,9 @@ class ElemMatchTests(mango.FriendDocsTextTests):
             }}
         }
         docs = self.db.find(q)
-        assert len(docs) == 1
-        assert docs[0]["user_id"] == 1
+        self.assertEqual(len(docs), 2)
+        for d in docs:
+            self.assertIn(d["user_id"], (1, 15))
 
         q = {
             "friends": {
@@ -505,9 +506,9 @@ class ElemMatchTests(mango.FriendDocsTextTests):
             }
         }
         docs = self.db.find(q)
-        assert len(docs) == 2
+        self.assertEqual(len(docs), 3)
         for d in docs:
-            assert d["user_id"] in (1, 4)
+            self.assertIn(d["user_id"], (1, 4, 15))
 
         # Same as last, but using $in
         q = {
@@ -519,9 +520,9 @@ class ElemMatchTests(mango.FriendDocsTextTests):
             }
         }
         docs = self.db.find(q)
-        assert len(docs) == 2
+        self.assertEqual(len(docs), 3)
         for d in docs:
-            assert d["user_id"] in (1, 4)
+            self.assertIn(d["user_id"], (1, 4, 15))
 
         q = {
             "$and": [{
@@ -564,9 +565,9 @@ class ElemMatchTests(mango.FriendDocsTextTests):
             ]
         }
         docs = self.db.find(q)
-        assert len(docs) == 3
+        self.assertEqual(len(docs), 3)
         for d in docs:
-            assert d["user_id"] in (10, 11,12)
+            self.assertIn(d["user_id"], (10, 11,12))
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class AllMatchTests(mango.FriendDocsTextTests):

--- a/src/mango/test/10-disable-array-length-field-test.py
+++ b/src/mango/test/10-disable-array-length-field-test.py
@@ -16,7 +16,7 @@ import unittest
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class DisableIndexArrayLengthsTest(mango.UserDocsTextTests):
 
-    def setUp(klass):
+    def setUp(self):
         self.db.recreate()
         self.db.create_text_index(ddoc="disable_index_array_lengths",
                                        analyzer="keyword",

--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -273,6 +273,6 @@ class IndexSelectorJson(mango.DbPerClass):
 
     @unittest.skipUnless(mango.has_text_service(), "requires text service")
     def test_text_partial_filter_only_in_return_if_not_default(self):
-        self.db.create_text_index(fields=[{"name":"location"}])
+        self.db.create_text_index(fields=[{"name":"location", "type":"string"}])
         index = self.db.list_indexes()[1]
         self.assertEqual('partial_filter_selector' in index['def'], False)


### PR DESCRIPTION
## Overview

The text index tests are not routinely run by the Couch CI
(due to an external dependency that isn't shipped with Couch).
This fixes a number of tests that were broken as a result of
recent feature changes.

## Testing recommendations

Run the mango tests with text indexes enabled.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
