### PR TITLE
404 status for non using uri in _scheduler (#953)

### DIFF
--- a/src/couch_replicator/src/couch_replicator_httpd.erl
+++ b/src/couch_replicator/src/couch_replicator_httpd.erl
@@ -82,6 +82,8 @@ handle_scheduler_req(#httpd{method='GET', path_parts=[_,<<"docs">>|Unquoted]}
         {error, invalid} ->
             throw(bad_request)
     end;
+handle_scheduler_req(#httpd{method='GET'} = Req) ->
+    send_json(Req, 404, {[{error, <<"not found">>}]});
 handle_scheduler_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 


### PR DESCRIPTION
## Overview

Show 404 for GET request which not handled in previous clauses.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
