### PR TITLE
Throw friendly error on invalid use_index value

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -50,11 +50,11 @@ create(Db, Selector0, Opts) ->
 
     {use_index, IndexSpecified} = proplists:lookup(use_index, Opts),
     case {length(UsableIndexes), length(IndexSpecified)} of
-        {0, 1} ->
-            ?MANGO_ERROR({no_usable_index, selector_unsupported});
         {0, 0} ->
             AllDocs = mango_idx:special(Db),
             create_cursor(Db, AllDocs, Selector, Opts);
+        {0, _} ->
+            ?MANGO_ERROR({no_usable_index, selector_unsupported});
         _ ->
             create_cursor(Db, UsableIndexes, Selector, Opts)
     end.

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -91,6 +91,20 @@ class IndexSelectionTests:
         else:
             raise AssertionError("did not reject bad use_index")
 
+    def test_reject_use_index_ddoc_and_name_invalid_fields(self):
+        # index on ["company","manager"] which should not be valid
+        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        name = "a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        selector = {
+            "company": "Pharmex"
+        }
+        try:
+            self.db.find(selector, use_index=[ddocid,name])
+        except Exception as e:
+            self.assertEqual(e.response.status_code, 400)
+        else:
+            raise AssertionError("did not reject bad use_index")
+
     def test_reject_use_index_sort_order(self):
         # index on ["company","manager"] which should not be valid
         ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
@@ -100,6 +114,21 @@ class IndexSelectionTests:
         }
         try:
             self.db.find(selector, use_index=ddocid, sort=[{"manager":"desc"}])
+        except Exception as e:
+            self.assertEqual(e.response.status_code, 400)
+        else:
+            raise AssertionError("did not reject bad use_index")
+
+    def test_reject_use_index_ddoc_and_name_sort_order(self):
+        # index on ["company","manager"] which should not be valid
+        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        name = "a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        selector = {
+            "company": {"$gt": None},
+            "manager": {"$gt": None}
+        }
+        try:
+            self.db.find(selector, use_index=[ddocid,name], sort=[{"manager":"desc"}])
         except Exception as e:
             self.assertEqual(e.response.status_code, 400)
         else:


### PR DESCRIPTION
## Overview

Throw an error when a user specifies a value in "use_index", of the form [<ddoc id>, <name>], that cannot be used for the current query selector.

## Testing recommendations

Run Mango test suite. Manually test as documented in #988

## Related Issues or Pull Requests

#988

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
