### PR TITLE
Improve Mango test suite performance

### DIFF
--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -82,9 +82,7 @@ class Database(object):
 
     def recreate(self):
         self.delete()
-        delay()
         self.create()
-        delay()
 
     def save_doc(self, doc):
         self.save_docs([doc])
@@ -126,7 +124,6 @@ class Database(object):
             body["index"]["partial_filter_selector"] = partial_filter_selector
         body = json.dumps(body)
         r = self.sess.post(self.path("_index"), data=body)
-        delay()
         r.raise_for_status()
         assert r.json()["id"] is not None
         assert r.json()["name"] is not None
@@ -157,7 +154,6 @@ class Database(object):
             body["ddoc"] = ddoc
         body = json.dumps(body)
         r = self.sess.post(self.path("_index"), data=body)
-        delay()
         r.raise_for_status()
         return r.json()["result"] == "created"
 
@@ -173,7 +169,6 @@ class Database(object):
     def delete_index(self, ddocid, name, idx_type="json"):
         path = ["_index", ddocid, idx_type, name]
         r = self.sess.delete(self.path(path), params={"w": "3"})
-        delay()
         r.raise_for_status()
 
     def bulk_delete(self, docs):
@@ -183,7 +178,6 @@ class Database(object):
         }
         body = json.dumps(body)
         r = self.sess.post(self.path("_index/_bulk_delete"), data=body)
-        delay(n=10)
         return r.json()
 
     def find(self, selector, limit=25, skip=0, sort=None, fields=None,

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -127,7 +127,14 @@ class Database(object):
         r.raise_for_status()
         assert r.json()["id"] is not None
         assert r.json()["name"] is not None
-        return r.json()["result"] == "created"
+
+        created = r.json()["result"] == "created"
+        if created:
+            # wait until the database reports the index as available
+            while len(self.get_index(r.json()["id"], r.json()["name"])) < 1:
+                delay(t=0.1)
+
+        return created
 
     def create_text_index(self, analyzer=None, idx_type="text",
         partial_filter_selector=None, default_field=None, fields=None, 

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -81,6 +81,12 @@ class Database(object):
         r = self.sess.delete(self.url)
 
     def recreate(self):
+        r = self.sess.get(self.url)
+        db_info = r.json()
+        docs = db_info["doc_count"] + db_info["doc_del_count"]
+        if docs == 0:
+            # db never used - create unnecessary
+            return
         self.delete()
         self.create()
 

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -268,7 +268,7 @@ class DbPerClass(unittest.TestCase):
     @classmethod
     def setUpClass(klass):
         klass.db = Database(random_db_name())
-        klass.db.create(q=1, n=3)
+        klass.db.create(q=1, n=1)
 
     def setUp(self):
         self.db = self.__class__.db

--- a/test/build/test-run-couch-for-mango.sh
+++ b/test/build/test-run-couch-for-mango.sh
@@ -24,6 +24,9 @@ while ( [ $COUCH_STARTED -ne 0 ] ); do
   fi
 done
 
+# wait for cluster setup to complete
+sleep 5
+
 cd src/mango/
 nosetests
 


### PR DESCRIPTION
## Overview

877c886d added delays into the Mango test suites to improve stability. However, the failures were never reproduced locally and significantly increase the time that it takes to run the tests. This is a PR to experiment with removing those delays to see whether we can get the test suite stable in Travis without them.

## Testing recommendations

Run the Mango test suite.

## Related Issues or Pull Requests

#923

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
