### PR TITLE
Allow couchspawnkillable to live in directories with spaces

### DIFF
--- a/src/couchdb/couch_os_daemons.erl
+++ b/src/couchdb/couch_os_daemons.erl
@@ -197,7 +197,7 @@ start_port(Command) ->
 
 start_port(Command, EnvPairs) ->
     PrivDir = couch_util:priv_dir(),
-    Spawnkiller = filename:join(PrivDir, "couchspawnkillable"),
+    Spawnkiller = "\"" ++ filename:join(PrivDir, "couchspawnkillable") ++ "\"",
     Opts = case lists:keytake(env, 1, ?PORT_OPTIONS) of
         false ->
             ?PORT_OPTIONS ++ [ {env,EnvPairs} ];

--- a/src/couchdb/couch_os_process.erl
+++ b/src/couchdb/couch_os_process.erl
@@ -142,7 +142,7 @@ pick_command1(_) ->
 % gen_server API
 init([Command, Options, PortOptions]) ->
     PrivDir = couch_util:priv_dir(),
-    Spawnkiller = filename:join(PrivDir, "couchspawnkillable"),
+    Spawnkiller = "\"" ++ filename:join(PrivDir, "couchspawnkillable") ++ "\"",
     BaseProc = #os_proc{
         command=Command,
         port=open_port({spawn, Spawnkiller ++ " " ++ Command}, PortOptions),


### PR DESCRIPTION
Ref #991.
Inspired by https://github.com/apache/couchdb/commit/f122f94291bfbc87496efca3c04540bb190b985a