### PR TITLE
Test duplicate fields in Mango selector

### DIFF
--- a/src/mango/test/02-basic-find-test.py
+++ b/src/mango/test/02-basic-find-test.py
@@ -159,6 +159,18 @@ class BasicFindTests(mango.UserDocsTests):
         assert len(docs) == 1
         assert docs[0]["user_id"] == 7
 
+    def test_multi_cond_duplicate_field(self):
+        # need to explicitly define JSON as dict won't allow duplicate keys
+        body = ("{\"selector\":{\"location.city\":{\"$regex\": \"^L+\"},"
+                "\"location.city\":{\"$exists\":true}}}") 
+        r = self.db.sess.post(self.db.path("_find"), data=body)
+        r.raise_for_status()
+        docs = r.json()["docs"]
+
+        # expectation is that only the second instance
+        # of the "location.city" field is used
+        self.assertEqual(len(docs), 15)
+
     def test_multi_cond_or(self):
         docs = self.db.find({
                 "$and":[


### PR DESCRIPTION
## Overview

Adds a test to verify the behaviour of duplicate fields in a Mango selector.

The fix for CVE-2017-12635 (#936) resulted in CouchDB's JSON parser only recognising the last instance of duplicated fields in a JSON object. This represents a breaking change to Mango (_find)
because, previuously, all instances would have been considered when evaluating a selector.

This test verifies that Mango now only considers the last instance of a field, silently ignoring
those that appear before it.

TBD whether we can or should show an error when this occurs, since this leads to predicates
silently being ignored.

## Testing recommendations

Run the Mango test suite.

## Related Issues or Pull Requests

#936

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
