### PR TITLE
Move cluster_start_period and cluster_quiet_period to replicator section

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -88,10 +88,6 @@ enable = false
 ; If set to true and a user is deleted, the respective database gets
 ; deleted as well.
 delete_dbs = false
-; Wait this many seconds after startup before attaching changes listeners
-; cluster_start_period = 5
-; Re-check cluster state at least every cluster_quiet_period seconds
-; cluster_quiet_period = 60
 
 [httpd]
 port = {{backend_port}}
@@ -408,6 +404,10 @@ ssl_certificate_max_depth = 3
 ; avoid crashing the whole replication job, which would consume more resources
 ; and add log noise.
 ;missing_doc_retry_msec = 2000
+; Wait this many seconds after startup before attaching changes listeners
+; cluster_start_period = 5
+; Re-check cluster state at least every cluster_quiet_period seconds
+; cluster_quiet_period = 60
 
 [compaction_daemon]
 ; The delay, in seconds, between each check for which database and view indexes


### PR DESCRIPTION
Somehow entries ended up under [couch_per_user] but should be in the
[replicator] section.
