### PR TITLE
Fix index validation for nested $and

### DIFF
--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -28,6 +28,16 @@ class IndexSelectionTests:
             }, explain=True)
         self.assertEqual(resp["index"]["type"], "json")
 
+    def test_with_nested_and(self):
+        resp = self.db.find({
+                "name.first": {
+                    "$gt": "a",
+                    "$lt": "z"
+                },
+                "name.last": "Foo"
+            }, explain=True)
+        self.assertEqual(resp["index"]["type"], "json")
+
     def test_use_most_columns(self):
         # ddoc id for the age index
         ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"


### PR DESCRIPTION
## Overview

mango_selector:has_required_fields checks that a list of
indexed fields is covered by a given selector. The implementation
recurses through the selector, tracking fields that encounters.

Unfortunately, this skipped peers of combination operators. For
example,

```
"selector": {
	"$and":[
		"$and":[
			"A": "foo"
		],
		"$and":[
			"B": "bar"
		]
	]
}
```

would skip the first nested "$and" operator and only return "B"
as a covered field.

This commit explicitly handles this situation (the only combination
operator we care about is $and), so for the above selector we
would correctly identify "A" and "B" as covered fields.

## Testing recommendations

Run the test suite. Test that Query selectors with nested `$and` operators correctly use `json` indexes that should cover them.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
