### PR TITLE
Allow replicator documents to include params for db creation

### DIFF
--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -499,6 +499,11 @@ convert_options([{<<"create_target">>, V} | _R]) when not is_boolean(V)->
     throw({bad_request, <<"parameter `create_target` must be a boolean">>});
 convert_options([{<<"create_target">>, V} | R]) ->
     [{create_target, V} | convert_options(R)];
+convert_options([{<<"create_target_params">>, V} | _R]) when not is_tuple(V) ->
+    throw({bad_request,
+        <<"parameter `create_target_params` must be a JSON object">>});
+convert_options([{<<"create_target_params">>, V} | R]) ->
+    [{create_target_params, V} | convert_options(R)];
 convert_options([{<<"continuous">>, V} | _R]) when not is_boolean(V)->
     throw({bad_request, <<"parameter `continuous` must be a boolean">>});
 convert_options([{<<"continuous">>, V} | R]) ->

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -587,8 +587,9 @@ init_state(Rep) ->
     % Adjust minimum number of http source connections to 2 to avoid deadlock
     Src = adjust_maxconn(Src0, BaseId),
     {ok, Source} = couch_replicator_api_wrap:db_open(Src, [{user_ctx, UserCtx}]),
+    {CreateTargetParams} = get_value(create_target_params, Options, {[]}),
     {ok, Target} = couch_replicator_api_wrap:db_open(Tgt, [{user_ctx, UserCtx}],
-        get_value(create_target, Options, false)),
+        get_value(create_target, Options, false), CreateTargetParams),
 
     {ok, SourceInfo} = couch_replicator_api_wrap:get_db_info(Source),
     {ok, TargetInfo} = couch_replicator_api_wrap:get_db_info(Target),

--- a/src/couch_replicator/test/couch_replicator_create_target_with_options_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_create_target_with_options_tests.erl
@@ -1,0 +1,154 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_replicator_create_target_with_options_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch_replicator/src/couch_replicator.hrl").
+
+
+setup(_) ->
+    Ctx1 = test_util:start_couch([fabric, mem3, couch_replicator]),
+    Ctx2 = chttpd_test_util:start_couch(),
+    Source = ?tempdb(),
+    Target = ?tempdb(),
+    {Ctx1, Ctx2, {Source, Target}}.
+
+
+teardown(_, {Ctx1, Ctx2, {_Source, _Target}}) ->
+    ok = test_util:stop_couch(Ctx1),
+    ok = chttpd_test_util:stop_couch(Ctx2).
+
+
+create_target_with_options_replication_test_() ->
+    Ps = [{local, remote}, {remote, remote}],
+    {
+        "Create target with range partitions tests",
+        {
+            foreachx,
+            fun setup/1, fun teardown/2,
+            [{P, fun should_create_target_with_q_4/2} || P <- Ps] ++
+            [{P, fun should_create_target_with_q_2_n_1/2} || P <- Ps] ++
+            [{P, fun should_create_target_with_default/2} || P <- Ps] ++
+            [{P, fun should_not_create_target_with_q_any/2} || P <- Ps]
+        }
+    }.
+
+
+should_create_target_with_q_4({From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+    RepObject = {[
+        {<<"source">>, db_url(From, Source)},
+        {<<"target">>, db_url(To, Target)},
+        {<<"create_target">>, true},
+        {<<"create_target_params">>, {[{<<"q">>, <<"4">>}]}}
+    ]},
+    create_db(From, Source),
+    create_doc(From, Source),
+    {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
+
+    {ok, TargetInfo} = fabric:get_db_info(Target),
+    {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
+    delete_db(From, Source),
+    delete_db(To, Target),
+    ?_assertEqual(4, couch_util:get_value(q, ClusterInfo)).
+
+
+should_create_target_with_q_2_n_1(
+    {From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+    RepObject = {[
+        {<<"source">>, db_url(From, Source)},
+        {<<"target">>, db_url(To, Target)},
+        {<<"create_target">>, true},
+        {<<"create_target_params">>,
+            {[{<<"q">>, <<"2">>}, {<<"n">>, <<"1">>}]}}
+    ]},
+    create_db(From, Source),
+    create_doc(From, Source),
+    {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
+
+    {ok, TargetInfo} = fabric:get_db_info(Target),
+    {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
+    delete_db(From, Source),
+    delete_db(To, Target),
+    [
+        ?_assertEqual(2, couch_util:get_value(q, ClusterInfo)),
+        ?_assertEqual(1, couch_util:get_value(n, ClusterInfo))
+    ].
+
+
+should_create_target_with_default(
+    {From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+    RepObject = {[
+        {<<"source">>, db_url(From, Source)},
+        {<<"target">>, db_url(To, Target)},
+        {<<"create_target">>, true}
+    ]},
+    create_db(From, Source),
+    create_doc(From, Source),
+    {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
+
+    {ok, TargetInfo} = fabric:get_db_info(Target),
+    {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
+    Q = config:get("cluster", "q", "8"),
+    delete_db(From, Source),
+    delete_db(To, Target),
+    ?_assertEqual(list_to_integer(Q), couch_util:get_value(q, ClusterInfo)).
+
+
+should_not_create_target_with_q_any(
+    {From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+    RepObject = {[
+        {<<"source">>, db_url(From, Source)},
+        {<<"target">>, db_url(To, Target)},
+        {<<"create_target">>, false},
+        {<<"create_target_params">>, {[{<<"q">>, <<"1">>}]}}
+    ]},
+    create_db(From, Source),
+    create_doc(From, Source),
+    {error, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
+    DbExist = is_list(catch mem3:shards(Target)),
+    delete_db(From, Source),
+    ?_assertEqual(false, DbExist).
+
+
+create_doc(local, DbName) ->
+    {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),
+    Body = {[{<<"foo">>, <<"bar">>}]},
+    NewDoc = #doc{body = Body},
+    {ok, _} = couch_db:update_doc(Db, NewDoc, []),
+    couch_db:close(Db);
+create_doc(remote, DbName) ->
+    Body = {[{<<"foo">>, <<"bar">>}]},
+    NewDoc = #doc{body = Body},
+    {ok, _} = fabric:update_doc(DbName, NewDoc, [?ADMIN_CTX]).
+
+
+create_db(local, DbName) ->
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
+    ok = couch_db:close(Db);
+create_db(remote, DbName) ->
+    ok = fabric:create_db(DbName, [?ADMIN_CTX]).
+
+
+delete_db(local, DbName) ->
+    ok = couch_server:delete(DbName, [?ADMIN_CTX]);
+delete_db(remote, DbName) ->
+    ok = fabric:delete_db(DbName, [?ADMIN_CTX]).
+
+
+db_url(local, DbName) ->
+    DbName;
+db_url(remote, DbName) ->
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    ?l2b(io_lib:format("http://~s:~b/~s", [Addr, Port, DbName])).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
If you specify "create_target": true in a replicator doc, the replicator creates the target database, with the default q value.

With this PR, it is allowed to specify "create_database_params": {"q": "1"} to have the replicator to create the target database with specified value (currently, the example is q=1 and q can be other value). The example of replication document looks like:
```
{
  "source": "http://foo:bar@localhost:15984/db1",
  "target": "http://foo:bar@localhost:15984/db22",
  "create_target": true,
  "continuous": false,
   "create_target_params": {"q": "1"}

}
```

One thing to be highlighted is about the value in `source` and `target` field in replication document.

Most of case database in `url` format were specified in replication document. 
```
{
  "source": "http://foo:bar@localhost:15984/db1",
  "target": "http://foo:bar@localhost:15984/db2",
  "create_target": true,
  "continuous": true
}
```
However, I found that the format `"source": "shards/00000000-1fffffff/db3.1511408454"` was also supported in replication document. But the database should be one in shard instead of logical database name. It looks to me that it doesn't make sense to specify q value if the shard database was specified.
https://github.com/apache/couchdb/pull/1017/files#diff-3a45ba156c61480ff98a83509af1b2cdR135

So right now, only database creation with url format approached was extended.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make check skip_deps+=couch_epi apps=couch_replicator tests=create_target_with_options_replication_test_

    Running test function(s):
      couch_replicator_create_target_with_options_tests:create_target_with_options_replication_test_/0
======================== EUnit ========================
Create target with range partitions tests
  couch_replicator_create_target_with_options_tests:63: should_create_target_with_q_4...ok
  couch_replicator_create_target_with_options_tests:63: should_create_target_with_q_4...ok
  couch_replicator_create_target_with_options_tests:84: should_create_target_with_q_2_n_1...ok
  couch_replicator_create_target_with_options_tests:85: should_create_target_with_q_2_n_1...ok
  couch_replicator_create_target_with_options_tests:84: should_create_target_with_q_2_n_1...ok
  couch_replicator_create_target_with_options_tests:85: should_create_target_with_q_2_n_1...ok
  couch_replicator_create_target_with_options_tests:105: should_create_target_with_default...ok
  couch_replicator_create_target_with_options_tests:105: should_create_target_with_default...ok
  couch_replicator_create_target_with_options_tests:121: should_not_create_target_with_q_any...ok
  couch_replicator_create_target_with_options_tests:121: should_not_create_target_with_q_any...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 6.025 s]
=======================================================
  All 10 tests passed.
==> rel (eunit)
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/issues/887
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
