### PR TITLE
Fix _explain for sort descending

### DIFF
--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -66,7 +66,7 @@ explain(Cursor) ->
         {include_docs, Args#mrargs.include_docs},
         {view_type, Args#mrargs.view_type},
         {reduce, Args#mrargs.reduce},
-        {start_key, Args#mrargs.start_key},
+        {start_key, maybe_replace_max_json(Args#mrargs.start_key)},
         {end_key, maybe_replace_max_json(Args#mrargs.end_key)},
         {direction, Args#mrargs.direction},
         {stable, Args#mrargs.stable},

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -181,6 +181,14 @@ class IndexSelectionTests:
             self.db.save_doc(design_doc)
 
 
+    def test_explain_sort_reverse(self):
+        selector = {
+            "manager": {"$gt": None}
+        }
+        resp_explain = self.db.find(selector, fields=["manager"], sort=[{"manager":"desc"}], explain=True)
+        self.assertEqual(resp_explain["index"]["type"], "json")
+        
+
 class JSONIndexSelectionTests(mango.UserDocsTests, IndexSelectionTests):
 
     @classmethod


### PR DESCRIPTION
## Overview

Handle the case when startkey and endkey are reversed. To create valid JSON we need to
replace the internal representation of the startkey with a string.

## Testing recommendations

Run the test suite. Manual reproduction steps as in case #1023.

## Related Issues or Pull Requests

Fixes #1023

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
