### PR TITLE
Fix: Added a temporary fix to avoid compaction failures #1001

### DIFF
--- a/src/couchdb/couch_db_updater.erl
+++ b/src/couchdb/couch_db_updater.erl
@@ -884,7 +884,10 @@ copy_docs(Db, #db{updater_fd = DestFd} = NewDb, InfoBySeq0, Retry) ->
                         fun({_, _, _, AttLen, _, _, _, _}, S) -> S + AttLen end,
                         SummarySize, AttsInfo),
                     {IsDel, Pos, Seq, TotalLeafSize}
-                end, RevTree)}
+                end, RevTree)};
+        (U) ->
+             ?LOG_INFO("Drop a document from compaction: not found in db : ~p", [U]),
+            []
         end, LookupResults),
 
     NewFullDocInfos = stem_full_doc_infos(Db, NewFullDocInfos1),


### PR DESCRIPTION
## Overview

Fix for #1001
Discarded any document not available in couchdb but only in main index. It seems couch db main index is not getting properly updated after purging documents. Compactor fails with error 'not_found' when it ties to get the full document from the couchdb.

This fix is cherry-picked from the fix done on top of 1.6.1 in #1003

## Testing recommendations

Compaction fails continuously when a document is actually purged but not cleaned up in main index. This issue is random. I tested couple of databases that had the issue and compaction is working fine after the fix.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
