### PR TITLE
Add support for queries in /{db}/_all_docs POST

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -520,14 +520,18 @@ db_req(#httpd{method='GET',path_parts=[_,OP]}=Req, Db) when ?IS_ALL_DOCS(OP) ->
 
 db_req(#httpd{method='POST',path_parts=[_,OP]}=Req, Db) when ?IS_ALL_DOCS(OP) ->
     chttpd:validate_ctype(Req, "application/json"),
-    {Fields} = chttpd:json_body_obj(Req),
-    case couch_util:get_value(<<"keys">>, Fields, nil) of
-    Keys when is_list(Keys) ->
-        all_docs_view(Req, Db, Keys, OP);
-    nil ->
-        all_docs_view(Req, Db, undefined, OP);
-    _ ->
-        throw({bad_request, "`keys` body member must be an array."})
+    Props = chttpd:json_body_obj(Req),
+    Keys = couch_mrview_util:get_view_keys(Props),
+    Queries = couch_mrview_util:get_view_queries(Props),
+    case {Queries, Keys} of
+        {Queries, undefined} when is_list(Queries) ->
+            multi_all_docs_view(Req, Db, OP, Queries);
+        {undefined, Keys} when is_list(Keys) ->
+            all_docs_view(Req, Db, Keys, OP);
+        {undefined, undefined} ->
+            all_docs_view(Req, Db, undefined, OP);
+        {_, _} ->
+            throw({bad_request, "`keys` and `queries` are mutually exclusive"})
     end;
 
 db_req(#httpd{path_parts=[_,OP]}=Req, _Db) when ?IS_ALL_DOCS(OP) ->
@@ -635,6 +639,28 @@ db_req(#httpd{path_parts=[_, DocId]}=Req, Db) ->
 
 db_req(#httpd{path_parts=[_, DocId | FileNameParts]}=Req, Db) ->
     db_attachment_req(Req, Db, DocId, FileNameParts).
+
+multi_all_docs_view(Req, Db, OP, Queries) ->
+    Args0 = couch_mrview_http:parse_params(Req, undefined),
+    Args1 = Args0#mrargs{view_type=map},
+    ArgQueries = lists:map(fun({Query}) ->
+        QueryArg1 = couch_mrview_http:parse_params(Query, undefined,
+            Args1, [decoded]),
+        QueryArgs2 = couch_mrview_util:validate_args(QueryArg1),
+        set_namespace(OP, QueryArgs2)
+    end, Queries),
+    Options = [{user_ctx, Req#httpd.user_ctx}],
+    VAcc0 = #vacc{db=Db, req=Req, prepend="\r\n"},
+    FirstChunk = "{\"results\":[",
+    {ok, Resp0} = chttpd:start_delayed_json_response(VAcc0#vacc.req, 200, [], FirstChunk),
+    VAcc1 = VAcc0#vacc{resp=Resp0},
+    VAcc2 = lists:foldl(fun(Args, Acc0) ->
+        {ok, Acc1} = fabric:all_docs(Db, Options,
+            fun couch_mrview_http:view_cb/2, Acc0, Args),
+        Acc1
+    end, VAcc1, ArgQueries),
+    {ok, Resp1} = chttpd:send_delayed_chunk(VAcc2#vacc.resp, "\r\n]}"),
+    chttpd:end_delayed_json_response(Resp1).
 
 all_docs_view(Req, Db, Keys, OP) ->
     Args0 = couch_mrview_http:parse_params(Req, Keys),

--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -65,7 +65,12 @@ all_test_() ->
                     fun should_return_200_for_del_att_with_rev/1,
                     fun should_return_409_for_put_att_nonexistent_rev/1,
                     fun should_return_update_seq_when_set_on_all_docs/1,
-                    fun should_not_return_update_seq_when_unset_on_all_docs/1
+                    fun should_not_return_update_seq_when_unset_on_all_docs/1,
+                    fun should_succeed_on_all_docs_with_queries_keys/1,
+                    fun should_succeed_on_all_docs_with_queries_limit_skip/1,
+                    fun should_succeed_on_all_docs_with_multiple_queries/1,
+                    fun should_succeed_on_design_docs_with_multiple_queries/1,
+                    fun should_fail_on_multiple_queries_with_keys_and_queries/1
                 ]
             }
         }
@@ -215,6 +220,86 @@ should_not_return_update_seq_when_unset_on_all_docs(Url) ->
             couch_util:get_value(<<"update_seq">>, ResultJson)),
         ?assertNotEqual(undefined,
             couch_util:get_value(<<"offset">>, ResultJson))
+    end).
+
+
+should_succeed_on_all_docs_with_queries_keys(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_all_docs_with_queries_limit_skip(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_all_docs_with_multiple_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]},
+            {\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson1} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
+        {InnerJson2} = lists:nth(2, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
+    end).
+
+
+should_succeed_on_design_docs_with_multiple_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"_design/ddoc3\",
+            \"_design/ddoc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_design_docs/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson1} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
+        {InnerJson2} = lists:nth(2, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
+    end).
+
+
+should_fail_on_multiple_queries_with_keys_and_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]}],
+            \"keys\": [ \"testdoc4\", \"testdoc9\"]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(400, RC),
+        ?assertMatch({[
+            {<<"error">>,<<"bad_request">>},
+            {<<"reason">>,<<"`keys` and `queries` are mutually exclusive">>}]},
+            ?JSON_DECODE(RespBody))
     end).
 
 

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -1161,7 +1161,7 @@ get_view_keys({Props}) ->
         Keys when is_list(Keys) ->
             Keys;
         _ ->
-            throw({bad_request, "`keys` member must be a array."})
+            throw({bad_request, "`keys` member must be an array."})
     end.
 
 
@@ -1172,7 +1172,7 @@ get_view_queries({Props}) ->
         Queries when is_list(Queries) ->
             Queries;
         _ ->
-            throw({bad_request, "`queries` member must be a array."})
+            throw({bad_request, "`queries` member must be an array."})
     end.
 
 

--- a/test/javascript/tests/basics.js
+++ b/test/javascript/tests/basics.js
@@ -268,7 +268,7 @@ couchTests.basics = function(debug) {
   T(xhr.status == 400);
   result = JSON.parse(xhr.responseText);
   T(result.error == "bad_request");
-  T(result.reason == "`keys` body member must be an array.");
+  T(result.reason == "`keys` member must be an array.");
 
   // oops, the doc id got lost in code nirwana
   xhr = CouchDB.request("DELETE", "/" + db_name + "/?rev=foobarbaz");

--- a/test/javascript/tests/view_errors.js
+++ b/test/javascript/tests/view_errors.js
@@ -169,7 +169,7 @@ couchTests.view_errors = function(debug) {
       T(xhr.status == 400);
       result = JSON.parse(xhr.responseText);
       T(result.error == "bad_request");
-      T(result.reason == "`keys` member must be a array.");
+      T(result.reason == "`keys` member must be an array.");
 
       // if the reduce grows to fast, throw an overflow error
       var path = "/" + db_name + "/_design/testbig/_view/reduce_too_big";


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Allow to POST to /{db}/_all_docs and specify a queries list in the body, the same way you can do with a regular MapReduce view, like

```
curl -u foo:bar -H "Content-Type: application/json" -X POST -d @multiple_queries.json http://localhost:15984/db97/_all_docs
{"results":[
{"total_rows":30,"rows":[
{"id":"point2","key":"point2","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"point3","key":"point3","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}}
]},
{"total_rows":30,"offset":2,"rows":[
{"id":"point11","key":"point11","value":{"rev":"1-ffb6c2ae737918f8f911e1fce668333e"}},
{"id":"point12","key":"point12","value":{"rev":"1-c32d315f69ce72128244a60d0cbe4628"}},
{"id":"point13","key":"point13","value":{"rev":"1-a9b955ca17f553398cd877629e803c5d"}},
{"id":"point14","key":"point14","value":{"rev":"1-2f2aa0db2a8c35754e7ab2308940f60c"}},
{"id":"point15","key":"point15","value":{"rev":"1-247191505d8fa6b4b9dc426321987b17"}}
]}
]}
```
multiple_queries.json looks like
```
    {
        "queries": [
            {
                "keys": [
                    "point2",
                    "point3"
                ]
            },
            {
                "limit": 5,
                "skip": 2
            }
        ]
    }
```
This also can work against /{db}/_design_docs and /{db}/_local_docs endpoints.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=chttpd tests=all_test_
```
======================== EUnit ========================
chttpd security tests
Application crypto was left running!
  chttpd_security_tests:118: should_allow_admin_db_compaction...[0.002 s] ok
  chttpd_security_tests:133: should_disallow_anonymous_db_compaction...ok
  chttpd_security_tests:141: should_disallow_db_member_db_compaction...ok
  chttpd_security_tests:144: should_allow_db_admin_db_compaction...[0.003 s] ok
  chttpd_security_tests:154: should_allow_admin_view_compaction...[0.010 s] ok
  chttpd_security_tests:169: should_disallow_anonymous_view_compaction...ok
  chttpd_security_tests:172: should_allow_admin_db_view_cleanup...[0.002 s] ok
  chttpd_security_tests:187: should_disallow_anonymous_db_view_cleanup...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 5.013 s]
chttpd db tests
  chttpd_db_test:79: should_return_ok_true_on_bulk_update...[0.058 s] ok
  chttpd_db_test:106: should_accept_live_as_an_alias_for_continuous...[0.178 s] ok
  chttpd_db_test:121: should_return_404_for_delete_att_on_notadoc...[0.005 s] ok
  chttpd_db_test:143: should_return_409_for_del_att_without_rev...[0.040 s] ok
  chttpd_db_test:161: should_return_200_for_del_att_with_rev...[0.058 s] ok
  chttpd_db_test:182: should_return_409_for_put_att_nonexistent_rev...[0.012 s] ok
  chttpd_db_test:197: should_succeed_on_all_docs_with_queries_keys...[0.256 s] ok
  chttpd_db_test:211: should_succeed_on_all_docs_with_queries_limit_skip...[0.241 s] ok
  chttpd_db_test:226: should_succeed_on_all_docs_with_multiple_queries...[0.231 s] ok
  chttpd_db_test:244: should_succeed_on_design_docs_with_multiple_queries...[0.229 s] ok
  chttpd_db_test:262: should_fail_on_multiple_queries_with_keys_and_queries...[0.257 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 3.655 s]
chttpd db max_document_size tests
  chttpd_db_doc_size_tests:84: post_single_doc...ok
  chttpd_db_doc_size_tests:92: put_single_doc...ok
  chttpd_db_doc_size_tests:101: bulk_doc...ok
  chttpd_db_doc_size_tests:127: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:128: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:129: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:130: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:152: put_multi_part_related...ok
  chttpd_db_doc_size_tests:153: put_multi_part_related...ok
  chttpd_db_doc_size_tests:177: post_multi_part_form...ok
  chttpd_db_doc_size_tests:178: post_multi_part_form...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 1.225 s]
=======================================================
  All 30 tests passed.
==> rel (eunit)
==> couchdb (eunit)
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
issue #820 
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
