### PR TITLE
Fix couch index compaction tests

### DIFF
--- a/src/couch_index/test/couch_index_compaction_tests.erl
+++ b/src/couch_index/test/couch_index_compaction_tests.erl
@@ -51,9 +51,7 @@ fake_index(DbName) ->
     end).
 
 teardown(_) ->
-    (catch meck:unload(test_index)),
-    (catch meck:unload(couch_util)),
-    ok.
+    meck:unload(test_index).
 
 compaction_test_() ->
     {

--- a/src/couch_index/test/couch_index_ddoc_updated_tests.erl
+++ b/src/couch_index/test/couch_index_ddoc_updated_tests.erl
@@ -121,7 +121,8 @@ fake_index() ->
             crypto:hash(md5, term_to_binary(DDoc));
         (update_seq, Seq) ->
             Seq
-    end).
+    end),
+    ok = meck:expect(test_index, shutdown, ['_'], ok).
 
 
 get_indexes_by_ddoc(DDocID, N) ->

--- a/src/couch_index/test/couch_index_ddoc_updated_tests.erl
+++ b/src/couch_index/test/couch_index_ddoc_updated_tests.erl
@@ -25,7 +25,7 @@ start() ->
 
 
 stop({Ctx, DbName}) ->
-    (catch meck:unload(test_index)),
+    meck:unload(test_index),
     ok = fabric:delete_db(DbName, [?ADMIN_CTX]),
     DbDir = config:get("couchdb", "database_dir", "."),
     WaitFun = fun() ->


### PR DESCRIPTION
## Overview

Mocked index module missing a couple of methods called on late compaction stages. This leads
to a crash, but since it's happening after the test's assertions, it bring the test to fail.

Also small refactoring to encapsulate all mocking in a single function and move unrelated parts back to test's setup.

## Testing recommendations

` make eunit apps=couch_index`

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
