### PR TITLE
Allow to use index with or

### DIFF
--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -693,7 +693,7 @@ has_required_fields_and_false_test() ->
     Normalized = normalize(Selector),
     ?assertEqual(false, has_required_fields(Normalized, RequiredFields)).
 
-has_required_fields_or_test() ->
+has_required_fields_or_false_test() ->
     RequiredFields = [<<"A">>],
     Selector = {[{<<"$or">>,
           [
@@ -703,5 +703,19 @@ has_required_fields_or_test() ->
     }]},
     Normalized = normalize(Selector),
     ?assertEqual(false, has_required_fields(Normalized, RequiredFields)).
+
+has_required_fields_or_true_test() ->
+    RequiredFields = [<<"A">>, <<"B">>, <<"C">>],
+    Selector = {[{<<"A">>, "foo"},
+          {<<"$or">>,
+              [
+                  {[{<<"B">>, <<"bar">>}]},
+                  {[{<<"B">>, <<"baz">>}]}
+              ]
+          },
+		  {<<"C">>, "qux"}
+	]},
+    Normalized = normalize(Selector),
+    ?assertEqual(true, has_required_fields(Normalized, RequiredFields)).
 
 -endif.

--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -820,5 +820,46 @@ has_required_fields_or_nested_and_true_test() ->
     Normalized = normalize(Selector),
     ?assertEqual(true, has_required_fields(Normalized, RequiredFields)).
 
+has_required_fields_or_nested_or_true_test() ->
+    RequiredFields = [<<"A">>],
+    Selector1 = {[{<<"$or">>,
+          [
+              {[{<<"A">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector2 = {[{<<"$or">>,
+          [
+              {[{<<"A">>, <<"bar">>}]}
+          ]
+    }]},
+    Selector = {[{<<"$or">>,
+          [
+              Selector1,
+              Selector2
+          ]
+    }]},
+    Normalized = normalize(Selector),
+    ?assertEqual(true, has_required_fields(Normalized, RequiredFields)).
+
+has_required_fields_or_nested_or_false_test() ->
+    RequiredFields = [<<"A">>],
+    Selector1 = {[{<<"$or">>,
+          [
+              {[{<<"A">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector2 = {[{<<"$or">>,
+          [
+              {[{<<"B">>, <<"bar">>}]}
+          ]
+    }]},
+    Selector = {[{<<"$or">>,
+          [
+              Selector1,
+              Selector2
+          ]
+    }]},
+    Normalized = normalize(Selector),
+    ?assertEqual(false, has_required_fields(Normalized, RequiredFields)).
 
 -endif.

--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -597,14 +597,31 @@ has_required_fields_int([], Remainder) ->
 has_required_fields_int(Selector, RequiredFields) when not is_list(Selector) ->
     has_required_fields_int([Selector], RequiredFields);
 
-% We can "see" through $and operator. We ignore other
-% combination operators because they can't be used to restrict
-% an index.
+% We can "see" through $and operator. Iterate
+% through the list of child operators.
 has_required_fields_int([{[{<<"$and">>, Args}]}], RequiredFields) 
         when is_list(Args) ->
     has_required_fields_int(Args, RequiredFields);
 
-% Handle $and operator where it has peers
+% We can "see" through $or operator. Required fields
+% must be covered by all children.
+has_required_fields_int([{[{<<"$or">>, Args}]} | Rest], RequiredFields) 
+        when is_list(Args) ->
+    Remainder0 = lists:foldl(fun(Arg, Acc) ->
+        % for each child test coverage against the full
+        % set of required fields
+        Remainder = has_required_fields_int(Arg, RequiredFields),
+
+        % collect the remaining fields across all children
+        Acc ++ Remainder
+    end, [], Args),
+
+    % remove duplicate fields
+    Remainder1 = lists:usort(Remainder0),
+    has_required_fields_int(Rest, Remainder1);
+
+% Handle $and operator where it has peers. Required fields
+% can be covered by any child.
 has_required_fields_int([{[{<<"$and">>, Args}]} | Rest], RequiredFields) 
         when is_list(Args) ->
     Remainder = has_required_fields_int(Args, RequiredFields),
@@ -680,7 +697,8 @@ has_required_fields_nested_and_true_test() ->
           ]
     }]},
 
-    ?assertEqual(true, has_required_fields(Selector, RequiredFields)).
+    Normalized = normalize(Selector),
+    ?assertEqual(true, has_required_fields(Normalized, RequiredFields)).
 
 has_required_fields_and_false_test() ->
     RequiredFields = [<<"A">>, <<"C">>],
@@ -717,5 +735,90 @@ has_required_fields_or_true_test() ->
 	]},
     Normalized = normalize(Selector),
     ?assertEqual(true, has_required_fields(Normalized, RequiredFields)).
+
+has_required_fields_and_nested_or_true_test() ->
+    RequiredFields = [<<"A">>, <<"B">>],
+    Selector1 = {[{<<"$and">>,
+          [
+              {[{<<"A">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector2 = {[{<<"$or">>,
+          [
+              {[{<<"B">>, <<"foo">>}]},
+              {[{<<"B">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector = {[{<<"$and">>,
+          [
+              Selector1,
+              Selector2
+          ]
+    }]},
+    Normalized = normalize(Selector),
+    ?assertEqual(true, has_required_fields(Normalized, RequiredFields)),
+
+    SelectorReverse = {[{<<"$and">>,
+          [
+              Selector2,
+              Selector1
+          ]
+    }]},
+    NormalizedReverse = normalize(SelectorReverse),
+    ?assertEqual(true, has_required_fields(NormalizedReverse, RequiredFields)).
+
+has_required_fields_and_nested_or_false_test() ->
+    RequiredFields = [<<"A">>, <<"B">>],
+    Selector1 = {[{<<"$and">>,
+          [
+              {[{<<"A">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector2 = {[{<<"$or">>,
+          [
+              {[{<<"A">>, <<"foo">>}]},
+              {[{<<"B">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector = {[{<<"$and">>,
+          [
+              Selector1,
+              Selector2
+          ]
+    }]},
+    Normalized = normalize(Selector),
+    ?assertEqual(false, has_required_fields(Normalized, RequiredFields)),
+
+    SelectorReverse = {[{<<"$and">>,
+          [
+              Selector2,
+              Selector1
+          ]
+    }]},
+
+    NormalizedReverse = normalize(SelectorReverse),
+    ?assertEqual(false, has_required_fields(NormalizedReverse, RequiredFields)).
+
+has_required_fields_or_nested_and_true_test() ->
+    RequiredFields = [<<"A">>],
+    Selector1 = {[{<<"$and">>,
+          [
+              {[{<<"A">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector2 = {[{<<"$and">>,
+          [
+              {[{<<"A">>, <<"foo">>}]}
+          ]
+    }]},
+    Selector = {[{<<"$or">>,
+          [
+              Selector1,
+              Selector2
+          ]
+    }]},
+    Normalized = normalize(Selector),
+    ?assertEqual(true, has_required_fields(Normalized, RequiredFields)).
+
 
 -endif.

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -38,6 +38,22 @@ class IndexSelectionTests:
             }, explain=True)
         self.assertEqual(resp["index"]["type"], "json")
 
+    def test_with_or(self):
+        # index on ["company","manager"]
+        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+
+        resp = self.db.find({
+                "company": {
+                    "$gt": "a",
+                    "$lt": "z"
+                },
+                "$or": [
+                    {"manager": "Foo"},
+                    {"manager": "Bar"}
+                ]
+            }, explain=True)
+        self.assertEqual(resp["index"]["ddoc"], ddocid)
+
     def test_use_most_columns(self):
         # ddoc id for the age index
         ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"


### PR DESCRIPTION
## Overview

Implementation of #1011 taking into account recent selector fixes.

## Testing recommendations

Run the mango test suite. Manually run some mango queries with/without JSON indexes and check that the results are as expected.

## Related Issues or Pull Requests

#1011

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
