### PR TITLE
Fix haproxy stats

### DIFF
--- a/rel/haproxy.cfg
+++ b/rel/haproxy.cfg
@@ -30,7 +30,7 @@ defaults
         timeout connect 500
 
         stats enable
-        stats uri /haproxy_stats
+        stats uri /_haproxy_stats
         # stats auth admin:admin # Uncomment for basic auth
 
 frontend http-in

--- a/rel/haproxy.cfg
+++ b/rel/haproxy.cfg
@@ -30,8 +30,8 @@ defaults
         timeout connect 500
 
         stats enable
-        stats scope .
-        stats uri /_stats
+        stats uri /haproxy_stats
+        # stats auth admin:admin # Uncomment for basic auth
 
 frontend http-in
          # This requires HAProxy 1.5.x


### PR DESCRIPTION
- `stats scope .` ends up blocking all backends
- Renaming endpoint from `_stats` to `haproxy_stats` so that it doesn't collide with CouchDB's `_stats` endpoint
- Added a commented out stats auth line so that you can easily password protect

## Testing recommendations

Visit `http://example.com:5984/_stats` now and you won't see any stats for any backends. With my changes you will see the backend specified when you visit `http://example.com:5984/haproxy_stats`
