### PR TITLE
Fix replicator create target options test

### DIFF
--- a/src/couch_replicator/test/couch_replicator_create_target_with_options_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_create_target_with_options_tests.erl
@@ -16,139 +16,128 @@
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch_replicator/src/couch_replicator.hrl").
 
+-define(USERNAME, "rep_admin").
+-define(PASSWORD, "secret").
 
-setup(_) ->
-    Ctx1 = test_util:start_couch([fabric, mem3, couch_replicator]),
-    Ctx2 = chttpd_test_util:start_couch(),
+setup() ->
+    Ctx = test_util:start_couch([fabric, mem3, couch_replicator, chttpd]),
+    Hashed = couch_passwords:hash_admin_password(?PASSWORD),
+    ok = config:set("admins", ?USERNAME, ?b2l(Hashed), _Persist=false),
     Source = ?tempdb(),
     Target = ?tempdb(),
-    {Ctx1, Ctx2, {Source, Target}}.
+    {Ctx, {Source, Target}}.
 
 
-teardown(_, {Ctx1, Ctx2, {_Source, _Target}}) ->
-    ok = test_util:stop_couch(Ctx1),
-    ok = chttpd_test_util:stop_couch(Ctx2).
+teardown({Ctx, {_Source, _Target}}) ->
+    config:delete("admins", ?USERNAME),
+    ok = test_util:stop_couch(Ctx).
 
 
 create_target_with_options_replication_test_() ->
-    Ps = [{local, remote}, {remote, remote}],
     {
         "Create target with range partitions tests",
         {
-            foreachx,
-            fun setup/1, fun teardown/2,
-            [{P, fun should_create_target_with_q_4/2} || P <- Ps] ++
-            [{P, fun should_create_target_with_q_2_n_1/2} || P <- Ps] ++
-            [{P, fun should_create_target_with_default/2} || P <- Ps] ++
-            [{P, fun should_not_create_target_with_q_any/2} || P <- Ps]
+            foreach,
+            fun setup/0, fun teardown/1,
+            [
+                fun should_create_target_with_q_4/1,
+                fun should_create_target_with_q_2_n_1/1,
+                fun should_create_target_with_default/1,
+                fun should_not_create_target_with_q_any/1
+            ]
         }
     }.
 
 
-should_create_target_with_q_4({From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+should_create_target_with_q_4({_Ctx, {Source, Target}}) ->
     RepObject = {[
-        {<<"source">>, db_url(From, Source)},
-        {<<"target">>, db_url(To, Target)},
+        {<<"source">>, db_url(Source)},
+        {<<"target">>, db_url(Target)},
         {<<"create_target">>, true},
         {<<"create_target_params">>, {[{<<"q">>, <<"4">>}]}}
     ]},
-    create_db(From, Source),
-    create_doc(From, Source),
+    create_db(Source),
+    create_doc(Source),
     {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
 
     {ok, TargetInfo} = fabric:get_db_info(Target),
     {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
-    delete_db(From, Source),
-    delete_db(To, Target),
+    delete_db(Source),
+    delete_db(Target),
     ?_assertEqual(4, couch_util:get_value(q, ClusterInfo)).
 
 
-should_create_target_with_q_2_n_1(
-    {From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+should_create_target_with_q_2_n_1({_Ctx, {Source, Target}}) ->
     RepObject = {[
-        {<<"source">>, db_url(From, Source)},
-        {<<"target">>, db_url(To, Target)},
+        {<<"source">>, db_url(Source)},
+        {<<"target">>, db_url(Target)},
         {<<"create_target">>, true},
         {<<"create_target_params">>,
             {[{<<"q">>, <<"2">>}, {<<"n">>, <<"1">>}]}}
     ]},
-    create_db(From, Source),
-    create_doc(From, Source),
+    create_db(Source),
+    create_doc(Source),
     {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
 
     {ok, TargetInfo} = fabric:get_db_info(Target),
     {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
-    delete_db(From, Source),
-    delete_db(To, Target),
+    delete_db(Source),
+    delete_db(Target),
     [
         ?_assertEqual(2, couch_util:get_value(q, ClusterInfo)),
         ?_assertEqual(1, couch_util:get_value(n, ClusterInfo))
     ].
 
 
-should_create_target_with_default(
-    {From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+should_create_target_with_default({_Ctx, {Source, Target}}) ->
     RepObject = {[
-        {<<"source">>, db_url(From, Source)},
-        {<<"target">>, db_url(To, Target)},
+        {<<"source">>, db_url(Source)},
+        {<<"target">>, db_url(Target)},
         {<<"create_target">>, true}
     ]},
-    create_db(From, Source),
-    create_doc(From, Source),
+    create_db(Source),
+    create_doc(Source),
     {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
 
     {ok, TargetInfo} = fabric:get_db_info(Target),
     {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
     Q = config:get("cluster", "q", "8"),
-    delete_db(From, Source),
-    delete_db(To, Target),
+    delete_db(Source),
+    delete_db(Target),
     ?_assertEqual(list_to_integer(Q), couch_util:get_value(q, ClusterInfo)).
 
 
-should_not_create_target_with_q_any(
-    {From, To}, {_Ctx1, _Ctx2, {Source, Target}}) ->
+should_not_create_target_with_q_any({_Ctx, {Source, Target}}) ->
     RepObject = {[
-        {<<"source">>, db_url(From, Source)},
-        {<<"target">>, db_url(To, Target)},
+        {<<"source">>, db_url(Source)},
+        {<<"target">>, db_url(Target)},
         {<<"create_target">>, false},
         {<<"create_target_params">>, {[{<<"q">>, <<"1">>}]}}
     ]},
-    create_db(From, Source),
-    create_doc(From, Source),
+    create_db(Source),
+    create_doc(Source),
     {error, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
     DbExist = is_list(catch mem3:shards(Target)),
-    delete_db(From, Source),
+    delete_db(Source),
     ?_assertEqual(false, DbExist).
 
 
-create_doc(local, DbName) ->
-    {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),
-    Body = {[{<<"foo">>, <<"bar">>}]},
-    NewDoc = #doc{body = Body},
-    {ok, _} = couch_db:update_doc(Db, NewDoc, []),
-    couch_db:close(Db);
-create_doc(remote, DbName) ->
+create_doc(DbName) ->
     Body = {[{<<"foo">>, <<"bar">>}]},
     NewDoc = #doc{body = Body},
     {ok, _} = fabric:update_doc(DbName, NewDoc, [?ADMIN_CTX]).
 
 
-create_db(local, DbName) ->
-    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
-    ok = couch_db:close(Db);
-create_db(remote, DbName) ->
+create_db(DbName) ->
     ok = fabric:create_db(DbName, [?ADMIN_CTX]).
 
 
-delete_db(local, DbName) ->
-    ok = couch_server:delete(DbName, [?ADMIN_CTX]);
-delete_db(remote, DbName) ->
+delete_db(DbName) ->
     ok = fabric:delete_db(DbName, [?ADMIN_CTX]).
 
 
-db_url(local, DbName) ->
-    DbName;
-db_url(remote, DbName) ->
+db_url(DbName) ->
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),
-    ?l2b(io_lib:format("http://~s:~b/~s", [Addr, Port, DbName])).
+    ?l2b(io_lib:format("http://~s:~s@~s:~b/~s", [?USERNAME, ?PASSWORD, Addr,
+        Port, DbName])).


### PR DESCRIPTION
Don't need to use local as source since it doesn't test anything specific to
the code in question. Use credentials with http requests as it's a more
realistic scenario. Avoid spawning couch server twice - once to start chttpd
and then to start other couch servers.
