### PR TITLE
Fix couch db tests

### DIFF
--- a/src/couch/test/couch_db_tests.erl
+++ b/src/couch/test/couch_db_tests.erl
@@ -17,18 +17,13 @@
 -define(TIMEOUT, 120).
 
 
-setup() ->
-    Ctx = test_util:start_couch(),
-    config:set("log", "include_sasl", "false", false),
-    Ctx.
-
 
 create_delete_db_test_()->
     {
         "Database create/delete tests",
         {
             setup,
-            fun setup/0, fun test_util:stop_couch/1,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
             fun(_) ->
                 [should_create_db(),
                  should_delete_db(),
@@ -44,7 +39,7 @@ open_db_test_()->
         "Database open tests",
         {
             setup,
-            fun setup/0, fun test_util:stop_couch/1,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
             fun(_) ->
                 [should_create_db_if_missing()]
             end

--- a/src/couch/test/couch_db_tests.erl
+++ b/src/couch/test/couch_db_tests.erl
@@ -26,10 +26,32 @@ create_delete_db_test_()->
             fun test_util:start_couch/0, fun test_util:stop_couch/1,
             fun(_) ->
                 [should_create_db(),
-                 should_delete_db(),
-                 should_create_multiple_dbs(),
-                 should_delete_multiple_dbs(),
-                 should_create_delete_database_continuously()]
+                 should_delete_db()]
+            end
+        }
+    }.
+
+create_delete_multiple_dbs_test_()->
+    {
+        "Multiple database create/delete tests",
+        {
+            setup,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            fun(_) ->
+                [should_create_multiple_dbs(),
+                 should_delete_multiple_dbs()]
+            end
+        }
+    }.
+
+create_delete_database_continuously_test_() ->
+    {
+        "Continious database create/delete tests",
+        {
+            setup,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            fun(_) ->
+                [should_create_delete_database_continuously()]
             end
         }
     }.

--- a/src/couch/test/couchdb_cookie_domain_tests.erl
+++ b/src/couch/test/couchdb_cookie_domain_tests.erl
@@ -49,23 +49,26 @@ cookie_test_() ->
     }.
 
 should_set_cookie_domain(Url) ->
-    ?_assertEqual(true,
-        begin
-            ok = config:set("couch_httpd_auth", "cookie_domain", "example.com", false),
-            {ok, Code, Headers, _} = test_request:post(Url, [{"Content-Type", "application/json"}],
-                "{\"name\":\"" ++ ?USER ++ "\", \"password\": \"" ++ ?PASS ++ "\"}"),
-            ?assert(Code =:= 200),
-            Cookie = proplists:get_value("Set-Cookie", Headers),
-            string:str(Cookie, "; Domain=example.com") > 0
-        end).
+    ?_test(begin
+        ok = config:set("couch_httpd_auth", "cookie_domain",
+            "example.com", false),
+        {ok, Code, Headers, _} = test_request:post(Url,
+            [{"Content-Type", "application/json"}],
+            "{\"name\":\"" ++ ?USER ++ "\", \"password\": \"" ++ ?PASS ++ "\"}"
+        ),
+        ?assertEqual(200, Code),
+        Cookie = proplists:get_value("Set-Cookie", Headers),
+        ?assert(string:str(Cookie, "; Domain=example.com") > 0)
+    end).
 
 should_not_set_cookie_domain(Url) ->
-    ?_assertEqual(0,
-        begin
-            ok = config:set("couch_httpd_auth", "cookie_domain", "", false),
-            {ok, Code, Headers, _} = test_request:post(Url, [{"Content-Type", "application/json"}],
-                "{\"name\":\"" ++ ?USER ++ "\", \"password\": \"" ++ ?PASS ++ "\"}"),
-            ?assert(Code =:= 200),
-            Cookie = proplists:get_value("Set-Cookie", Headers),
-            string:str(Cookie, "; Domain=")
-        end).
+    ?_test(begin
+        ok = config:set("couch_httpd_auth", "cookie_domain", "", false),
+        {ok, Code, Headers, _} = test_request:post(Url,
+            [{"Content-Type", "application/json"}],
+            "{\"name\":\"" ++ ?USER ++ "\", \"password\": \"" ++ ?PASS ++ "\"}"
+        ),
+        ?assertEqual(200, Code),
+        Cookie = proplists:get_value("Set-Cookie", Headers),
+        ?assertEqual(0, string:str(Cookie, "; Domain="))
+    end).

--- a/src/couch/test/couchdb_cookie_domain_tests.erl
+++ b/src/couch/test/couchdb_cookie_domain_tests.erl
@@ -55,7 +55,7 @@ should_set_cookie_domain(_PortType, Url) ->
             ok = config:set("couch_httpd_auth", "cookie_domain", "example.com", false),
             {ok, Code, Headers, _} = test_request:post(Url, [{"Content-Type", "application/json"}],
                 "{\"name\":\"" ++ ?USER ++ "\", \"password\": \"" ++ ?PASS ++ "\"}"),
-            ?_assert(Code =:= 200),
+            ?assert(Code =:= 200),
             Cookie = proplists:get_value("Set-Cookie", Headers),
             string:str(Cookie, "; Domain=example.com") > 0
         end).
@@ -66,7 +66,7 @@ should_not_set_cookie_domain(_PortType, Url) ->
             ok = config:set("couch_httpd_auth", "cookie_domain", "", false),
             {ok, Code, Headers, _} = test_request:post(Url, [{"Content-Type", "application/json"}],
                 "{\"name\":\"" ++ ?USER ++ "\", \"password\": \"" ++ ?PASS ++ "\"}"),
-            ?_assert(Code =:= 200),
+            ?assert(Code =:= 200),
             Cookie = proplists:get_value("Set-Cookie", Headers),
             string:str(Cookie, "; Domain=")
         end).

--- a/src/couch/test/global_changes_tests.erl
+++ b/src/couch/test/global_changes_tests.erl
@@ -32,7 +32,7 @@ teardown({_, DbName}) ->
     ok.
 
 http_create_db(Name) ->
-    Resp = {ok, Status, _, _} = test_request:put(db_url(Name), [?AUTH], ""),
+    {ok, Status, _, _} = test_request:put(db_url(Name), [?AUTH], ""),
     true = lists:member(Status, [201, 202]),
     ok.
     


### PR DESCRIPTION
## Overview

Multiple fixes and refactoring for couch tests.

#### couch_db_tests

Proper usage of test assertions to detect fixture failing, pre-test config setup cleanup, remove custom loop in favour of standard eunit `foreach` and forechx`

#### cookie_domain_test
Fix of invalid assertions, remove obsolete helpers, proper usage of test setup.

#### global_changes_tests

Remove unused var assignment to avoid compilation warning

## Testing recommendations

`make eunit apps=couch` should pass 1219 tests

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
