### PR TITLE
Add couch_stats tracking back to couch_log

### DIFF
--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -28,35 +28,51 @@
 
 
 -spec debug(string(), list()) -> ok.
-debug(Fmt, Args) -> log(debug, Fmt, Args).
+debug(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, debug]),
+    log(debug, Fmt, Args).
 
 
 -spec info(string(), list()) -> ok.
-info(Fmt, Args) -> log(info, Fmt, Args).
+info(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, info]),
+    log(info, Fmt, Args).
 
 
 -spec notice(string(), list()) -> ok.
-notice(Fmt, Args) -> log(notice, Fmt, Args).
+notice(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, notice]),
+    log(notice, Fmt, Args).
 
 
 -spec warning(string(), list()) -> ok.
-warning(Fmt, Args) -> log(warning, Fmt, Args).
+warning(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, warning]),
+    log(warning, Fmt, Args).
 
 
 -spec error(string(), list()) -> ok.
-error(Fmt, Args) -> log(error, Fmt, Args).
+error(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, error]),
+    log(error, Fmt, Args).
 
 
 -spec critical(string(), list()) -> ok.
-critical(Fmt, Args) -> log(critical, Fmt, Args).
+critical(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, critical]),
+    log(critical, Fmt, Args).
 
 
 -spec alert(string(), list()) -> ok.
-alert(Fmt, Args) -> log(alert, Fmt, Args).
+alert(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, alert]),
+    log(alert, Fmt, Args).
 
 
 -spec emergency(string(), list()) -> ok.
-emergency(Fmt, Args) -> log(emergency, Fmt, Args).
+emergency(Fmt, Args) ->
+    couch_stats:increment_counter([couch_log, level, emergency]),
+    log(emergency, Fmt, Args).
 
 
 -spec set_level(atom() | string() | integer()) -> true.

--- a/src/couch_log/test/couch_log_test_util.erl
+++ b/src/couch_log/test/couch_log_test_util.erl
@@ -22,12 +22,15 @@ start() ->
     application:set_env(config, ini_files, config_files()),
     application:start(config),
     ignore_common_loggers(),
-    application:start(couch_log).
+    application:start(couch_log),
+    meck:new(couch_stats),
+    ok = meck:expect(couch_stats, increment_counter, ['_'], ok).
 
 
 stop(_) ->
     application:stop(config),
-    application:stop(couch_log).
+    application:stop(couch_log),
+    meck:unload(couch_stats).
 
 
 with_level(Name, Fun) ->

--- a/src/couch_stats/src/couch_stats.app.src
+++ b/src/couch_stats/src/couch_stats.app.src
@@ -14,7 +14,7 @@
     {description, "Simple statistics collection"},
     {vsn, git},
     {registered, [couch_stats_aggregator, couch_stats_process_tracker]},
-    {applications, [kernel, stdlib, folsom, couch_log]},
+    {applications, [kernel, stdlib, folsom]},
     {mod, {couch_stats_app, []}},
     {env, []}
 ]}.

--- a/src/couch_stats/src/couch_stats.erl
+++ b/src/couch_stats/src/couch_stats.erl
@@ -119,7 +119,7 @@ notify_existing_metric(Name, Op, Type) ->
     try
         ok = folsom_metrics:notify_existing_metric(Name, Op, Type)
     catch _:_ ->
-        couch_log:notice("unknown metric: ~p", [Name]),
+        error_logger:error_msg("unknown metric: ~p", [Name]),
         {error, unknown_metric}
     end.
 

--- a/src/couch_stats/src/couch_stats_process_tracker.erl
+++ b/src/couch_stats/src/couch_stats_process_tracker.erl
@@ -48,7 +48,7 @@ init([]) ->
     {ok, #st{}}.
 
 handle_call(Msg, _From, State) ->
-    couch_log:notice("~p received unknown call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("~p received unknown call ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 handle_cast({track, Pid, Name}, State) ->
@@ -57,13 +57,13 @@ handle_cast({track, Pid, Name}, State) ->
     ets:insert(?MODULE, {Ref, Name}),
     {noreply, State};
 handle_cast(Msg, State) ->
-    couch_log:notice("~p received unknown cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("~p received unknown cast ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 handle_info({'DOWN', Ref, _, _, _}=Msg, State) ->
     case ets:lookup(?MODULE, Ref) of
         [] ->
-            couch_log:notice(
+            error_logger:error_msg(
                 "~p received unknown exit; message was ~p", [?MODULE, Msg]
             );
         [{Ref, Name}] ->
@@ -72,7 +72,7 @@ handle_info({'DOWN', Ref, _, _, _}=Msg, State) ->
     end,
     {noreply, State};
 handle_info(Msg, State) ->
-    couch_log:notice("~p received unknown message ~p", [?MODULE, Msg]),
+    error_logger:error_msg("~p received unknown message ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Add couch_stats tracking back to couch_log using stats defined in
https://github.com/apache/couchdb/blob/master/src/couch_log/priv/stats_descriptions.cfg
## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
jiangphs-mbp-2:dev jiangph$ ./remsh
Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Eshell V7.2.1  (abort with ^G)
(node1@127.0.0.1)1> couch_stats:sample([couch_log, level, debug]).
169
(node1@127.0.0.1)2> couch_stats:sample([couch_log, level, info]).
13
(node1@127.0.0.1)3> couch_stats:sample([couch_log, level, notice]).
37
(node1@127.0.0.1)4> couch_stats:sample([couch_log, level, warning]).
1
(node1@127.0.0.1)5> couch_stats:sample([couch_log, level, error]).
0
(node1@127.0.0.1)6> couch_stats:sample([couch_log, level, critical]).
0
(node1@127.0.0.1)7> couch_stats:sample([couch_log, level, alert]).
0
(node1@127.0.0.1)8> couch_stats:sample([couch_log, level, emergency]).
0
```


```
make check skip_deps+=couch_epi apps=couch_log

...
[0.183 s] ok
  [done in 0.196 s]
module 'couch_log_test_util'
module 'couch_log_app'
module 'couch_log_config'
module 'couch_log_config_dyn'
module 'couch_log_formatter'
module 'couch_log_error_logger_h'
module 'couch_log_trunc_io_fmt'
module 'couch_log_monitor'
module 'couch_log_server'
module 'couch_log_sup'
module 'couch_log_util'
module 'couch_log_writer_file'
module 'couch_log_writer_syslog'
module 'couch_log_writer_stderr'
module 'couch_log'
module 'couch_log_writer'
=======================================================
  All 155 tests passed.
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
issue #832

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
