### PR TITLE
Fix mango native proc crash

### DIFF
--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -330,7 +330,7 @@ indexable_fields(Fields, {op_not, {ExistsQuery, Arg}}) when is_tuple(Arg) ->
     Fields0 = indexable_fields(Fields, ExistsQuery),
     indexable_fields(Fields0, Arg);
 % forces "$exists" : false to use _all_docs
-indexable_fields(Fields, {op_not, {ExistsQuery, false}}) ->
+indexable_fields(_, {op_not, {_, false}}) ->
     [];
 
 indexable_fields(Fields, {op_insert, Arg}) when is_binary(Arg) ->


### PR DESCRIPTION
## Overview

When soft limit is reached couch_proc_manager evicts idle processes by casting on them `stop`
message. Since mango_native_proc doesn't handle this message it results to its crash with
`invalid_cast` reason.

## Testing recommendations

`make eunit apps=mango` or `make eunit apps=mango suites=mango_native_proc` for isolated test.

`make mango-test` for integration test.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
