### PR TITLE
Make peruser database prefix configurable

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -91,6 +91,10 @@ delete_dbs = false
 ; Set a default q value for peruser-created databases that is different from
 ; cluster / q
 ;q = 1
+; prefix for user databases. If you change this after user dbs have been
+; created, the existing databases won’t get deleted if the associated user
+; gets deleted because of the then prefix mismatch.
+database_prefix = userdb-
 
 [httpd]
 port = {{backend_port}}

--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -156,6 +156,20 @@ should_create_user_db_with_default(TestAuthDb) ->
         ?_assertEqual(1, couch_util:get_value(q, ClusterInfo))
     ].
 
+should_create_user_db_with_custom_prefix(TestAuthDb) ->
+    set_config("couch_peruser", "database_prefix", "newuserdb-"),
+    create_user(TestAuthDb, "fooo"),
+    wait_for_db_create(<<"newuserdb-666f6f6f">>),
+    delete_config("couch_peruser", "database_prefix", "newuserdb-"),
+    ?_assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs())).
+
+should_create_user_db_with_custom_special_prefix(TestAuthDb) ->
+    set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    create_user(TestAuthDb, "fooo"),
+    wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
+    delete_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    ?_assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs())).
+
 should_create_anon_user_db_with_default(TestAuthDb) ->
     create_anon_user(TestAuthDb, "fooo"),
     wait_for_db_create(<<"userdb-666f6f6f">>),
@@ -165,6 +179,20 @@ should_create_anon_user_db_with_default(TestAuthDb) ->
         ?_assert(lists:member(<<"userdb-666f6f6f">>, all_dbs())),
         ?_assertEqual(1, couch_util:get_value(q, ClusterInfo))
     ].
+
+should_create_anon_user_db_with_custom_prefix(TestAuthDb) ->
+    set_config("couch_peruser", "database_prefix", "newuserdb-"),
+    create_anon_user(TestAuthDb, "fooo"),
+    wait_for_db_create(<<"newuserdb-666f6f6f">>),
+    delete_config("couch_peruser", "database_prefix", "newuserdb-"),
+    ?_assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs())).
+
+should_create_anon_user_db_with_custom_special_prefix(TestAuthDb) ->
+    set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    create_anon_user(TestAuthDb, "fooo"),
+    wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
+    delete_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    ?_assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs())).
 
 should_create_user_db_with_q4(TestAuthDb) ->
     set_config("couch_peruser", "q", "4"),
@@ -213,6 +241,40 @@ should_delete_user_db(TestAuthDb) ->
     wait_for_db_delete(UserDbName),
     AfterDelete = lists:member(UserDbName, all_dbs()),
     [?_assert(AfterCreate), ?_assertNot(AfterDelete)].
+
+should_delete_user_db_with_custom_prefix(TestAuthDb) ->
+    User = "bar",
+    UserDbName = <<"newuserdb-626172">>,
+    set_config("couch_peruser", "delete_dbs", "true"),
+    set_config("couch_peruser", "database_prefix", "newuserdb-"),
+    create_user(TestAuthDb, User),
+    wait_for_db_create(UserDbName),
+    AfterCreate = lists:member(UserDbName, all_dbs()),
+    delete_user(TestAuthDb, User),
+    wait_for_db_delete(UserDbName),
+    delete_config("couch_peruser", "database_prefix", "newuserdb-"),
+    AfterDelete = lists:member(UserDbName, all_dbs()),
+    [
+        ?_assert(AfterCreate),
+        ?_assertNot(AfterDelete)
+    ].
+
+should_delete_user_db_with_custom_special_prefix(TestAuthDb) ->
+    User = "bar",
+    UserDbName = <<"userdb_$()+--/626172">>,
+    set_config("couch_peruser", "delete_dbs", "true"),
+    set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    create_user(TestAuthDb, User),
+    wait_for_db_create(UserDbName),
+    AfterCreate = lists:member(UserDbName, all_dbs()),
+    delete_user(TestAuthDb, User),
+    wait_for_db_delete(UserDbName),
+    delete_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    AfterDelete = lists:member(UserDbName, all_dbs()),
+    [
+        ?_assert(AfterCreate),
+        ?_assertNot(AfterDelete)
+    ].
 
 should_reflect_config_changes(TestAuthDb) ->
     User = "baz",
@@ -445,11 +507,17 @@ couch_peruser_test_() ->
                 fun setup/0, fun teardown/1,
                 [
                     fun should_create_anon_user_db_with_default/1,
+                    fun should_create_anon_user_db_with_custom_prefix/1,
+                    fun should_create_anon_user_db_with_custom_special_prefix/1,
                     fun should_create_user_db_with_default/1,
+                    fun should_create_user_db_with_custom_prefix/1,
+                    fun should_create_user_db_with_custom_special_prefix/1,
                     fun should_create_user_db_with_q4/1,
                     fun should_create_anon_user_db_with_q4/1,
                     fun should_not_delete_user_db/1,
                     fun should_delete_user_db/1,
+                    fun should_delete_user_db_with_custom_prefix/1,
+                    fun should_delete_user_db_with_custom_special_prefix/1,
                     fun should_reflect_config_changes/1,
                     fun should_add_user_to_db_admins/1,
                     fun should_add_user_to_db_members/1,


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
At the moment, peruser-managed databases are prefixed with userdb- and that’s hardcoded.

This PR allows users to specify a different prefix, so we make this configurable.

The peruser config section looks:
```
[couch_peruser]
; If enabled, couch_peruser ensures that a private per-user database
; exists for each document in _users. These databases are writable only
; by the corresponding user. Databases are in the following form:
; userdb-{hex encoded username}
enable = false
; If set to true and a user is deleted, the respective database gets
; deleted as well.
delete_dbs = false
; prefix for user databases. If you change this after user dbs have been
; created, the existing databases won’t get deleted if the associated user
; gets deleted because of the then prefix mismatch.
database_prefix = userdb-
```
## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make check skip_deps+=couch_epi apps=couch_peruser
======================== EUnit ========================
module 'couch_peruser_test'
  couch_peruser test
Application crypto was left running!
    couch_peruser_test:179: should_create_anon_user_db_with_default...[0.002 s] ok
    couch_peruser_test:180: should_create_anon_user_db_with_default...ok
    couch_peruser_test:188: should_create_anon_user_db_with_custom_prefix...[0.003 s] ok
    couch_peruser_test:195: should_create_anon_user_db_with_custom_special_prefix...[0.003 s] ok
    couch_peruser_test:155: should_create_user_db_with_default...[0.004 s] ok
    couch_peruser_test:156: should_create_user_db_with_default...ok
    couch_peruser_test:164: should_create_user_db_with_custom_prefix...[0.003 s] ok
    couch_peruser_test:171: should_create_user_db_with_custom_special_prefix...[0.003 s] ok
    couch_peruser_test:206: should_create_user_db_with_q4...[0.003 s] ok
    couch_peruser_test:207: should_create_user_db_with_q4...ok
    couch_peruser_test:218: should_create_anon_user_db_with_q4...[0.003 s] ok
    couch_peruser_test:219: should_create_anon_user_db_with_q4...ok
    couch_peruser_test:230: should_not_delete_user_db...[0.005 s] ok
    couch_peruser_test:241: should_delete_user_db...[0.002 s] ok
    couch_peruser_test:254: should_delete_user_db_with_custom_prefix...[0.003 s] ok
    couch_peruser_test:267: should_delete_user_db_with_custom_special_prefix...[0.002 s] ok
    couch_peruser_test:296: should_reflect_config_changes...[0.006 s] ok
    couch_peruser_test:303: should_add_user_to_db_admins...[0.002 s] ok
    couch_peruser_test:312: should_add_user_to_db_members...[0.002 s] ok
    couch_peruser_test:331: should_not_remove_existing_db_admins...ok
    couch_peruser_test:332: should_not_remove_existing_db_admins...ok
    couch_peruser_test:333: should_not_remove_existing_db_admins...ok
    couch_peruser_test:351: should_not_remove_existing_db_members...ok
    couch_peruser_test:352: should_not_remove_existing_db_members...ok
    couch_peruser_test:353: should_not_remove_existing_db_members...ok
    couch_peruser_test:379: should_remove_user_from_db_admins...ok
    couch_peruser_test:380: should_remove_user_from_db_admins...ok
    couch_peruser_test:381: should_remove_user_from_db_admins...ok
    couch_peruser_test:407: should_remove_user_from_db_members...ok
    couch_peruser_test:408: should_remove_user_from_db_members...ok
    couch_peruser_test:409: should_remove_user_from_db_members...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 66.533 s]
  [done in 68.219 s]
module 'couch_peruser_sup'
module 'couch_peruser_app'
module 'couch_peruser'
=======================================================
  All 31 tests passed.
```
## Related Issues or Pull Requests
issue #876
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
