### PR TITLE
Mango: change catch-all field range priority

### DIFF
--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -264,6 +264,13 @@ class OperatorTextTests(mango.UserDocsTextTests, OperatorTests):
 
 
 class OperatorAllDocsTests(mango.UserDocsTestsNoIndexes, OperatorTests):
-    pass
+    def test_range_id_eq(self):
+        doc_id = "8e1c90c0-ac18-4832-8081-40d14325bde0"
+        r = self.db.find({
+                "_id": doc_id
+            }, explain=True, return_raw=True)
+        
+        self.assertEqual(r["mrargs"]["end_key"], doc_id)
+        self.assertEqual(r["mrargs"]["start_key"], doc_id)
 
 


### PR DESCRIPTION
## Overview

01252f97 introduced a "catch-all" feature to Mango that allowed
queries to fall back on a full database scan (_all_docs) when
no valid index was available.

This worked by creating a special index range representing
the full database scan.

For example, a selector:

`{ "_id": "foo" }`

would be translated into a field range of:

`[{ "startkey": "foo", "endkey": "foo"}]`

then prepending the catch-all field range, we would have:

```
[
{ "startkey": null, "endkey": max_json_value},
{ "startkey": "foo", "endkey": "foo"}
]
```

This set gets passed into
mango_cursor_view:choose_best_index to determine most selective
index and field range combination to use. Unfortunately, in
the event that we have one possible index (all_docs) and multiple
valid ranges, it just chooses the first range it finds -
the full index scan in this case.

This commit makes the catch-all field range the last
available option, ensuring we use the more selective
range where available.

## Testing recommendations

Run queries against a large database with no indexes. Check execution_stats and _explain output to see that the startkey and endkey used are appropriate.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
