### PR TITLE
Decode destination header for doc copy

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -851,7 +851,8 @@ db_doc_req(#httpd{method='COPY', user_ctx=Ctx}=Req, Db, SourceDocId) ->
         missing_rev -> nil;
         Rev -> Rev
     end,
-    {TargetDocId, TargetRevs} = couch_httpd_db:parse_copy_destination_header(Req),
+    {TargetDocId0, TargetRevs} = couch_httpd_db:parse_copy_destination_header(Req),
+    TargetDocId = list_to_binary(mochiweb_util:unquote(TargetDocId0)),
     % open old doc
     Doc = couch_doc_open(Db, SourceDocId, SourceRev, []),
     % save new doc

--- a/src/couch/src/couch_httpd_db.erl
+++ b/src/couch/src/couch_httpd_db.erl
@@ -616,7 +616,8 @@ db_doc_req(#httpd{method='COPY'}=Req, Db, SourceDocId) ->
         missing_rev -> nil;
         Rev -> Rev
     end,
-    {TargetDocId, TargetRevs} = parse_copy_destination_header(Req),
+    {TargetDocId0, TargetRevs} = parse_copy_destination_header(Req),
+    TargetDocId = list_to_binary(mochiweb_util:unquote(TargetDocId0)),
     % open old doc
     Doc = couch_doc_open(Db, SourceDocId, SourceRev, []),
     % save new doc

--- a/src/couch/src/test_request.erl
+++ b/src/couch/src/test_request.erl
@@ -12,12 +12,22 @@
 
 -module(test_request).
 
+-export([copy/1, copy/2, copy/3]).
 -export([get/1, get/2, get/3]).
 -export([post/2, post/3, post/4]).
 -export([put/2, put/3, put/4]).
 -export([delete/1, delete/2, delete/3]).
 -export([options/1, options/2, options/3]).
 -export([request/3, request/4, request/5]).
+
+copy(Url) ->
+    copy(Url, []).
+
+copy(Url, Headers) ->
+    copy(Url, Headers, []).
+
+copy(Url, Headers, Opts) ->
+    request(copy, Url, Headers, [], Opts).
 
 get(Url) ->
     get(Url, []).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
 The Fauxton URL request to CouchDB encodes the user input and sets the Destination header with the encoded value of the new ID when sending the COPY request. This PR is aimed to make CouchDB to decode Destination header, and creates the ID without escaped values.

```
jiangphs-mbp-2:geotest jiangph$ curl -u foo:bar http://127.0.0.1:15984/testdb1/point11 -X COPY -H 'Content-Type: application/json'  -H 'Destination: xxx%E5%95%8Axxx'
{"ok":true,"ok":true,"id":"xxx啊xxx","rev":"1-ffb6c2ae737918f8f911e1fce668333e"}
jiangphs-mbp-2:geotest jiangph$ curl -u foo:bar http://127.0.0.1:15984/testdb1/point11 -X COPY -H 'Content-Type: application/json'  -H 'Destination: this/is/an/example'
{"ok":true,"ok":true,"id":"this/is/an/example","rev":"1-ffb6c2ae737918f8f911e1fce668333e"}
```

## Testing recommendations

```
make check skip_deps+=couch_epi apps=chttpd tests=all_test_
======================== EUnit ========================
chttpd db tests
Application crypto was left running!
  chttpd_db_test:84: should_return_ok_true_on_bulk_update...[0.089 s] ok
  chttpd_db_test:111: should_accept_live_as_an_alias_for_continuous...[0.043 s] ok
  chttpd_db_test:126: should_return_404_for_delete_att_on_notadoc...[0.004 s] ok
  chttpd_db_test:148: should_return_409_for_del_att_without_rev...[0.038 s] ok
  chttpd_db_test:166: should_return_200_for_del_att_with_rev...[0.069 s] ok
  chttpd_db_test:187: should_return_409_for_put_att_nonexistent_rev...[0.011 s] ok
  chttpd_db_test:282: should_return_correct_id_on_doc_copy...[0.083 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 3.898 s]
=======================================================
  All 7 tests passed.
==> rel (eunit)
==> couchdb (eunit)
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
issue #977
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
