### PR TITLE
Refactor couch_log.erl

### DIFF
--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -28,51 +28,35 @@
 
 
 -spec debug(string(), list()) -> ok.
-debug(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, debug]),
-    log(debug, Fmt, Args).
+debug(Fmt, Args) -> log(debug, Fmt, Args).
 
 
 -spec info(string(), list()) -> ok.
-info(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, info]),
-    log(info, Fmt, Args).
+info(Fmt, Args) -> log(info, Fmt, Args).
 
 
 -spec notice(string(), list()) -> ok.
-notice(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, notice]),
-    log(notice, Fmt, Args).
+notice(Fmt, Args) -> log(notice, Fmt, Args).
 
 
 -spec warning(string(), list()) -> ok.
-warning(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, warning]),
-    log(warning, Fmt, Args).
+warning(Fmt, Args) -> log(warning, Fmt, Args).
 
 
 -spec error(string(), list()) -> ok.
-error(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, error]),
-    log(error, Fmt, Args).
+error(Fmt, Args) -> log(error, Fmt, Args).
 
 
 -spec critical(string(), list()) -> ok.
-critical(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, critical]),
-    log(critical, Fmt, Args).
+critical(Fmt, Args) -> log(critical, Fmt, Args).
 
 
 -spec alert(string(), list()) -> ok.
-alert(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, alert]),
-    log(alert, Fmt, Args).
+alert(Fmt, Args) -> log(alert, Fmt, Args).
 
 
 -spec emergency(string(), list()) -> ok.
-emergency(Fmt, Args) ->
-    couch_stats:increment_counter([couch_log, level, emergency]),
-    log(emergency, Fmt, Args).
+emergency(Fmt, Args) -> log(emergency, Fmt, Args).
 
 
 -spec set_level(atom() | string() | integer()) -> true.
@@ -84,6 +68,7 @@ set_level(Level) ->
 log(Level, Fmt, Args) ->
     case couch_log_util:should_log(Level) of
         true ->
+            couch_stats:increment_counter([couch_log, level, Level]),
             Entry = couch_log_formatter:format(Level, self(), Fmt, Args),
             ok = couch_log_server:log(Entry);
         false ->


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Move `couch_stats:increment_counter/1` to `log/3`  in order to refactor `couch_log.erl`.
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
localhost:dev jiangph$ ./remsh
Erlang/OTP 18 [erts-7.2.1] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Eshell V7.2.1  (abort with ^G)
(node1@127.0.0.1)1> couch_stats:sample([couch_log, level, debug]).
20
(node1@127.0.0.1)2> couch_stats:sample([couch_log, level, info]).
17
(node1@127.0.0.1)3> couch_stats:sample([couch_log, level, notice]).
38
(node1@127.0.0.1)4> couch_stats:sample([couch_log, level, warning]).
3
(node1@127.0.0.1)5> couch_stats:sample([couch_log, level, error]).
0
(node1@127.0.0.1)6> couch_stats:sample([couch_log, level, critical]).
0
(node1@127.0.0.1)7> couch_stats:sample([couch_log, level, alert]).
0
(node1@127.0.0.1)8> couch_stats:sample([couch_log, level, emergency]).
0
```
## Related Issues or Pull Requests
issue #832
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
