### PR TITLE
Introduce new _dbs_info endpoint to get info of a list of databases

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -69,6 +69,10 @@ require_valid_user = false
 ; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
 ; If Server header is left out, Mochiweb will add its own one in.
 prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;
+; Limit maximum number of databases when tying to get detailed information using
+; _dbs_info in a request
+max_db_number_for_dbs_info_req = 100
 
 [database_compaction]
 ; larger buffer sizes can originate smaller files

--- a/src/chttpd/src/chttpd_auth_request.erl
+++ b/src/chttpd/src/chttpd_auth_request.erl
@@ -35,6 +35,8 @@ authorize_request_int(#httpd{path_parts=[<<"favicon.ico">>|_]}=Req) ->
     Req;
 authorize_request_int(#httpd{path_parts=[<<"_all_dbs">>|_]}=Req) ->
     Req;
+authorize_request_int(#httpd{path_parts=[<<"_dbs_info">>|_]}=Req) ->
+    Req;
 authorize_request_int(#httpd{path_parts=[<<"_replicator">>], method='PUT'}=Req) ->
     require_admin(Req);
 authorize_request_int(#httpd{path_parts=[<<"_replicator">>], method='DELETE'}=Req) ->
@@ -80,6 +82,8 @@ server_authorization_check(#httpd{path_parts=[<<"_replicate">>]}=Req) ->
 server_authorization_check(#httpd{path_parts=[<<"_stats">>]}=Req) ->
     Req;
 server_authorization_check(#httpd{path_parts=[<<"_active_tasks">>]}=Req) ->
+    Req;
+server_authorization_check(#httpd{path_parts=[<<"_dbs_info">>]}=Req) ->
     Req;
 server_authorization_check(#httpd{method=Method, path_parts=[<<"_utils">>|_]}=Req)
   when Method =:= 'HEAD' orelse Method =:= 'GET' ->

--- a/src/chttpd/src/chttpd_httpd_handlers.erl
+++ b/src/chttpd/src/chttpd_httpd_handlers.erl
@@ -18,6 +18,7 @@ url_handler(<<>>)                  -> fun chttpd_misc:handle_welcome_req/1;
 url_handler(<<"favicon.ico">>)     -> fun chttpd_misc:handle_favicon_req/1;
 url_handler(<<"_utils">>)          -> fun chttpd_misc:handle_utils_dir_req/1;
 url_handler(<<"_all_dbs">>)        -> fun chttpd_misc:handle_all_dbs_req/1;
+url_handler(<<"_dbs_info">>)       -> fun chttpd_misc:handle_dbs_info_req/1;
 url_handler(<<"_active_tasks">>)   -> fun chttpd_misc:handle_task_status_req/1;
 url_handler(<<"_scheduler">>)      -> fun couch_replicator_httpd:handle_scheduler_req/1;
 url_handler(<<"_node">>)           -> fun chttpd_misc:handle_node_req/1;

--- a/src/chttpd/test/chttpd_dbs_info_test.erl
+++ b/src/chttpd/test/chttpd_dbs_info_test.erl
@@ -1,0 +1,169 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_dbs_info_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(USER, "chttpd_db_test_admin").
+-define(PASS, "pass").
+-define(AUTH, {basic_auth, {?USER, ?PASS}}).
+-define(CONTENT_JSON, {"Content-Type", "application/json"}).
+
+
+setup() ->
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    Url = lists:concat(["http://", Addr, ":", Port, "/"]),
+    Db1Url = lists:concat([Url, "db1"]),
+    create_db(Db1Url),
+    Db2Url = lists:concat([Url, "db2"]),
+    create_db(Db2Url),
+    Url.
+
+teardown(Url) ->
+    Db1Url = lists:concat([Url, "db1"]),
+    Db2Url = lists:concat([Url, "db2"]),
+    delete_db(Db1Url),
+    delete_db(Db2Url),
+    ok = config:delete("admins", ?USER, _Persist=false).
+
+create_db(Url) ->
+    {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),
+    ?assert(Status =:= 201 orelse Status =:= 202).
+
+delete_db(Url) ->
+    {ok, 200, _, _} = test_request:delete(Url, [?AUTH]).
+
+dbs_info_test_() ->
+    {
+        "chttpd dbs info tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_return_error_for_get_db_info/1,
+                    fun should_return_dbs_info_for_single_db/1,
+                    fun should_return_dbs_info_for_multiple_dbs/1,
+                    fun should_return_error_for_exceeded_keys/1,
+                    fun should_return_error_for_missing_keys/1,
+                    fun should_return_dbs_info_for_dbs_with_mixed_state/1
+                ]
+            }
+        }
+    }.
+
+
+should_return_error_for_get_db_info(Url) ->
+    ?_test(begin
+        {ok, Code, _, ResultBody} = test_request:get(Url ++ "/_dbs_info?"
+            ++ "keys=[\"db1\"]", [?CONTENT_JSON, ?AUTH]),
+        {Body} = jiffy:decode(ResultBody),
+        [
+            ?assertEqual(<<"method_not_allowed">>,
+                couch_util:get_value(<<"error">>, Body)),
+            ?assertEqual(405, Code)
+        ]
+    end).
+
+
+should_return_dbs_info_for_single_db(Url) ->
+    ?_test(begin
+        NewDoc = "{\"keys\": [\"db1\"]}",
+        {ok, _, _, ResultBody} = test_request:post(Url ++ "/_dbs_info/",
+            [?CONTENT_JSON, ?AUTH], NewDoc),
+        BodyJson = jiffy:decode(ResultBody),
+        {Db1Data} = lists:nth(1, BodyJson),
+        [
+            ?assertEqual(<<"db1">>,
+                couch_util:get_value(<<"key">>, Db1Data)),
+            ?assertNotEqual(undefined,
+                couch_util:get_value(<<"info">>, Db1Data))
+        ]
+    end).
+
+
+should_return_dbs_info_for_multiple_dbs(Url) ->
+    ?_test(begin
+        NewDoc = "{\"keys\": [\"db1\", \"db2\"]}",
+        {ok, _, _, ResultBody} = test_request:post(Url ++ "/_dbs_info/",
+            [?CONTENT_JSON, ?AUTH], NewDoc),
+        BodyJson = jiffy:decode(ResultBody),
+        {Db1Data} = lists:nth(1, BodyJson),
+        {Db2Data} = lists:nth(2, BodyJson),
+        [
+            ?assertEqual(<<"db1">>,
+                couch_util:get_value(<<"key">>, Db1Data)),
+            ?assertNotEqual(undefined,
+                couch_util:get_value(<<"info">>, Db1Data)),
+            ?assertEqual(<<"db2">>,
+                couch_util:get_value(<<"key">>, Db2Data)),
+            ?assertNotEqual(undefined,
+                couch_util:get_value(<<"info">>, Db2Data))
+        ]
+    end).
+
+
+should_return_error_for_exceeded_keys(Url) ->
+    ?_test(begin
+        NewDoc = "{\"keys\": [\"db1\", \"db2\"]}",
+        ok = config:set("chttpd", "max_db_number_for_dbs_info_req", "1"),
+        {ok, Code, _, ResultBody} = test_request:post(Url ++ "/_dbs_info/",
+                   [?CONTENT_JSON, ?AUTH], NewDoc),
+        {Body} = jiffy:decode(ResultBody),
+        ok = config:delete("chttpd", "max_db_number_for_dbs_info_req"),
+        [
+            ?assertEqual(<<"bad_request">>,
+                couch_util:get_value(<<"error">>, Body)),
+            ?assertEqual(400, Code)
+        ]
+    end).
+
+
+should_return_error_for_missing_keys(Url) ->
+    ?_test(begin
+        NewDoc = "{\"missingkeys\": [\"db1\", \"db2\"]}",
+        {ok, Code, _, ResultBody} = test_request:post(Url ++ "/_dbs_info/",
+            [?CONTENT_JSON, ?AUTH], NewDoc),
+        {Body} = jiffy:decode(ResultBody),
+        [
+            ?assertEqual(<<"bad_request">>,
+                couch_util:get_value(<<"error">>, Body)),
+            ?assertEqual(400, Code)
+        ]
+    end).
+
+
+should_return_dbs_info_for_dbs_with_mixed_state(Url) ->
+    ?_test(begin
+        NewDoc = "{\"keys\": [\"db1\", \"noexisteddb\"]}",
+        {ok, _, _, ResultBody} = test_request:post(Url ++ "/_dbs_info/",
+            [?CONTENT_JSON, ?AUTH], NewDoc),
+        Json = jiffy:decode(ResultBody),
+        {Db1Data} = lists:nth(1, Json),
+        {Db2Data} = lists:nth(2, Json),
+        [
+            ?assertEqual(
+                <<"db1">>, couch_util:get_value(<<"key">>, Db1Data)),
+            ?assertNotEqual(undefined,
+                couch_util:get_value(<<"info">>, Db1Data)),
+            ?assertEqual(
+                <<"noexisteddb">>, couch_util:get_value(<<"key">>, Db2Data)),
+            ?assertEqual(undefined, couch_util:get_value(<<"info">>, Db2Data))
+        ]
+    end).

--- a/src/couch/test/chttpd_endpoints_tests.erl
+++ b/src/couch/test/chttpd_endpoints_tests.erl
@@ -41,6 +41,7 @@ handlers(url_handler) ->
         {<<"favicon.ico">>, chttpd_misc, handle_favicon_req},
         {<<"_utils">>, chttpd_misc, handle_utils_dir_req},
         {<<"_all_dbs">>, chttpd_misc, handle_all_dbs_req},
+        {<<"_dbs_info">>, chttpd_misc, handle_dbs_info_req},
         {<<"_active_tasks">>, chttpd_misc, handle_task_status_req},
         {<<"_node">>, chttpd_misc, handle_node_req},
         {<<"_reload_query_servers">>, chttpd_misc, handle_reload_query_servers_req},


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Before this PR, if you want the database info for all databases on a server, you must individually access /{db} for each database. This PR makes a single request to retrieve all of that.

You can specify keys=[....] to select a subset of all databases on a server to monitor.

```
curl -X POST 'localhost:15984/_dbs_info' -u foo:bar -H "Content-Type: application/json"  -d @dblist.json -g|jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   971    0   938  100    33   104k   3770 --:--:-- --:--:-- --:--:--  114k
[
  {
    "key": "dbname1",
    "info": {
      "db_name": "dbname1",
      "update_seq": "0-g1AAAAFDeJzLYWBg4MhgTmHgz8tPSTV0MDQy1zMAQsMcoARTIkOS_P___7MSGXAqSVIAkkn2hFQ5gFTFE1KVAFJVT0BVHguQZGgAUkCF85FVGmNVuQCicj9hMw9AVN4nrPIBRCXInVkAHz1WeA",
      "sizes": {
        "file": 33936,
        "external": 0,
        "active": 0
      },
      "purge_seq": 0,
      "other": {
        "data_size": 0
      },
      "doc_del_count": 0,
      "doc_count": 0,
      "disk_size": 33936,
      "disk_format_version": 6,
      "data_size": 0,
      "compact_running": false,
      "cluster": {
        "q": 8,
        "n": 3,
        "w": 2,
        "r": 2
      },
      "instance_start_time": "0"
    }
  },
  {
    "key": "dbname2",
    "info": {
      "db_name": "dbname2",
      "update_seq": "0-g1AAAAFDeJzLYWBg4MhgTmHgz8tPSTV0MDQy1zMAQsMcoARTIkOS_P___7MSGXAqSVIAkkn2hFQ5gFTFE1KVAFJVT0BVHguQZGgAUkCF8wmrXABRuZ-wygMQlfcJq3wAUQlyZxYAHlFWdg",
      "sizes": {
        "file": 33936,
        "external": 0,
        "active": 0
      },
      "purge_seq": 0,
      "other": {
        "data_size": 0
      },
      "doc_del_count": 0,
      "doc_count": 0,
      "disk_size": 33936,
      "disk_format_version": 6,
      "data_size": 0,
      "compact_running": false,
      "cluster": {
        "q": 8,
        "n": 3,
        "w": 2,
        "r": 2
      },
      "instance_start_time": "0"
    }
  }
]
```
```
more dblist.json
{"keys" : ["dbname1", "dbname2"]}
```

```
curl -X GET 'localhost:15984/_dbs_info?keys=["db1"]' -u foo:bar -g|jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    60  100    60    0     0  10284      0 --:--:-- --:--:-- --:--:-- 12000
{
  "error": "method_not_allowed",
  "reason": "Only POST allowed"
}
```

for database which doesn't exist, there is the following behavior.
```
 curl -X POST 'localhost:15984/_dbs_info' -u foo:bar -H "Content-Type: application/json"  -d @dblist.json -g|jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   555    0   519  100    36  13046    904 --:--:-- --:--:-- --:--:-- 13307
[
  {
    "key": "dbname1",
    "info": {
      "db_name": "dbname1",
      "update_seq": "0-g1AAAAFDeJzLYWBg4MhgTmHgz8tPSTV0MDQy1zMAQsMcoARTIkOS_P___7MSGeBKjNCUJCkAySR7NFXoBiU5gFTFE1KVAFJVT0BVHguQZGgAUkCF8wmrXABRuZ-wygMQlffx-Rei8gFEJcidWQAfhVZ4",
      "sizes": {
        "file": 33936,
        "external": 0,
        "active": 0
      },
      "purge_seq": 0,
      "other": {
        "data_size": 0
      },
      "doc_del_count": 0,
      "doc_count": 0,
      "disk_size": 33936,
      "disk_format_version": 6,
      "data_size": 0,
      "compact_running": false,
      "cluster": {
        "q": 8,
        "n": 3,
        "w": 2,
        "r": 2
      },
      "instance_start_time": "0"
    }
  },
  {
    "key": "unknown_db",
    "error": "not_found"
  }
]
```
Note:
1. Only POST is supported
2. one configuration item is introduced to limit maximum number of databases 
```
; Limit maximum number of databases when tying to get detailed information using
; _dbs_info in a request
max_db_number_for_dbs_info_req = 100
```
## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=chttpd tests=dbs_info_test_
```

Compiled test/chttpd_dbs_info_test.erl
    Running test function(s):
      chttpd_dbs_info_test:dbs_info_test_/0
======================== EUnit ========================
chttpd dbs info tests
Application crypto was left running!
  chttpd_dbs_info_test:73: should_return_error_for_get_db_info...[0.013 s] ok
  chttpd_dbs_info_test:86: should_return_dbs_info_for_single_db...[0.045 s] ok
  chttpd_dbs_info_test:102: should_return_dbs_info_for_multiple_dbs...[0.006 s] ok
  chttpd_dbs_info_test:123: should_return_error_for_exceeded_keys...[0.014 s] ok
  chttpd_dbs_info_test:139: should_return_error_for_missing_keys...[0.004 s] ok
  chttpd_dbs_info_test:153: should_return_dbs_info_for_dbs_with_mixed_state...[0.006 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 2.399 s]
=======================================================
  All 6 tests passed.
==> rel (eunit)
```
## Related Issues or Pull Requests
issue #822
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
