### PR TITLE
Return update_seq and offset when update_seq is true and keys is set

### DIFF
--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -59,7 +59,8 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
         conflicts = Conflicts,
         skip = Skip,
         keys = Keys0,
-        extra = Extra
+        extra = Extra,
+        update_seq = UpdateSeq
     } = QueryArgs,
     DocOptions1 = case Conflicts of
         true -> [conflicts|DocOptions0];
@@ -97,7 +98,12 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
     end,
     case Resp of
         {ok, TotalRows} ->
-            {ok, Acc1} = Callback({meta, [{total, TotalRows}]}, Acc0),
+            Meta = case UpdateSeq of
+                false -> [{total, TotalRows}, {offset, null}];
+                true ->
+                    [{total, TotalRows}, {offset, null}, {update_seq, null}]
+            end,
+            {ok, Acc1} = Callback({meta, Meta}, Acc0),
             {ok, Acc2} = doc_receive_loop(
                 Keys3, queue:new(), SpawnFun, MaxJobs, Callback, Acc1
             ),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Before this PR, if `keys` parameter is set for `_all_docs` endpoint, there is no `update_seq` and `offset` returned in response even if `update_seq` parameter is set to true. This is not consistent with description in http://docs.couchdb.org/en/2.1.1/api/database/bulk-api.html

```
update_seq (boolean) – Response includes an update_seq value indicating which sequence id of the underlying database the view reflects. Default is false.
```

This PR is aimed to return update_seq and offset with null if `update_seq` is set to true and `keys` is specified as well.

```
 curl -X GET 'localhost:15984/db3/_all_docs?update_seq=true&keys=["bar"]&skip=0' -u foo:bar -g|jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   157    0   157    0     0  14275      0 --:--:-- --:--:-- --:--:-- 15700
{
  "total_rows": 14,
  "offset": null,
  "update_seq": null,
  "rows": [
    {
      "id": "bar",
      "key": "bar",
      "value": {
        "rev": "1-9393bddaf4aecebfe0cd04a6558d8731"
      }
    }
  ]
}
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make check skip_deps+=couch_epi apps=chttpd tests=all_test_
======================== EUnit ========================
chttpd db tests
Application crypto was left running!
  chttpd_db_test:78: should_return_ok_true_on_bulk_update...[0.104 s] ok
  chttpd_db_test:105: should_accept_live_as_an_alias_for_continuous...[0.050 s] ok
  chttpd_db_test:120: should_return_404_for_delete_att_on_notadoc...[0.005 s] ok
  chttpd_db_test:142: should_return_409_for_del_att_without_rev...[0.040 s] ok
  chttpd_db_test:160: should_return_200_for_del_att_with_rev...[0.053 s] ok
  chttpd_db_test:181: should_return_409_for_put_att_nonexistent_rev...[0.008 s] ok
  chttpd_db_test:196: should_return_update_seq_when_set_on_all_docs...[0.257 s] ok
  chttpd_db_test:212: should_not_return_update_seq_when_unset_on_all_docs...[0.251 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 2.258 s]
=======================================================
  All 8 tests passed.
==> rel (eunit)
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
issue #969

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;

  
  