### PR TITLE
Return friendly error message when creating user with invalid password

### DIFF
--- a/src/couch/src/couch_passwords.erl
+++ b/src/couch/src/couch_passwords.erl
@@ -26,6 +26,9 @@ simple(Password, Salt) when is_binary(Password), is_binary(Salt) ->
     ?l2b(couch_util:to_hex(crypto:hash(sha, <<Password/binary, Salt/binary>>)));
 simple(Password, Salt) when is_binary(Salt) ->
     Msg = io_lib:format("Password value of '~p' is invalid.", [Password]),
+    throw({forbidden, Msg});
+simple(Password, Salt) when is_binary(Password) ->
+    Msg = io_lib:format("Salt value of '~p' is invalid.", [Salt]),
     throw({forbidden, Msg}).
 
 %% CouchDB utility functions
@@ -74,6 +77,11 @@ pbkdf2(Password, Salt, Iterations) when is_binary(Salt),
                                         is_integer(Iterations),
                                         Iterations > 0 ->
     Msg = io_lib:format("Password value of '~p' is invalid.", [Password]),
+    throw({forbidden, Msg});
+pbkdf2(Password, Salt, Iterations) when is_binary(Password),
+                                        is_integer(Iterations),
+                                        Iterations > 0 ->
+    Msg = io_lib:format("Salt value of '~p' is invalid.", [Salt]),
     throw({forbidden, Msg}).
 
 -spec pbkdf2(binary(), binary(), integer(), integer())

--- a/src/couch/src/couch_passwords.erl
+++ b/src/couch/src/couch_passwords.erl
@@ -23,7 +23,10 @@
 %% legacy scheme, not used for new passwords.
 -spec simple(binary(), binary()) -> binary().
 simple(Password, Salt) when is_binary(Password), is_binary(Salt) ->
-    ?l2b(couch_util:to_hex(crypto:hash(sha, <<Password/binary, Salt/binary>>))).
+    ?l2b(couch_util:to_hex(crypto:hash(sha, <<Password/binary, Salt/binary>>)));
+simple(Password, Salt) when is_binary(Salt) ->
+    Msg = io_lib:format("Password value of '~p' is invalid.", [Password]),
+    throw({forbidden, Msg}).
 
 %% CouchDB utility functions
 -spec hash_admin_password(binary() | list()) -> binary().
@@ -66,7 +69,12 @@ pbkdf2(Password, Salt, Iterations) when is_binary(Password),
                                         is_integer(Iterations),
                                         Iterations > 0 ->
     {ok, Result} = pbkdf2(Password, Salt, Iterations, ?SHA1_OUTPUT_LENGTH),
-    Result.
+    Result;
+pbkdf2(Password, Salt, Iterations) when is_binary(Salt),
+                                        is_integer(Iterations),
+                                        Iterations > 0 ->
+    Msg = io_lib:format("Password value of '~p' is invalid.", [Password]),
+    throw({forbidden, Msg}).
 
 -spec pbkdf2(binary(), binary(), integer(), integer())
     -> {ok, binary()} | {error, derived_key_too_long}.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Before this PR, couch returns unknown_error/function_clause when creating a user with non-string password.
```
curl -u foo:bar http://127.0.0.1:15984/_users  -X POST -H "Content-Type: application/json" -d @test.json
{"error":"unknown_error","reason":"function_clause","ref":1311610859}
```
This PR is aimed to return one friendly error message when creating user with invalid password.
```
curl -u foo:bar http://127.0.0.1:15984/_users  -X POST -H "Content-Type: application/json" -d @test.json
{"error":"forbidden","reason":"Password value of '123' is invalid."}

```
```
more test.json
{
    "_id": "org.couchdb.user:test",
    "name": "test",
    "type": "user",
    "roles": [],
    "password": 123
}
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make check skip_deps+=couch_epi apps=chttpd tests=all_test_
==> chttpd (eunit)
    Running test function(s):
      chttpd_security_tests:all_sec_test_/0
======================== EUnit ========================
chttpd security tests
Application crypto was left running!
  chttpd_security_tests:120: should_allow_admin_db_compaction...[0.002 s] ok
  chttpd_security_tests:137: should_allow_valid_password_to_create_user...ok
  chttpd_security_tests:147: should_disallow_invalid_password_to_create_user...ok
  chttpd_security_tests:155: should_disallow_anonymous_db_compaction...ok
  chttpd_security_tests:163: should_disallow_db_member_db_compaction...ok
  chttpd_security_tests:166: should_allow_db_admin_db_compaction...[0.002 s] ok
  chttpd_security_tests:176: should_allow_admin_view_compaction...[0.008 s] ok
  chttpd_security_tests:191: should_disallow_anonymous_view_compaction...ok
  chttpd_security_tests:194: should_allow_admin_db_view_cleanup...[0.002 s] ok
  chttpd_security_tests:209: should_disallow_anonymous_db_view_cleanup...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 6.539 s]
=======================================================
  All 10 tests passed.
```
## Related Issues or Pull Requests
issue #1051
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
