### PR TITLE
Extract helper to execute a function in a new process

### DIFF
--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -20,6 +20,7 @@
 -export([log_timeout/2, remove_done_workers/2]).
 -export([is_users_db/1, is_replicator_db/1, fake_db/2]).
 -export([upgrade_mrargs/1]).
+-export([defer/3]).
 
 -compile({inline, [{doc_id_and_rev,1}]}).
 
@@ -263,6 +264,29 @@ create_monitors(Shards) ->
         rexi_utils:server_pid(N) || #shard{node=N} <- Shards
     ]),
     rexi_monitor:start(MonRefs).
+
+
+defer(Mod, Fun, Args) ->
+    {Pid, Ref} = erlang:spawn_monitor(?MODULE, do_defer, [Mod, Fun, Args]),
+    receive
+        {'DOWN', Ref, process, Pid, {defer_ok, Value}} ->
+            Value;
+        {'DOWN', Ref, process, Pid, {defer_failed, Class, Reason, Stack}} ->
+            erlang:raise(Class, Reason, Stack)
+    end.
+
+
+do_defer(Mod, Fun, Args) ->
+    try erlang:apply(Mod, Fun, Args) of
+        Resp ->
+            erlang:exit({defer_ok, Resp})
+    catch
+        Class:Reason ->
+            Stack = erlang:get_stacktrace(),
+            couch_log:error("Defered error: ~w~n    ~p", [{Class, Reason}, Stack]),
+            erlang:exit({defer_failed, Class, Reason, Stack})
+    end.
+
 
 %% verify only id and rev are used in key.
 update_counter_test() ->

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -340,7 +340,7 @@ doc_member(Db, RowProps, Opts, ExecutionStats) ->
         undefined ->
             ExecutionStats1 = mango_execution_stats:incr_quorum_docs_examined(ExecutionStats),
             Id = couch_util:get_value(id, RowProps),
-            case mango_util:defer(fabric, open_doc, [Db, Id, Opts]) of
+            case fabric_util:defer(fabric, open_doc, [Db, Id, Opts]) of
                 {ok, #doc{}=Doc} ->
                     {ok, couch_doc:to_json_obj(Doc, []), {execution_stats, ExecutionStats1}};
                 Else ->

--- a/src/mango/src/mango_util.erl
+++ b/src/mango/src/mango_util.erl
@@ -19,9 +19,6 @@
     load_ddoc/2,
     load_ddoc/3,
 
-    defer/3,
-    do_defer/3,
-
     assert_ejson/1,
 
     to_lower/1,
@@ -85,7 +82,7 @@ open_doc(Db, DocId) ->
 
 
 open_doc(Db, DocId, Options) ->
-    case mango_util:defer(fabric, open_doc, [Db, DocId, Options]) of
+    case fabric_util:defer(fabric, open_doc, [Db, DocId, Options]) of
         {ok, Doc} ->
             {ok, Doc};
         {not_found, _} ->
@@ -96,7 +93,7 @@ open_doc(Db, DocId, Options) ->
 
 
 open_ddocs(Db) ->
-    case mango_util:defer(fabric, design_docs, [Db]) of
+    case fabric_util:defer(fabric, design_docs, [Db]) of
         {ok, Docs} ->
             {ok, Docs};
         _ ->
@@ -116,40 +113,6 @@ load_ddoc(Db, DDocId, DbOpts) ->
                 {<<"language">>, <<"query">>}
             ]},
             {ok, #doc{id = DDocId, body = Body}}
-    end.
-
-
-defer(Mod, Fun, Args) ->
-    {Pid, Ref} = erlang:spawn_monitor(?MODULE, do_defer, [Mod, Fun, Args]),
-    receive
-        {'DOWN', Ref, process, Pid, {mango_defer_ok, Value}} ->
-            Value;
-        {'DOWN', Ref, process, Pid, {mango_defer_throw, Value}} ->
-            erlang:throw(Value);
-        {'DOWN', Ref, process, Pid, {mango_defer_error, Value}} ->
-            erlang:error(Value);
-        {'DOWN', Ref, process, Pid, {mango_defer_exit, Value}} ->
-            erlang:exit(Value)
-    end.
-
-
-do_defer(Mod, Fun, Args) ->
-    try erlang:apply(Mod, Fun, Args) of
-        Resp ->
-            erlang:exit({mango_defer_ok, Resp})
-    catch
-        throw:Error ->
-            Stack = erlang:get_stacktrace(),
-            couch_log:error("Defered error: ~w~n    ~p", [{throw, Error}, Stack]),
-            erlang:exit({mango_defer_throw, Error});
-        error:Error ->
-            Stack = erlang:get_stacktrace(),
-            couch_log:error("Defered error: ~w~n    ~p", [{error, Error}, Stack]),
-            erlang:exit({mango_defer_error, Error});
-        exit:Error ->
-            Stack = erlang:get_stacktrace(),
-            couch_log:error("Defered error: ~w~n    ~p", [{exit, Error}, Stack]),
-            erlang:exit({mango_defer_exit, Error})
     end.
 
 


### PR DESCRIPTION
## Overview

Adds a helper that executes a function in a new process, with standardized error handling and logging.

## Testing recommendations

The test suite should exercise the code paths that have changed (currently document update and _find).

## Related Issues or Pull Requests

n/a

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
