### PR TITLE
Make sure mango tests's recreate fun creates db

### DIFF
--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -82,13 +82,15 @@ class Database(object):
 
     def recreate(self):
         r = self.sess.get(self.url)
-        db_info = r.json()
-        docs = db_info["doc_count"] + db_info["doc_del_count"]
-        if docs == 0:
-            # db never used - create unnecessary
-            return
-        self.delete()
+        if r.status_code == 200:
+            db_info = r.json()
+            docs = db_info["doc_count"] + db_info["doc_del_count"]
+            if docs == 0:
+                # db never used - create unnecessary
+                return
+            self.delete()
         self.create()
+        self.recreate()
 
     def save_doc(self, doc):
         self.save_docs([doc])


### PR DESCRIPTION
## Overview

Rapid same database deletion/creation is a known antipattern prone to a race condition, especially on slow VMs.

This fix modifies mango test's helper function used for db recreation to ensure that we are actually starting tests when a database created and empty.

## Testing recommendations

`make mang-test` should finish with something like:

```
...
Ran 278 tests in 7.100s

OK (SKIP=127)
```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
