### PR TITLE
Use uuid in tmp db names in unit tests

### DIFF
--- a/src/couch/include/couch_eunit.hrl
+++ b/src/couch/include/couch_eunit.hrl
@@ -40,17 +40,14 @@
 
 -define(tempfile,
     fun() ->
-        A = integer_to_list(couch_util:unique_monotonic_integer()),
-        N = node(),
-        FileName = lists:flatten(io_lib:format("~p-~s", [N, A])),
+        Suffix = couch_uuids:random(),
+        FileName = io_lib:format("~p-~s", [node(), Suffix]),
         filename:join([?TEMPDIR, FileName])
     end).
 -define(tempdb,
     fun() ->
-            Nums = integer_to_list(couch_util:unique_monotonic_integer()),
-            Prefix = "eunit-test-db",
-            Suffix = lists:concat([integer_to_list(Num) || Num <- Nums]),
-            list_to_binary(Prefix ++ "-" ++ Suffix)
+        Suffix = couch_uuids:random(),
+        iolist_to_binary(["eunit-test-db-", Suffix])
     end).
 -define(docid,
     fun() ->


### PR DESCRIPTION
## Overview

This changes naming of temporary eunit databases and files from using unique_monotonic_integer to couch_uuids:random to remove performance penalty and normalize naming across erlang releases.

Also getting rid of unnecessary inter-types convertion.

## Testing recommendations

`make eunit` should come clean. Files in `$PWD/tmp` should be named like `tmp/data/eunit-test-db-a6a4cd31f2addf2791440b3e8b54f860.1515084353.couch` or `tmp/tmp_data/nonode@nohost-018448e4ebb1f85812fd96d56939a620`

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
