### PR TITLE
Allow override of `-args_file` and `-config` parameters

### DIFF
--- a/rel/overlay/bin/couchdb
+++ b/rel/overlay/bin/couchdb
@@ -26,6 +26,10 @@ export BINDIR="$ROOTDIR/erts-$ERTS_VSN/bin"
 export EMU=beam
 export PROGNAME=`echo $0 | sed 's/.*\///'`
 
+ARGS_FILE="${COUCHDB_ARGS_FILE:-$ROOTDIR/etc/vm.args}"
+SYSCONFIG_FILE="${COUCHDB_SYSCONFIG_FILE:-$ROOTDIR/releases/$APP_VSN/sys.config}"
+
 exec "$BINDIR/erlexec" -boot "$ROOTDIR/releases/$APP_VSN/couchdb" \
-     -args_file "$ROOTDIR/etc/vm.args" \
-     -config "$ROOTDIR/releases/$APP_VSN/sys.config" "$@"
+     -args_file "${ARGS_FILE}" \
+     -config "${SYSCONFIG_FILE}" "$@"
+


### PR DESCRIPTION
## Overview

The existing `couchdb` start script hard-codes the arguments to
`-args_file` and `-config`. Although it is possible to copy this
script and modify it, or modify it in place, that is less than ideal
and can lead to all kinds of difficulties.

This PR adds the following environment variables:

- `ARGS_FILE`: By default, set to the existing hard-coded value.
- `SYSCONFIG_FILE`: By default, set to the existing hard-coded value.
- `COUCHDB_ARGS_FILE`: If non-empty, overrides `$ARGS_FILE`.
- `COUCHDB_SYSCONFIG_FILE`: If non-empty, overrides `$SYSCONFIG_FILE`.

By changing the script to use these environment variables, it makes it easily possible
to use different settings without tinkering with the pristine installed CouchDB environment.

Kindly consider this feature request as a useful, and "mostly harmless" addition to CouchDB.

## Testing recommendations

This pull request is designed to be completely backward-compatible with the existing `couchdb` script.

Testing can be very simple:

1. Run without any environment changes - should do precisely what the existing start script does.
2. Run as `COUCHDB_ARGS_FILE=/some/different/vm.args couchdb` - should use the args from the specified `vm.args`.
3. Run as `COUCHDB_SYSCONFIG_FILE=/some/different/sys.config couchdb` - should use the configuration in the specified `sys.config`.
4. Run with both overrides - should be a combination of the above two tests.

## Related Issues or Pull Requests

PR apache/couchdb-documentation#227

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
