### PR TITLE
Mango: fallback to "selector" on empty "partial_filter_selector"

### DIFF
--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -172,19 +172,12 @@ get_text_entries({IdxProps}, Doc) ->
 
 
 get_index_partial_filter_selector(IdxProps) ->
-    case couch_util:get_value(<<"partial_filter_selector">>, IdxProps) of
-        undefined ->
+    case couch_util:get_value(<<"partial_filter_selector">>, IdxProps, {[]}) of
+        {[]} ->
             % this is to support legacy text indexes that had the partial_filter_selector
             % set as selector
-            case couch_util:get_value(<<"selector">>, IdxProps, []) of
-                [] -> 
-                    {[]};
-                Else -> 
-                    Else
-            end;
-        [] -> 
-            {[]};
-        Else -> 
+            couch_util:get_value(<<"selector">>, IdxProps, {[]});
+        Else ->
             Else
     end.
 

--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -272,6 +272,16 @@ class IndexSelectorJson(mango.DbPerClass):
         self.assertEqual(len(docs), 3)
 
     @unittest.skipUnless(mango.has_text_service(), "requires text service")
+    def test_text_old_selector_still_supported_via_api(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.create_text_index(fields=[{"name":"location", "type":"string"}], 
+            selector=selector, 
+            ddoc="Selected", 
+            name="Selected")
+        docs = self.db.find({"location": {"$exists":True}}, use_index='Selected')
+        self.assertEqual(len(docs), 3)
+
+    @unittest.skipUnless(mango.has_text_service(), "requires text service")
     def test_text_partial_filter_only_in_return_if_not_default(self):
         self.db.create_text_index(fields=[{"name":"location", "type":"string"}])
         index = self.db.list_indexes()[1]

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -145,7 +145,7 @@ class Database(object):
         return created
 
     def create_text_index(self, analyzer=None, idx_type="text",
-        partial_filter_selector=None, default_field=None, fields=None, 
+        partial_filter_selector=None, selector=None, default_field=None, fields=None, 
         name=None, ddoc=None,index_array_lengths=None):
         body = {
             "index": {
@@ -161,6 +161,8 @@ class Database(object):
             body["index"]["default_field"] = default_field
         if index_array_lengths is not None:
             body["index"]["index_array_lengths"] = index_array_lengths
+        if selector is not None:
+            body["index"]["selector"] = selector
         if partial_filter_selector is not None:
             body["index"]["partial_filter_selector"] = partial_filter_selector
         if fields is not None:


### PR DESCRIPTION
## Overview

Mango text indexes historically supported partial indexes
defined via a "selector" field. This was renamed to
"partial_filter_selector" in b98de40 but the fallback
code did not correctly handle the case where
a "selector" existed alongside a "partial_filter_selector".

This situation can occur when a the _index endpoint is
used to create a text index with a "selector". The resulting
design document contains an empty "partial_filter_selector"
field *and* the "selector" field that was passed in. The
previous implementation of the fallback would detect the
presence of "partial_filter_selector" and use the empty
value (match all docs) instead of faling back to the
"selector" field.

This commit changes the behaviour so that a "selector"
will be used even if an empty "partial_filter_selector"
is present. A secondary fix would be to change the index
creation so that we never use "selector" in the underlying
index design document, even if it is passed to the _index
API.

## Testing recommendations

Run the test suite (with text indexes enabled). Attempt to create text indexes using the _index endpoint, specifying a "selector" field. Test that the partial index contains only the documents that match the selector.

## Related Issues or Pull Requests

#818 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
