### PR TITLE
Remove warning on `couch_epi_codegen` compilation

### DIFF
--- a/src/couch_epi/rebar.config
+++ b/src/couch_epi/rebar.config
@@ -1,3 +1,7 @@
 {cover_enabled, true}.
 
 {cover_print_enabled, true}.
+
+{erl_opts, [
+    {platform_define, "^R16", 'pre18'},
+    {platform_define, "^17", 'pre18'}]}.

--- a/src/couch_epi/src/couch_epi_codegen.erl
+++ b/src/couch_epi/src/couch_epi_codegen.erl
@@ -70,11 +70,16 @@ fixup_terminator(Tokens) ->
             Tokens ++ [{dot, Line}]
     end.
 
+
+-ifdef(pre18).
+
 line(Token) ->
-    case erlang:function_exported(erl_scan, line, 1) of
-        true ->
-            erl_scan:line(Token);
-        false ->
-            {line, Line} = erl_scan:token_info(Token, line),
-            Line
-    end.
+    {line, Line} = erl_scan:token_info(Token, line),
+    Line.
+
+-else.
+
+line(Token) ->
+    erl_scan:line(Token).
+
+-endif.


### PR DESCRIPTION
## Overview

There are mouthful depreciation warning on epi compilation on none-ancient versions of erlang
```
Warning: erl_scan:token_info/2: removed in 19.0; use erl_scan:{category,column,line,location,symbol,text}/1 instead
```

The module `couch_epi_codegen` actually decides what scan token to use based on `function_exported`, but the warning is thrown anyway.

The patch changes runtime choice between `erl_scan:token_info` and `erl_scan:line` to compilation conditional one based in rebar's `platform_define`.

This is getting rid of compilation deprecation warning and also should speed up things a bit.

## Testing recommendations

Basic recompile to confirm the warning is gone and `make eunit apps=couch_epi` to ensure that things are not broken.

I've tested it on:
- 17.5
- 18.3
- 19.3
- 20.2

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
