### PR TITLE
Remove outdated docker targets and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,24 +211,6 @@ dialyze: .rebar
 	@$(REBAR) -r dialyze $(DIALYZE_OPTS)
 
 
-.PHONY: docker-image
-# target: docker-image - Build Docker image
-docker-image:
-	@docker build --rm -t couchdb/dev-cluster .
-
-
-.PHONY: docker-start
-# target: docker-start - Start CouchDB in Docker container
-docker-start:
-	@docker run -d -P -t couchdb/dev-cluster > .docker-id
-
-
-.PHONY: docker-stop
-# target: docker-stop - Stop Docker container
-docker-stop:
-	@docker stop `cat .docker-id`
-
-
 .PHONY: introspect
 # target: introspect - Check for commits difference between rebar.config and repository
 introspect:

--- a/Makefile.win
+++ b/Makefile.win
@@ -137,24 +137,6 @@ dialyze: .rebar
 	@$(REBAR) -r dialyze $(DIALYZE_OPTS)
 
 
-.PHONY: docker-image
-# target: docker-image - Build Docker image
-docker-image:
-	@docker build --rm -t couchdb\dev-cluster .
-
-
-.PHONY: docker-start
-# target: docker-start - Start CouchDB in Docker container
-docker-start:
-	@docker run -d -P -t couchdb\dev-cluster > .docker-id
-
-
-.PHONY: docker-stop
-# target: docker-stop - Stop Docker container
-docker-stop:
-	@docker stop `cat .docker-id`
-
-
 .PHONY: introspect
 # target: introspect - Check for commits difference between rebar.config and repository
 introspect:

--- a/README-DEV.rst
+++ b/README-DEV.rst
@@ -198,30 +198,6 @@ See ``make help`` for more info and useful commands.
 
 Please report any problems to the developer's mailing list.
 
-Testing a cluster
------------------
-
-We use `Docker <https://docker.io>`_ to safely run a local three node
-cluster all inside a single docker container.
-
-Assuming you have Docker installed and running::
-
-    make docker-image
-
-This will create a docker image (tagged 'couchdb/dev-cluster') capable
-of running a joined three node cluster.
-
-To start it up::
-
-    make docker-start
-
-A three node cluster should now be running (you can now use ``docker ps``
-to find the exposed ports of the nodes).
-
-To stop it::
-
-    make docker-stop
-
 Releasing
 ---------
 


### PR DESCRIPTION
## Overview

We removed the Dockerfile in 6e57c43a and moved all Docker-related materials to [apache/couchdb-docker](https://github.com/apache/couchdb-docker), but we never cleaned up the Makefile targets or developer documentation.