### PR TITLE
Make _design_docs to respect query parameters

### DIFF
--- a/test/javascript/tests/design_docs_query.js
+++ b/test/javascript/tests/design_docs_query.js
@@ -1,0 +1,154 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+couchTests.design_docs_query = function(debug) {
+  var db_name = get_random_db_name();
+  var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
+  db.createDb();
+  if (debug) debugger;
+  
+  var docs = makeDocs(5);
+
+  // create the docs
+  var results = db.bulkSave(docs);
+  T(results.length == 5);
+  for (var i = 0; i < 5; i++) {
+    T(results[i].id == docs[i]._id);
+  }
+  
+  // create the ddocs
+  for (var i = 0; i < 5; i++) {
+    T(db.save({
+      _id : "_design/ddoc0" + (i+1).toString(),
+      views : {
+        "testing" : {
+          "map" : "function(){emit(1,1)}"
+        }
+      }
+    }).ok);
+  }  
+  
+  // test design_docs 
+  var path = "/" + db_name + "/_design_docs?";
+  var xhr_AllDDocs = CouchDB.request("GET", path);
+  T(xhr_AllDDocs.status == 200, "standard get should be 200");
+  var allDDocs = JSON.parse(xhr_AllDDocs.responseText);
+  TEquals(10, allDDocs.total_rows, "total_rows mismatch");
+  TEquals(5, allDDocs.rows.length, "amount of rows mismatch");
+  
+  // test key="_design/ddoc03"
+  var xhr = CouchDB.request("GET", path + "key=\"_design/ddoc03\"");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(1, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[0].key, "key test");
+
+  // test descending=true
+  var xhr = CouchDB.request("GET", path + "descending=true");
+  T(xhr.status == 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(5, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc05", result.rows[0].key, "descending test");
+
+  // test descending=false
+  var xhr = CouchDB.request("GET", path + "descending=false");
+  T(xhr.status == 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(5, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc01", result.rows[0].key, "descending test");
+
+  // test end_key="_design/ddoc03"
+  var xhr = CouchDB.request("GET", path + "end_key=\"_design/ddoc03\"");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(3, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[2].key, "end_key test");
+  
+  // test endkey="_design/ddoc03"
+  var xhr = CouchDB.request("GET", path + "endkey=\"_design/ddoc03\"");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(3, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[2].key, "endkey test");
+  
+  // test start_key="_design/ddoc03"
+  var xhr = CouchDB.request("GET", path + "start_key=\"_design/ddoc03\"");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(3, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[0].key, "start_key test");
+  
+  // test startkey="_design/ddoc03"
+  var xhr = CouchDB.request("GET", path + "startkey=\"_design/ddoc03\"");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(3, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[0].key, "startkey test");
+
+  // test end_key="_design/ddoc03"&inclusive_end=true
+  var xhr = CouchDB.request("GET", path + "end_key=\"_design/ddoc03\"&inclusive_end=true");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(3, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[2].key, "end_key and inclusive_end test");
+
+  // test end_key="_design/ddoc03"&inclusive_end=false
+  var xhr = CouchDB.request("GET", path + "end_key=\"_design/ddoc03\"&inclusive_end=false");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(2, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc02", result.rows[1].key, "end_key and inclusive_end test");
+  
+  // test end_key="_design/ddoc03"&inclusive_end=false&descending=true
+  var xhr = CouchDB.request("GET", path + 
+                            "end_key=\"_design/ddoc03\"&inclusive_end=false&descending=true");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(2, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc04", result.rows[1].key, "end_key, inclusive_end and descending test");
+  
+  // test end_key="_design/ddoc05"&limit=2
+  var xhr = CouchDB.request("GET", path + 
+                            "end_key=\"_design/ddoc05\"&limit=2");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(2, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc02", result.rows[1].key, "end_key and limit test");
+  
+  // test end_key="_design/ddoc05"&skip=2
+  var xhr = CouchDB.request("GET", path + 
+                            "end_key=\"_design/ddoc05\"&skip=2");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(3, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[0].key, "end_key and skip test");
+  TEquals("_design/ddoc05", result.rows[2].key, "end_key and skip test");
+  
+  // test end_key="_design/ddoc05"&update_seq=true
+  var xhr = CouchDB.request("GET", path + 
+                            "end_key=\"_design/ddoc05\"&update_seq=true");
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  T(result.update_seq);
+  
+  // test POST with keys
+  var xhr = CouchDB.request("POST", path, {
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({"keys" : ["_design/ddoc02", "_design/ddoc03"]})
+  });
+  T(xhr.status = 200, "standard get should be 200");
+  var result = JSON.parse(xhr.responseText);
+  TEquals(2, result.rows.length, "amount of rows mismatch");
+  TEquals("_design/ddoc03", result.rows[1].key, "POST test");
+
+  db.deleteDb();
+};


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The aim of this PR is to make `_design_docs` to respect query parameters correctly, like parameters for `_all_docs` endpoint.

http://docs.couchdb.org/en/2.1.1/api/database/bulk-api.html

### base line
```
curl -u foo:bar http://127.0.0.1:15984/dbname/_all_docs
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}},
{"id":"doc1","key":"doc1","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"doc2","key":"doc2","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"doc3","key":"doc3","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"doc4","key":"doc4","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"doc5","key":"doc5","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}}
]}
```

### _design_docs
```
curl -u foo:bar http://127.0.0.1:15984/dbname/_design_docs
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}}
]}
```
### _design_docs?key="_design/ddoc03"
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?key="_design/ddoc03"'
{"total_rows":10,"offset":2,"rows":[
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}}
]}
```

### _design_docs?descending=true
```
 curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?descending=true'
{"total_rows":10,"offset":5,"rows":[
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}}
]}
```

### _design_docs?descending=false
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?descending=false'
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}}
]}
```

### _design_docs?end_key=_design/ddoc03
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?end_key="_design/ddoc03"'
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}}
]}
```

### _design_docs?endkey="_design/ddoc03"
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?endkey="_design/ddoc03"'
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}}
]}
```

### _design_docs?start_key="_design/ddoc03"
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?start_key="_design/ddoc03"'
{"total_rows":10,"offset":2,"rows":[
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}}
]}
```

### _design_docs?startkey="_design/ddoc03"
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?startkey="_design/ddoc03"'
{"total_rows":10,"offset":2,"rows":[
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}}
]}
```

### design_docs?endkey="_design/ddoc03"&inclusive_end=true
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?endkey="_design/ddoc03"&inclusive_end=true'
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}}
]}
```

### _design_docs?endkey="_design/ddoc03"&inclusive_end=false
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?endkey="_design/ddoc03"&inclusive_end=false'
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}}
]}
```

### _design_docs?endkey="_design/ddoc03"&inclusive_end=false&descending=true
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?endkey="_design/ddoc03"&inclusive_end=false&descending=true'
{"total_rows":10,"offset":5,"rows":[
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}}
]}
```

### _design_docs?endkey="_design/ddoc05"&limit=2
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?endkey="_design/ddoc05"&limit=2'
{"total_rows":10,"offset":0,"rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}}
]}
```

### _design_docs?endkey="_design/ddoc05"&skip=2
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?endkey="_design/ddoc05"&skip=2'
{"total_rows":10,"offset":2,"rows":[
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}}
]}
```

### _design_docs?endkey="_design/ddoc05"&update_seq=true
```
curl -u foo:bar 'http://127.0.0.1:15984/dbname/_design_docs?endkey="_design/ddoc05"&update_seq=true'
{"total_rows":10,"offset":0,"update_seq":"10-g1AAAAFDeJzLYWBg4MhgTmHgz8tPSTV2MDQy1zMAQsMcoARTHguQZHgApP4DQVYiIwGVByAq72clMuFUmZQAJJPq0cwzxGreAoh5-wmrbIConI9PZSJDkjzYWiacSpIUQI6zJ-C4JAeQqniIqiwAd45Whg","rows":[
{"id":"_design/ddoc01","key":"_design/ddoc01","value":{"rev":"1-7407569d54af5bc94c266e70cbf8a180"}},
{"id":"_design/ddoc02","key":"_design/ddoc02","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"_design/ddoc03","key":"_design/ddoc03","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}},
{"id":"_design/ddoc04","key":"_design/ddoc04","value":{"rev":"1-32c76b46ca61351c75a84fbcbceece2f"}},
{"id":"_design/ddoc05","key":"_design/ddoc05","value":{"rev":"1-af856babf9cf746b48ae999645f9541e"}}
```

## Testing recommendations



<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make javascript suites=design_docs_query
test/javascript/tests/design_docs_query.js   pass
=======================================================
JavaScript tests complete.
  Failed: 0.  Skipped or passed: 1.
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
issue #1100
document PR https://github.com/apache/couchdb-documentation/pull/242

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
