### PR TITLE
Set update_lru_on_read=false as default

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -32,7 +32,6 @@ default_security = admin_local
 ; btree_chunk_size = 1279
 ; maintenance_mode = false
 ; stem_interactive_updates = true
-; update_lru_on_read = true
 ; uri_file =
 ; The speed of processing the _changes feed with doc_ids filter can be
 ; influenced directly with this setting - increase for faster processing at the
@@ -49,9 +48,13 @@ changes_doc_ids_optimization_threshold = 100
 ; applied conservatively. For example 1.0e+16 could be encoded as 1e16, so 4 used
 ; for size calculation instead of 7.
 ;max_document_size = 4294967296 ; bytes
-
+;
 ; Maximum attachment size.
 ; max_attachment_size = infinity
+;
+; Do not update the least recently used DB cache on reads, only writes
+;update_lru_on_read = false
+;
 ; The default storage engine to use when creating databases
 ; is set as a key into the [couchdb_engines] section.
 default_engine = couch

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -223,7 +223,7 @@ init([]) ->
     MaxDbsOpen = list_to_integer(
             config:get("couchdb", "max_dbs_open", integer_to_list(?MAX_DBS_OPEN))),
     UpdateLruOnRead =
-        config:get("couchdb", "update_lru_on_read", "true") =:= "true",
+        config:get("couchdb", "update_lru_on_read", "false") =:= "true",
     ok = config:listen_for_changes(?MODULE, nil),
     ok = couch_file:init_delete_dir(RootDir),
     hash_admin_passwords(),


### PR DESCRIPTION
See https://github.com/apache/couchdb/issues/796#issuecomment-359060816

From IRC:

```
15:18 <+Wohali> davisp: is update_lru_on_read something that should be in default.ini?
15:18 <+davisp> Mebbe
15:18 <+davisp> We run it by default cause a good number of clusters would get crushed without it
15:19 <+davisp> But its a behavior change so never made default
```

Discussion welcome.