### PR TITLE
Set eunit timeout on a whole test object

### DIFF
--- a/src/couch/test/couch_db_tests.erl
+++ b/src/couch/test/couch_db_tests.erl
@@ -128,15 +128,13 @@ should_delete_multiple_dbs(DbNames) ->
 
 should_create_delete_database_continuously(Times, DbName) ->
     {lists:flatten(io_lib:format("~b times", [Times])),
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         ?assert(create_db(DbName)),
         lists:foreach(fun(_) ->
-            {timeout, ?TIMEOUT, [
-                ?assert(delete_db(DbName)),
-                ?assert(create_db(DbName))
-            ]}
+            ?assert(delete_db(DbName)),
+            ?assert(create_db(DbName))
         end, lists:seq(1, Times))
-    end)}.
+    end)}}.
 
 should_create_db_if_missing(DbName) ->
     ?_test(begin


### PR DESCRIPTION
## Overview

I've accidentally overrode custom 2 mins timeout for `should_create_delete_database_continuously` tests to default 5 sec with`?_test` wrapper.  It went unnoticed in local tests and travis, since in general "should_create_delete_database_continuously (100 times)" passes within 1.096s, but Jenkins prove to be more sensitive.

## Testing recommendations

Standard `make eunit apps=couch` should pass. More importantly Jenkins now should not throw timeout on this test.

## Related Issues or Pull Requests

Fixes: #1122 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
