### PR TITLE
Hide credential information in replication document for reader

### DIFF
--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -695,7 +695,8 @@ strip_credentials(Url) when is_binary(Url) ->
         "http\\1://\\2",
         [{return, binary}]);
 strip_credentials({Props}) ->
-    {lists:keydelete(<<"oauth">>, 1, Props)}.
+    Props1 = lists:keydelete(<<"oauth">>, 1, Props),
+    {lists:keydelete(<<"headers">>, 1, Props1)}.
 
 
 error_reason({shutdown, Error}) ->
@@ -760,5 +761,34 @@ check_convert_options_fail_test() ->
         convert_options([{<<"doc_ids">>, not_a_list}])),
     ?assertThrow({bad_request, _},
         convert_options([{<<"selector">>, [{key, value}]}])).
+
+check_strip_credentials_test() ->
+    [?assertEqual(Expected, strip_credentials(Body)) || {Expected, Body} <- [
+        {
+            undefined,
+            undefined
+        },
+        {
+            <<"https://remote_server/database">>,
+            <<"https://foo:bar@remote_server/database">>
+        },
+        {
+            {[{<<"_id">>, <<"foo">>}]},
+            {[{<<"_id">>, <<"foo">>}, {<<"oauth">>, <<"bar">>}]}
+        },
+        {
+            {[{<<"_id">>, <<"foo">>}]},
+            {[{<<"_id">>, <<"foo">>}, {<<"headers">>, <<"bar">>}]}
+        },
+        {
+            {[{<<"_id">>, <<"foo">>}, {<<"other">>, <<"bar">>}]},
+            {[{<<"_id">>, <<"foo">>}, {<<"other">>, <<"bar">>}]}
+        },
+        {
+            {[{<<"_id">>, <<"foo">>}]},
+            {[{<<"_id">>, <<"foo">>}, {<<"oauth">>, <<"bar">>},
+                {<<"headers">>, <<"baz">>}]}
+        }
+    ]].
 
 -endif.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Replication document is available for user to check replication status. It includes some credential information. Before this PR, the `oauth` field is removed when replication status is displayed to user.  However, for basic authentication, the credential information is also saved in `headers` field and exposed to users. The aim of this PR is to hide credential information even if customer uses basic authentication case.

```

  "source": {
    "headers": {
      "Authorization": *****
    },
    "url": "https://testy011-user1.cloudant.com/testy_db_ctkzwqshsk"
  },
  "target": {
    "headers": {
      "Authorization": *****
    },
    "url": "https://testy011-user1.cloudant.com/test-db-auth"
  },
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

make check skip_deps+=couch_epi apps=couch_replicator
```
module 'couch_replicator_docs'
couch_replicator_docs: check_options_pass_values_test...ok
couch_replicator_docs: check_options_fail_values_test...ok
couch_replicator_docs: check_convert_options_pass_test...ok
couch_replicator_docs: check_convert_options_fail_test...ok
couch_replicator_docs: check_strip_credentials_test...ok
[done in 0.015 s]
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
N/A

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
