### PR TITLE
Fix for issue #603 - Error 500 when creating a db below quorum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ fauxton: share/www
 .PHONY: check
 # target: check - Test everything
 check: all
+	@$(MAKE) test-cluster-with-quorum
+	@$(MAKE) test-cluster-without-quorum
 	@$(MAKE) eunit
 	@$(MAKE) javascript
 	@$(MAKE) mango-test
@@ -129,6 +131,7 @@ endif
             'test/javascript/run --suites "$(suites)" \
             --ignore "$(ignore_js_suites)"'
 
+# TODO: port to Makefile.win
 .PHONY: test-cluster-with-quorum
 test-cluster-with-quorum:
 	@mkdir -p share/www/script/test
@@ -146,6 +149,7 @@ endif
             --ignore "$(ignore_js_suites)" \
 	    --path test/javascript/tests-cluster/with-quorum'
 
+# TODO: port to Makefile.win
 .PHONY: test-cluster-without-quorum
 test-cluster-without-quorum:
 	@mkdir -p share/www/script/test

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,40 @@ endif
             'test/javascript/run --suites "$(suites)" \
             --ignore "$(ignore_js_suites)"'
 
+.PHONY: test-cluster-with-quorum
+test-cluster-with-quorum:
+	@mkdir -p share/www/script/test
+ifeq ($(IN_RELEASE), true)
+	@cp test/javascript/tests/lorem*.txt share/www/script/test/
+else
+	@mkdir -p src/fauxton/dist/release/test
+	@cp test/javascript/tests/lorem*.txt src/fauxton/dist/release/test/
+endif
+	@rm -rf dev/lib
+	@dev/run -n 3 -q --with-admin-party-please \
+            --enable-erlang-views --degrade-cluster 1 \
+            -c 'startup_jitter=0' \
+            'test/javascript/run --suites "$(suites)" \
+            --ignore "$(ignore_js_suites)" \
+	    --path test/javascript/tests-cluster/with-quorum'
+
+.PHONY: test-cluster-without-quorum
+test-cluster-without-quorum:
+	@mkdir -p share/www/script/test
+ifeq ($(IN_RELEASE), true)
+	@cp test/javascript/tests/lorem*.txt share/www/script/test/
+else
+	@mkdir -p src/fauxton/dist/release/test
+	@cp test/javascript/tests/lorem*.txt src/fauxton/dist/release/test/
+endif
+	@rm -rf dev/lib
+	@dev/run -n 3 -q --with-admin-party-please \
+            --enable-erlang-views --degrade-cluster 2 \
+            -c 'startup_jitter=0' \
+            'test/javascript/run --suites "$(suites)" \
+            --ignore "$(ignore_js_suites)" \
+            --path test/javascript/tests-cluster/without-quorum'
+
 .PHONY: soak-javascript
 soak-javascript:
 	@mkdir -p share/www/script/test

--- a/dev/run
+++ b/dev/run
@@ -130,6 +130,8 @@ def setup_argparse():
                       help='The node number to seed them when creating the node(s)')
     parser.add_option('-c', '--config-overrides', action="append", default=[],
                       help='Optional key=val config overrides. Can be repeated')
+    parser.add_option('--degrade-cluster', dest="degrade_cluster",type=int, default=0,
+                      help='The number of nodes that should be stopped after cluster config')
     return parser.parse_args()
 
 
@@ -142,6 +144,7 @@ def setup_context(opts, args):
             'admin': opts.admin.split(':', 1) if opts.admin else None,
             'nodes': ['node%d' % (i + opts.node_number) for i in range(opts.nodes)],
             'node_number': opts.node_number,
+            'degrade_cluster': opts.degrade_cluster,
             'devdir': os.path.dirname(fpath),
             'rootdir': os.path.dirname(os.path.dirname(fpath)),
             'cmd': ' '.join(args),
@@ -337,18 +340,35 @@ def startup(ctx):
         cluster_setup_with_admin_party(ctx)
     else:
         cluster_setup(ctx)
-
+    if ctx['degrade_cluster'] > 0:
+        degrade_cluster(ctx)
 
 def kill_processes(ctx):
     for proc in ctx['procs']:
         if proc and proc.returncode is None:
             proc.kill()
 
+def degrade_cluster(ctx):
+    if ctx['with_haproxy']:
+        haproxy_proc = ctx['procs'].pop()
+    for i in range(0,ctx['degrade_cluster']):
+        proc = ctx['procs'].pop()
+        if proc is not None:
+            kill_process(proc)
+    if ctx['with_haproxy']:
+         ctx['procs'].append(haproxy_proc)
+
+@log('Stoping proc {proc.pid}')
+def kill_process(proc):
+    if proc and proc.returncode is None:
+        proc.kill()
 
 def boot_nodes(ctx):
     for node in ctx['nodes']:
         ctx['procs'].append(boot_node(ctx, node))
-    ctx['procs'].append(boot_haproxy(ctx))
+    haproxy_proc = boot_haproxy(ctx)
+    if haproxy_proc is not None:
+        ctx['procs'].append(haproxy_proc)
 
 
 def ensure_all_nodes_alive(ctx):

--- a/src/fabric/src/fabric_db_create.erl
+++ b/src/fabric/src/fabric_db_create.erl
@@ -146,9 +146,9 @@ maybe_stop(W, Counters) ->
         {ok, {W, Counters}};
     false ->
         case lists:sum([1 || {_, ok} <- Counters]) of
-        W ->
+        NumOk when NumOk >= (W div 2 +1) ->
             {stop, ok};
-        NumOk when NumOk >= (W div 2 + 1) ->
+        NumOk when NumOk > 0 ->
             {stop, accepted};
         _ ->
             {error, internal_server_error}

--- a/test/javascript/run
+++ b/test/javascript/run
@@ -107,7 +107,10 @@ def options():
                        dest="ignore", help="Ignore test suites"),
         op.make_option("-u", "--suites", type="string", action="callback",
                        default=None, callback=get_delimited_list,
-                       dest="suites", help="Run specific suites")
+                       dest="suites", help="Run specific suites"),
+        op.make_option("-p", "--path", type="string",
+                       default="test/javascript/tests",
+                       dest="test_path", help="Path where the tests are located")
     ]
 
 
@@ -118,10 +121,9 @@ def main():
     run_list = []
     ignore_list = []
     tests = []
-
-    run_list = ["test/javascript/tests"] if not opts.suites else opts.suites
-    run_list = build_test_case_paths(run_list)
-    ignore_list = build_test_case_paths(opts.ignore)
+    run_list = [opts.test_path] if not opts.suites else opts.suites
+    run_list = build_test_case_paths(opts.test_path,run_list)
+    ignore_list = build_test_case_paths(opts.test_path,opts.ignore)
     # sort is needed because certain tests fail if executed out of order
     tests = sorted(list(set(run_list)-set(ignore_list)))
 
@@ -151,7 +153,7 @@ def main():
         failed, passed) + os.linesep)
     exit(failed > 0)
 
-def build_test_case_paths(args=None):
+def build_test_case_paths(path,args=None):
     tests = []
     if args is None:
         args = []
@@ -161,7 +163,7 @@ def build_test_case_paths(args=None):
         elif os.path.isfile(name):
             check = tests.append(name)
         else:
-            pname = os.path.join("test/javascript/tests", name)
+            pname = os.path.join(path, name)
             if os.path.isfile(pname):
                 tests.append(pname)
             elif os.path.isfile(pname + ".js"):

--- a/test/javascript/tests-cluster/with-quorum/db-creation.js
+++ b/test/javascript/tests-cluster/with-quorum/db-creation.js
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// Do DB creation under cluster with quorum conditions.
+couchTests.db_creation = function(debug) {
+
+  if (debug) debugger;
+
+  var db_name = get_random_db_name()
+  var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
+
+  // DB Creation should return 201 - Created
+  xhr = CouchDB.request("PUT", "/" + db_name + "/");
+  T(xhr.status == 201);
+
+  // cleanup
+  db.deleteDb();
+};

--- a/test/javascript/tests-cluster/without-quorum/db-creation.js
+++ b/test/javascript/tests-cluster/without-quorum/db-creation.js
@@ -1,0 +1,28 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// Do DB creation under cluster without quorum conditions.
+couchTests.db_creation = function(debug) {
+
+  if (debug) debugger;
+
+  var db_name = get_random_db_name()
+  var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
+
+  // DB Creation should return 202- Accepted
+  xhr = CouchDB.request("PUT", "/" + db_name + "/");
+  T(xhr.status == 202);
+
+  // cleanup
+  // TODO DB deletions fails if the quorum is not met.
+  xhr = CouchDB.request("DELETE", "/" + db_name + "/");
+};


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Current behaviour of DB creation in a cluster degraded situation is not consistent with the general behaviour described for document creation in the same situation.

> The number of copies of a document with the same revision that have to be read before CouchDB returns with a 200 is equal to a half of total copies of the document plus one. It is the same for the number of nodes that need to save a document before a write is returned with 201. If there are less nodes than that number, then 202 is returned. Both read and write numbers can be specified with a request as r and w parameters accordingly.

The current behaviour for database creation in a cluster is:
 - Database creation returns 201 - Created if all nodes responds ok
 - Database creation returns 202 - Accepted if the quorum is met
 - Database creation returns 500 - Error if the responses are bellow quorum

The quorum is the default: Number of nodes/2 +1

This PR changes the database creation result with the following behaviour:
- Database creation returns 201 - Creation if the quorum is met
- Database creation returns 202 - Accepted if at least one node responds ok
- Database creation returns 500 - Error if there is no correct response from any node

## Testing recommendations

- All previous tests are ok
- I've focused on chttpd and javascript tests 
- I've skiped reduce_builtin.js test as it is failing even in master branch
`test/javascript/tests/reduce_builtin.js                        
    Error: {gen_server,call,[<0.2426.1>,{get_state,49},infinity]}`

`make check apps=chttpd ignore_js_suites=reduce_builtin`

I didn't identify testing infrastructure for testing cluster degradation issues. So I decided to add some support for testing in different cluster conditions. Now make has two more task:
- test-cluster-with-quorum, which launch a three node cluster and stops one node then executes the tests
- test-cluster-without-quorum which launch a three node cluster and stops two nodes then executes the tests

This PR can be tested in this way
```
 make test-cluster-with-quorum
 make test-cluster-without-quorum
```

## Related Issues or Pull Requests
Issue #603 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests; (DB creation yes, Cluster degradation no)
- [ ] Documentation reflects the changes;
