### PR TITLE
Remove 'smartquote' from default.ini, broke the build

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -92,7 +92,7 @@ delete_dbs = false
 ; cluster / q
 ;q = 1
 ; prefix for user databases. If you change this after user dbs have been
-; created, the existing databases won’t get deleted if the associated user
+; created, the existing databases won't get deleted if the associated user
 ; gets deleted because of the then prefix mismatch.
 database_prefix = userdb-
 


### PR DESCRIPTION
Fixes bug introduced by d16f2db901c9b3b24c7189acfec35ec42895bd25.