### PR TITLE
Remove _config call in couch_peruser_test

### DIFF
--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -42,7 +42,6 @@ setup() ->
     set_config("couch_peruser", "cluster_start_period", "1"),
     set_config("couch_peruser", "enable", "true"),
     set_config("cluster", "n", "1"),
-    timer:sleep(1000),
     TestAuthDb.
 
 teardown(TestAuthDb) ->
@@ -62,9 +61,7 @@ teardown(TestAuthDb) ->
     end, all_dbs()).
 
 set_config(Section, Key, Value) ->
-    Url = lists:concat([
-        get_base_url(), "/_config/", Section, "/", Key]),
-    do_request(put, Url, "\"" ++ Value ++ "\"").
+    ok = config:set(Section, Key, Value, _Persist=false).
 
 delete_config(Section, Key, Value) ->
     Url = lists:concat([


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Replaced the `/_config` endpoint call using `config:set()` in the `set_config()` call to be more sure about configuration changes.

https://github.com/apache/couchdb/pull/1068#pullrequestreview-89269772
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

make check skip_deps+=couch_epi apps=couch_peruser
```
======================== EUnit ========================
module 'couch_peruser_app'
module 'couch_peruser_sup'
module 'couch_peruser_test'
  couch_peruser test
Application crypto was left running!
    couch_peruser_test:162: should_create_anon_user_db_with_default...[0.002 s] ok
    couch_peruser_test:163: should_create_anon_user_db_with_default...ok
    couch_peruser_test:152: should_create_user_db_with_default...[0.002 s] ok
    couch_peruser_test:153: should_create_user_db_with_default...ok
    couch_peruser_test:175: should_create_user_db_with_q4...[0.002 s] ok
    couch_peruser_test:176: should_create_user_db_with_q4...ok
    couch_peruser_test:187: should_create_anon_user_db_with_q4...[0.002 s] ok
    couch_peruser_test:188: should_create_anon_user_db_with_q4...ok
    couch_peruser_test:200: should_not_delete_user_db...ok
    couch_peruser_test:200: should_not_delete_user_db...ok
    couch_peruser_test:212: should_delete_user_db...ok
    couch_peruser_test:212: should_delete_user_db...ok
    couch_peruser_test:243: should_reflect_config_changes...ok
    couch_peruser_test:244: should_reflect_config_changes...ok
    couch_peruser_test:245: should_reflect_config_changes...ok
    couch_peruser_test:246: should_reflect_config_changes...ok
    couch_peruser_test:247: should_reflect_config_changes...ok
    couch_peruser_test:248: should_reflect_config_changes...ok
    couch_peruser_test:257: should_add_user_to_db_admins...[0.001 s] ok
    couch_peruser_test:266: should_add_user_to_db_members...[0.001 s] ok
    couch_peruser_test:285: should_not_remove_existing_db_admins...ok
    couch_peruser_test:286: should_not_remove_existing_db_admins...ok
    couch_peruser_test:287: should_not_remove_existing_db_admins...ok
    couch_peruser_test:305: should_not_remove_existing_db_members...ok
    couch_peruser_test:306: should_not_remove_existing_db_members...ok
    couch_peruser_test:307: should_not_remove_existing_db_members...ok
    couch_peruser_test:336: should_remove_user_from_db_admins...ok
    couch_peruser_test:337: should_remove_user_from_db_admins...ok
    couch_peruser_test:338: should_remove_user_from_db_admins...ok
    couch_peruser_test:339: should_remove_user_from_db_admins...ok
    couch_peruser_test:340: should_remove_user_from_db_admins...ok
    couch_peruser_test:341: should_remove_user_from_db_admins...ok
    couch_peruser_test:370: should_remove_user_from_db_members...ok
    couch_peruser_test:371: should_remove_user_from_db_members...ok
    couch_peruser_test:372: should_remove_user_from_db_members...ok
    couch_peruser_test:373: should_remove_user_from_db_members...ok
    couch_peruser_test:374: should_remove_user_from_db_members...ok
    couch_peruser_test:375: should_remove_user_from_db_members...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 41.180 s]
  [done in 42.834 s]
module 'couch_peruser'
=======================================================
  All 38 tests passed.
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
issue #876
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
