### PR TITLE
Remove queries for _all_docs,  _design_docs and _local_docs

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -520,18 +520,14 @@ db_req(#httpd{method='GET',path_parts=[_,OP]}=Req, Db) when ?IS_ALL_DOCS(OP) ->
 
 db_req(#httpd{method='POST',path_parts=[_,OP]}=Req, Db) when ?IS_ALL_DOCS(OP) ->
     chttpd:validate_ctype(Req, "application/json"),
-    Props = chttpd:json_body_obj(Req),
-    Keys = couch_mrview_util:get_view_keys(Props),
-    Queries = couch_mrview_util:get_view_queries(Props),
-    case {Queries, Keys} of
-        {Queries, undefined} when is_list(Queries) ->
-            multi_all_docs_view(Req, Db, OP, Queries);
-        {undefined, Keys} when is_list(Keys) ->
-            all_docs_view(Req, Db, Keys, OP);
-        {undefined, undefined} ->
-            all_docs_view(Req, Db, undefined, OP);
-        {_, _} ->
-            throw({bad_request, "`keys` and `queries` are mutually exclusive"})
+    {Fields} = chttpd:json_body_obj(Req),
+    case couch_util:get_value(<<"keys">>, Fields, nil) of
+    Keys when is_list(Keys) ->
+        all_docs_view(Req, Db, Keys, OP);
+    nil ->
+        all_docs_view(Req, Db, undefined, OP);
+    _ ->
+        throw({bad_request, "`keys` body member must be an array."})
     end;
 
 db_req(#httpd{path_parts=[_,OP]}=Req, _Db) when ?IS_ALL_DOCS(OP) ->
@@ -639,28 +635,6 @@ db_req(#httpd{path_parts=[_, DocId]}=Req, Db) ->
 
 db_req(#httpd{path_parts=[_, DocId | FileNameParts]}=Req, Db) ->
     db_attachment_req(Req, Db, DocId, FileNameParts).
-
-multi_all_docs_view(Req, Db, OP, Queries) ->
-    Args0 = couch_mrview_http:parse_params(Req, undefined),
-    Args1 = Args0#mrargs{view_type=map},
-    ArgQueries = lists:map(fun({Query}) ->
-        QueryArg1 = couch_mrview_http:parse_params(Query, undefined,
-            Args1, [decoded]),
-        QueryArgs2 = couch_mrview_util:validate_args(QueryArg1),
-        set_namespace(OP, QueryArgs2)
-    end, Queries),
-    Options = [{user_ctx, Req#httpd.user_ctx}],
-    VAcc0 = #vacc{db=Db, req=Req, prepend="\r\n"},
-    FirstChunk = "{\"results\":[",
-    {ok, Resp0} = chttpd:start_delayed_json_response(VAcc0#vacc.req, 200, [], FirstChunk),
-    VAcc1 = VAcc0#vacc{resp=Resp0},
-    VAcc2 = lists:foldl(fun(Args, Acc0) ->
-        {ok, Acc1} = fabric:all_docs(Db, Options,
-            fun couch_mrview_http:view_cb/2, Acc0, Args),
-        Acc1
-    end, VAcc1, ArgQueries),
-    {ok, Resp1} = chttpd:send_delayed_chunk(VAcc2#vacc.resp, "\r\n]}"),
-    chttpd:end_delayed_json_response(Resp1).
 
 all_docs_view(Req, Db, Keys, OP) ->
     Args0 = couch_mrview_http:parse_params(Req, Keys),

--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -70,11 +70,6 @@ all_test_() ->
                     fun should_return_409_for_put_att_nonexistent_rev/1,
                     fun should_return_update_seq_when_set_on_all_docs/1,
                     fun should_not_return_update_seq_when_unset_on_all_docs/1,
-                    fun should_succeed_on_all_docs_with_queries_keys/1,
-                    fun should_succeed_on_all_docs_with_queries_limit_skip/1,
-                    fun should_succeed_on_all_docs_with_multiple_queries/1,
-                    fun should_succeed_on_design_docs_with_multiple_queries/1,
-                    fun should_fail_on_multiple_queries_with_keys_and_queries/1,
                     fun should_return_correct_id_on_doc_copy/1
                 ]
             }
@@ -225,86 +220,6 @@ should_not_return_update_seq_when_unset_on_all_docs(Url) ->
             couch_util:get_value(<<"update_seq">>, ResultJson)),
         ?assertNotEqual(undefined,
             couch_util:get_value(<<"offset">>, ResultJson))
-    end).
-
-
-should_succeed_on_all_docs_with_queries_keys(Url) ->
-    ?_test(begin
-        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]}]}",
-        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
-            [?CONTENT_JSON, ?AUTH], QueryDoc),
-        ?assertEqual(200, RC),
-        {ResultJson} = ?JSON_DECODE(RespBody),
-        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
-        {InnerJson} = lists:nth(1, ResultJsonBody),
-        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
-
-
-should_succeed_on_all_docs_with_queries_limit_skip(Url) ->
-    ?_test(begin
-        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-        QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
-        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
-            [?CONTENT_JSON, ?AUTH], QueryDoc),
-        ?assertEqual(200, RC),
-        {ResultJson} = ?JSON_DECODE(RespBody),
-        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
-        {InnerJson} = lists:nth(1, ResultJsonBody),
-        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
-        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
-
-
-should_succeed_on_all_docs_with_multiple_queries(Url) ->
-    ?_test(begin
-        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]},
-            {\"limit\": 5, \"skip\": 2}]}",
-        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
-            [?CONTENT_JSON, ?AUTH], QueryDoc),
-        ?assertEqual(200, RC),
-        {ResultJson} = ?JSON_DECODE(RespBody),
-        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
-        {InnerJson1} = lists:nth(1, ResultJsonBody),
-        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
-        {InnerJson2} = lists:nth(2, ResultJsonBody),
-        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
-        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
-    end).
-
-
-should_succeed_on_design_docs_with_multiple_queries(Url) ->
-    ?_test(begin
-        [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-        QueryDoc = "{\"queries\": [{\"keys\": [ \"_design/ddoc3\",
-            \"_design/ddoc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
-        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_design_docs/",
-            [?CONTENT_JSON, ?AUTH], QueryDoc),
-        ?assertEqual(200, RC),
-        {ResultJson} = ?JSON_DECODE(RespBody),
-        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
-        {InnerJson1} = lists:nth(1, ResultJsonBody),
-        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
-        {InnerJson2} = lists:nth(2, ResultJsonBody),
-        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
-        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
-    end).
-
-
-should_fail_on_multiple_queries_with_keys_and_queries(Url) ->
-    ?_test(begin
-        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]}],
-            \"keys\": [ \"testdoc4\", \"testdoc9\"]}",
-        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/",
-            [?CONTENT_JSON, ?AUTH], QueryDoc),
-        ?assertEqual(400, RC),
-        ?assertMatch({[
-            {<<"error">>,<<"bad_request">>},
-            {<<"reason">>,<<"`keys` and `queries` are mutually exclusive">>}]},
-            ?JSON_DECODE(RespBody))
     end).
 
 

--- a/test/javascript/tests/basics.js
+++ b/test/javascript/tests/basics.js
@@ -268,7 +268,7 @@ couchTests.basics = function(debug) {
   T(xhr.status == 400);
   result = JSON.parse(xhr.responseText);
   T(result.error == "bad_request");
-  T(result.reason == "`keys` member must be an array.");
+  T(result.reason == "`keys` body member must be an array.");
 
   // oops, the doc id got lost in code nirwana
   xhr = CouchDB.request("DELETE", "/" + db_name + "/?rev=foobarbaz");


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
In the https://github.com/apache/couchdb/pull/1032, queries are supported to `_all_docs`, `_design_docs` and `_local_docs` to address the requirement in https://github.com/apache/couchdb/issues/820.
However, the response schema changes depending on what is POSTed. This makes it quite hard to interact with from static type languages. So we plan to move the implementation to separate endpoint. As the first step, this PR is used to remove queries for _all_docs,  _design_docs and _local_docs.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=chttpd tests=all_test_
```
==> chttpd (eunit)
Compiled test/chttpd_db_test.erl
Compiled src/chttpd_db.erl
    Running test function(s):
      chttpd_db_doc_size_tests:all_test_/0
      chttpd_db_test:all_test_/0
      chttpd_security_tests:all_test_/0
======================== EUnit ========================
chttpd security tests
Application crypto was left running!
  chttpd_security_tests:120: should_allow_admin_db_compaction...[0.003 s] ok
  chttpd_security_tests:137: should_allow_valid_password_to_create_user...ok
  chttpd_security_tests:147: should_disallow_invalid_password_to_create_user...ok
  chttpd_security_tests:155: should_disallow_anonymous_db_compaction...ok
  chttpd_security_tests:163: should_disallow_db_member_db_compaction...ok
  chttpd_security_tests:166: should_allow_db_admin_db_compaction...[0.002 s] ok
  chttpd_security_tests:176: should_allow_admin_view_compaction...[0.009 s] ok
  chttpd_security_tests:191: should_disallow_anonymous_view_compaction...ok
  chttpd_security_tests:194: should_allow_admin_db_view_cleanup...[0.002 s] ok
  chttpd_security_tests:209: should_disallow_anonymous_db_view_cleanup...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 5.346 s]
chttpd db tests
  chttpd_db_test:81: should_return_ok_true_on_bulk_update...[0.048 s] ok
  chttpd_db_test:108: should_accept_live_as_an_alias_for_continuous...[0.034 s] ok
  chttpd_db_test:123: should_return_404_for_delete_att_on_notadoc...[0.005 s] ok
  chttpd_db_test:145: should_return_409_for_del_att_without_rev...[0.040 s] ok
  chttpd_db_test:163: should_return_200_for_del_att_with_rev...[0.061 s] ok
  chttpd_db_test:184: should_return_409_for_put_att_nonexistent_rev...[0.010 s] ok
  chttpd_db_test:199: should_return_update_seq_when_set_on_all_docs...[0.134 s] ok
  chttpd_db_test:213: should_not_return_update_seq_when_unset_on_all_docs...[0.077 s] ok
  chttpd_db_test:227: should_return_correct_id_on_doc_copy...[0.086 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 2.029 s]
chttpd db max_document_size tests
  chttpd_db_doc_size_tests:84: post_single_doc...ok
  chttpd_db_doc_size_tests:92: put_single_doc...ok
  chttpd_db_doc_size_tests:101: bulk_doc...ok
  chttpd_db_doc_size_tests:127: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:128: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:129: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:130: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:152: put_multi_part_related...ok
  chttpd_db_doc_size_tests:153: put_multi_part_related...ok
  chttpd_db_doc_size_tests:177: post_multi_part_form...ok
  chttpd_db_doc_size_tests:178: post_multi_part_form...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 1.162 s]
=======================================================
  All 30 tests passed.
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/issues/820
https://github.com/apache/couchdb/pull/1032

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
