### PR TITLE
Add _all_docs_view_query endpoint

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -533,6 +533,18 @@ db_req(#httpd{method='POST',path_parts=[_,OP]}=Req, Db) when ?IS_ALL_DOCS(OP) ->
 db_req(#httpd{path_parts=[_,OP]}=Req, _Db) when ?IS_ALL_DOCS(OP) ->
     send_method_not_allowed(Req, "GET,HEAD,POST");
 
+db_req(#httpd{method='POST', path_parts=[_, <<"_all_docs_view_query">>]}=Req, Db) ->
+    Props = chttpd:json_body_obj(Req),
+    case couch_mrview_util:get_view_queries(Props) of
+        Queries when Queries =/= undefined ->
+            multi_all_docs_view(Req, Db, <<"_all_docs">>, Queries);
+        undefined ->
+            throw({bad_request, <<"POST body must include `queries` parameter.">>})
+    end;
+
+db_req(#httpd{path_parts=[_, <<"_all_docs_view_quiery">>]}=Req, _Db) ->
+    send_method_not_allowed(Req, "POST");
+
 db_req(#httpd{method='POST',path_parts=[_,<<"_missing_revs">>]}=Req, Db) ->
     chttpd:validate_ctype(Req, "application/json"),
     {JsonDocIdRevs} = chttpd:json_body_obj(Req),
@@ -635,6 +647,28 @@ db_req(#httpd{path_parts=[_, DocId]}=Req, Db) ->
 
 db_req(#httpd{path_parts=[_, DocId | FileNameParts]}=Req, Db) ->
     db_attachment_req(Req, Db, DocId, FileNameParts).
+
+multi_all_docs_view(Req, Db, OP, Queries) ->
+    Args0 = couch_mrview_http:parse_params(Req, undefined),
+    Args1 = Args0#mrargs{view_type=map},
+    ArgQueries = lists:map(fun({Query}) ->
+        QueryArg1 = couch_mrview_http:parse_params(Query, undefined,
+            Args1, [decoded]),
+        QueryArgs2 = couch_mrview_util:validate_args(QueryArg1),
+        set_namespace(OP, QueryArgs2)
+    end, Queries),
+    Options = [{user_ctx, Req#httpd.user_ctx}],
+    VAcc0 = #vacc{db=Db, req=Req, prepend="\r\n"},
+    FirstChunk = "{\"results\":[",
+    {ok, Resp0} = chttpd:start_delayed_json_response(VAcc0#vacc.req, 200, [], FirstChunk),
+    VAcc1 = VAcc0#vacc{resp=Resp0},
+    VAcc2 = lists:foldl(fun(Args, Acc0) ->
+        {ok, Acc1} = fabric:all_docs(Db, Options,
+            fun couch_mrview_http:view_cb/2, Acc0, Args),
+        Acc1
+    end, VAcc1, ArgQueries),
+    {ok, Resp1} = chttpd:send_delayed_chunk(VAcc2#vacc.resp, "\r\n]}"),
+    chttpd:end_delayed_json_response(Resp1).
 
 all_docs_view(Req, Db, Keys, OP) ->
     Args0 = couch_mrview_http:parse_params(Req, Keys),

--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -70,6 +70,9 @@ all_test_() ->
                     fun should_return_409_for_put_att_nonexistent_rev/1,
                     fun should_return_update_seq_when_set_on_all_docs/1,
                     fun should_not_return_update_seq_when_unset_on_all_docs/1,
+                    fun should_succeed_on_all_docs_with_queries_keys/1,
+                    fun should_succeed_on_all_docs_with_queries_limit_skip/1,
+                    fun should_succeed_on_all_docs_with_multiple_queries/1,
                     fun should_return_correct_id_on_doc_copy/1
                 ]
             }
@@ -220,6 +223,52 @@ should_not_return_update_seq_when_unset_on_all_docs(Url) ->
             couch_util:get_value(<<"update_seq">>, ResultJson)),
         ?assertNotEqual(undefined,
             couch_util:get_value(<<"offset">>, ResultJson))
+    end).
+
+should_succeed_on_all_docs_with_queries_keys(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs_view_query/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_all_docs_with_queries_limit_skip(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs_view_query/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_all_docs_with_multiple_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]},
+            {\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs_view_query/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson1} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
+        {InnerJson2} = lists:nth(2, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
     end).
 
 


### PR DESCRIPTION
## Overview

Add new feature for executing specified built-in view queries of all
documents in the database. This enables user to request multiple queries
in a single request, in place of multiple `POST /{db}/_all_docs` requests.

Rationale for new endpoint rather than modifying _all_docs:

    New endpoint is added to make sure we are not mutating response
    depending on the object we receive in POST

Notes:
 * The implementation is taken from previously merged https://github.com/apache/couchdb/pull/1032 almost literally. 

## Testing recommendations

make check skip_deps+=couch_epi apps=chttpd tests=all_test_
```
==> chttpd (eunit)
    Running test function(s):
      chttpd_db_doc_size_tests:all_test_/0
      chttpd_db_test:all_test_/0
      chttpd_security_tests:all_test_/0
======================== EUnit ========================
chttpd security tests
Application crypto was left running!
  chttpd_security_tests:120: should_allow_admin_db_compaction...[0.002 s] ok
  chttpd_security_tests:137: should_allow_valid_password_to_create_user...ok
  chttpd_security_tests:147: should_disallow_invalid_password_to_create_user...ok
  chttpd_security_tests:155: should_disallow_anonymous_db_compaction...ok
  chttpd_security_tests:163: should_disallow_db_member_db_compaction...ok
  chttpd_security_tests:166: should_allow_db_admin_db_compaction...[0.002 s] ok
  chttpd_security_tests:176: should_allow_admin_view_compaction...[0.008 s] ok
  chttpd_security_tests:191: should_disallow_anonymous_view_compaction...ok
  chttpd_security_tests:194: should_allow_admin_db_view_cleanup...[0.001 s] ok
  chttpd_security_tests:209: should_disallow_anonymous_db_view_cleanup...ok
  [done in 2.701 s]
chttpd db tests
  chttpd_db_test:84: should_return_ok_true_on_bulk_update...[0.022 s] ok
  chttpd_db_test:111: should_accept_live_as_an_alias_for_continuous...[0.036 s] ok
  chttpd_db_test:126: should_return_404_for_delete_att_on_notadoc...[0.004 s] ok
  chttpd_db_test:148: should_return_409_for_del_att_without_rev...[0.026 s] ok
  chttpd_db_test:166: should_return_200_for_del_att_with_rev...[0.034 s] ok
  chttpd_db_test:187: should_return_409_for_put_att_nonexistent_rev...[0.011 s] ok
  chttpd_db_test:202: should_return_update_seq_when_set_on_all_docs...[0.054 s] ok
  chttpd_db_test:216: should_not_return_update_seq_when_unset_on_all_docs...[0.036 s] ok
  chttpd_db_test:229: should_succeed_on_all_docs_with_queries_keys...[0.132 s] ok
  chttpd_db_test:243: should_succeed_on_all_docs_with_queries_limit_skip...[0.116 s] ok
  chttpd_db_test:258: should_succeed_on_all_docs_with_multiple_queries...[0.116 s] ok
  chttpd_db_test:276: should_return_correct_id_on_doc_copy...[0.047 s] ok
  [done in 1.539 s]
chttpd db max_document_size tests
  chttpd_db_doc_size_tests:84: post_single_doc...ok
  chttpd_db_doc_size_tests:92: put_single_doc...ok
  chttpd_db_doc_size_tests:101: bulk_doc...ok
  chttpd_db_doc_size_tests:127: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:128: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:129: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:130: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:152: put_multi_part_related...ok
  chttpd_db_doc_size_tests:153: put_multi_part_related...ok
  chttpd_db_doc_size_tests:177: post_multi_part_form...ok
  chttpd_db_doc_size_tests:178: post_multi_part_form...ok
  [done in 0.546 s]
=======================================================
  All 33 tests passed.
```
## Related Issues or Pull Requests

* https://github.com/apache/couchdb/issues/820
* This replaces the previous implementation of the feature https://github.com/apache/couchdb/pull/1032 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
