### PR TITLE
Fix: Various small fixes

### DIFF
--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -23,6 +23,9 @@
 -define(JSON_ENCODE(V), couch_util:json_encode(V)).
 -define(JSON_DECODE(V), couch_util:json_decode(V)).
 
+-define(LOG_INFO(V), couch_log:info("~p ~p/~p Line Number: ~p ------- ~p",
+                     [?FILE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE, V])).
+
 -define(IS_OLD_RECORD(V, R), (tuple_size(V) /= tuple_size(R))).
 
 -define(b2l(V), binary_to_list(V)).

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -23,9 +23,6 @@
 -define(JSON_ENCODE(V), couch_util:json_encode(V)).
 -define(JSON_DECODE(V), couch_util:json_decode(V)).
 
--define(LOG_INFO(V), couch_log:info("~p ~p/~p Line Number: ~p ------- ~p",
-                     [?FILE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE, V])).
-
 -define(IS_OLD_RECORD(V, R), (tuple_size(V) /= tuple_size(R))).
 
 -define(b2l(V), binary_to_list(V)).

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -213,8 +213,12 @@ truncate(Fd, Pos) ->
 %%----------------------------------------------------------------------
 
 sync(Filepath) when is_list(Filepath) ->
-    {ok, Fd} = file:open(Filepath, [append, raw]),
-    try ok = file:sync(Fd) after ok = file:close(Fd) end;
+    case file:open(Filepath, [append, raw]) of
+      {ok, Fd} ->
+        try ok = file:sync(Fd) after ok = file:close(Fd) end;
+      {error, Reason} ->
+        throw({error, Reason})
+     end;
 sync(Fd) ->
     gen_server:call(Fd, sync, infinity).
 

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -388,8 +388,8 @@ init({Filepath, Options, ReturnPid, Ref}) ->
                 erlang:send_after(?INITIAL_WAIT, self(), maybe_close),
                 {ok, #file{fd=Fd, is_sys=IsSys, pread_limit=Limit}}
             end;
-        Error ->
-            init_status_error(ReturnPid, Ref, Error)
+        {error, Reason} ->
+            init_status_error(ReturnPid, Ref, {error, Reason})
         end;
     false ->
         % open in read mode first, so we don't create the file if it doesn't exist.
@@ -403,8 +403,8 @@ init({Filepath, Options, ReturnPid, Ref}) ->
             {ok, Eof} = file:position(Fd, eof),
             erlang:send_after(?INITIAL_WAIT, self(), maybe_close),
             {ok, #file{fd=Fd, eof=Eof, is_sys=IsSys, pread_limit=Limit}};
-        Error ->
-            init_status_error(ReturnPid, Ref, Error)
+        {error, Reason} ->
+            init_status_error(ReturnPid, Ref, {error, Reason})
         end
     end.
 

--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -324,7 +324,7 @@ validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
         couch_stats:increment_counter([couchdb, query_server, vdu_rejects], 1)
     end,
     case Resp of
-        1 ->
+        RespCode when is_atom(RespCode); is_number(RespCode) ->
             ok;
         {[{<<"forbidden">>, Message}]} ->
             throw({forbidden, Message});

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -800,7 +800,8 @@ reduced_external_size(Tree) ->
     case couch_btree:full_reduce(Tree) of
         {ok, {_, _, Size}} -> Size;
         % return 0 for versions of the reduce function without Size
-        {ok, {_, _}} -> 0
+        {ok, {_, _}} -> 0;
+        _ -> 0
     end.
 
 


### PR DESCRIPTION
## Overview

This PR contains small fixes for some minor flaws in CouchDB which affected me during the development of the new functionality.

1. Proper error handling of `file:open/2` calls in `couch_file.erl`. According to Erlang [file module docs](http://erlang.org/doc/man/file.html#open-2) `open` returns `{error, Reason}`  in case of failure but in the `couch_file:sync` and `init` functions there are no such checks. Consequently when I received `{error, emfile}` kind of error, process crashed with `badmatch` instead of proper error. 
2. When you implement `validate_doc_update` as an Erlang function it doesn't work because of a missing case clause, namely: when `couch_query_servers:try_compile()` calls `proc_prompt_raw()` which in turn calls `erlang:apply()` for a native function the return value of it is an atom `ok` or `true` but in case of JS function we have response code `1`. I added a more general check in the `validate_doc_update` and now it works for Erlang functions as well. This was crucial in our case because JS functions are much slower and in our production system we are going to use validation functions implemented in Erlang.
3. When we tested CouchDB 2.1 with our production DB which contains gazillion of different document `couch_mrview_util:reduced_external_size()` crashed with `badmatch` randomly because of some broken docs in our DB. This is because `full_reduce` returned response in the format `{_, _}` and not `{ok, {_, _}}` as was expected there. After this crash CouchDB was broken completely for me. In order to fix this I added an additional "match-anything" `case` clause, because even if we had something really broken in our DB, CouchDB still should handle this more gracefully I believe. 

## Testing recommendations

These fixes were tested and they resolved all the problems i reported.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
