### PR TITLE
Fix: Proper error handling for file:open() call in couch_file.erl

### DIFF
--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -214,11 +214,11 @@ truncate(Fd, Pos) ->
 
 sync(Filepath) when is_list(Filepath) ->
     case file:open(Filepath, [append, raw]) of
-      {ok, Fd} ->
-         try ok = file:sync(Fd) after ok = file:close(Fd) end;
-      Error ->
-         throw(Error)
-      end;
+        {ok, Fd} ->
+            try ok = file:sync(Fd) after ok = file:close(Fd) end;
+        Error ->
+            throw(Error)
+        end;
 sync(Fd) ->
     gen_server:call(Fd, sync, infinity).
 

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -213,8 +213,12 @@ truncate(Fd, Pos) ->
 %%----------------------------------------------------------------------
 
 sync(Filepath) when is_list(Filepath) ->
-    {ok, Fd} = file:open(Filepath, [append, raw]),
-    try ok = file:sync(Fd) after ok = file:close(Fd) end;
+    case file:open(Filepath, [append, raw]) of
+      {ok, Fd} ->
+         try ok = file:sync(Fd) after ok = file:close(Fd) end;
+      Error ->
+         throw(Error)
+      end;
 sync(Fd) ->
     gen_server:call(Fd, sync, infinity).
 
@@ -389,14 +393,18 @@ init({Filepath, Options, ReturnPid, Ref}) ->
         % open in read mode first, so we don't create the file if it doesn't exist.
         case file:open(Filepath, [read, raw]) of
         {ok, Fd_Read} ->
-            {ok, Fd} = file:open(Filepath, OpenOptions),
-            %% Save Fd in process dictionary for debugging purposes
-            put(couch_file_fd, {Fd, Filepath}),
-            ok = file:close(Fd_Read),
-            maybe_track_open_os_files(Options),
-            {ok, Eof} = file:position(Fd, eof),
-            erlang:send_after(?INITIAL_WAIT, self(), maybe_close),
-            {ok, #file{fd=Fd, eof=Eof, is_sys=IsSys, pread_limit=Limit}};
+             case file:open(Filepath, OpenOptions) of
+               {ok, Fd} ->
+                  %% Save Fd in process dictionary for debugging purposes
+                  put(couch_file_fd, {Fd, Filepath}),
+                  ok = file:close(Fd_Read),
+                  maybe_track_open_os_files(Options),
+                  {ok, Eof} = file:position(Fd, eof),
+                  erlang:send_after(?INITIAL_WAIT, self(), maybe_close),
+                  {ok, #file{fd=Fd, eof=Eof, is_sys=IsSys, pread_limit=Limit}};
+                Error ->
+                  init_status_error(ReturnPid, Ref, Error)
+                end;
         Error ->
             init_status_error(ReturnPid, Ref, Error)
         end


### PR DESCRIPTION
## Overview

According to Erlang's [file:open](http://erlang.org/doc/man/file.html#open-2) docs this function returns `{error, Reason}` in case of failure but inside `couch_file:sync` and `init` functions there are no checks for this in two places. Consequently when I received `{error, emfile}` kind of error, process crashed with `badmatch` instead of a proper error.

## Testing recommendations

Simulate `{error, emfile}` conditions (e.g. decrease `ulimit` on your OS) and observe an error.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
