### PR TITLE
Fix: badmatch crash in couch_mrview_util.erl reduced_external_size()

### DIFF
--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -800,7 +800,8 @@ reduced_external_size(Tree) ->
     case couch_btree:full_reduce(Tree) of
         {ok, {_, _, Size}} -> Size;
         % return 0 for versions of the reduce function without Size
-        {ok, {_, _}} -> 0
+        {ok, {_, _}} -> 0;
+        _ -> 0
     end.
 
 


### PR DESCRIPTION
## Overview

When we tested CouchDB 2.1 with our production DB which contains gazillion of different documents `couch_mrview_util:reduced_external_size()` crashed with `badmatch` error randomly because of some broken docs in our DB. This is because `full_reduce` returned response in the format `{_, _}` (no nested tuple)  and not `{ok, {_, _}}` as was expected there. After this crash CouchDB was broken completely for me. In order to fix this I added an additional "match-anything" case clause, because even if we had something really broken in our DB, CouchDB still should handle this more gracefully I believe. 

P.S. I wasn't sure what is better: add a wildcard `_` after `{ok, {_, _}} -> 0` or  just replace latter with it. Feel free to suggest.

## Testing recommendations

Unfortunately can't describe formal steps because this thing happened randomly for us several times on one of the production databases. But I think expecting that `full_reduce` may return another response is good instead of crashing Couch and polluting logs.

UPD: Managed to reproduce this issue with this simple ddoc in the db:

```json
{
  "_id": "_design/index",
  "_rev": "2-451ebcdefd873e3a8f76e6b3dfb83db4",
  "language": "javascript",
  "views": {
    "type": {
      "map": "function(doc){if(doc.type){log(\"index/type: \"+JSON.stringify(doc));emit(doc.type)}}",
      "options": {
        "seq_indexed": true
      }
    }
  },
  "options": {
    "seq_indexed": true,
    "include_deleted": true,
    "include_design": true
  }
}
```


## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
