### PR TITLE
Add config app to couch_replicator app dependencies

### DIFF
--- a/src/couch_replicator/src/couch_replicator.app.src
+++ b/src/couch_replicator/src/couch_replicator.app.src
@@ -29,6 +29,7 @@
         stdlib,
         couch_log,
         mem3,
+        config,
         couch,
         couch_event,
         couch_stats


### PR DESCRIPTION
It depends on and uses `config`. Obviously it still works without it, but this
eliminates Dialyzer errors such as:

`Callback info about the config_listener behaviour is not available`
