### PR TITLE
Increase timeout for storage engine tests

### DIFF
--- a/src/couch/src/test_engine_util.erl
+++ b/src/couch/src/test_engine_util.erl
@@ -58,7 +58,7 @@ gather(Module) ->
         case {atom_to_list(Fun), Arity} of
             {[$c, $e, $t, $_ | _], 0} ->
                 TestFun = make_test_fun(Module, Fun),
-                [{spawn, TestFun} | Acc];
+                [{timeout, 60, {spawn, TestFun}} | Acc];
             _ ->
                 Acc
         end


### PR DESCRIPTION
The compaction test takes quite a long time on purpose to show that we
can run a compaction that has many batches. On resource constrained
build machines like Jenkins and TravisCI this can end up taking longer
than the default 5s timeout.

## Testing recommendations

Run the test suite on a resource constrained build machine (i.e., our Jenkins CI)

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
