### PR TITLE
Remove unused code for starting compactions

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -224,18 +224,7 @@ monitor(#db{main_pid=MainPid}) ->
     erlang:monitor(process, MainPid).
 
 start_compact(#db{} = Db) ->
-    start_compact(Db, []).
-
-start_compact(#db{} = Db, Opts) ->
-    case lists:keyfind(notify, 1, Opts) of
-        {notify, Pid, Term} ->
-            % We fake a gen_server call here which sends the
-            % response back to the specified pid.
-            Db#db.main_pid ! {'$gen_call', {Pid, Term}, start_compact},
-            ok;
-        _ ->
-            gen_server:call(Db#db.main_pid, start_compact)
-    end.
+    gen_server:call(Db#db.main_pid, start_compact).
 
 cancel_compact(#db{main_pid=Pid}) ->
     gen_server:call(Pid, cancel_compact).


### PR DESCRIPTION
This was left over from an earlier attempt at being a bit more strict on
removing access to the #db record. Its not used as is obvious by the
fact that the 2-arity version isn't even exported from the module.

## Testing recommendations

`$ make check`

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
