### PR TITLE
Fix dialyzer warning for couch_att:from_disk_term

### DIFF
--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -152,9 +152,31 @@
     data_prop() | encoding_prop()
 ].
 
+-type disk_att_v1() :: {
+    Name :: binary(),
+    Type :: binary(),
+    Sp :: any(),
+    AttLen :: non_neg_integer(),
+    RevPos :: non_neg_integer(),
+    Md5 :: binary()
+}.
 
--type att() :: #att{} | attachment().
+-type disk_att_v2() :: {
+    Name :: binary(),
+    Type :: binary(),
+    Sp :: any(),
+    AttLen :: non_neg_integer(),
+    DiskLen :: non_neg_integer(),
+    RevPos :: non_neg_integer(),
+    Md5 :: binary(),
+    Enc :: identity | gzip
+}.
 
+-type disk_att_v3() :: {Base :: tuple(), Extended :: list()}.
+
+-type disk_att() :: disk_att_v1() | disk_att_v2() | disk_att_v3().
+
+-type att() :: #att{} | attachment() | disk_att().
 
 new() ->
     %% We construct a record by default for compatability. This will be


### PR DESCRIPTION
## Overview

The `couch_att:from_disk_term` function is responible for conversion of
a disk format to #att{} record. However the way it is called
produces a dialyzer complaint.
Because `couch_att:from_disk_term` is always called as
`[couch_att:from_disk_term(Db, T) || T <- Doc1#doc.atts]`.

The `atts` field of `#doc{}` record is defined as
`[couch_att:att()] | binary()`

This is problematic because `att()` definition doesn't include disk
format representation. This commit adds disk format to the spec.


## Testing recommendations

Run dialyzer tool and make sure there are no complains about `couch_att:from_disk_term`
1. Prepare for analysis:
  ```
make build-plt
  ```
2. Run analysis 
  ```
make dialyze apps=couch
  ```
The dialyzer might fail but it shouldn't fail in analysis of couch_att.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
