### PR TITLE
Fix dialyzer warning on `couch_key_tree:merge/2`

### DIFF
--- a/src/couch/src/couch_key_tree.erl
+++ b/src/couch/src/couch_key_tree.erl
@@ -73,7 +73,7 @@ stem/2
 
 %% @doc Merge a path into the given tree and then stem the result.
 %% Although Tree is of type tree(), it must not contain any branches.
--spec merge(revtree(), tree(), pos_integer()) ->
+-spec merge(revtree(), tree() | path(), pos_integer()) ->
                 {revtree(), new_leaf | new_branch | internal_node}.
 merge(RevTree, Tree, StemDepth) ->
     {Merged, Result} = merge(RevTree, Tree),
@@ -84,7 +84,7 @@ merge(RevTree, Tree, StemDepth) ->
 
 
 %% @doc Merge a path into a tree.
--spec merge(revtree(), tree()) ->
+-spec merge(revtree(), tree() | path()) ->
                 {revtree(), new_leaf | new_branch | internal_node}.
 merge(RevTree, Tree) ->
     {Merged, Result} = merge_tree(RevTree, Tree, []),
@@ -94,7 +94,7 @@ merge(RevTree, Tree) ->
 %% @doc Attempt to merge Tree into each branch of the RevTree.
 %% If it can't find a branch that the new tree merges into, add it as a
 %% new branch in the RevTree.
--spec merge_tree(revtree(), tree(), revtree()) ->
+-spec merge_tree(revtree(), tree() | path(), revtree()) ->
                 {revtree(), new_leaf | new_branch | internal_node}.
 merge_tree([], Tree, []) ->
     {[Tree], new_leaf};


### PR DESCRIPTION
## Overview

The spec of `couch_key_tree:merge/2` doesn't include the `path()`
type. However we pass `path()` in few places. One of such places is
`couch_db:prep_and_validate_replicated_updates/5`.

```
{NewTree, _} = couch_key_tree:merge(AccTree,
    couch_doc:to_path(NewDoc), RevsLimit),
NewTree
```

The spec for `couch_doc:to_path/1` is defined as:
```
-spec to_path(#doc{}) -> path().
```

This PR adds `path()` type to `couch_key_tree:merge/2` spec.

## Testing recommendations

Run dialyzer tool and make sure there are no complains about `couch_key_tree:merge`
1. Prepare for analysis:
  ```
make build-plt
  ```
2. Run analysis 
  ```
make dialyze apps=couch
  ```
The dialyzer might fail but it shouldn't fail in analysis of `couch_key_tree`, `couch_db` or `test_engine_util`.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
