### PR TITLE
Use `chttpd:send_error/2` in mango_httpd

### DIFF
--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -41,7 +41,7 @@ handle_req(#httpd{} = Req, Db0) ->
             case mango_error:info(Module, Reason) of
             {500, ErrorStr, ReasonStr} ->
                 Stack = erlang:get_stacktrace(),
-                chttpd:send_error(Req, 500, [], ErrorStr, ReasonStr, Stack);
+                chttpd:send_error(Req, {ErrorStr, ReasonStr, Stack});
             {Code, ErrorStr, ReasonStr} ->
                 chttpd:send_error(Req, Code, ErrorStr, ReasonStr)
             end


### PR DESCRIPTION
## Overview

We used to call non exported function chttpd:send_error/6. Switch to
public `chttpd:send_error/2` for sending error.

## Testing recommendations

induce error in mango or update code as follows 
```
diff --git a/src/mango/src/mango_httpd.erl b/src/mango/src/mango_httpd.erl
index 2e87771..e69001a 100644
--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -33,6 +33,8 @@
 }).

 handle_req(#httpd{} = Req, Db0) ->
+    Stack = erlang:get_stacktrace(),
+    chttpd:send_error(Req, {<<"ErrorStr">>, <<"ReasonStr">>, Stack}),
```

Issue mango query request
```
http --auth=adm:pass http://127.0.0.1:15984/mango_test_ffdbb10509f046cea3883d144586c02d/_index
HTTP/1.1 500 Internal Server Error
Cache-Control: must-revalidate
Content-Length: 59
Content-Type: application/json
Date: Fri, 02 Mar 2018 15:16:21 GMT
Server: CouchDB/2.1.1 (Erlang OTP/17)
X-Couch-Request-ID: f942b096d7
X-Couch-Stack-Hash: 1466922193
X-CouchDB-Body-Time: 0

{
    "error": "ErrorStr",
    "reason": "ReasonStr",
    "ref": 1466922193
}
```

Check that 
- response has `error` and `reason`.
- response code is 500
- logs contain stacktrace
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
