### PR TITLE
Eliminate "default" Erlang platform from Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,31 +118,6 @@ pipeline {
             deleteDir()
           } // node
         },
-        centos7erlangdefault: {
-          node(label: 'ubuntu') {
-            timeout(time: 45, unit: "MINUTES") {
-              sh 'docker pull couchdbdev/centos-7-erlang-default'
-              withDockerContainer(image: 'couchdbdev/centos-7-erlang-default', args: '-e LD_LIBRARY_PATH=/usr/local/bin') {
-                sh 'rm -f apache-couchdb-*.tar.gz'
-                unstash 'tarball'
-                sh '''
-                  cwd=$(pwd)
-                  mkdir -p $COUCHDB_IO_LOG_DIR
-
-                  # Build CouchDB from tarball
-                  builddir=$(mktemp -d)
-                  cd $builddir
-                  tar -xf $cwd/apache-couchdb-*.tar.gz
-                  cd apache-couchdb-*
-                  ./configure --with-curl
-                  make all
-                  make check || (build-aux/logfile-uploader.py && false)
-                '''
-              } // withDocker
-            } // timeout
-            deleteDir()
-          } // node
-        },
         centos7erlang183: {
           node(label: 'ubuntu') {
             timeout(time: 60, unit: "MINUTES") {
@@ -180,29 +155,6 @@ pipeline {
               } // withDocker
             } // timeout
             archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
-            deleteDir()
-          } // node
-        },
-        ubuntu1404erlangdefault: {
-          node(label: 'ubuntu') {
-            timeout(time: 45, unit: "MINUTES") {
-              sh 'docker pull couchdbdev/ubuntu-14.04-erlang-default'
-              withDockerContainer(image: 'couchdbdev/ubuntu-14.04-erlang-default') {
-                sh 'rm -f apache-couchdb-*.tar.gz'
-                unstash 'tarball'
-                sh '''
-                  cwd=$(pwd)
-                  mkdir -p $COUCHDB_IO_LOG_DIR
-                  builddir=$(mktemp -d)
-                  cd $builddir
-                  tar -xf $cwd/apache-couchdb-*.tar.gz
-                  cd apache-couchdb-*
-                  ./configure --with-curl
-                  make all
-                  make check || (build-aux/logfile-uploader.py && false)
-                '''
-              } // withDocker
-            } // timeout
             deleteDir()
           } // node
         },
@@ -246,29 +198,6 @@ pipeline {
             deleteDir()
           } // node
         },
-        ubuntu1604erlangdefault: {
-          node(label: 'ubuntu') {
-            timeout(time: 45, unit: "MINUTES") {
-              sh 'docker pull couchdbdev/ubuntu-16.04-erlang-default'
-              withDockerContainer(image: 'couchdbdev/ubuntu-16.04-erlang-default') {
-                sh 'rm -f apache-couchdb-*.tar.gz'
-                unstash 'tarball'
-                sh '''
-                  cwd=$(pwd)
-                  mkdir -p $COUCHDB_IO_LOG_DIR
-                  builddir=$(mktemp -d)
-                  cd $builddir
-                  tar -xf $cwd/apache-couchdb-*.tar.gz
-                  cd apache-couchdb-*
-                  ./configure --with-curl
-                  make all
-                  make check || (build-aux/logfile-uploader.py && false)
-                '''
-              } // withDocker
-            } // timeout
-            deleteDir()
-          } // node
-        },
         ubuntu1604erlang183: {
           node(label: 'ubuntu') {
             timeout(time: 60, unit: "MINUTES") {
@@ -309,29 +238,6 @@ pipeline {
             deleteDir()
           } // node
         },
-        debian8erlangdefault: {
-          node(label: 'ubuntu') {
-            timeout(time: 45, unit: "MINUTES") {
-              sh 'docker pull couchdbdev/debian-8-erlang-default'
-              withDockerContainer(image: 'couchdbdev/debian-8-erlang-default') {
-                sh 'rm -f apache-couchdb-*.tar.gz'
-                unstash 'tarball'
-                sh '''
-                  cwd=$(pwd)
-                  mkdir -p $COUCHDB_IO_LOG_DIR
-                  builddir=$(mktemp -d)
-                  cd $builddir
-                  tar -xf $cwd/apache-couchdb-*.tar.gz
-                  cd apache-couchdb-*
-                  ./configure --with-curl
-                  make all
-                  make check || (build-aux/logfile-uploader.py && false)
-                '''
-              } // withDocker
-            } // timeout
-            deleteDir()
-          } // node
-        },
         debian8erlang183: {
           node(label: 'ubuntu') {
             timeout(time: 60, unit: "MINUTES") {
@@ -369,29 +275,6 @@ pipeline {
               } // withDocker
             } // timeout
             archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
-            deleteDir()
-          } // node
-        },
-        debian9erlangdefault: {
-          node(label: 'ubuntu') {
-            timeout(time: 45, unit: "MINUTES") {
-              sh 'docker pull couchdbdev/debian-9-erlang-default'
-              withDockerContainer(image: 'couchdbdev/debian-9-erlang-default') {
-                sh 'rm -f apache-couchdb-*.tar.gz'
-                unstash 'tarball'
-                sh '''
-                  cwd=$(pwd)
-                  mkdir -p $COUCHDB_IO_LOG_DIR
-                  builddir=$(mktemp -d)
-                  cd $builddir
-                  tar -xf $cwd/apache-couchdb-*.tar.gz
-                  cd apache-couchdb-*
-                  ./configure --with-curl
-                  make all
-                  make check || (build-aux/logfile-uploader.py && false)
-                '''
-              } // withDocker
-            } // timeout
             deleteDir()
           } // node
         },


### PR DESCRIPTION
Currently, we run Jenkins CI builds on 11 platforms:

Erlang 18.3 + [centos6|centos7|debian8|debian9|ubuntu1404|ubuntu1604]
"Default" (ships-with-the-distro) Erlang + [same list but not centos6]

The intent was ensure that CouchDB ran fine both with our preferred
Erlang version (right now, 18.3) as well as the Erlang that ships with
various common distributions. This would help ease consumption of
CouchDB by end users, we thought.

With CouchDB 2.1.0 we started providing convenience binary packages,
built with Erlang 18.3. This (along with Docker) has become the most
common way people consume CouchDB today. Those binaries are generated
directly from the Jenkins builds.

Further, Travis CI already runs our test suite against a variety of
Erlang distributions, from 16B03 right through 20.1 (as of today).

There is little value in the extra Jenkins runs at this point, beyond
catching any vagaries of distro-specific Erlang weirdness that we
would probably wash our hands of anyway.

This change removes 5 of our 11 platform builds. This will be valuable
as we move towards regression testing other platforms (ppc64le, arm).
It also lightens our load on the ASF Jenkins infrastructure.

NOTE that we will still need to maintain the Docker image for
ubuntu1404erlangdefault, as this contains 16B03, the earliest version
of Erlang that we support. The initial "Build" step in our Jenkins
run uses this to build the couchdb.tar.gz dist tarball, which is then
compiled and tested on each platform during the "Test" step.