### PR TITLE
Prevent access to Fauxton on node-local port (5986)

### DIFF
--- a/src/chttpd/test/chttpd_csp_tests.erl
+++ b/src/chttpd/test/chttpd_csp_tests.erl
@@ -10,21 +10,20 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
--module(couchdb_csp_tests).
+-module(chttpd_csp_tests).
 
 -include_lib("couch/include/couch_eunit.hrl").
-
--define(TIMEOUT, 1000).
 
 
 setup() ->
     ok = config:set("csp", "enable", "true", false),
-    Addr = config:get("httpd", "bind_address", "127.0.0.1"),
-    Port = integer_to_list(mochiweb_socket_server:get(couch_httpd, port)),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
     lists:concat(["http://", Addr, ":", Port, "/_utils/"]).
 
 teardown(_) ->
     ok.
+
 
 
 csp_test_() ->
@@ -32,7 +31,7 @@ csp_test_() ->
         "Content Security Policy tests",
         {
             setup,
-            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
             {
                 foreach,
                 fun setup/0, fun teardown/1,

--- a/src/couch/src/couch_httpd_misc_handlers.erl
+++ b/src/couch/src/couch_httpd_misc_handlers.erl
@@ -61,30 +61,9 @@ handle_file_req(#httpd{method='GET'}=Req, Document) ->
 handle_file_req(Req, _) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
-handle_utils_dir_req(#httpd{method='GET'}=Req, DocumentRoot) ->
-    "/" ++ UrlPath = couch_httpd:path(Req),
-    case couch_httpd:partition(UrlPath) of
-    {_ActionKey, "/", RelativePath} ->
-        % GET /_utils/path or GET /_utils/
-        CachingHeaders = [{"Cache-Control", "private, must-revalidate"}],
-        EnableCsp = config:get("csp", "enable", "false"),
-        Headers = maybe_add_csp_headers(CachingHeaders, EnableCsp),
-        couch_httpd:serve_file(Req, RelativePath, DocumentRoot, Headers);
-    {_ActionKey, "", _RelativePath} ->
-        % GET /_utils
-        RedirectPath = couch_httpd:path(Req) ++ "/",
-        couch_httpd:send_redirect(Req, RedirectPath)
-    end;
 handle_utils_dir_req(Req, _) ->
-    send_method_not_allowed(Req, "GET,HEAD").
-
-maybe_add_csp_headers(Headers, "true") ->
-    DefaultValues = "default-src 'self'; img-src 'self' data:; font-src 'self'; "
-                    "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
-    Value = config:get("csp", "header_value", DefaultValues),
-    [{"Content-Security-Policy", Value} | Headers];
-maybe_add_csp_headers(Headers, _) ->
-    Headers.
+    send_error(Req, 410, <<"no_node_local_fauxton">>,
+        ?l2b("The web interface is no longer available on the node-local port.")).
 
 
 handle_all_dbs_req(#httpd{method='GET'}=Req) ->


### PR DESCRIPTION
Will help stop people shooting themselves in the foot and/or using
node-local CouchDB as their "main" CouchDB port.

I'll file a separate docs repo PR on this once this merges.

Test results:

```
$ curl -v http://localhost:15986/_utils
*   Trying ::1...
* TCP_NODELAY set
* connect to ::1 port 15986 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 15986 (#0)
> GET /_utils HTTP/1.1
> Host: localhost:15986
> User-Agent: curl/7.52.1
> Accept: */*
>
< HTTP/1.1 410 Gone
< Cache-Control: must-revalidate
< Content-Length: 110
< Content-Type: application/json
< Date: Sat, 03 Mar 2018 00:45:22 GMT
< Server: CouchDB/2.2.0-51cb6aecc (Erlang OTP/19)
<
{"error":"no_node_local_fauxton","reason":"The web interface is no longer available on the node-local port."}
```

Closes #1198 