### PR TITLE
[DISCUSS] CouchDB Request Size Limits

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1266,6 +1266,7 @@ db_attachment_req(#httpd{method=Method, user_ctx=Ctx}=Req, Db, DocId, FileNamePa
     DocEdited = Doc#doc{
         atts = NewAtt ++ [A || A <- Atts, couch_att:fetch(name, A) /= FileName]
     },
+    couch_att:validate_attachment_count(length(DocEdited#doc.atts)),
     W = chttpd:qs_value(Req, "w", integer_to_list(mem3:quorum(Db))),
     case fabric:update_doc(Db, DocEdited, [{user_ctx,Ctx}, {w,W}]) of
     {ok, UpdatedRev} ->

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -52,7 +52,8 @@
 
 -export([
     max_attachment_size/0,
-    validate_attachment_size/3
+    validate_attachment_size/3,
+    validate_attachment_count/1
 ]).
 
 -compile(nowarn_deprecated_type).
@@ -715,6 +716,25 @@ max_attachment_size() ->
             infinity;
         MaxAttSize ->
             list_to_integer(MaxAttSize)
+    end.
+
+
+max_attachment_count() ->
+    case config:get("couchdb", "max_attachments_per_document", "infinity") of
+        "infinity" ->
+            infinity;
+        MaxAttSize ->
+            list_to_integer(MaxAttSize)
+    end.
+
+
+validate_attachment_count(AttCount) ->
+    case max_attachment_count() of
+        infinity -> ok;
+        MaxAttCount when AttCount =< MaxAttCount -> ok;
+        _TooManyAttachments ->
+            throw({request_entity_too_large,
+                <<"hit max_attachments_per_document">>})
     end.
 
 

--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -135,6 +135,7 @@ from_json_obj_validate(EJson, DbName) ->
     Doc = from_json_obj(EJson, DbName),
     case couch_ejson_size:encoded_size(Doc#doc.body) =< MaxSize of
         true ->
+             validate_attachment_count(Doc#doc.atts),
              validate_attachment_sizes(Doc#doc.atts),
              Doc;
         false ->
@@ -152,6 +153,9 @@ validate_attachment_sizes(Atts) ->
          couch_att:validate_attachment_size(AttName, AttSize, MaxAttSize)
     end, Atts).
 
+
+validate_attachment_count(Atts) ->
+    couch_att:validate_attachment_count(length(Atts)).
 
 from_json_obj({Props}) ->
     from_json_obj({Props}, undefined).


### PR DESCRIPTION
*Note: the text below is written in a style that would allow it to be included in the CouchDB 2.2.0 documentation and/or release notes.*

# CouchDB Request Size Limits

There are multiple configuration variables for CouchDB that determine request size limits. This document explains the configuration variables, how they work together, and why they exist in the first place

## Why Limit Requests by Size

Allowing requests of unlimited size to any network server is a [denial of service vector](wikipedia: denial of service). To allow safe operation of CouchDB, even on a network with hostile third parties, various request size limits exist.

## The Request Size Limits

`max_http_request_size`: the maximum number bytes a request to a CouchDB server can have.

`max_document_size`: the maximum number of bytes for a JSON document written to CouchDB.

`max_attachment_size`: the maximum number of bytes for any one attachment written to CouchDB.

## Background

There are three distinct ways of getting data into CouchDB:

1. The standard JSON Document API, which uses plain JSON, if binary data is involved, it has to be encoded as base64. The base64 option only exists for legacy reasons and it is not recommended to be used.
2. The standalone attachment API, which allows transferring of binary attachment data without encoding as base64.
3. The multipart HTTP API: it allows the mix of JSON data and binary attachment data without encoding as base64. The CouchDB replicator uses this.

In version 2.1, CouchDB started enforcing a 64MB limit for `max_http_request_size` on all requests, but did not apply this to the standalone attachment API.

This had the unfortunate side effect that one could create a doc that is smaller than `max_http_request_size` with an attachment that is bigger than `max_http_request_size`. In addition, one could create a doc with two or more attachments that were each smaller than `max_http_request_size` but together bigger than `max_http_request_size`. The result in this scenario now is that these documents could no longer be replicated to CouchDB nodes with the same default configuration (or even to the same node).

Regardless to say, this is a very unfortunate user experience: create a number of documents with attachments, and at some not immediately obvious point, replications start failing.

### Large Documents and Attachments

While CouchDB works reasonably well with almost any sort of JSON data sizes and attachment sizes. The development team makes recommendations as to the various limits for ideal and optimal uses. CouchDB users may vary from these recommendations, but will need to be okay with the resulting operational implications, like increased CPU & RAM usage as well as increased latency for many core operations.

Before CouchDB 2.1.0 there were no real limits imposed, and before CouchDB 2.2.0 the available limits weren’t applied uniformly, leading to surprising behaviour as for example  outlined above.

CouchDB 2.2.0 and later aims to have a complete set of limits that avoids any unexpected behaviour, but the limits imposed won’t be set by default in order to preserve backwards compatibility. Starting with 

CouchDB 3.0.0 the recommended limits will be set by default and users migrating from earlier versions of CouchDB need to adjust them, if their use-case requires it. The CouchDB team might produce a utility script that would allow to determine the required settings from an existing CouchDB installation, if resources can be made available for this.

Starting with CouchDB 2.2.0, the CouchDB distribution will come with an additional configuration file local.ini-recommended* with the developer-recommended defaults and explanations for what happens when these defaults are exceeded.

*An alternative solution could avoid using the `max_attachments_per_doc` and reject attachment additions based on the existing doc + attachments size plus the new attachment size, but this PR/Discussion suggests that having another config value with sensible defaults here will nudge users into doing the right thing*

## Limits by Version

In order to account for all use-cases and the interplay of the different APIs, CouchDB 2.2.0 introduces a new limit `max_attachments_per_document`. This allows the application of a formula to show the interplay of all limits:

```
max_http_request_size = max_document_size + multipart HTTP boundary data
                        + max_attachments_per_doc
                        * (max_attachment_size + multipart HTTP boundary data)
```

Using this formula, any doc update (JSON or attachments) can check whether it would exceed `max_http_request_size` which would cause replication to fail.

CouchDB Version | `max_http_request_size` | `max_document_size` | `max_attachment_size` | `max_attachments_per_document*`
----------------|-----------------------|-------------------|---------------------|------------------------------
2.0.0 and earlier | unlimited | 4GB | N/a | N/a
2.1.0 | 64MB | 4GB | Unlimited | N/a
2.2.0* | 64MB | 4GB | Unlimited | Unlimited
3.0.0* | 64MB | 4MB | 6MB | 10

* Proposed names and values

The table shows the approximate sizes (sans HTTP multipart boundaries) for all limits. CouchDB versions earlier than 3.0.0 will still encounter the behaviour of not being able to replicate documents that have attachments that alone or together exceed `max_http_request_size`.

# Implementation

This draft implementation introduces the new `max_attachments_per_document` to show how it could work. Tests will need to be added to validate that all three API routes are covered (casual review suggests they are, but we do, of course need tests). I stopped short of adding tests so we can discuss the details of this suggestion first.

# To 2.2.0 or not to 2.2.0

Since we started on [the 2.2.0 milestone](https://github.com/apache/couchdb/milestone/3), this might be too big a thing to discuss and finish. I’d be very okay with bumping this to 2.3.0 as long as we document the behaviour in the 2.2.0 release notes.