### PR TITLE
Compaction Daemon & db-per-user

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -438,6 +438,12 @@ check_interval = 3600
 ; compaction will not happen. Very small files always have a very high
 ; fragmentation therefore it's not worth to compact them.
 min_file_size = 131072
+; With lots of databases and/or with lots of design docs in one or more
+; databases, the compaction_daemon can create significant CPU load when
+; checking whether databases and view indexes need compacting. The
+; snooze_period setting ensures a smoother CPU load. Defaults to
+; 3 seconds wait.
+; snooze_period = 3
 
 [compactions]
 ; List of compaction rules for the compaction daemon.

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -433,7 +433,7 @@ ssl_certificate_max_depth = 3
 [compaction_daemon]
 ; The delay, in seconds, between each check for which database and view indexes
 ; need to be compacted.
-check_interval = 300
+check_interval = 3600
 ; If a database or view index file is smaller then this value (in bytes),
 ; compaction will not happen. Very small files always have a very high
 ; fragmentation therefore it's not worth to compact them.

--- a/src/couch/src/couch_compaction_daemon.erl
+++ b/src/couch/src/couch_compaction_daemon.erl
@@ -126,6 +126,7 @@ handle_config_terminate(_Server, _Reason, _State) ->
     erlang:send_after(?RELISTEN_DELAY, whereis(?MODULE), restart_config_listener).
 
 compact_loop(Parent) ->
+    SnoozePeriod = config:get_integer("compaction_daemon", "snooze_period", 3),
     {ok, _} = couch_server:all_databases(
         fun(DbName, Acc) ->
             case ets:info(?CONFIG_ETS, size) =:= 0 of
@@ -138,7 +139,8 @@ compact_loop(Parent) ->
                 {ok, Config} ->
                     case check_period(Config) of
                     true ->
-                        maybe_compact_db(Parent, DbName, Config);
+                        maybe_compact_db(Parent, DbName, Config),
+                        ok = timer:sleep(SnoozePeriod * 1000);
                     false ->
                         ok
                     end
@@ -229,7 +231,9 @@ maybe_compact_views(DbName, [DDocName | Rest], Config) ->
             maybe_compact_views(DbName, Rest, Config);
         timeout ->
             ok
-        end;
+        end,
+        SnoozePeriod = config:get_integer("compaction_daemon", "snooze_period", 3),
+        ok = timer:sleep(SnoozePeriod * 1000);
     false ->
         ok
     end.

--- a/src/couch/src/couch_compaction_daemon.erl
+++ b/src/couch/src/couch_compaction_daemon.erl
@@ -152,8 +152,7 @@ compact_loop(Parent) ->
     true ->
         receive {Parent, have_config} -> ok end;
     false ->
-        PausePeriod = list_to_integer(
-            config:get("compaction_daemon", "check_interval", "300")),
+        PausePeriod = config:get_integer("compaction_daemon", "check_interval", 3600),
         ok = timer:sleep(PausePeriod * 1000)
     end,
     compact_loop(Parent).

--- a/src/couch/test/couchdb_compaction_daemon_tests.erl
+++ b/src/couch/test/couchdb_compaction_daemon_tests.erl
@@ -24,6 +24,7 @@
 start() ->
     Ctx = test_util:start_couch(),
     ok = config:set("compaction_daemon", "check_interval", "3", false),
+    ok = config:set("compaction_daemon", "snooze_period", "0", false),
     ok = config:set("compaction_daemon", "min_file_size", "100000", false),
     ok = config:delete("compactions", "_default", false),
     ok = meck:new(?MODS_TO_MOCK, [passthrough]),

--- a/src/couch_index/src/couch_index.erl
+++ b/src/couch_index/src/couch_index.erl
@@ -104,7 +104,7 @@ init({Mod, IdxState}) ->
                 Mod:get(idx_name, IdxState),
                 couch_index_util:hexsig(Mod:get(signature, IdxState))
             ],
-            couch_log:info("Opening index for db: ~s idx: ~s sig: ~p", Args),
+            couch_log:debug("Opening index for db: ~s idx: ~s sig: ~p", Args),
             proc_lib:init_ack({ok, self()}),
             gen_server:enter_loop(?MODULE, [], State);
         Other ->
@@ -131,7 +131,7 @@ terminate(Reason0, State) ->
         couch_index_util:hexsig(Mod:get(signature, IdxState)),
         Reason
     ],
-    couch_log:info("Closing index for db: ~s idx: ~s sig: ~p because ~r", Args),
+    couch_log:debug("Closing index for db: ~s idx: ~s sig: ~p because ~r", Args),
     ok.
 
 
@@ -366,7 +366,7 @@ handle_info(maybe_close, State) ->
     end;
 handle_info({'DOWN', _, _, _Pid, _}, #st{mod=Mod, idx_state=IdxState}=State) ->
     Args = [Mod:get(db_name, IdxState), Mod:get(idx_name, IdxState)],
-    couch_log:info("Index shutdown by monitor notice for db: ~s idx: ~s", Args),
+    couch_log:debug("Index shutdown by monitor notice for db: ~s idx: ~s", Args),
     catch send_all(State#st.waiters, shutdown),
     {stop, normal, State#st{waiters=[]}}.
 


### PR DESCRIPTION
This PR addresses a number of issues with the Compaction Daemon when run under a db-per-user scenario:

1. with many database and/or many view groups in one or more databases, checking whether a file should be compacted can create significant CPU load. This PR both:
   1. spaces the `check_interval` from 5 minutes to 60 minutes,
   2. and introduces a 3 second `snooze_period` between compacting any two files.
2. when a view index is opened or closed, we send a `notice` level log line. In this scenario, this balloons the log file for no good benefit. The logs are not demoted to `debug`.

- [x] code works
- [x] no tests
- [x] documented in `default.ini`