### PR TITLE
Switching `couch_stats_process_tracker:track/2` argument names

### DIFF
--- a/src/couch_stats/src/couch_stats_process_tracker.erl
+++ b/src/couch_stats/src/couch_stats_process_tracker.erl
@@ -37,8 +37,8 @@ track(Name) ->
     track(self(), Name).
 
 -spec track(pid(), any()) -> ok.
-track(Name, Pid) ->
-    gen_server:cast(?MODULE, {track, Name, Pid}).
+track(Pid, Name) ->
+    gen_server:cast(?MODULE, {track, Pid, Name}).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The argument names in `couch_stats_process_tracker:track/2` where the wrong way around leading to confusion.

## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
