### PR TITLE
Add error tuple return type to replicator auth spec and callback

### DIFF
--- a/src/couch_replicator/src/couch_replicator_auth.erl
+++ b/src/couch_replicator/src/couch_replicator_auth.erl
@@ -33,7 +33,8 @@
 
 % Behavior API
 
--callback initialize(#httpdb{}) -> {ok, #httpdb{}, term()} | ignore.
+-callback initialize(#httpdb{}) ->
+    {ok, #httpdb{}, term()} | {error, term()} | ignore.
 
 -callback update_headers(term(), headers()) -> {headers(), term()}.
 

--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -100,7 +100,8 @@
 
 % Behavior API callbacks
 
--spec initialize(#httpdb{}) -> {ok, #httpdb{}, term()} | ignore.
+-spec initialize(#httpdb{}) ->
+    {ok, #httpdb{}, term()} | {error, term()} | ignore.
 initialize(#httpdb{} = HttpDb) ->
     case init_state(HttpDb) of
         {ok, HttpDb1, State} ->


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The `{error, term()}` return type is added to both the `initialize/1`
callback and spec, which matches the underlying implementation.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Prior to this change, `make dialyze` should have displayed an error for these missing return types. That it didn't is presumably a dialyzer bug. In any case, run `make dialyze` should show no additional type check errors.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests; (I'm not aware of explicit tests for type checking)
- [x] Documentation reflects the changes; (in some sense, type specs *are* documentation)
