### PR TITLE
Demote free space calculation failure warning to debug

### DIFF
--- a/src/couch/src/couch_compaction_daemon.erl
+++ b/src/couch/src/couch_compaction_daemon.erl
@@ -529,7 +529,7 @@ free_space_rec(Path, [{MountPoint0, Total, Usage} | Rest]) ->
             trunc(Total - (Total * (Usage / 100))) * 1024
         end;
     {error, Reason} ->
-        couch_log:warning("Compaction daemon - unable to calculate free space"
+        couch_log:debug("Compaction daemon - unable to calculate free space"
             " for `~s`: `~s`",
             [MountPoint0, Reason]),
         free_space_rec(Path, Rest)


### PR DESCRIPTION
Fixes #1097 by demoting the warning message to a debug message.

This is an innocuous message; failure to calculate free space on a volume that lacks proper `{fs,ls}tat()` support won't block the compaction daemon from proceeding.