### PR TITLE
Introduce bin_opt_info erl_opts compilation option

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -92,7 +92,7 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, [debug_info, {i, "../"}]},
+    {erl_opts, [bin_opt_info, debug_info, {i, "../"}]},
     {eunit_opts, [verbose]},
     {plugins, [eunit_plugin]},
     {dialyzer, [


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

As discussed in
http://erlang.org/doc/efficiency_guide/binaryhandling.html, the
bin_opt_info option can have the compiler print information about
binary optimizations. Typically, it issues warnings about code that
can not be optimized. For example, with the option enabled, it warns
about this line of code (among many others) like this:
```
src/chttpd/src/chttpd_auth_cache.erl:183: Warning: NOT OPTIMIZED: sub binary is used or returned
```
Not only should having this option enabled draw awareness to existing
sub-optimal binary constructs, it should help developers avoid
creating new ones.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

This is a compiler configuration change, so test it by running `make clean && make`. You should now see numerous warnings about failed binary optimizations such as
```
/Users/jay/proj/couchdb/src/couch_replicator/src/couch_replicator_api_wrap.erl:401: Warning: INFO: matching anything else but a plain variable to the left of binary pattern will prevent delayed sub binary optimization; SUGGEST changing argument order
/Users/jay/proj/couchdb/src/couch_replicator/src/couch_replicator_api_wrap.erl:1019: Warning: NOT OPTIMIZED: sub binary is used or returned
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
