### PR TITLE
 Support queries endpoints

### DIFF
--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -21,8 +21,6 @@
 -define(CONTENT_JSON, {"Content-Type", "application/json"}).
 -define(DESTHEADER1, {"Destination", "foo%E5%95%8Abar"}).
 -define(DESTHEADER2, {"Destination", "foo%2Fbar%23baz%3Fpow%3Afiz"}).
-
-
 -define(FIXTURE_TXT, ?ABS_PATH(?FILE)).
 -define(i2l(I), integer_to_list(I)).
 
@@ -71,7 +69,16 @@ all_test_() ->
                     fun should_return_update_seq_when_set_on_all_docs/1,
                     fun should_not_return_update_seq_when_unset_on_all_docs/1,
                     fun should_return_correct_id_on_doc_copy/1,
-                    fun should_return_400_for_bad_engine/1
+                    fun should_return_400_for_bad_engine/1,
+                    fun should_succeed_on_all_docs_with_queries_keys/1,
+                    fun should_succeed_on_all_docs_with_queries_limit_skip/1,
+                    fun should_succeed_on_all_docs_with_multiple_queries/1,
+                    fun should_succeed_on_design_docs_with_queries_keys/1,
+                    fun should_succeed_on_design_docs_with_queries_limit_skip/1,
+                    fun should_succeed_on_design_docs_with_multiple_queries/1,
+                    fun should_succeed_on_local_docs_with_queries_keys/1,
+                    fun should_succeed_on_local_docs_with_queries_limit_skip/1,
+                    fun should_succeed_on_local_docs_with_multiple_queries/1
                 ]
             }
         }
@@ -264,4 +271,145 @@ should_return_400_for_bad_engine(_) ->
         Url = BaseUrl ++ "?engine=cowabunga",
         {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),
         ?assertEqual(400, Status)
+    end).
+
+
+should_succeed_on_all_docs_with_queries_keys(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/queries/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_all_docs_with_queries_limit_skip(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/queries/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_all_docs_with_multiple_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]},
+            {\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/queries/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson1} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
+        {InnerJson2} = lists:nth(2, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
+    end).
+
+
+should_succeed_on_design_docs_with_queries_keys(Url) ->
+    ?_test(begin
+        [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"_design/ddoc3\",
+            \"_design/ddoc8\"]}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++
+            "/_design_docs/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_design_docs_with_queries_limit_skip(Url) ->
+    ?_test(begin
+        [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++
+            "/_design_docs/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_design_docs_with_multiple_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"_design/ddoc3\",
+            \"_design/ddoc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++
+            "/_design_docs/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson1} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
+        {InnerJson2} = lists:nth(2, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
+    end).
+
+
+should_succeed_on_local_docs_with_queries_keys(Url) ->
+    ?_test(begin
+        [create_doc(Url, "_local/doc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\":
+            [ \"_local/doc3\", \"_local/doc8\"]}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_local_docs/queries/",
+            [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_local_docs_with_queries_limit_skip(Url) ->
+    ?_test(begin
+        [create_doc(Url, "_local/doc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++
+            "/_local_docs/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_local_docs_with_multiple_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "_local/doc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"_local/doc3\",
+            \"_local/doc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++
+            "/_local_docs/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson1} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
+        {InnerJson2} = lists:nth(2, ResultJsonBody),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
     end).

--- a/src/chttpd/test/chttpd_view_test.erl
+++ b/src/chttpd/test/chttpd_view_test.erl
@@ -1,0 +1,123 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_view_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(USER, "chttpd_view_test_admin").
+-define(PASS, "pass").
+-define(AUTH, {basic_auth, {?USER, ?PASS}}).
+-define(CONTENT_JSON, {"Content-Type", "application/json"}).
+-define(DDOC, "{\"_id\": \"_design/bar\", \"views\": {\"baz\":
+               {\"map\": \"function(doc) {emit(doc._id, doc._id);}\"}}}").
+
+-define(FIXTURE_TXT, ?ABS_PATH(?FILE)).
+-define(i2l(I), integer_to_list(I)).
+
+setup() ->
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
+    TmpDb = ?tempdb(),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    Url = lists:concat(["http://", Addr, ":", Port, "/", ?b2l(TmpDb)]),
+    create_db(Url),
+    Url.
+
+teardown(Url) ->
+    delete_db(Url),
+    ok = config:delete("admins", ?USER, _Persist=false).
+
+create_db(Url) ->
+    {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),
+    ?assert(Status =:= 201 orelse Status =:= 202).
+
+
+create_doc(Url, Id) ->
+    test_request:put(Url ++ "/" ++ Id,
+      [?CONTENT_JSON, ?AUTH], "{\"mr\": \"rockoartischocko\"}").
+
+delete_db(Url) ->
+    {ok, 200, _, _} = test_request:delete(Url, [?AUTH]).
+
+all_view_test_() ->
+    {
+        "chttpd view tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0, fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_succeed_on_view_with_queries_keys/1,
+                    fun should_succeed_on_view_with_queries_limit_skip/1,
+                    fun should_succeed_on_view_with_multiple_queries/1
+                ]
+            }
+        }
+    }.
+
+
+should_succeed_on_view_with_queries_keys(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        {ok, _, _, _} = test_request:put(Url ++ "/_design/bar",
+            [?CONTENT_JSON, ?AUTH], ?DDOC),
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\",
+            \"testdoc8\"]}]}",
+        {ok, _, _, RespBody} = test_request:post(Url ++ "/_design/bar/"
+            ++ "_view/baz/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_view_with_queries_limit_skip(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        {ok, _, _, _} = test_request:put(Url ++ "/_design/bar",
+            [?CONTENT_JSON, ?AUTH], ?DDOC),
+        QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_design/bar/"
+            ++ "_view/baz/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
+    end).
+
+
+should_succeed_on_view_with_multiple_queries(Url) ->
+    ?_test(begin
+        [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
+        {ok, _, _, _} = test_request:put(Url ++ "/_design/bar",
+            [?CONTENT_JSON, ?AUTH], ?DDOC),
+        QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\",
+            \"testdoc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
+        {ok, RC, _, RespBody} = test_request:post(Url ++ "/_design/bar/"
+            ++ "_view/baz/queries/", [?CONTENT_JSON, ?AUTH], QueryDoc),
+        ?assertEqual(200, RC),
+        {ResultJson} = ?JSON_DECODE(RespBody),
+        ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
+        {InnerJson1} = lists:nth(1, ResultJsonBody),
+        ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
+        {InnerJson2} = lists:nth(2, ResultJsonBody),
+        ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
+        ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
+    end).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Allow to POST to `/{db}/_all_docs/queries` and specify a queries list in the body, the same way you can do 
 - for design documents `/{db}/_design_docs/queries`
 - for local documents `/{db}/_local_docs/queries`
 -  and for a regular MapReduce view `/{db}/_design/{ddoc}/_view/{viewname}/queries`

```
curl -u foo:bar -H "Content-Type: application/json" -X POST -d @multiple_queries.json http://localhost:15984/db/_all_docs/queries
{"results":[
{"total_rows":30,"rows":[
{"id":"point2","key":"point2","value":{"rev":"1-d942f0ce01647aa0f46518b213b5628e"}},
{"id":"point3","key":"point3","value":{"rev":"1-721fead6e6c8d811a225d5a62d08dfd0"}}
]},
{"total_rows":30,"offset":2,"rows":[
{"id":"point11","key":"point11","value":{"rev":"1-ffb6c2ae737918f8f911e1fce668333e"}},
{"id":"point12","key":"point12","value":{"rev":"1-c32d315f69ce72128244a60d0cbe4628"}},
{"id":"point13","key":"point13","value":{"rev":"1-a9b955ca17f553398cd877629e803c5d"}},
{"id":"point14","key":"point14","value":{"rev":"1-2f2aa0db2a8c35754e7ab2308940f60c"}},
{"id":"point15","key":"point15","value":{"rev":"1-247191505d8fa6b4b9dc426321987b17"}}
]}
]}
```
multiple_queries.json looks like
```
    {
        "queries": [
            {
                "keys": [
                    "point2",
                    "point3"
                ]
            },
            {
                "limit": 5,
                "skip": 2
            }
        ]
    }
```
## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make check skip_deps+=couch_epi apps=chttpd tests=all_test_

Compiled test/chttpd_db_test.erl
    Running test function(s):
      chttpd_db_test:all_db_test_/0
======================== EUnit ========================
chttpd db tests
Application crypto was left running!
  chttpd_db_test:90: should_return_ok_true_on_bulk_update...[0.082 s] ok
  chttpd_db_test:117: should_accept_live_as_an_alias_for_continuous...[0.051 s] ok
  chttpd_db_test:132: should_return_404_for_delete_att_on_notadoc...[0.006 s] ok
  chttpd_db_test:154: should_return_409_for_del_att_without_rev...[0.072 s] ok
  chttpd_db_test:172: should_return_200_for_del_att_with_rev...[0.061 s] ok
  chttpd_db_test:193: should_return_409_for_put_att_nonexistent_rev...[0.016 s] ok
  chttpd_db_test:208: should_return_update_seq_when_set_on_all_docs...[0.095 s] ok
  chttpd_db_test:222: should_not_return_update_seq_when_unset_on_all_docs...[0.080 s] ok
  chttpd_db_test:236: should_return_correct_id_on_doc_copy...[0.091 s] ok
  chttpd_db_test:267: should_return_400_for_bad_engine...[0.003 s] ok
  chttpd_db_test:279: should_succeed_on_all_docs_with_queries_keys...[0.250 s] ok
  chttpd_db_test:293: should_succeed_on_all_docs_with_queries_limit_skip...[0.266 s] ok
  chttpd_db_test:308: should_succeed_on_all_docs_with_multiple_queries...[0.259 s] ok
  chttpd_db_test:326: should_succeed_on_design_docs_with_queries_keys...[0.246 s] ok
  chttpd_db_test:341: should_succeed_on_design_docs_with_queries_limit_skip...[0.267 s] ok
  chttpd_db_test:356: should_succeed_on_design_docs_with_multiple_queries...[0.253 s] ok
  chttpd_db_test:374: should_succeed_on_local_docs_with_queries_keys...[0.237 s] ok
  chttpd_db_test:389: should_succeed_on_local_docs_with_queries_limit_skip...[0.239 s] ok
  chttpd_db_test:403: should_succeed_on_local_docs_with_multiple_queries...[0.253 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 5.480 s]
=======================================================
  All 19 tests passed.

make check skip_deps+=couch_epi apps=chttpd tests=all_view_test_

Compiled src/chttpd_db.erl
    Running test function(s):
      chttpd_view_test:all_view_test_/0
======================== EUnit ========================
chttpd view tests
Application crypto was left running!
  chttpd_view_test:74: should_succeed_on_view_with_queries_keys...[0.510 s] ok
  chttpd_view_test:90: should_succeed_on_view_with_queries_limit_skip...[0.282 s] ok
  chttpd_view_test:107: should_succeed_on_view_with_multiple_queries...[0.280 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 1.650 s]
=======================================================
  All 3 tests passed.
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/issues/820
https://github.com/apache/couchdb/pull/1032
https://github.com/apache/couchdb/pull/1143
https://github.com/apache/couchdb-documentation/pull/241

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
https://github.com/apache/couchdb-documentation/pull/241
