### PR TITLE
Make bcrypt optional

### DIFF
--- a/rel/apps/couch.config
+++ b/rel/apps/couch.config
@@ -1,2 +1,3 @@
 {applications, [
+    bcrypt
 ]}.

--- a/rel/apps/couch.config
+++ b/rel/apps/couch.config
@@ -1,0 +1,2 @@
+{applications, [
+]}.

--- a/src/couch/src/couch.app.src.script
+++ b/src/couch/src/couch.app.src.script
@@ -9,6 +9,8 @@
 % WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 % License for the specific language governing permissions and limitations under
 % the License.
+ConfigFile = filename:join([os:getenv("COUCHDB_APPS_CONFIG_DIR"), "couch.config"]).
+{ok, AppConfig} = file:consult(ConfigFile).
 
 {application, couch, [
     {description, "Apache CouchDB"},
@@ -48,5 +50,5 @@
         couch_event,
         ioq,
         couch_stats
-    ]}
+    ] ++ proplists:get_value(applications, AppConfig, [])}
 ]}.

--- a/src/couch/src/couch.app.src.script
+++ b/src/couch/src/couch.app.src.script
@@ -33,7 +33,6 @@ ConfigFile = filename:join([os:getenv("COUCHDB_APPS_CONFIG_DIR"), "couch.config"
         kernel,
         stdlib,
         crypto,
-        bcrypt,
         sasl,
         inets,
         ssl,


### PR DESCRIPTION
## Overview

Support additional dependencies for couch app and make bcrypt optional. This changes a build system to allow exclusion of bcrypt dependency. There should be no functionality changes.

## Testing recommendations

1. do a fresh clone
2. run `./configure`
3. run `make && dev/run --admin=adm:pass`
4. run `dev/remsh`
5. In `remsh` make sure you still have `bcrypt` by running the following 

```
lists:usort([A || {A, _, _} <- application:loaded_applications()]).
```

## Related Issues or Pull Requests

None

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
