### PR TITLE
Validate password_scheme in user doc

### DIFF
--- a/src/couch/include/couch_js_functions.hrl
+++ b/src/couch/include/couch_js_functions.hrl
@@ -64,6 +64,15 @@
             });
         }
 
+        var available_schemes = [\"simple\", \"pbkdf2\", \"bcrypt\"];
+        if (newDoc.password_scheme
+                && available_schemes.indexOf(newDoc.password_scheme) == -1) {
+            throw({
+                forbidden: 'Password scheme `' + newDoc.password_scheme
+                    + '` not supported.'
+            });
+        }
+
         if (newDoc.password_scheme === \"pbkdf2\") {
             if (typeof(newDoc.iterations) !== \"number\") {
                throw({forbidden: \"iterations must be a number.\"});


### PR DESCRIPTION
## Overview

We allow to specify `password_scheme` in user doc, but never check that it is one of the supported types. As a result it is possible to successfully create a user that'd throw error 500 on access attempt.

```bash
$ curl -X PUT http://localhost:15984/_users/org.couchdb.user:wooser -d'{"name":"wooser", "roles":[], "derived_key":"0123456789acbdef", "iterations":10, "salt":"heteronym", "password_sha":"alalalalalalalalala", "password_scheme":"wooser", "type":"user"}'
{"ok":true,"id":"org.couchdb.user:wooser","rev":"1-65c51dd556a8b03f040309e87308eda1"}

$ curl http://localhost:15984/_users/org.couchdb.user:wooser -u wooser:wooser
{"error":"case_clause","reason":"wooser","ref":17603030}
```

## Testing recommendations

With this patch validator should output a proper warning

```bash
$ curl -X PUT http://localhost:15984/_users/org.couchdb.user:wooser -d'{"name":"wooser", "roles":[], "derived_key":"0123456789acbdef", "iterations":10, "salt":"heteronym", "password_sha":"alalalalalalalalala", "password_scheme":"wooser", "type":"user"}'
{"error":"forbidden","reason":"Password scheme `wooser` not supported."}
```

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
