### PR TITLE
Replace resource expensive bcrypt test with shorter version

### DIFF
--- a/src/couch/test/couch_passwords_tests.erl
+++ b/src/couch/test/couch_passwords_tests.erl
@@ -53,19 +53,15 @@ pbkdf2_test_()->
            )}}]}.
 
 
-
-setup() ->
-    test_util:start(?MODULE, [bcrypt]).
-
-teardown(Ctx)->
-    test_util:stop(Ctx).
-
 bcrypt_test_() ->
     {
         "Bcrypt",
         {
-            foreach,
-            fun setup/0, fun teardown/1,
+            setup,
+            fun() ->
+                test_util:start_applications([bcrypt])
+            end,
+            fun test_util:stop_applications/1,
             [
                 {timeout, 1, fun bcrypt_logRounds_4/0},
                 {timeout, 1, fun bcrypt_logRounds_5/0},

--- a/src/couch/test/couch_passwords_tests.erl
+++ b/src/couch/test/couch_passwords_tests.erl
@@ -68,6 +68,7 @@ bcrypt_test_() ->
             fun setup/0, fun teardown/1,
             [
                 {timeout, 1, fun bcrypt_logRounds_4/0},
+                {timeout, 1, fun bcrypt_logRounds_5/0},
                 {timeout, 5, fun bcrypt_logRounds_12/0},
                 {timeout, 5, fun bcrypt_null_byte/0}
 
@@ -77,6 +78,9 @@ bcrypt_test_() ->
 
 bcrypt_logRounds_4() ->
     bcrypt_assert_equal(<<"password">>, 4).
+
+bcrypt_logRounds_5() ->
+    bcrypt_assert_equal(<<"password">>, 5).
 
 bcrypt_logRounds_12() ->
     bcrypt_assert_equal(<<"password">>, 12).

--- a/src/couch/test/couch_passwords_tests.erl
+++ b/src/couch/test/couch_passwords_tests.erl
@@ -63,10 +63,14 @@ bcrypt_test_() ->
             end,
             fun test_util:stop_applications/1,
             [
-                {timeout, 1, fun bcrypt_logRounds_4/0},
-                {timeout, 1, fun bcrypt_logRounds_5/0},
-                {timeout, 5, fun bcrypt_logRounds_12/0},
-                {timeout, 5, fun bcrypt_null_byte/0}
+                {"Log rounds: 4",
+                {timeout, 1, fun bcrypt_logRounds_4/0}},
+                {"Log rounds: 5",
+                {timeout, 1, fun bcrypt_logRounds_5/0}},
+                {"Log rounds: 12",
+                {timeout, 5, fun bcrypt_logRounds_12/0}},
+                {"Null byte",
+                {timeout, 5, fun bcrypt_null_byte/0}}
 
             ]
         }

--- a/src/couch/test/couch_passwords_tests.erl
+++ b/src/couch/test/couch_passwords_tests.erl
@@ -91,4 +91,4 @@ bcrypt_null_byte() ->
 bcrypt_assert_equal(Password, Rounds) when is_integer(Rounds) ->
     HashPass = couch_passwords:bcrypt(Password, Rounds),
     ReHashPass = couch_passwords:bcrypt(Password, HashPass),
-    ?_assertEqual(HashPass, ReHashPass).
+    ?assertEqual(HashPass, ReHashPass).

--- a/src/couch/test/couch_passwords_tests.erl
+++ b/src/couch/test/couch_passwords_tests.erl
@@ -69,7 +69,6 @@ bcrypt_test_() ->
             [
                 {timeout, 1, fun bcrypt_logRounds_4/0},
                 {timeout, 5, fun bcrypt_logRounds_12/0},
-                {timeout, 180, fun bcrypt_logRounds_18/0},
                 {timeout, 5, fun bcrypt_null_byte/0}
 
             ]
@@ -81,9 +80,6 @@ bcrypt_logRounds_4() ->
 
 bcrypt_logRounds_12() ->
     bcrypt_assert_equal(<<"password">>, 12).
-
-bcrypt_logRounds_18() ->
-    bcrypt_assert_equal(<<"password">>, 18).
 
 bcrypt_null_byte() ->
     bcrypt_assert_equal(<<"passw\0rd">>, 12).


### PR DESCRIPTION
Since we are using 3rd party app for `bcrypt` and `couch_passwords: bcrypt/2` is just an interface for it there are no need to test correctness of the lib itself, just the fact that we are using it properly.

Test `bcrypt_logRounds_18` is kind of a resource hog, so I suggest to remove it to easy a  burden on Travis and Jenkins. This reduces the test runtime on my laptop from 75s to 15s and I suspect the difference for CI will be even greater.