### PR TITLE
[WIP] Re-introduce etags in view

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -682,7 +682,11 @@ multi_all_docs_view(Req, Db, OP, Queries) ->
 
 all_docs_view(Req, Db, Keys, OP) ->
     Args0 = couch_mrview_http:parse_params(Req, Keys),
-    Args1 = Args0#mrargs{view_type=map},
+    ETagFun = fun(Sig, Acc) ->
+        ETag = couch_httpd:make_etag(Sig),
+        {ok, Acc#vacc{etag=ETag}}
+    end,
+    Args1 = Args0#mrargs{view_type=map, preflight_fun=ETagFun},
     Args2 = couch_mrview_util:validate_args(Args1),
     Args3 = set_namespace(OP, Args2),
     Options = [{user_ctx, Req#httpd.user_ctx}],

--- a/src/chttpd/src/chttpd_view.erl
+++ b/src/chttpd/src/chttpd_view.erl
@@ -41,7 +41,12 @@ multi_query_view(Req, Db, DDoc, ViewName, Queries) ->
 
 
 design_doc_view(Req, Db, DDoc, ViewName, Keys) ->
-    Args = couch_mrview_http:parse_params(Req, Keys),
+    Args0 = couch_mrview_http:parse_params(Req, Keys),
+    ETagFun = fun(Sig, Acc) ->
+        ETag = couch_httpd:make_etag(Sig),
+        {ok, Acc#vacc{etag=ETag}}
+    end,
+    Args = Args0#mrargs{preflight_fun=ETagFun},
     Max = chttpd:chunked_response_buffer_size(),
     VAcc = #vacc{db=Db, req=Req, threshold=Max},
     Options = [{user_ctx, Req#httpd.user_ctx}],

--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -216,7 +216,9 @@ query_all_docs(Db, Args, Callback, Acc) when is_list(Args) ->
     query_all_docs(Db, to_mrargs(Args), Callback, Acc);
 query_all_docs(Db, Args0, Callback, Acc) ->
     Sig = couch_util:with_db(Db, fun(WDb) ->
-        {ok, Info} = couch_db:get_db_info(WDb),
+        {ok, Info0} = couch_db:get_db_info(WDb),
+        Keys = [db_name, doc_count, doc_del_count, update_seq, purge_seq],
+        Info = lists:filter(fun({K, _}) -> lists:member(K, Keys) end, Info0),
         couch_index_util:hexsig(crypto:hash(md5, term_to_binary(Info)))
     end),
     Args1 = Args0#mrargs{view_type=map},

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -351,7 +351,7 @@ view_cb(Msg, #vacc{resp=undefined, etag=undefined}=Acc) ->
     view_cb(Msg, Acc#vacc{resp=Resp, should_close=true});
 
 view_cb(Msg, #vacc{req=Req, resp=undefined, etag=ETag}=Acc) ->
-    Headers = [{"ETag", ETag}],
+    Headers = [{"ETag", ETag}, {<<"Vary">>, <<"Accept">>}],
     case chttpd:etag_match(Req, ETag) of
         true ->
             {ok, Resp} = chttpd:send_response(Req, 304, Headers, <<>>),

--- a/src/fabric/include/fabric.hrl
+++ b/src/fabric/include/fabric.hrl
@@ -32,7 +32,7 @@
     sorted,
     user_acc,
     update_seq,
-    etag = sets:new()
+    etag = []
 }).
 
 -record(stream_acc, {

--- a/src/fabric/include/fabric.hrl
+++ b/src/fabric/include/fabric.hrl
@@ -31,7 +31,8 @@
     lang,
     sorted,
     user_acc,
-    update_seq
+    update_seq,
+    etag = sets:new()
 }).
 
 -record(stream_acc, {

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -302,9 +302,9 @@ get_or_create_db(DbName, Options) ->
     couch_db:open_int(DbName, [{create_if_missing, true} | Options]).
 
 
-view_cb({meta, Meta}, Acc) ->
+view_cb({meta, Meta}, #vacc{etag = ETag} = Acc) ->
     % Map function starting
-    ok = rexi:stream2({meta, Meta}),
+    ok = rexi:stream2([{meta, Meta}, {etag, ETag}]),
     {ok, Acc};
 view_cb({row, Row}, Acc) ->
     % Adding another row

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -324,9 +324,9 @@ view_cb(ok, ddoc_updated) ->
     rexi:reply({ok, ddoc_updated}).
 
 
-reduce_cb({meta, Meta}, Acc) ->
+reduce_cb({meta, Meta}, #vacc{etag = ETag} = Acc) ->
     % Map function starting
-    ok = rexi:stream2({meta, Meta}),
+    ok = rexi:stream2([{meta, Meta}, {etag, ETag}]),
     {ok, Acc};
 reduce_cb({row, Row}, Acc) ->
     % Adding another row

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -313,6 +313,8 @@ maybe_set_etag(undefined, Acc) ->
     {ok, Acc};
 maybe_set_etag(ETag, #vacc{} = Acc) ->
     {ok, Acc#vacc{etag = ETag}};
+maybe_set_etag(ETag, #lacc{} = Acc) ->
+    {ok, Acc#lacc{etag = ETag}};
 maybe_set_etag(_, Acc) ->
     {ok, Acc}.
 

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -316,10 +316,12 @@ maybe_set_etag(ETag, #vacc{} = Acc) ->
 maybe_set_etag(_, Acc) ->
     {ok, Acc}.
 
+make_etag([]) ->
+    undefined;
 make_etag(ETags) ->
-    case sets:size(ETags) > 0 andalso not sets:is_element(undefined, ETags) of
-        true -> ?b2l(chttpd:make_etag(ETags));
-        false -> undefined
+    case lists:member(undefined, ETags) of
+        true -> undefined;
+        false -> ?b2l(chttpd:make_etag(lists:usort(ETags)))
     end.
 
 %% test function
@@ -394,11 +396,29 @@ upgrade_mrargs({mrargs,
 -include_lib("eunit/include/eunit.hrl").
 
 make_etag_test() ->
-    ETagsEmpty = sets:new(),
-    ETagsUndef1 = sets:from_list([undefined]),
-    ETagsUndef2 = sets:from_list([chttpd:make_etag(a), undefined]),
-    ETags1 = sets:from_list([chttpd:make_etag(A) || A <- [a, b, a, c, c, b]]),
-    ETags2 = sets:from_list([chttpd:make_etag(A) || A <- [b, c, a, b, a, c]]),
+    ETagsEmpty = [],
+    ETagsUndef1 = [undefined],
+    ETagsUndef2 = [chttpd:make_etag(a), undefined],
+    ETags1 = [
+        <<"\"2F332B4YM6IYB0S4TL61WB07T\"">>,
+        <<"\"AVHZC4PRSDE1I6C13FMROYFER\"">>,
+        <<"\"D7Q054EV4MVV6G57TRLUVQUNG\"">>,
+        <<"\"CT8FCP4VF9AHGS75L255B4TAN\"">>,
+        <<"\"8WRGVGKV4IQWH5JELHHBD8SCP\"">>,
+        <<"\"1YTAPUW4HXKHL3JO3Y487O5H\"">>,
+        <<"\"189S9QEX2P5CG3XSYHX0DMIUM\"">>,
+        <<"\"DXK436MEITBQGE9CY61MH6OFD\"">>
+    ],
+    ETags2 = [
+        <<"\"189S9QEX2P5CG3XSYHX0DMIUM\"">>,
+        <<"\"2F332B4YM6IYB0S4TL61WB07T\"">>,
+        <<"\"8WRGVGKV4IQWH5JELHHBD8SCP\"">>,
+        <<"\"D7Q054EV4MVV6G57TRLUVQUNG\"">>,
+        <<"\"DXK436MEITBQGE9CY61MH6OFD\"">>,
+        <<"\"CT8FCP4VF9AHGS75L255B4TAN\"">>,
+        <<"\"AVHZC4PRSDE1I6C13FMROYFER\"">>,
+        <<"\"1YTAPUW4HXKHL3JO3Y487O5H\"">>
+    ],
     [
         ?assertEqual(undefined, make_etag(ETagsEmpty)),
         ?assertEqual(undefined, make_etag(ETagsUndef1)),

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -394,15 +394,15 @@ upgrade_mrargs({mrargs,
 -include_lib("eunit/include/eunit.hrl").
 
 make_etag_test() ->
-    EtagsEmpty = sets:new(),
-    EtagsUndef1 = sets:from_list([undefined]),
-    EtagsUndef2 = sets:from_list([chttpd:make_etag(a), undefined]),
+    ETagsEmpty = sets:new(),
+    ETagsUndef1 = sets:from_list([undefined]),
+    ETagsUndef2 = sets:from_list([chttpd:make_etag(a), undefined]),
     ETags1 = sets:from_list([chttpd:make_etag(A) || A <- [a, b, a, c, c, b]]),
     ETags2 = sets:from_list([chttpd:make_etag(A) || A <- [b, c, a, b, a, c]]),
     [
-        ?assertEqual(undefined, make_etag(EtagsEmpty)),
-        ?assertEqual(undefined, make_etag(EtagsUndef1)),
-        ?assertEqual(undefined, make_etag(EtagsUndef2)),
+        ?assertEqual(undefined, make_etag(ETagsEmpty)),
+        ?assertEqual(undefined, make_etag(ETagsUndef1)),
+        ?assertEqual(undefined, make_etag(ETagsUndef2)),
         ?assertEqual(make_etag(ETags1), make_etag(ETags2))
     ].
 

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -143,6 +143,9 @@ handle_message({rexi_EXIT, Reason}, Worker, State) ->
     fabric_view:handle_worker_exit(State, Worker, Reason);
 
 handle_message({meta, Meta0}, {Worker, From}, State) ->
+    handle_message([{meta, Meta0}, {etag, undefined}], {Worker, From}, State);
+
+handle_message([{meta, Meta0}, {etag, _}], {Worker, From}, State) ->
     Tot = couch_util:get_value(total, Meta0, 0),
     Off = couch_util:get_value(offset, Meta0, 0),
     Seq = couch_util:get_value(update_seq, Meta0, 0),

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -170,7 +170,7 @@ handle_message([{meta, Meta0}, {etag, ETag0}], {Worker, From}, State) ->
         {_, null} -> null;
         _   -> [{Worker, Seq} | UpdateSeq0]
     end,
-    ETags = sets:add_element(ETag0, ETags0),
+    ETags = [ETag0 | ETags0],
     case fabric_dict:any(0, Counters1) of
     true ->
         {ok, State#collector{

--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -121,7 +121,7 @@ handle_message([{meta, Meta0}, {etag, ETag0}], {Worker, From}, State) ->
         nil -> nil;
         _   -> [{Worker, Seq} | UpdateSeq0]
     end,
-    ETags = sets:add_element(ETag0, ETags0),
+    ETags = [ETag0 | ETags0],
     case fabric_dict:any(0, Counters1) of
     true ->
         {ok, State#collector{


### PR DESCRIPTION
*This is Work In Progress, not ready for review yet.*

## Overview

We had to remove `ETag` header from views in clustered env. Reportedly this had a noticeable effect on performance, so this PR is making an attempt to bring reliable etags back.

## Testing recommendations

For now the standard test suite should continue to pass.

## Related Issues or Pull Requests

  - #1226 
  - [COUCHDB-2859](https://issues.apache.org/jira/browse/COUCHDB-2859)

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
