### PR TITLE
Allow couch_os_daemons to live in directories with spaces

### DIFF
--- a/src/couch/src/couch_os_daemons.erl
+++ b/src/couch/src/couch_os_daemons.erl
@@ -216,7 +216,7 @@ start_port(Command) ->
 
 start_port(Command, EnvPairs) ->
     PrivDir = couch_util:priv_dir(),
-    Spawnkiller = filename:join(PrivDir, "couchspawnkillable"),
+    Spawnkiller = "\"" ++ filename:join(PrivDir, "couchspawnkillable") ++ "\"",
     Opts = case lists:keytake(env, 1, ?PORT_OPTIONS) of
         false ->
             ?PORT_OPTIONS ++ [ {env,EnvPairs} ];


### PR DESCRIPTION
See #997 and https://github.com/apache/couchdb/commit/f122f94291bfbc87496efca3c04540bb190b985a for context.