### PR TITLE
Fix couch peruser test suite

### DIFF
--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -196,7 +196,6 @@ should_create_user_db_with_q4(TestAuthDb) ->
     {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f">>),
     {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
     delete_config("couch_peruser", "q"),
-
     [
         ?_assert(lists:member(<<"userdb-666f6f">>, all_dbs())),
         ?_assertEqual(4, couch_util:get_value(q, ClusterInfo))

--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -63,10 +63,8 @@ teardown(TestAuthDb) ->
 set_config(Section, Key, Value) ->
     ok = config:set(Section, Key, Value, _Persist=false).
 
-delete_config(Section, Key, Value) ->
-    Url = lists:concat([
-        get_base_url(), "/_config/", Section, "/", Key]),
-    do_request(delete, Url, "\"" ++ Value ++ "\"").
+delete_config(Section, Key) ->
+    ok = config:delete(Section, Key, _Persist=false).
 
 do_request(Method, Url) ->
     Headers = [{basic_auth, {?ADMIN_USERNAME, ?ADMIN_PASSWORD}}],
@@ -157,14 +155,14 @@ should_create_user_db_with_custom_prefix(TestAuthDb) ->
     set_config("couch_peruser", "database_prefix", "newuserdb-"),
     create_user(TestAuthDb, "fooo"),
     wait_for_db_create(<<"newuserdb-666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix", "newuserdb-"),
+    delete_config("couch_peruser", "database_prefix"),
     ?_assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs())).
 
 should_create_user_db_with_custom_special_prefix(TestAuthDb) ->
     set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
     create_user(TestAuthDb, "fooo"),
     wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    delete_config("couch_peruser", "database_prefix"),
     ?_assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs())).
 
 should_create_anon_user_db_with_default(TestAuthDb) ->
@@ -181,14 +179,14 @@ should_create_anon_user_db_with_custom_prefix(TestAuthDb) ->
     set_config("couch_peruser", "database_prefix", "newuserdb-"),
     create_anon_user(TestAuthDb, "fooo"),
     wait_for_db_create(<<"newuserdb-666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix", "newuserdb-"),
+    delete_config("couch_peruser", "database_prefix"),
     ?_assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs())).
 
 should_create_anon_user_db_with_custom_special_prefix(TestAuthDb) ->
     set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
     create_anon_user(TestAuthDb, "fooo"),
     wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    delete_config("couch_peruser", "database_prefix"),
     ?_assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs())).
 
 should_create_user_db_with_q4(TestAuthDb) ->
@@ -197,7 +195,7 @@ should_create_user_db_with_q4(TestAuthDb) ->
     wait_for_db_create(<<"userdb-666f6f">>),
     {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f">>),
     {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
-    delete_config("couch_peruser", "q", "4"),
+    delete_config("couch_peruser", "q"),
 
     [
         ?_assert(lists:member(<<"userdb-666f6f">>, all_dbs())),
@@ -210,7 +208,7 @@ should_create_anon_user_db_with_q4(TestAuthDb) ->
     wait_for_db_create(<<"userdb-666f6f6f">>),
     {ok, TargetInfo} = fabric:get_db_info(<<"userdb-666f6f6f">>),
     {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
-    delete_config("couch_peruser", "q", "4"),
+    delete_config("couch_peruser", "q"),
     [
         ?_assert(lists:member(<<"userdb-666f6f6f">>, all_dbs())),
         ?_assertEqual(4, couch_util:get_value(q, ClusterInfo))
@@ -249,7 +247,7 @@ should_delete_user_db_with_custom_prefix(TestAuthDb) ->
     AfterCreate = lists:member(UserDbName, all_dbs()),
     delete_user(TestAuthDb, User),
     wait_for_db_delete(UserDbName),
-    delete_config("couch_peruser", "database_prefix", "newuserdb-"),
+    delete_config("couch_peruser", "database_prefix"),
     AfterDelete = lists:member(UserDbName, all_dbs()),
     [
         ?_assert(AfterCreate),
@@ -266,7 +264,7 @@ should_delete_user_db_with_custom_special_prefix(TestAuthDb) ->
     AfterCreate = lists:member(UserDbName, all_dbs()),
     delete_user(TestAuthDb, User),
     wait_for_db_delete(UserDbName),
-    delete_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+    delete_config("couch_peruser", "database_prefix"),
     AfterDelete = lists:member(UserDbName, all_dbs()),
     [
         ?_assert(AfterCreate),

--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -111,9 +111,13 @@ delete_user(AuthDb, Name) ->
 get_security(DbName) ->
     Url = lists:concat([
         get_cluster_base_url(), "/", ?b2l(DbName), "/_security"]),
-    {ok, 200, _, Body} = do_request(get, Url),
-    {SecurityProperties} = jiffy:decode(Body),
-    SecurityProperties.
+    test_util:wait(fun() ->
+        {ok, 200, _, Body} = do_request(get, Url),
+        case jiffy:decode(Body) of
+            {[]} -> wait;
+            {SecurityProperties} -> SecurityProperties
+        end
+    end).
 
 set_security(DbName, SecurityProperties) ->
     Url = lists:concat([

--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -53,10 +53,10 @@ teardown(TestAuthDb) ->
     set_config("cluster", "n", "3"),
     do_request(delete, get_cluster_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     do_request(delete, get_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
-    lists:foreach(fun (DbName) ->
-        case DbName of
-        <<"userdb-",_/binary>> -> delete_db(DbName);
-        _ -> ok
+    lists:foreach(fun(DbName) ->
+        case binary:part(DbName, 0, 7) of
+            <<"userdb-">> -> delete_db(DbName);
+            _ -> ok
         end
     end, all_dbs()).
 

--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -18,7 +18,6 @@
 -define(ADMIN_USERNAME, "admin").
 -define(ADMIN_PASSWORD, "secret").
 
--define(WAIT_FOR_DB_TIMEOUT, 1000).
 -define(WAIT_FOR_USER_DELETE_TIMEOUT, 3000).
 
 setup_all() ->


### PR DESCRIPTION
## Overview

This PR removes some unreliable helper functions and addresses a race condition in acquiring security object that triggered occasionally test failures.

## Testing recommendations
Local run `make eunit apps=couch_peruser suites=couch_peruser_test`, but most important Travis should stop breaking in couch peruser test suite.

## Related Issues or Pull Requests

Resolves #1236 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
