### PR TITLE
fix: more reliable password scheme tests

### DIFF
--- a/test/javascript/couch_test_runner.js
+++ b/test/javascript/couch_test_runner.js
@@ -427,7 +427,9 @@ function waitForSuccess(fun, tag) {
       try {
         fun();
         break;
-      } catch (e) {}
+      } catch (e) {
+        log(e)
+      }
       // sync http req allow async req to happen
       try {
         CouchDB.request("GET", "/test_suite_db/?tag="+encodeURIComponent(tag));

--- a/test/javascript/tests/users_db_security.js
+++ b/test/javascript/tests/users_db_security.js
@@ -411,11 +411,27 @@ couchTests.users_db_security = function(debug) {
       function() {
         try {
           testFun(scheme, derivedKeyTests[scheme], saltTests[scheme]);
+        } catch (e) {
+          throw(e)
         } finally {
           CouchDB.login("jan", "apple");
           usersDb.deleteDb(); // cleanup
-          sleep(5000);
+          waitForSuccess(function() {
+            var req = CouchDB.request("GET", db_name);
+            if (req.status == 404) {
+              return true
+            }
+            throw({});
+          }, 'usersDb.deleteDb')
+
           usersDb.createDb();
+          waitForSuccess(function() {
+            var req = CouchDB.request("GET", db_name);
+            if (req.status == 200) {
+              return true
+            }
+            throw({});
+          }, 'usersDb.creteDb')
         }
       }
     );
@@ -501,8 +517,21 @@ couchTests.users_db_security = function(debug) {
       } finally {
         CouchDB.login("jan", "apple");
         usersDb.deleteDb(); // cleanup
-        sleep(5000);
+        waitForSuccess(function() {
+          var req = CouchDB.request("GET", db_name);
+          if (req.status == 404) {
+            return true
+          }
+          throw({});
+        }, 'usersDb.deleteDb')
         usersDb.createDb();
+        waitForSuccess(function() {
+          var req = CouchDB.request("GET", db_name);
+          if (req.status == 200) {
+            return true
+          }
+          throw({});
+        }, 'usersDb.creteDb')
       }
     }
   );


### PR DESCRIPTION
Closes #1238

1. log errors from waitForSuccess
2. log errors in testFun()
3. spinloop replaces arbitrary wait timeout
