### PR TITLE
Fix shard substitution in changes feeds

### DIFF
--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -341,14 +341,12 @@ find_repl_doc(SrcDb, TgtUUIDPrefix) ->
     SrcUUID = couch_db:get_uuid(SrcDb),
     S = couch_util:encodeBase64Url(crypto:hash(md5, term_to_binary(SrcUUID))),
     DocIdPrefix = <<"_local/shard-sync-", S/binary, "-">>,
-    FoldFun = fun({DocId, {Rev0, {BodyProps}}}, _) ->
+    FoldFun = fun(#doc{id = DocId, body = {BodyProps}} = Doc, _) ->
         TgtUUID = couch_util:get_value(<<"target_uuid">>, BodyProps, <<>>),
         case is_prefix(DocIdPrefix, DocId) of
             true ->
                 case is_prefix(TgtUUIDPrefix, TgtUUID) of
                     true ->
-                        Rev = list_to_binary(integer_to_list(Rev0)),
-                        Doc = #doc{id=DocId, revs={0, [Rev]}, body={BodyProps}},
                         {stop, {TgtUUID, Doc}};
                     false ->
                         {ok, not_found}


### PR DESCRIPTION
PSE changed the local_tree's join function so we need to update this. Previously we read _local docs out of the btree that ended up just giving us {DocId, {RevId, {BodyProps}}} to our callback. PSE changed things such that we now use couch_db:fold_local_docs which provides `#doc` records.

Shard substitution happens when a changes feed is provided with a since_seq that references a ndoe that does not or has errored out some how. The substitution then goes and looks for an internal replication document so that we don't have to rewrind the changes feed entirely (i.e., we look at the internal replication checkpoint and can rewind to the place where the node-being-replaced last sent us documents).