### PR TITLE
Fix killing of OS processes

### DIFF
--- a/src/couch/src/couch_os_process.erl
+++ b/src/couch/src/couch_os_process.erl
@@ -167,7 +167,6 @@ init([Command, Options, PortOptions]) ->
     spawn(fun() ->
             % this ensure the real os process is killed when this process dies.
             erlang:monitor(process, Pid),
-            receive _ -> ok end,
             killer(?b2l(KillCmd))
         end),
     OsProc =


### PR DESCRIPTION
This was a latent bad merge that failed to remove the duplicate receive
statement. This ended up discarding the monitor's 'DOWN' message which
leads to an infinite loop in couch_os_proces:killer/1.
