### PR TITLE
Fix compaction resumption for the BT engine

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -92,6 +92,7 @@
 % Used by the compactor
 -export([
     set_update_seq/2,
+    update_header/2,
     copy_security/2
 ]).
 

--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -386,7 +386,7 @@ commit_compaction_data(#st{header = OldHeader} = St0, Fd) ->
     MetaFd = couch_emsort:get_fd(St0#st.id_tree),
     MetaState = couch_emsort:get_state(St0#st.id_tree),
     St1 = bind_id_tree(St0, St0#st.fd, DataState),
-    Header = St1#st.header,
+    Header = couch_bt_engine:update_header(St1, St1#st.header),
     CompHeader = #comp_header{
         db_header = Header,
         meta_state = MetaState


### PR DESCRIPTION
This bug prevents the proper resumption of compactions that died during
the meta copy phase. The issue is that we were setting the update_seq
but not copying over the id and seq tree states. Thus when compaction
resumed from the bad files we'd end up skipping the part where we copy
docs over and then think everything was finished. Thus completely
clearing a database of its contents.

Luckily this isn't release code and as such should have fairly minimal
impact other than those who might be running off master.

Note: Once I finish emergency patching everything affected by this bug I'm gonna add a unit test that shows this behavior.