### PR TITLE
Make loginUser wait for successful authentication

### DIFF
--- a/test/javascript/tests/users_db_security.js
+++ b/test/javascript/tests/users_db_security.js
@@ -32,7 +32,13 @@ couchTests.users_db_security = function(debug) {
     // the actual tests
     var username1 = username.replace(/[0-9]$/, "");
     var password = pws[username];
-    T(CouchDB.login(username1, pws[username]).ok);
+    waitForSuccess(function() {
+      var req = CouchDB.login(username1, pws[username]);
+      if (req.ok) {
+        return true
+      }
+      throw({});
+    }, 'loginUser');
   };
 
   var open_as = function(db, docId, username) {
@@ -107,7 +113,6 @@ couchTests.users_db_security = function(debug) {
 
     // jan's gonna be admin as he's the first user
     TEquals(true, usersDb.save(userDoc).ok, "should save document");
-    wait(5000);
     userDoc = open_as(usersDb, "org.couchdb.user:jchris", "jchris");
     TEquals(undefined, userDoc.password, "password field should be null 1");
     TEquals(scheme, userDoc.password_scheme, "password_scheme should be " + scheme);


### PR DESCRIPTION
## Overview

On restrained hosts bcrypt and sometimes pbkdf2 can't finish hashing for new users within 5 sec timeout leading to tests failures. This fix makes `loginUser` to actually wait for successful authentication.

## Testing recommendations

Javascript test suite should pass on both Travis and Jenkins


## Related Issues or Pull Requests

Fixes #1238 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
