### PR TITLE
fix file_compression value description

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -16,7 +16,7 @@ delayed_commits = false
 ;
 ; none         - no compression
 ; snappy       - use google snappy, a very fast compressor/decompressor
-; deflate_[N]  - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
+; deflate_N    - use zlib's deflate, N is the compression level which ranges from 1 (fastest,
 ;                lowest compression ratio) to 9 (slowest, highest compression ratio)
 file_compression = snappy
 ; Higher values may give better read performance due to less read operations


### PR DESCRIPTION
## Overview

deflate_N value is more clear description and obvious to replace only N. The same description is used in documentation.

## Checklist

- [x] Documentation reflects the changes;
