### PR TITLE
Fix typo in node local _replicate handler

### DIFF
--- a/src/couch_replicator/src/couch_replicator_httpd.erl
+++ b/src/couch_replicator/src/couch_replicator_httpd.erl
@@ -91,7 +91,7 @@ handle_scheduler_req(Req) ->
 handle_req(#httpd{method = 'POST', user_ctx = UserCtx} = Req) ->
     couch_httpd:validate_ctype(Req, "application/json"),
     RepDoc = {Props} = couch_httpd:json_body_obj(Req),
-    couch_replicator_httpd_utils:validate_rep_props(Props),
+    couch_replicator_httpd_util:validate_rep_props(Props),
     case couch_replicator:replicate(RepDoc, UserCtx) of
     {error, {Error, Reason}} ->
         send_json(


### PR DESCRIPTION
Dialyzer run discovered:

```
Unknown function couch_replicator_httpd_utils:validate_rep_props/1
```

Indeed, the function should be
```
couch_replicator_httpd_util:validate_rep_props/1
```
