### PR TITLE
Document enable_database_recovery ini option

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -58,6 +58,12 @@ changes_doc_ids_optimization_threshold = 100
 ; The default storage engine to use when creating databases
 ; is set as a key into the [couchdb_engines] section.
 default_engine = couch
+;
+; Enable this to only "soft-delete" databases when DELETE /{db} requests are
+; made. This will place a .recovery directory in your data directory and
+; move deleted databases/shards there instead. You can then manually delete
+; these files later, as desired.
+;enable_database_recovery = false
 
 [couchdb_engines]
 ; The keys in this section are the filename extension that


### PR DESCRIPTION
Documents the heretofore hidden `[couchdb] enable_database_recovery` ini file option.

A similar PR against couchdb-documentation is coming.