### PR TITLE
Fix length badarg error in mp parser

### DIFF
--- a/src/couch/src/couch_httpd_multipart.erl
+++ b/src/couch/src/couch_httpd_multipart.erl
@@ -208,7 +208,8 @@ remove_writer(WriterPid, WriterRef, Counters) ->
         {ok, {WriterRef, _}} ->
             case num_mp_writers() of
                 N when N > 1 ->
-                    num_mp_writers(N - 1);
+                    num_mp_writers(N - 1),
+                    orddict:erase(WriterPid, Counters);
                 _ ->
                     abort_parsing
             end;


### PR DESCRIPTION
This was introduced in:

https://github.com/apache/couchdb/commit/083239353e919e897b97e8a96ee07cb42ca4eccd

Issue #1286
