### PR TITLE
Force use of SMP enabled BEAM VM, fixes #1296

### DIFF
--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -45,3 +45,6 @@
 
 # Comment this line out to enable the interactive Erlang shell on startup
 +Bd -noinput
+
+# Force use of the smp scheduler, fixes #1296
+-smp enable


### PR DESCRIPTION
enif_send (in bcrypt support) requires beam.smp. So, force its use everywhere.

Fixes #1296 