### PR TITLE
Bump fauxton to fix CI builds

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -58,7 +58,7 @@ DepDescs = [
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
                    {tag, "2.1.0"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
-                   {tag, "v1.1.13"}, [raw]},
+                   {tag, "v1.1.15"}, [raw]},
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.2"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1"}},


### PR DESCRIPTION
Pursuant to apache/couchdb-fauxton#1079 we need to bump our fauxton dependency to fix Fauxton builds. (Right now, Jenkins is completely broken because of a renamed dependency in npm-land preventing Fauxton from building.)