### PR TITLE
Add SSL session_lifetime limit for ibrowse pids

### DIFF
--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -48,3 +48,6 @@
 
 # Force use of the smp scheduler, fixes #1296
 -smp enable
+
+# Set maximum SSL session lifetime to reap terminated replication readers
+-ssl session_lifetime 300


### PR DESCRIPTION
In chats with @nickva it became clear that this is a recommended setting. I have found this to limit pid explosion (and thus RAM explosion) across multiple production envs, especially where https is used for the replication reader.

We should make it the default going forward.