### PR TITLE
Mango: implicit coverage for _id and _rev during index selection

### DIFF
--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -127,7 +127,7 @@ is_usable(Idx, Selector, SortFields) ->
     % _id and _rev are implicitly in every document so
     % we don't need to check the selector for these either
     RequiredFields2 = ordsets:subtract(
-        lists:usort(RequiredFields1), 
+        RequiredFields1,
         [<<"_id">>, <<"_rev">>]),
 
     mango_selector:has_required_fields(Selector, RequiredFields2)

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -124,7 +124,13 @@ is_usable(Idx, Selector, SortFields) ->
     % we don't need to check the selector for these
     RequiredFields1 = ordsets:subtract(lists:usort(RequiredFields), lists:usort(SortFields)),
 
-    mango_selector:has_required_fields(Selector, RequiredFields1)
+    % _id and _rev are implicitly in every document so
+    % we don't need to check the selector for these either
+    RequiredFields2 = ordsets:subtract(
+        lists:usort(RequiredFields1), 
+        [<<"_id">>, <<"_rev">>]),
+
+    mango_selector:has_required_fields(Selector, RequiredFields2)
         andalso not is_text_search(Selector).
 
 

--- a/src/mango/test/12-use-correct-index-test.py
+++ b/src/mango/test/12-use-correct-index-test.py
@@ -114,3 +114,16 @@ class ChooseCorrectIndexForDocs(mango.DbPerClass):
         explain = self.db.find(selector, explain=True)
         self.assertEqual(explain["index"]["ddoc"], "_design/bbb")
         self.assertEqual(explain["mrargs"]["end_key"], [10, '<MAX>'])
+
+    # all documents contain an _id and _rev field they
+    # should not be used to restrict indexes based on the
+    # fields required by the selector
+    def test_choose_index_with_id(self):
+        self.db.create_index(["name", "_id"], ddoc="aaa")
+        explain = self.db.find({"name": "Eddie"}, explain=True)
+        self.assertEqual(explain["index"]["ddoc"], '_design/aaa')
+
+    def test_choose_index_with_rev(self):
+        self.db.create_index(["name", "_rev"], ddoc="aaa")
+        explain = self.db.find({"name": "Eddie"}, explain=True)
+        self.assertEqual(explain["index"]["ddoc"], '_design/aaa')


### PR DESCRIPTION
## Overview

Mango requires that a JSON index can only be used to fulfil
a query if the "selector" field covers all of the fields the
index. For example, if an index contains ["a", "b"] but the
selector only requires field ["a"] to exist in the matching documents,
the index would not be valid for the query (because it only includes
documents containing both "a" and "b").

There is a special case here around built-in fields; _id and _rev
specifically, because they are guaranteed to exist in any matching
documents.

If a user declares an index ["a", "_id"], we can safely exclude "_id"
from the index coverage check, so a selector of {"a": "foo"} should be
able to use this index.

Prior to this commit, a user would have to alter the selector so that
it covered the "_id" field, e.g. {"a": "foo",
"_id": {"$exists": true}}. The commit removes the need to explicitly
cover _id or _rev fields in the query selector.

## Testing recommendations

Tests have been added to the Mango test suite. To manually test, create an index which includes `"_id"` and/or `"_rev"` and another field. Check that calling `_find` (or `_explain`) with a selector that does not include `"_id"` or `"_rev"` but does reference the other indexed fields will use the index.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
