### PR TITLE
[4/5] Clustered Purge: Add on_compact EPI hook

### DIFF
--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -44,6 +44,8 @@ start(#st{} = St, DbName, Options, Parent) ->
     } = St,
     couch_log:debug("Compaction process spawned for db \"~s\"", [DbName]),
 
+    couch_db_engine:trigger_on_compact(DbName),
+
     {ok, NewSt, DName, DFd, MFd, Retry} =
             open_compaction_files(Header, FilePath, Options),
     erlang:monitor(process, MFd),

--- a/src/couch/src/couch_db_plugin.erl
+++ b/src/couch/src/couch_db_plugin.erl
@@ -18,6 +18,7 @@
     after_doc_read/2,
     validate_docid/1,
     check_is_admin/1,
+    on_compact/2,
     on_delete/2
 ]).
 
@@ -55,6 +56,10 @@ check_is_admin(Db) ->
     Handle = couch_epi:get_handle(?SERVICE_ID),
     %% callbacks return true only if it specifically allow the given Id
     couch_epi:any(Handle, ?SERVICE_ID, check_is_admin, [Db], []).
+
+on_compact(DbName, DDocs) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    couch_epi:apply(Handle, ?SERVICE_ID, on_compact, [DbName, DDocs], []).
 
 on_delete(DbName, Options) ->
     Handle = couch_epi:get_handle(?SERVICE_ID),


### PR DESCRIPTION
This adds an on_compact hook to the couch_db_plugin. This is so that secondary indices can create their local purge sequence docs when a database is upgraded to use clustered purge.

This depends on PRs #1366, #1367, and #1368.