### PR TITLE
Fix _approx_count_distinct on non-clustered interface, optimize _stats

### DIFF
--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -87,12 +87,12 @@ group_reductions_results(List) ->
      [Heads | group_reductions_results(Tails)]
     end.
 
-finalize(<<"_approx_count_distinct">>, Reduction) ->
+finalize(<<"_approx_count_distinct",_/binary>>, Reduction) ->
     true = hyper:is_hyper(Reduction),
     {ok, round(hyper:card(Reduction))};
-finalize(<<"_stats">>, {_, _, _, _, _} = Unpacked) ->
+finalize(<<"_stats",_/binary>>, {_, _, _, _, _} = Unpacked) ->
     {ok, pack_stats(Unpacked)};
-finalize(<<"_stats">>, {Packed}) ->
+finalize(<<"_stats",_/binary>>, {Packed}) ->
     % Legacy code path before we had the finalize operation
     {ok, {Packed}};
 finalize(_RedSrc, Reduction) ->

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -142,8 +142,9 @@ reduce_view(DbName, DDoc, ViewName, Args0, DbOptions) ->
     couch_mrview:query_view(Db, DDoc, ViewName, Args, fun reduce_cb/2, VAcc0).
 
 fix_skip_and_limit(Args) ->
-    #mrargs{skip=Skip, limit=Limit}=Args,
-    Args#mrargs{skip=0, limit=Skip+Limit}.
+    #mrargs{skip=Skip, limit=Limit, extra=Extra}=Args,
+    % the coordinator needs to finalize each row, so make sure the shards don't
+    Args#mrargs{skip=0, limit=Skip+Limit, extra=[{finalizer,null} | Extra]}.
 
 create_db(DbName) ->
     create_db(DbName, []).

--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -230,7 +230,7 @@ get_next_row(#collector{reducer = RedSrc} = St) when RedSrc =/= undefined ->
         end, Counters0, Records),
         Wrapped = [[V] || #view_row{value=V} <- Records],
         {ok, [Reduced]} = couch_query_servers:rereduce(Lang, [RedSrc], Wrapped),
-        {ok, [Finalized]} = couch_query_servers:finalize([Reduced]),
+        {ok, Finalized} = couch_query_servers:finalize(RedSrc, Reduced),
         NewSt = St#collector{keys=RestKeys, rows=NewRowDict, counters=Counters},
         {#view_row{key=Key, id=reduced, value=Finalized}, NewSt};
     error ->


### PR DESCRIPTION
## Overview

One bugfix and one enhancement here. The bugfix is that the `finalize` operation introduced for `_approx_count_distinct` was not being executed on view requests coming in through the non-clustered interface, so any attempt to use that reduce function there would crash.

The enhancement is to take advantage of that `finalize` operation to optimize the builtin `_stats` reduce function. Previously the reduce function would always write down an ejson form for the 5 statistical quantities to disk as it could never know whether the `rereduce` function was being called during indexing or during querying. Now that we have the `finalize` operation (which only runs at query time) we can store a more compact format on disk and avoid continuously translating back and forth between the compact and ejson formats during indexing. This should result in slightly more efficient builds and slightly smaller resulting indexes.

## Testing recommendations

Run the _stats tests against clustered and non-clustered interfaces.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;