### PR TITLE
Make `bin_opt_info` optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ help:
 
 
 .PHONY: couch
-# target: couch - Build CouchDB core
+# target: couch - Build CouchDB core, use ERL_OPTS to provide custom compiler's options
 couch: config.erl
 	@COUCHDB_VERSION=$(COUCHDB_VERSION) $(REBAR) compile $(COMPILE_OPTS)
 	@cp src/couch/priv/couchjs bin/

--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,19 @@ skip_deps=folsom,meck,mochiweb,triq,snappy,bcrypt,hyper
 suites=
 tests=
 
+COMPILE_OPTS=$(shell echo "\
+	apps=$(apps) \
+	" | sed -e 's/[a-z_]\{1,\}= / /g')
 EUNIT_OPTS=$(shell echo "\
 	apps=$(apps) \
 	skip_deps=$(skip_deps) \
 	suites=$(suites) \
 	tests=$(tests) \
-	" | sed -e 's/[a-z]\+= / /g')
+	" | sed -e 's/[a-z]\{1,\}= / /g')
 DIALYZE_OPTS=$(shell echo "\
 	apps=$(apps) \
 	skip_deps=$(skip_deps) \
-	" | sed -e 's/[a-z]\+= / /g')
+	" | sed -e 's/[a-z]\{1,\}= / /g')
 
 #ignore javascript tests
 ignore_js_suites=
@@ -75,7 +78,7 @@ help:
 .PHONY: couch
 # target: couch - Build CouchDB core
 couch: config.erl
-	@COUCHDB_VERSION=$(COUCHDB_VERSION) $(REBAR) compile
+	@COUCHDB_VERSION=$(COUCHDB_VERSION) $(REBAR) compile $(COMPILE_OPTS)
 	@cp src/couch/priv/couchjs bin/
 
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -88,8 +88,8 @@ MakeDep = fun
 end,
 
 ErlOpts = case os:getenv("ERL_OPTS") of
-    "bin_opt_info" -> [bin_opt_info, debug_info, {i, "../"}];
-    Else -> [Else, {i, "../"}]
+    false -> [];
+    Opts -> [list_to_atom(O) || O <- string:tokens(Opts, ",")]
 end,
 
 AddConfig = [
@@ -98,7 +98,7 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, ErlOpts},
+    {erl_opts, [{i, "../"} | ErlOpts]},
     {eunit_opts, [verbose]},
     {plugins, [eunit_plugin]},
     {dialyzer, [

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -93,7 +93,7 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, [bin_opt_info, debug_info, {i, "../"}]},
+    {erl_opts, [debug_info, {i, "../"}]},
     {eunit_opts, [verbose]},
     {plugins, [eunit_plugin]},
     {dialyzer, [

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -87,13 +87,18 @@ MakeDep = fun
         {AppName, ".*", {git, Url, Version}, Options}
 end,
 
+ErlOpts = case os:getenv("ERL_OPTS") of
+    "bin_opt_info" -> [bin_opt_info, debug_info, {i, "../"}];
+    Else -> [Else, {i, "../"}]
+end,
+
 AddConfig = [
     {require_otp_vsn, "R16B03|R16B03-1|17|18|19|20"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, [{i, "../"}]},
+    {erl_opts, ErlOpts},
     {eunit_opts, [verbose]},
     {plugins, [eunit_plugin]},
     {dialyzer, [

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -93,7 +93,7 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, [debug_info, {i, "../"}]},
+    {erl_opts, [{i, "../"}]},
     {eunit_opts, [verbose]},
     {plugins, [eunit_plugin]},
     {dialyzer, [


### PR DESCRIPTION
## Overview

This modification allows to run compile on individual applications and makes compiler flag `bin_opt_info` optional to reduce amount of compiler's warnings as discussed [here](https://github.com/apache/couchdb/pull/1215#issuecomment-392826035)

## Testing recommendations

Standard test suite should pass

Command `make apps=chttpd` should compile only `chttpd` application (may need to delete its `ebin` first to actually recompile)

Command `ERL_OPTS=bin_opt_info make apps=chttpd` should recompile `chttpd` with all compiler's warnings.

## Related Issues or Pull Requests

Discussion on #1215 

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
