### PR TITLE
Fix active size calculations for views

### DIFF
--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -61,13 +61,14 @@ get(info, State) ->
     } = State,
     {ok, FileSize} = couch_file:bytes(Fd),
     {ok, ExternalSize} = couch_mrview_util:calculate_external_size(Views),
+    {ok, ActiveViewSize} = couch_mrview_util:calculate_active_size(Views),
     LogBtSize = case LogBtree of
         nil ->
             0;
         _ ->
             couch_btree:size(LogBtree)
     end,
-    ActiveSize = couch_btree:size(IdBtree) + LogBtSize + ExternalSize,
+    ActiveSize = couch_btree:size(IdBtree) + LogBtSize + ActiveViewSize,
 
     UpdateOptions0 = get(update_options, State),
     UpdateOptions = [atom_to_binary(O, latin1) || O <- UpdateOptions0],


### PR DESCRIPTION
It was brought to my attention that the active size looked a bit funny
occasionally as it could be larger than the file size. Given that active
size is defined to be the number of bytes used in a view file it must be
strictly greater than or equal to zero as well as less than or equal to
file size. Thus the great hunt had begun!

While I'd love more than anything to regail you, Dear Reader, with the
tales, the joys, the highs, and yes, even the lows of this search, it
turns out that I cannot. I must not. For there were none!

Turns out this was a trivial bug where we were re-using the ExternalSize
calculation instead of applying `couch_btree:size/1` to all of the
btrees in the `#mrview` records. Simple bug comes with a correspondingly
simple fix.

I also noticed that the info tests were broken and not being run so I
spent a few minutes cleaning those up to make the various assumptions.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
