### PR TITLE
Switch away from passing funs between nodes when uploading attachments

### DIFF
--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -277,7 +277,7 @@ purge_docs(_DbName, _IdsRevs) ->
         {unknown_transfer_encoding, any()}) ->
     function() | binary().
 att_receiver(Req, Length) ->
-    fabric_doc_attachments:receiver(Req, Length).
+    fabric_doc_attachments2:receiver_tuple(Req, Length).
 
 %% @equiv all_docs(DbName, [], Callback, Acc0, QueryArgs)
 all_docs(DbName, Callback, Acc, QueryArgs) ->

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -440,6 +440,8 @@ make_att_reader({follows, Parser, Ref}) ->
                 throw({mp_parser_died, Reason})
         end
     end;
+make_att_reader({fabric_attachment_receiver, Middleman, Length}) ->
+    fabric_doc_attachments2:receiver_callback(Middleman, Length);
 make_att_reader(Else) ->
     Else.
 


### PR DESCRIPTION
Passing closures around is fragile and prevents smooth upgrading. Instead pass
a tuple with a data from the receiver closure explicitly and convert to back to
a local fun locally on each node.

Config options `[fabric] attachment_receiver_tuple` controls how receivers are
encoded. To upgrade a cluster to use the new format, first upgrade all nodes to
the new code, then flip the value to `true`. In the future, the option and the
old closure handling code will be removed.

