### PR TITLE
[wip] Create property storage in db engine

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -791,16 +791,25 @@ increment_update_seq(#st{header = Header} = St) ->
     }.
 
 
-set_default_security_object(Fd, Header, Compression, Options) ->
-    case couch_bt_engine_header:get(Header, security_ptr) of
+set_default_values(Fd, Header, Compression, Options, PtrName, OptName, DefaultValue) ->
+    case couch_bt_engine_header:get(Header, PtrName) of
         Pointer when is_integer(Pointer) ->
             Header;
-        _ ->
-            Default = couch_util:get_value(default_security_object, Options),
+        Val when Val =:= nil; Val =:= undefined ->
+            Default = couch_util:get_value(OptName, Options, DefaultValue),
             AppendOpts = [{compression, Compression}],
             {ok, Ptr, _} = couch_file:append_term(Fd, Default, AppendOpts),
-            couch_bt_engine_header:set(Header, security_ptr, Ptr)
+            couch_bt_engine_header:set(Header, PtrName, Ptr)
     end.
+
+set_default_security_object(Fd, Header, Compression, Options) ->
+    set_default_values(Fd, Header, Compression, Options,
+        security_ptr, default_security_object, undefined).
+
+
+set_default_props(Fd, Header, Compression, Options) ->
+    set_default_values(Fd, Header, Compression, Options,
+        props_ptr, default_props, []).
 
 
 delete_compaction_files(FilePath) ->

--- a/src/couch/src/couch_bt_engine_header.erl
+++ b/src/couch/src/couch_bt_engine_header.erl
@@ -66,7 +66,8 @@
     revs_limit = 1000,
     uuid,
     epochs,
-    compacted_seq
+    compacted_seq,
+    props_ptr
 }).
 
 

--- a/src/couch/src/couch_db_engine.erl
+++ b/src/couch/src/couch_db_engine.erl
@@ -225,6 +225,17 @@
 -callback get_security(DbHandle::db_handle()) -> SecProps::any().
 
 
+% Get the current properties. This should just return
+% the last value that was passed to set_prop/2.
+-callback get_prop(DbHandle::db_handle(), Prop::atom()) -> 
+    {ok, SecProps::json()}.
+
+% Get the current properties. If the value isn't set it will return the set default value.
+% This should just return the last value that was passed to set_prop/2.
+-callback get_prop(DbHandle::db_handle(), Prop::atom(), DefaultValue::any()) -> 
+    {ok, SecProps::json()}.
+
+
 % This information is displayed in the database info poperties. It
 % should just be a list of {Name::atom(), Size::non_neg_integer()}
 % tuples that will then be combined across shards. Currently,
@@ -262,6 +273,15 @@
         {ok, NewDbHandle::db_handle()}.
 
 -callback set_security(DbHandle::db_handle(), SecProps::any()) ->
+        {ok, NewDbHandle::db_handle()}.
+
+
+% This function is only called by couch_db_updater and
+% as such is guaranteed to be single threaded calls. The
+% database should simply store prop key and value somewhere so
+% they can be returned by the corresponding get_prop calls.
+
+-callback set_prop(DbHandle::db_handle(), PropKey::atom(), PropValue::any()) ->
         {ok, NewDbHandle::db_handle()}.
 
 
@@ -601,12 +621,15 @@
     get_purge_seq/1,
     get_revs_limit/1,
     get_security/1,
+    get_prop/2,
+    get_prop/3,
     get_size_info/1,
     get_update_seq/1,
     get_uuid/1,
 
     set_revs_limit/2,
     set_security/2,
+    set_prop/3,
 
     open_docs/2,
     open_local_docs/2,
@@ -757,6 +780,16 @@ get_security(#db{} = Db) ->
     Engine:get_security(EngineState).
 
 
+get_prop(#db{} = Db, Prop) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    Engine:get_prop(EngineState, Prop).
+
+
+get_prop(#db{} = Db, Prop, DefaultValue) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    Engine:get_prop(EngineState, Prop, DefaultValue).
+
+
 get_size_info(#db{} = Db) ->
     #db{engine = {Engine, EngineState}} = Db,
     Engine:get_size_info(EngineState).
@@ -780,6 +813,12 @@ set_revs_limit(#db{} = Db, RevsLimit) ->
 set_security(#db{} = Db, SecProps) ->
     #db{engine = {Engine, EngineState}} = Db,
     {ok, NewSt} = Engine:set_security(EngineState, SecProps),
+    {ok, Db#db{engine = {Engine, NewSt}}}.
+
+
+set_prop(#db{} = Db, Key, Value) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    {ok, NewSt} = Engine:set_prop(EngineState, Key, Value),
     {ok, Db#db{engine = {Engine, NewSt}}}.
 
 

--- a/src/couch/src/test_engine_get_set_props.erl
+++ b/src/couch/src/test_engine_get_set_props.erl
@@ -50,6 +50,41 @@ cet_set_revs_limit() ->
     check_prop_set(get_revs_limit, set_revs_limit, 1000, 50).
 
 
+cet_set_props_at_init() ->
+    Engine = test_engine_util:get_engine(),
+    DbPath = test_engine_util:dbpath(),
+
+    {ok, St} = Engine:init(DbPath, [
+            create,
+            {default_security_object, dso},
+            {default_props, [{shardkey, true}]}
+        ]),
+    
+    ?assertEqual({ok, true}, Engine:get_prop(St, shardkey)).
+
+
+cet_set_prop() ->
+    Engine = test_engine_util:get_engine(),
+    DbPath = test_engine_util:dbpath(),
+
+    {ok, St0} = Engine:init(DbPath, [
+            create,
+            {default_security_object, dso}
+        ]),
+    ?assertEqual({error, no_value}, Engine:get_prop(St0, shardkey)),
+
+    ?assertEqual({ok, false}, Engine:get_prop(St0, shardkey, false)),
+
+    {ok, St1} = Engine:set_prop(St0, shardkey, true),
+    ?assertEqual({ok, true}, Engine:get_prop(St1, shardkey)),
+
+    {ok, St2} = Engine:commit_data(St1),
+    Engine:terminate(normal, St2),
+
+    {ok, St3} = Engine:init(DbPath, []),
+    ?assertEqual({ok, true}, Engine:get_prop(St3, shardkey)).
+
+
 check_prop_set(GetFun, SetFun, Default, Value) ->
     Engine = test_engine_util:get_engine(),
     DbPath = test_engine_util:dbpath(),


### PR DESCRIPTION
## Overview

Add the ability to properties to a database. This would allow us to define if the database supports `shardkeys` or `_access` or anything unique to it.

## Testing recommendations

The eunit tests should all pass.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
