### PR TITLE
Update snappy dep to CouchDB-1.0.1 with 21.0 support

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -51,7 +51,7 @@ DepDescs = [
 {b64url,           "b64url",           {tag, "1.0.1"}},
 {ets_lru,          "ets-lru",          {tag, "1.0.0"}},
 {khash,            "khash",            {tag, "1.0.1"}},
-{snappy,           "snappy",           {tag, "CouchDB-1.0.0"}},
+{snappy,           "snappy",           {tag, "CouchDB-1.0.1"}},
 {ioq,              "ioq",              {tag, "1.0.1"}},
 
 %% Non-Erlang deps


### PR DESCRIPTION
Issue #1396

