### PR TITLE
Fix for a function_clause crash in the couch_native_process for Erlang views

### DIFF
--- a/src/couch/src/couch_native_process.erl
+++ b/src/couch/src/couch_native_process.erl
@@ -226,6 +226,18 @@ ddoc(State, {_, Fun}, [<<"filters">>|_], [Docs, Req]) ->
     end,
     Resp = lists:map(FilterFunWrapper, Docs),
     {State, [true, Resp]};
+ddoc(State, {_, Fun}, [<<"views">>|_], [Docs]) ->
+    MapFunWrapper = fun(Doc) ->
+        case catch Fun(Doc) of
+        undefined -> true;
+        ok -> false;
+        false -> false;
+        [_|_] -> true;
+        {'EXIT', Error} -> couch_log:error("~p", [Error])
+        end
+    end,
+    Resp = lists:map(MapFunWrapper, Docs),
+    {State, [true, Resp]};
 ddoc(State, {_, Fun}, [<<"shows">>|_], Args) ->
     Resp = case (catch apply(Fun, Args)) of
         FunResp when is_list(FunResp) ->


### PR DESCRIPTION
## Overview

In case when CouchDB has a native query server enabled and we call an Erlang `map` function for the first time (therefore there is no view index) `couch_mrview_updater:start_update` calls `run(State, [<<"map_doc">> , Doc])` from the `couch_native_process` and after this view index is built and data is read from it. Unfortunately when the same Erlang map function is used for changes feed with `_view` filter, `couch_native_process` crashes with:

```
{"error":"error","reason":"{{function_clause,\n     
[{couch_native_process,ddoc,\n          [{evstate, 
```

Changes feed with `_view` filter allows to use existing map function as the filter and it doesn’t query the view index files. Furthermore `seq_indexed` option doesn't work correctly in the mrview (more details in [this thread](https://github.com/apache/couchdb/issues/1142#issuecomment-378228093)) hence `fast_view` filter (which allows to use a dedicated `seq` and `keyseq` indexes) was disabled in the CouchDB 2. As a consequence changes feed with `_view` will always call `run(#evstate{ddocs=DDocs}=State, [<<"ddoc">>])` and this call will crash with the aforementioned error.
This crash is caused by a missing implementation of `ddoc` function for `<<"views">>` FunPath case, because for requests like `/_changes?style=all_docs&filter=_view&view=test/repl` the `FunPath` will be: `[<<"views">>,<<"repl">>,<<"map">>]`. For JS map functions this does work because in this case `couch_query_server` delegates map to an external `couch_js` OS process.
This fix effectively provides that missing `ddoc` clause and it is based on the `FilterFun` one but matches return values of the `erlang:put()` function (which is called from the native `Emit` function) and it also matches `ok` and `false` return values for the cases when docs were not emitted and Erlang view just returned either `ok` or a `false` atom. 

## Testing recommendations

`should_filter_by_erlang_view/1` test function was added to the `couch_changes_test.erl` test suite.
Kudos to @iilyak for it. 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
