### PR TITLE
Don't set context for compaction files during db delete

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -114,7 +114,7 @@ delete(RootDir, FilePath, Async) ->
     %% Delete any leftover compaction files. If we don't do this a
     %% subsequent request for this DB will try to open them to use
     %% as a recovery.
-    delete_compaction_files(RootDir, FilePath, [{context, delete}]),
+    delete_compaction_files(RootDir, FilePath, [{context, compaction}]),
 
     % Delete the actual database file
     couch_file:delete(RootDir, FilePath, Async).
@@ -765,7 +765,7 @@ set_default_security_object(Fd, Header, Compression, Options) ->
 
 delete_compaction_files(FilePath) ->
     RootDir = config:get("couchdb", "database_dir", "."),
-    DelOpts = [{context, delete}],
+    DelOpts = [{context, compaction}],
     delete_compaction_files(RootDir, FilePath, DelOpts).
 
 

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -525,7 +525,7 @@ handle_call({delete, DbName, Options}, _From, Server) ->
         DelOpt = [{context, delete} | Options],
 
         % Make sure and remove all compaction data
-        delete_compaction_files(DbNameList, DelOpt),
+        delete_compaction_files(DbNameList, Options),
 
         {ok, {Engine, FilePath}} = get_engine(Server, DbNameList),
         RootDir = Server#server.root_dir,


### PR DESCRIPTION
## Overview

When we delete files with context option set to `delete`, `couch_file` respects configuration flag "enable_database_recovery" and just renames the files in case it's set to true.

This change removes context for compaction files deleted during database deletion to make sure we are actually erasing them and not just renaming and leaving behind.

## Testing recommendations

Change config `rel/overlay/etc/local.ini` and add into `[couchdb]` section 
```
enable_database_recovery = true
delete_after_rename = false
```
Then run
```
curl -X PUT http://127.0.0.1:15984/koi
curl -X POST http://127.0.0.1:15984//koi/_compact
curl -X DELETE http://127.0.0.1:15984/koi
```
Check files in `./dev/lib/node1/data`, without this fix it should look something like:
```
...
|   |-- nodes.couch
|   `-- shards
|       |-- 00000000-1fffffff
|       |   |-- koi.1530196798.20180628.144003.deleted.couch
|       |   |-- koi.1530196798.couch.compact.20180628.144003.deleted.data
|       |   |-- koi.1530196798.couch.compact.20180628.144003.deleted.meta
|       |   |-- koi.1530205729.20180628.170851.deleted.couch
|       |   |-- koi.1530205729.couch.compact.20180628.170851.deleted.data
|       |   `-- koi.1530205729.couch.compact.20180628.170851.deleted.meta
|       |-- 20000000-3fffffff
|       |   |-- koi.1530196798.20180628.144003.deleted.couch
|       |   |-- koi.1530196798.couch.compact.20180628.144003.deleted.data
|       |   |-- koi.1530196798.couch.compact.20180628.144003.deleted.meta
|       |   |-- koi.1530205729.20180628.170851.deleted.couch
|       |   |-- koi.1530205729.couch.compact.20180628.170851.deleted.data
|       |   `-- koi.1530205729.couch.compact.20180628.170851.deleted.meta
|       |-- 40000000-5fffffff
...
```

With this change there shouldn't be `.deleted.data` and `.deleted.meta` leftovers.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
