### PR TITLE
Support callback module data provider

### DIFF
--- a/src/couch_epi/README.md
+++ b/src/couch_epi/README.md
@@ -39,7 +39,8 @@ could add an entry in its implementation of couch_epi_plugin behaviour:
                 {priv_file, "stats_descriptions.cfg"}, [{interval, 5000}]}
             {{couch_stats, descriptions},
                 {file, "/tmp/extra_stats.cfg"}, [{interval, 5000}]},
-            {{couch_stats, descriptions}, {module, my_stats}}
+            {{couch_stats, descriptions}, {static_module, my_stats}},
+            {{couch_stats, descriptions}, {callback_module, my_stats}}
         ].
 
 When service provider wants to learn about all the installed config data for it to use

--- a/src/couch_epi/README.md
+++ b/src/couch_epi/README.md
@@ -66,6 +66,38 @@ There are also additional functions to get the same data in various formats
 - `couch_epi:keys(Handle)` - returns list of configured keys
 - `couch_epi:subscribers(Handle)` - return list of known subscribers
 
+The difference between `static_module` and `callback_module` providers is in how
+couch_epi detects the changes. `static_module` is designed for the cases when you
+have your data hardcoded in the module. For example you might have the following:
+
+```
+-export([data/0]).
+
+data() ->
+    [
+        {[complex, key, 2], [
+            {type, counter},
+            {desc, bar}
+        ]},
+        {[complex, key, 1], [
+            {type, counter},
+            {desc, updated_foo}
+        ]}
+    ].
+```
+
+The changes are detected by relying on `vsn` module attribute. Therefore we
+would notice the change only when data source module is recompiled.
+
+The `callback_module` provider uses the return value from `data/0` to detect
+changes and it is useful for cases when the data term is constructed dynamically.
+For example to cache values of CouchDB config one could use the following:
+
+```
+-export([data/0]).
+data() ->
+    config:get("dreyfus").
+```
 
 # Function dispatch example
 

--- a/src/couch_epi/src/couch_epi_data.erl
+++ b/src/couch_epi/src/couch_epi_data.erl
@@ -102,9 +102,9 @@ definitions({file, FilePath}) ->
         {error, Reason} ->
             {error, {FilePath, Reason}}
     end;
-definitions({module, Module}) when is_atom(Module) ->
-    definitions({module, [Module]});
-definitions({module, Modules}) ->
+definitions({static_module, Module}) when is_atom(Module) ->
+    definitions({static_module, [Module]});
+definitions({static_module, Modules}) ->
     Data = lists:append([M:data() || M <- Modules]),
     Hash = couch_epi_functions_gen:hash(Modules),
     {ok, Hash, Data}.

--- a/src/couch_epi/src/couch_epi_data.erl
+++ b/src/couch_epi/src/couch_epi_data.erl
@@ -107,7 +107,10 @@ definitions({static_module, Module}) when is_atom(Module) ->
 definitions({static_module, Modules}) ->
     Data = lists:append([M:data() || M <- Modules]),
     Hash = couch_epi_functions_gen:hash(Modules),
-    {ok, Hash, Data}.
+    {ok, Hash, Data};
+definitions({callback_module, Module}) ->
+    Data = Module:data(),
+    {ok, erlang:phash2(Data), Data}.
 
 hash_of_file(FilePath) ->
     {ok, Data} = file:read_file(FilePath),

--- a/src/couch_epi/src/couch_epi_sup.erl
+++ b/src/couch_epi/src/couch_epi_sup.erl
@@ -121,7 +121,7 @@ modules(#couch_epi_spec{kind = services, value = Module}) ->
     [Module];
 modules(#couch_epi_spec{kind = data_providers, value = Value}) ->
     case Value of
-        {module, Module} -> [Module];
+        {static_module, Module} -> [Module];
         _ -> []
     end;
 modules(#couch_epi_spec{kind = data_subscriptions, behaviour = Module}) ->
@@ -159,7 +159,7 @@ services() ->
 
 data_providers() ->
     [
-        {{test_app, descriptions}, {module, ?MODULE}, [{interval, 100}]}
+        {{test_app, descriptions}, {static_module, ?MODULE}, [{interval, 100}]}
     ].
 
 data_subscriptions() ->

--- a/src/couch_epi/src/couch_epi_sup.erl
+++ b/src/couch_epi/src/couch_epi_sup.erl
@@ -122,6 +122,7 @@ modules(#couch_epi_spec{kind = services, value = Module}) ->
 modules(#couch_epi_spec{kind = data_providers, value = Value}) ->
     case Value of
         {static_module, Module} -> [Module];
+        {callback_module, Module} -> [Module];
         _ -> []
     end;
 modules(#couch_epi_spec{kind = data_subscriptions, behaviour = Module}) ->

--- a/src/couch_epi/test/couch_epi_tests.erl
+++ b/src/couch_epi/test/couch_epi_tests.erl
@@ -175,7 +175,7 @@ setup(data_file) ->
         handle = couch_epi:get_handle(Key),
         kv = KV,
         pid = Pid};
-setup(data_module) ->
+setup(static_data_module) ->
     error_logger:tty(false),
 
     Key = {test_app, descriptions},
@@ -183,7 +183,7 @@ setup(data_module) ->
     ok = generate_module(provider, ?DATA_MODULE1(provider)),
     KV = start_state_storage(),
 
-    ok = start_epi([{provider_epi, plugin_module([KV, {module, provider}])}]),
+    ok = start_epi([{provider_epi, plugin_module([KV, {static_module, provider}])}]),
 
     Pid = whereis(couch_epi:get_handle(Key)),
     Handle = couch_epi:get_handle(Key),
@@ -244,7 +244,7 @@ epi_config_update_test_() ->
     ],
     Cases = [
         data_file,
-        data_module,
+        static_data_module,
         functions
     ],
     {
@@ -264,7 +264,7 @@ epi_data_source_test_() ->
     ],
     Cases = [
         data_file,
-        data_module
+        static_data_module
     ],
     {
         "epi data API tests",
@@ -305,7 +305,7 @@ epi_providers_order_test_() ->
 epi_reload_test_() ->
     Cases = [
         data_file,
-        data_module,
+        static_data_module,
         functions
     ],
     Funs = [
@@ -565,7 +565,7 @@ update(Case, #ctx{pid = Pid, modules = Modules} = Ctx) ->
 update_definitions(data_file, #ctx{file = File}) ->
     {ok, _} = file:copy(?DATA_FILE2, File),
     ok;
-update_definitions(data_module, #ctx{}) ->
+update_definitions(static_data_module, #ctx{}) ->
     ok = generate_module(provider, ?DATA_MODULE2(provider));
 update_definitions(functions, #ctx{}) ->
     ok = generate_module(provider1, ?MODULE2(provider1)).


### PR DESCRIPTION
## Overview

This fixes the use case when data provider module for `couch_epi` is not a pure functional.
To illustrate the issue let's look at the following code:
```
-export([data/0]).

data() ->
   config:get("some_section").
```

We would want to regenerate dynamically compiled module when term returned from `data/0` is changed. However the previous implementation of `module` data provider was relying on `vsn` attribute of a module. Which is valid approach if the data term is hard coded in the module source.

This PR also renames `module` data provider into `static_module`.

## Testing recommendations

```
make eunit apps=couch_epi
```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
