### PR TITLE
Views now retain update_seq after compaction.

### DIFF
--- a/src/couch_mrview/src/couch_mrview_compactor.erl
+++ b/src/couch_mrview/src/couch_mrview_compactor.erl
@@ -233,6 +233,8 @@ compact_view(#mrview{id_num=VID}=View, EmptyView, BufferSize, Acc0) ->
 
     {EmptyView#mrview{btree=NewBt,
                       seq_btree=NewSeqBt,
+                      update_seq=View#mrview.update_seq,
+                      purge_seq=View#mrview.purge_seq,
                       key_byseq_btree=NewKeyBySeqBt}, FinalAcc}.
 
 compact_view_btree(Btree, EmptyBtree, VID, BufferSize, Acc0) ->


### PR DESCRIPTION
Previously on view compaction, the new index state would not carry
over the associated database update sequence. As a result, views
who were compacted at least once could no longer use the ?update_seq
query option.

Closes #984
