### PR TITLE
Replace R16B03 with 17.5.3 for PR#1427

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,13 +39,13 @@ pipeline {
       }
       steps {
         // This image has the oldest Erlang we support, 16B03
-        sh 'docker pull couchdbdev/ubuntu-trusty-erlang-default:latest'
+        sh 'docker pull couchdbdev/debian-jessie-erlang-17.5.3:latest'
         timeout(time: 15, unit: "MINUTES") {
           // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
           // We need the jenkins user mapped inside of the image
           // npm config cache below is required because /home/jenkins doesn't
           // ACTUALLY exist in the image
-          withDockerContainer(image: 'couchdbdev/ubuntu-trusty-erlang-default', args: '-e npm_config_cache=npm-cache -e HOME=. -v=/etc/passwd:/etc/passwd -v /etc/group:/etc/group') {
+          withDockerContainer(image: 'couchdbdev/debian-jessie-erlang-17.5.3', args: '-e npm_config_cache=npm-cache -e HOME=. -v=/etc/passwd:/etc/passwd -v /etc/group:/etc/group') {
             sh '''
               set
               rm -rf apache-couchdb-*


### PR DESCRIPTION
This PR changes our Jenkins setup to run the `make dist` process on Erlang 17.5.3 instead of R16B03. This will allow us to drop R16B03 support in `rebar.config.script` as proposed in #1427.

https://builds.apache.org/job/CouchDB/job/jenkins-ditch-16b03/ when this lights up green, I will merge this.