### PR TITLE
Optionally prevent non-admins from accessing /_all_dbs

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -98,6 +98,9 @@ max_db_number_for_dbs_info_req = 100
 ; uncomment the next line to enable proxy authentication
 ; authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
+; prevent non-admins from accessing /_all_dbs
+;admin_only_all_dbs = false
+
 [database_compaction]
 ; larger buffer sizes can originate smaller files
 doc_buffer_size = 524288 ; value in bytes

--- a/src/chttpd/src/chttpd_auth_request.erl
+++ b/src/chttpd/src/chttpd_auth_request.erl
@@ -34,7 +34,10 @@ authorize_request_int(#httpd{path_parts=[]}=Req) ->
 authorize_request_int(#httpd{path_parts=[<<"favicon.ico">>|_]}=Req) ->
     Req;
 authorize_request_int(#httpd{path_parts=[<<"_all_dbs">>|_]}=Req) ->
-    Req;
+   case config:get_boolean("chttpd", "admin_only_all_dbs", false) of
+       true -> require_admin(Req);
+       false -> Req
+   end;
 authorize_request_int(#httpd{path_parts=[<<"_dbs_info">>|_]}=Req) ->
     Req;
 authorize_request_int(#httpd{path_parts=[<<"_replicator">>], method='PUT'}=Req) ->


### PR DESCRIPTION
This is a leftover from the 1.x -> 2.x transition. Adds a config option (bike shed away pls) to block non-admins from accessing `/_all_dbs`, which we should set to `true` in 3.0.0