### PR TITLE
re-raise max_http_request_size to 4GB

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -152,7 +152,7 @@ enable_xframe_options = false
 ; x_forwarded_proto = X-Forwarded-Proto
 ; x_forwarded_ssl = X-Forwarded-Ssl
 ; Maximum allowed http request size. Applies to both clustered and local port.
-max_http_request_size = 67108864 ; 64 MB
+max_http_request_size = 4294967296 ; 4GB
 
 ; [httpd_design_handlers]
 ; _view = 


### PR DESCRIPTION
If #1253 doesn't make it into 2.2.0, this one should go in.