### PR TITLE
add retry to test_request:request()

### DIFF
--- a/src/couch/src/test_request.erl
+++ b/src/couch/src/test_request.erl
@@ -101,7 +101,11 @@ request(Method, Url, Headers, Body, Opts, N) ->
         {error, {'EXIT', {normal, _}}} ->
             % Connection closed right after a successful request that
             % used the same connection.
-            request(Method, Url, Headers, Body, N - 1);
+            request(Method, Url, Headers, Body, Opts, N - 1);
+        {error, retry_later} ->
+            % CouchDB is busy, let’s wait a bit
+            timer:sleep(3000 div N),
+            request(Method, Url, Headers, Body, Opts, N - 1);
         Error ->
             Error
     end.


### PR DESCRIPTION
should close #884 and a lot of other spurious errors.