### PR TITLE
Switch fabric attachment reciever to use messages instead of function closures

### DIFF
--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -271,13 +271,14 @@ purge_docs(_DbName, _IdsRevs) ->
     not_implemented.
 
 %% @doc spawns a process to upload attachment data and
-%%      returns a function that shards can use to communicate
-%%      with the spawned middleman process
+%%      returns a fabric attachment receiver context tuple
+%%      with the spawned middleman process, an empty binary,
+%%      or exits with an error tuple {Error, Arg}
 -spec att_receiver(#httpd{}, Length :: undefined | chunked | pos_integer() |
         {unknown_transfer_encoding, any()}) ->
-    function() | binary().
+    {fabric_attachment_receiver, pid(), chunked | pos_integer()} | binary().
 att_receiver(Req, Length) ->
-    fabric_doc_attachments:receiver(Req, Length).
+    fabric_doc_atts:receiver(Req, Length).
 
 %% @equiv all_docs(DbName, [], Callback, Acc0, QueryArgs)
 all_docs(DbName, Callback, Acc, QueryArgs) ->


### PR DESCRIPTION

Function closures are fragile and attachment uploads would break if
fabric_doc_attachments is different on any of the nodes in a cluster, like it
might happen during a roling cluster upgrade.

Previously fe53e437ca5ec9d23aa1b55d7934daced157a9e3 introduced two versions of
the module one which handles function closure, other which handled message but
only in this commit messages are starting to be sent.

To avoid breakages in attachemnt uploads during the period of a rolling cluster
upgrade, make sure to upgrade to that commit first then upgrade to this change.

Issue #1394

