### PR TITLE
Enable replication client _session auth by default

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -433,12 +433,11 @@ ssl_certificate_max_depth = 3
 ; There are currently two plugins available:
 ;   couch_replicator_auth_session - use _session cookie authentication
 ;   couch_replicator_auth_noop - use basic authentication (previous default)
-; Currently previous default behavior is still the default. To start using
-; session auth, use this as the list of plugins:
-; `couch_replicator_auth_session,couch_replicator_auth_noop`.
-; In a future release the session plugin might be used by default.
+; Currently, the new _session cookie authentication is tried first, before
+; falling back to the old basic authenticaion default:
+;auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
+; To restore the old behaviour, use the following value:
 ;auth_plugins = couch_replicator_auth_noop
-
 
 [compaction_daemon]
 ; The delay, in seconds, between each check for which database and view indexes

--- a/src/couch_replicator/src/couch_replicator_auth.erl
+++ b/src/couch_replicator/src/couch_replicator_auth.erl
@@ -28,7 +28,7 @@
 -type code() :: non_neg_integer().
 
 
--define(DEFAULT_PLUGINS, "couch_replicator_auth_noop").
+-define(DEFAULT_PLUGINS, "couch_replicator_auth_session,couch_replicator_auth_noop").
 
 
 % Behavior API


### PR DESCRIPTION
Given the potential this has to increase replication performance, I don't see why we shouldn't make this the new default ASAP, plus calling out how to revert to the original behaviour in `default.ini` as well as in the release notes. I think the benefits outweigh the drawbacks.

## Related work

Relates to #1153 and #1176.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes; (is already in release notes, or at least will be when I push the commit to couchdb-documentation)
