### PR TITLE
bump docs dependency, travis 20.1 -> 20.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 os: linux
 otp_release:
-   - 20.1
+   - 20.3
    - 19.3
    - 18.3
    - 17.5

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -56,7 +56,7 @@ DepDescs = [
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
-                   {tag, "2.1.2"}, [raw]},
+                   {tag, "2.2.0"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.1.15"}, [raw]},
 %% Third party deps


### PR DESCRIPTION
20.x release series is done now, use the latest version for regression testing.