### PR TITLE
Improve logging from test_util

### DIFF
--- a/src/couch/src/test_util.erl
+++ b/src/couch/src/test_util.erl
@@ -101,6 +101,9 @@ start_applications([App|Apps], Acc) ->
         io:format(standard_error, "Application ~s was left running!~n", [App]),
         application:stop(App),
         start_applications([App|Apps], Acc);
+    {error, Reason} ->
+        io:format(standard_error, "Cannot start application '~s', reason ~p~n", [App, Reason]),
+        throw({error, {cannot_start, App, Reason}});
     ok ->
         start_applications(Apps, [App|Acc])
     end.


### PR DESCRIPTION
## Overview

Sometimes it is hard to guess what went wrong when application
started via `test_util:start_applications` or `test_util:start_couch`
is unable to start. Since the traceback was truncated.
This change would print the reason in addition to the traceback.

## Testing recommendations

1. Modify code so application is unable to start
    ```
    git diff
    diff --git a/src/config_app.erl b/src/config_app.erl
    index 8ba58e6..140e6df 100644
    --- a/src/config_app.erl
    +++ b/src/config_app.erl
    @@ -22,7 +22,7 @@
    %% ===================================================================

    start(_StartType, _StartArgs) ->
    -    config_sup:start_link(get_ini_files()).
    +    nok = config_sup:start_link(get_ini_files()).
    ```
2. Run tests for config app `make eunit apps=config tests=config_del_test`
3. Make sure the error is printed
    ```
    Compiled src/config_app.erl
        Running test function(s):
          config_tests:config_del_test_/0
    ======================== EUnit ========================
    Config deletion tests
    Cannot start application config, reason {bad_return,
                                             {{config_app,start,[normal,[]]},
                                              {'EXIT',
                                               {{badmatch,{ok,<0.217.0>}},
                                                [{config_app,start,2,
                                                  [{file,"src/config_app.erl"},
                                                   {line,25}]},
                                                 {application_master,
                                                  start_it_old,4,
                                                  [{file,"application_master.erl"},
                                                   {line,273}]}]}}}}
      undefined
      *** context setup failed ***
    **in function test_util:start_applications/2 (src/test_util.erl, line 106)
    **throw:{error,
        {cannot_start,config,
            {bad_return,
                {{config_app,start,[normal,[]]},
                 {'EXIT',
                     {{badmatch,{ok,<0.217.0>}},
                      [{config_app,start,2,[{...}|...]},
                       {application_master,start_it_old,4,[...]}]}}}}}}
    
    
    undefined
    *** context setup failed ***
    **in function meck_proc:start/2 (src/meck_proc.erl, line 96)
      called as start(couch_log,[])
    in call from config_tests:setup/1 (test/config_tests.erl, line 69)
    **error:{already_started,<0.204.0>}
    ```

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
