### PR TITLE
Fix calculation of external size for attachments

### DIFF
--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -415,7 +415,7 @@ check_doc_atts(Db, Doc) ->
     end.
 
 
-add_sizes(Type, #leaf{deleted=Deleted, sizes=Sizes, atts=AttSizes}, Acc) ->
+add_sizes(Type, #leaf{sizes=Sizes, atts=AttSizes}, Acc) ->
     % Maybe upgrade from disk_size only
     #size_info{
         active = ActiveSize,
@@ -423,14 +423,12 @@ add_sizes(Type, #leaf{deleted=Deleted, sizes=Sizes, atts=AttSizes}, Acc) ->
     } = upgrade_sizes(Sizes),
     {ASAcc, ESAcc, AttsAcc} = Acc,
     NewASAcc = ActiveSize + ASAcc,
-    NewESAcc = case {Type, Deleted} of
-        {leaf, false} ->
+    NewESAcc = if
+        Type == leaf ->
             SumFun = fun({_, S}, A) -> S + A end,
             TotalAttSizes = lists:foldl(SumFun, 0, AttSizes),
             ESAcc + ExternalSize + TotalAttSizes;
-        {leaf, _} ->
-            ESAcc + ExternalSize;
-        _ -> 0
+        true -> 0
     end,
     NewAttsAcc = lists:umerge(AttSizes, AttsAcc),
     {NewASAcc, NewESAcc, NewAttsAcc}.

--- a/src/couch/test/couch_db_info_tests.erl
+++ b/src/couch/test/couch_db_info_tests.erl
@@ -53,91 +53,59 @@ db_info_sizes_test_() ->
 
 
 should_change_with_doc_insert(DbName, DocId) ->
-    {ok, PreSizes} = get_db_sizes(DbName),
-    PreActiveSize = couch_util:get_value(active, PreSizes),
-    PreExternalSize = couch_util:get_value(external, PreSizes),
+    {PreActiveSize, PreExternalSize, _} = get_db_sizes(DbName),
     {ok, _} = update_doc(DbName, DocId, ?l2b(lists:duplicate(60, $#))),
-    {ok, PostSizes} = get_db_sizes(DbName),
-    PostActiveSize = couch_util:get_value(active, PostSizes),
-    PostExternalSize = couch_util:get_value(external, PostSizes),
+    {PostActiveSize, PostExternalSize, _} = get_db_sizes(DbName),
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize > PreExternalSize).
 
 should_change_with_doc_update(DbName, DocId) ->
-    {ok, PreSizes} = get_db_sizes(DbName),
-    PreActiveSize = couch_util:get_value(active, PreSizes),
-    PreExternalSize = couch_util:get_value(external, PreSizes),
+    {PreActiveSize, PreExternalSize, _} = get_db_sizes(DbName),
     {ok, _} = update_doc(DbName, DocId, <<>>),
-    {ok, PostSizes} = get_db_sizes(DbName),
-    PostActiveSize = couch_util:get_value(active, PostSizes),
-    PostExternalSize = couch_util:get_value(external, PostSizes),
+    {PostActiveSize, PostExternalSize, _} = get_db_sizes(DbName),
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize < PreExternalSize).
 
 should_change_with_att_upload(DbName, DocId) ->
-    {ok, PreSizes} = get_db_sizes(DbName),
-    PreActiveSize = couch_util:get_value(active, PreSizes),
-    PreExternalSize = couch_util:get_value(external, PreSizes),
+    {PreActiveSize, PreExternalSize, _} = get_db_sizes(DbName),
     Atts = [new_att(<<"one">>, 1024), new_att(<<"two">>, 8192)],
     {ok, _} = update_doc(DbName, DocId, <<>>, Atts),
-    {ok, PostSizes} = get_db_sizes(DbName),
-    PostActiveSize = couch_util:get_value(active, PostSizes),
-    PostExternalSize = couch_util:get_value(external, PostSizes),
+    {PostActiveSize, PostExternalSize, _} = get_db_sizes(DbName),
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize > PreExternalSize).
 
 should_change_with_att_update(DbName, DocId) ->
-    {ok, PreSizes} = get_db_sizes(DbName),
-    PreActiveSize = couch_util:get_value(active, PreSizes),
-    PreExternalSize = couch_util:get_value(external, PreSizes),
+    {PreActiveSize, PreExternalSize, _} = get_db_sizes(DbName),
     Atts = [new_att(<<"one">>, 1024), new_att(<<"two">>, 4096)],
     {ok, _} = update_doc(DbName, DocId, <<>>, Atts),
-    {ok, PostSizes} = get_db_sizes(DbName),
-    PostActiveSize = couch_util:get_value(active, PostSizes),
-    PostExternalSize = couch_util:get_value(external, PostSizes),
+    {PostActiveSize, PostExternalSize, _} = get_db_sizes(DbName),
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize < PreExternalSize).
 
 should_change_with_att_delete(DbName, DocId) ->
-    {ok, PreSizes} = get_db_sizes(DbName),
-    PreActiveSize = couch_util:get_value(active, PreSizes),
-    PreExternalSize = couch_util:get_value(external, PreSizes),
+    {PreActiveSize, PreExternalSize, _} = get_db_sizes(DbName),
     %% we are deleting attachment <<"one">> by excluding it from upload
     Atts = [new_att(<<"two">>, 4096)],
     {ok, _} = update_doc(DbName, DocId, <<>>, Atts),
-    {ok, PostSizes} = get_db_sizes(DbName),
-    PostActiveSize = couch_util:get_value(active, PostSizes),
-    PostExternalSize = couch_util:get_value(external, PostSizes),
+    {PostActiveSize, PostExternalSize, _} = get_db_sizes(DbName),
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize < PreExternalSize).
 
 should_change_with_doc_delete(DbName, DocId) ->
-    {ok, PreSizes} = get_db_sizes(DbName),
-    PreActiveSize = couch_util:get_value(active, PreSizes),
-    PreExternalSize = couch_util:get_value(external, PreSizes),
-    PreFileSize = couch_util:get_value(file, PreSizes),
+    {PreActiveSize, PreExternalSize, PreFileSize} = get_db_sizes(DbName),
     {ok, _} = delete_doc(DbName, DocId),
-    {ok, PostSizes} = get_db_sizes(DbName),
-    PostActiveSize = couch_util:get_value(active, PostSizes),
-    PostExternalSize = couch_util:get_value(external, PostSizes),
-    PostFileSize = couch_util:get_value(file, PostSizes),
+    {PostActiveSize, PostExternalSize, PostFileSize} = get_db_sizes(DbName),
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize < PreExternalSize),
     ?assert(PostFileSize > PreFileSize).
 
 should_change_after_compact(DbName) ->
-    {ok, PreSizes} = get_db_sizes(DbName),
-    PreActiveSize = couch_util:get_value(active, PreSizes),
-    PreExternalSize = couch_util:get_value(external, PreSizes),
-    PreFileSize = couch_util:get_value(file, PreSizes),
+    {PreActiveSize, PreExternalSize, PreFileSize} = get_db_sizes(DbName),
     {ok, Db} = couch_db:open_int(DbName, []),
     {ok, _} = couch_db:start_compact(Db),
     ok = couch_db:close(Db),
     wait_compact_done(DbName, ?WAIT_DELAY_COUNT),
-    {ok, PostSizes} = get_db_sizes(DbName),
-    PostActiveSize = couch_util:get_value(active, PostSizes),
-    PostExternalSize = couch_util:get_value(external, PostSizes),
-    PostFileSize = couch_util:get_value(file, PostSizes),
+    {PostActiveSize, PostExternalSize, PostFileSize} = get_db_sizes(DbName),
     ?assert(PostActiveSize < PreActiveSize),
     ?assert(PostExternalSize == PreExternalSize),
     ?assert(PostFileSize < PreFileSize).
@@ -202,7 +170,10 @@ get_db_info(DbName) ->
 get_db_sizes(DbName) ->
     {ok, Info} = get_db_info(DbName),
     {Sizes} = couch_util:get_nested_json_value({Info}, [sizes]),
-    {ok, Sizes}.
+    ActiveSize = couch_util:get_value(active, Sizes),
+    ExternalSize = couch_util:get_value(external, Sizes),
+    FileSize = couch_util:get_value(file, Sizes),
+    {ActiveSize, ExternalSize, FileSize}.
 
 new_att(Name, Size) ->
     couch_att:new([

--- a/src/couch/test/couch_db_info_tests.erl
+++ b/src/couch/test/couch_db_info_tests.erl
@@ -1,0 +1,216 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_db_info_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(DELAY, 100).
+-define(WAIT_DELAY_COUNT, 40).
+
+setup() ->
+    Ctx = test_util:start_couch(),
+    config:set("couchdb", "file_compression", "none", false),
+    DbName = ?tempdb(),
+    DocId = couch_uuids:random(),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
+    ok = couch_db:close(Db),
+    {DbName, DocId, Ctx}.
+
+teardown({DbName, _, Ctx}) ->
+    ok = couch_server:delete(DbName, [?ADMIN_CTX]),
+    test_util:stop_couch(Ctx).
+
+db_info_sizes_test_() ->
+    {
+        setup,
+        fun setup/0, fun teardown/1,
+        fun({DbName, DocId, _}) ->
+            {
+                with,
+                {DbName, DocId},
+                [
+                    fun should_change_with_doc_insert/1,
+                    fun should_change_with_doc_update/1,
+                    fun should_change_with_att_upload/1,
+                    fun should_change_with_att_update/1,
+                    fun should_change_with_att_delete/1,
+                    fun should_change_with_doc_delete/1,
+                    fun should_change_after_compact/1
+                ]
+            }
+        end
+    }.
+
+
+should_change_with_doc_insert({DbName, DocId}) ->
+    {ok, PreSizes} = get_db_sizes(DbName),
+    PreActiveSize = couch_util:get_value(active, PreSizes),
+    PreExternalSize = couch_util:get_value(external, PreSizes),
+    {ok, _} = update_doc(DbName, DocId, ?l2b(lists:duplicate(60, $#))),
+    {ok, PostSizes} = get_db_sizes(DbName),
+    PostActiveSize = couch_util:get_value(active, PostSizes),
+    PostExternalSize = couch_util:get_value(external, PostSizes),
+    ?assert(PostActiveSize > PreActiveSize),
+    ?assert(PostExternalSize > PreExternalSize).
+
+should_change_with_doc_update({DbName, DocId}) ->
+    {ok, PreSizes} = get_db_sizes(DbName),
+    PreActiveSize = couch_util:get_value(active, PreSizes),
+    PreExternalSize = couch_util:get_value(external, PreSizes),
+    {ok, _} = update_doc(DbName, DocId, <<>>),
+    {ok, PostSizes} = get_db_sizes(DbName),
+    PostActiveSize = couch_util:get_value(active, PostSizes),
+    PostExternalSize = couch_util:get_value(external, PostSizes),
+    ?assert(PostActiveSize > PreActiveSize),
+    ?assert(PostExternalSize < PreExternalSize).
+
+should_change_with_att_upload({DbName, DocId}) ->
+    {ok, PreSizes} = get_db_sizes(DbName),
+    PreActiveSize = couch_util:get_value(active, PreSizes),
+    PreExternalSize = couch_util:get_value(external, PreSizes),
+    Atts = [new_att(<<"one">>, 1024), new_att(<<"two">>, 8192)],
+    {ok, _} = update_doc(DbName, DocId, <<>>, Atts),
+    {ok, PostSizes} = get_db_sizes(DbName),
+    PostActiveSize = couch_util:get_value(active, PostSizes),
+    PostExternalSize = couch_util:get_value(external, PostSizes),
+    ?assert(PostActiveSize > PreActiveSize),
+    ?assert(PostExternalSize > PreExternalSize).
+
+should_change_with_att_update({DbName, DocId}) ->
+    {ok, PreSizes} = get_db_sizes(DbName),
+    PreActiveSize = couch_util:get_value(active, PreSizes),
+    PreExternalSize = couch_util:get_value(external, PreSizes),
+    Atts = [new_att(<<"one">>, 1024), new_att(<<"two">>, 4096)],
+    {ok, _} = update_doc(DbName, DocId, <<>>, Atts),
+    {ok, PostSizes} = get_db_sizes(DbName),
+    PostActiveSize = couch_util:get_value(active, PostSizes),
+    PostExternalSize = couch_util:get_value(external, PostSizes),
+    ?assert(PostActiveSize > PreActiveSize),
+    ?assert(PostExternalSize < PreExternalSize).
+
+should_change_with_att_delete({DbName, DocId}) ->
+    {ok, PreSizes} = get_db_sizes(DbName),
+    PreActiveSize = couch_util:get_value(active, PreSizes),
+    PreExternalSize = couch_util:get_value(external, PreSizes),
+    %% we are deleting attachment <<"one">> by excluding it from upload
+    Atts = [new_att(<<"two">>, 4096)],
+    {ok, _} = update_doc(DbName, DocId, <<>>, Atts),
+    {ok, PostSizes} = get_db_sizes(DbName),
+    PostActiveSize = couch_util:get_value(active, PostSizes),
+    PostExternalSize = couch_util:get_value(external, PostSizes),
+    ?assert(PostActiveSize > PreActiveSize),
+    ?assert(PostExternalSize < PreExternalSize).
+
+should_change_with_doc_delete({DbName, DocId}) ->
+    {ok, PreSizes} = get_db_sizes(DbName),
+    PreActiveSize = couch_util:get_value(active, PreSizes),
+    PreExternalSize = couch_util:get_value(external, PreSizes),
+    PreFileSize = couch_util:get_value(file, PreSizes),
+    {ok, _} = delete_doc(DbName, DocId),
+    {ok, PostSizes} = get_db_sizes(DbName),
+    PostActiveSize = couch_util:get_value(active, PostSizes),
+    PostExternalSize = couch_util:get_value(external, PostSizes),
+    PostFileSize = couch_util:get_value(file, PostSizes),
+    ?assert(PostActiveSize > PreActiveSize),
+    ?assert(PostExternalSize < PreExternalSize),
+    ?assert(PostFileSize > PreFileSize).
+
+should_change_after_compact({DbName, _}) ->
+    {ok, PreSizes} = get_db_sizes(DbName),
+    PreActiveSize = couch_util:get_value(active, PreSizes),
+    PreExternalSize = couch_util:get_value(external, PreSizes),
+    PreFileSize = couch_util:get_value(file, PreSizes),
+    {ok, Db} = couch_db:open_int(DbName, []),
+    {ok, _} = couch_db:start_compact(Db),
+    ok = couch_db:close(Db),
+    wait_compact_done(DbName, ?WAIT_DELAY_COUNT),
+    {ok, PostSizes} = get_db_sizes(DbName),
+    PostActiveSize = couch_util:get_value(active, PostSizes),
+    PostExternalSize = couch_util:get_value(external, PostSizes),
+    PostFileSize = couch_util:get_value(file, PostSizes),
+    ?assert(PostActiveSize < PreActiveSize),
+    ?assert(PostExternalSize == PreExternalSize),
+    ?assert(PostFileSize < PreFileSize).
+
+
+update_doc(DbName, DocId, DocBody) ->
+    update_doc(DbName, DocId, DocBody, []).
+
+update_doc(DbName, DocId, DocBody, Atts) ->
+    {ok, Db} = couch_db:open_int(DbName, []),
+    Doc = case couch_db:get_doc_info(Db, DocId) of
+        not_found ->
+            couch_doc:from_json_obj({[
+                {<<"_id">>, DocId},
+                {<<"body">>, DocBody}
+            ]});
+        {ok, _} ->
+            Doc0 = couch_httpd_db:couch_doc_open(Db, DocId, nil, []),
+            Doc0#doc{body = {[{<<"body">>, DocBody}]}, atts = Atts}
+    end,
+    Result = couch_db:update_doc(Db, Doc, []),
+    couch_db:close(Db),
+    Result.
+
+delete_doc(DbName, DocId) ->
+    {ok, Db} = couch_db:open_int(DbName, []),
+    {ok, DI} = couch_db:get_doc_info(Db, DocId),
+    RR = hd(DI#doc_info.revs),
+    Rev = RR#rev_info.rev,
+    Doc = couch_doc:from_json_obj({[
+        {<<"_id">>, DocId},
+        {<<"_rev">>, couch_doc:rev_to_str(Rev)},
+        {<<"_deleted">>, true}
+    ]}),
+    Result = couch_db:update_doc(Db, Doc, [Rev]),
+    couch_db:close(Db),
+    Result.
+
+wait_compact_done(_DbName, 0) ->
+    erlang:error({assertion_failed, [
+        {module, ?MODULE},
+        {line, ?LINE},
+        {reason, "DB compaction failed to finish"}
+    ]});
+wait_compact_done(DbName, N) ->
+    {ok, Db} = couch_db:open_int(DbName, []),
+    ok = couch_db:close(Db),
+    CompactorPid = couch_db:get_compactor_pid(Db),
+    case is_pid(CompactorPid) of
+        false ->
+            ok;
+        true ->
+            ok = timer:sleep(?DELAY),
+            wait_compact_done(DbName, N - 1)
+    end.
+
+get_db_info(DbName) ->
+    {ok, Db} = couch_db:open_int(DbName, []),
+    ok = couch_db:close(Db),
+    couch_db:get_db_info(Db).
+
+get_db_sizes(DbName) ->
+    {ok, Info} = get_db_info(DbName),
+    {Sizes} = couch_util:get_nested_json_value({Info}, [sizes]),
+    {ok, Sizes}.
+
+new_att(Name, Size) ->
+    couch_att:new([
+        {name, Name},
+        {type, <<"application/octet-stream">>},
+        {data, crypto:strong_rand_bytes(Size)},
+        {att_len, undefined},
+        {md5, <<>>},
+        {encoding, identity}
+    ]).

--- a/src/couch/test/couch_db_info_tests.erl
+++ b/src/couch/test/couch_db_info_tests.erl
@@ -37,23 +37,22 @@ db_info_sizes_test_() ->
         fun setup/0, fun teardown/1,
         fun({DbName, DocId, _}) ->
             {
-                with,
-                {DbName, DocId},
+                inorder,
                 [
-                    fun should_change_with_doc_insert/1,
-                    fun should_change_with_doc_update/1,
-                    fun should_change_with_att_upload/1,
-                    fun should_change_with_att_update/1,
-                    fun should_change_with_att_delete/1,
-                    fun should_change_with_doc_delete/1,
-                    fun should_change_after_compact/1
+                    ?_test(should_change_with_doc_insert(DbName, DocId)),
+                    ?_test(should_change_with_doc_update(DbName, DocId)),
+                    ?_test(should_change_with_att_upload(DbName, DocId)),
+                    ?_test(should_change_with_att_update(DbName, DocId)),
+                    ?_test(should_change_with_att_delete(DbName, DocId)),
+                    ?_test(should_change_with_doc_delete(DbName, DocId)),
+                    ?_test(should_change_after_compact(DbName))
                 ]
             }
         end
     }.
 
 
-should_change_with_doc_insert({DbName, DocId}) ->
+should_change_with_doc_insert(DbName, DocId) ->
     {ok, PreSizes} = get_db_sizes(DbName),
     PreActiveSize = couch_util:get_value(active, PreSizes),
     PreExternalSize = couch_util:get_value(external, PreSizes),
@@ -64,7 +63,7 @@ should_change_with_doc_insert({DbName, DocId}) ->
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize > PreExternalSize).
 
-should_change_with_doc_update({DbName, DocId}) ->
+should_change_with_doc_update(DbName, DocId) ->
     {ok, PreSizes} = get_db_sizes(DbName),
     PreActiveSize = couch_util:get_value(active, PreSizes),
     PreExternalSize = couch_util:get_value(external, PreSizes),
@@ -75,7 +74,7 @@ should_change_with_doc_update({DbName, DocId}) ->
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize < PreExternalSize).
 
-should_change_with_att_upload({DbName, DocId}) ->
+should_change_with_att_upload(DbName, DocId) ->
     {ok, PreSizes} = get_db_sizes(DbName),
     PreActiveSize = couch_util:get_value(active, PreSizes),
     PreExternalSize = couch_util:get_value(external, PreSizes),
@@ -87,7 +86,7 @@ should_change_with_att_upload({DbName, DocId}) ->
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize > PreExternalSize).
 
-should_change_with_att_update({DbName, DocId}) ->
+should_change_with_att_update(DbName, DocId) ->
     {ok, PreSizes} = get_db_sizes(DbName),
     PreActiveSize = couch_util:get_value(active, PreSizes),
     PreExternalSize = couch_util:get_value(external, PreSizes),
@@ -99,7 +98,7 @@ should_change_with_att_update({DbName, DocId}) ->
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize < PreExternalSize).
 
-should_change_with_att_delete({DbName, DocId}) ->
+should_change_with_att_delete(DbName, DocId) ->
     {ok, PreSizes} = get_db_sizes(DbName),
     PreActiveSize = couch_util:get_value(active, PreSizes),
     PreExternalSize = couch_util:get_value(external, PreSizes),
@@ -112,7 +111,7 @@ should_change_with_att_delete({DbName, DocId}) ->
     ?assert(PostActiveSize > PreActiveSize),
     ?assert(PostExternalSize < PreExternalSize).
 
-should_change_with_doc_delete({DbName, DocId}) ->
+should_change_with_doc_delete(DbName, DocId) ->
     {ok, PreSizes} = get_db_sizes(DbName),
     PreActiveSize = couch_util:get_value(active, PreSizes),
     PreExternalSize = couch_util:get_value(external, PreSizes),
@@ -126,7 +125,7 @@ should_change_with_doc_delete({DbName, DocId}) ->
     ?assert(PostExternalSize < PreExternalSize),
     ?assert(PostFileSize > PreFileSize).
 
-should_change_after_compact({DbName, _}) ->
+should_change_after_compact(DbName) ->
     {ok, PreSizes} = get_db_sizes(DbName),
     PreActiveSize = couch_util:get_value(active, PreSizes),
     PreExternalSize = couch_util:get_value(external, PreSizes),


### PR DESCRIPTION
## Overview

A database external size is growing on any operation with attachments.

The external size of a database defined as an uncompressed size of its content, so expectation would be that with updating or deleting a document's attachment the external size would change accordingly, i.e. increase or decrease to a size of the attachment.

The external size, however, _always_ growing and shrinks to the expected values only on a database compression.

Here is an example:
```bash
$ curl -X PUT http://127.0.0.1:15984/koi
{"ok":true}
$ curl -X PUT http://127.0.0.1:15984/koi/holder -d'{}'
{"ok":true,"id":"holder","rev":"1-967a00dff5e02add41819138abb3284d"}
$ curl http://127.0.0.1:15984/koi | jq .sizes.external
4
$ curl -X PUT http://127.0.0.1:15984/koi/holder/keeper.bin?rev=1-967a00dff5e02add41819138abb3284d -H'Content-Type:application/octet-stream' --data-binary @data2K.bin
{"ok":true,"id":"holder","rev":"2-9125078ed1a87fcfca3d32d0834e41c8"}
$ curl http://127.0.0.1:15984/koi | jq .sizes.external
2052
$ curl -X PUT http://127.0.0.1:15984/koi/holder/filler.bin?rev=2-9125078ed1a87fcfca3d32d0834e41c8 -H'Content-Type:application/octet-stream' --data-binary @data8K.bin
{"ok":true,"id":"holder","rev":"3-eb058b53377ede2720530b6ff073813a"}
$ curl http://127.0.0.1:15984/koi | jq .sizes.external
10244
```

So far everything goes as expected and external size is growing in sync with attachment sizes. Let's try to update big attachment with a smaller file and then just delete the document completely:
```bash
$ curl -X PUT http://127.0.0.1:15984/koi/holder/filler.bin?rev=3-eb058b53377ede2720530b6ff073813a -H'Content-Type:application/octet-stream' --data-binary @data4K.bin
{"ok":true,"id":"holder","rev":"4-e1ce5b2ae946a8a64f3503cb6d646686"}
$ curl http://127.0.0.1:15984/koi | jq .sizes.external
14340
$ curl -X POST http://127.0.0.1:15984/koi/_compact
{"ok":true}
$ curl http://127.0.0.1:15984/koi | jq .sizes.external
6148
$ curl -X DELETE http://127.0.0.1:15984/koi/holder?rev=4-e1ce5b2ae946a8a64f3503cb6d646686
{"ok":true,"id":"holder","rev":"5-548de2faf802ebcca8de0c3ca3c32c09"}
$ curl http://127.0.0.1:15984/koi | jq .sizes.external
6148
$ curl -X POST http://127.0.0.1:15984/koi/_compact
{"ok":true}
$ curl http://127.0.0.1:15984/koi | jq .sizes.external
4
```

## Testing recommendations

Surprisingly we don't have any tests for database info and I couldn't find an appropriate place to add new tests, so I just wrote a new test suite.
```bash
$ make eunit apps=couch suites=couch_db_info_tests
...
======================== EUnit ========================
module 'couch_db_info_tests'
Application crypto was left running!
  couch_db_info_tests: db_info_sizes_test_...[0.014 s] ok
  couch_db_info_tests: db_info_sizes_test_...[0.023 s] ok
  couch_db_info_tests: db_info_sizes_test_...[0.015 s] ok
  couch_db_info_tests: db_info_sizes_test_...[0.010 s] ok
  couch_db_info_tests: db_info_sizes_test_...[0.010 s] ok
  couch_db_info_tests: db_info_sizes_test_...[0.010 s] ok
  couch_db_info_tests: db_info_sizes_test_...[0.101 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 0.204 s]
=======================================================
  All 7 tests passed.
```

Naturally Travis and Jenkins should pass too.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
