### PR TITLE
Add `POST /_node/$node/_restart` endpoint

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -313,7 +313,6 @@ _active_tasks = {couch_httpd_misc_handlers, handle_task_status_req}
 _config = {couch_httpd_misc_handlers, handle_config_req}
 _replicate = {couch_replicator_httpd, handle_req}
 _uuids = {couch_httpd_misc_handlers, handle_uuids_req}
-_restart = {couch_httpd_misc_handlers, handle_restart_req}
 _stats = {couch_stats_httpd, handle_stats_req}
 _session = {couch_httpd_auth, handle_session_req}
 _plugins = {couch_plugins_httpd, handle_req}

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -344,6 +344,12 @@ handle_node_req(#httpd{method='GET', path_parts=[_, Node, <<"_system">>]}=Req) -
     send_json(Req, EJSON);
 handle_node_req(#httpd{path_parts=[_, _Node, <<"_system">>]}=Req) ->
     send_method_not_allowed(Req, "GET");
+% POST /_node/$node/_restart
+handle_node_req(#httpd{method='POST', path_parts=[_, Node, <<"_restart">>]}=Req) ->
+    call_node(Node, init, restart, []),
+    send_json(Req, 200, {[{ok, true}]});
+handle_node_req(#httpd{path_parts=[_, _Node, <<"_restart">>]}=Req) ->
+    send_method_not_allowed(Req, "POST");
 handle_node_req(#httpd{path_parts=[_]}=Req) ->
     chttpd:send_error(Req, {bad_request, <<"Incomplete path to _node request">>});
 handle_node_req(#httpd{path_parts=[_, _Node]}=Req) ->

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -401,7 +401,7 @@ get_stats() ->
     MessageQueues0 = [{couch_file, {CF}}, {couch_db_updater, {CDU}}],
     MessageQueues = MessageQueues0 ++ message_queues(registered()),
     [
-        {uptime, element(1,statistics(wall_clock)) div 1000},
+        {uptime, couch_app:uptime() div 1000},
         {memory, {Memory}},
         {run_queue, statistics(run_queue)},
         {ets_table_count, length(ets:all())},

--- a/src/couch/src/couch_app.erl
+++ b/src/couch/src/couch_app.erl
@@ -16,11 +16,17 @@
 
 -include_lib("couch/include/couch_db.hrl").
 
--export([start/2, stop/1]).
+-export([
+    start/2,
+    stop/1,
+    uptime/0
+]).
 
 start(_Type, _) ->
     case couch_sup:start_link() of
         {ok, _} = Resp ->
+            {Time, _} = statistics(wall_clock),
+            application:set_env(couch, start_time, Time),
             Resp;
         Else ->
             throw(Else)
@@ -29,3 +35,6 @@ start(_Type, _) ->
 stop(_) ->
     ok.
 
+uptime() ->
+    {Time, _} = statistics(wall_clock),
+    Time - application:get_env(couch, start_time, Time).

--- a/src/couch/src/couch_httpd_misc_handlers.erl
+++ b/src/couch/src/couch_httpd_misc_handlers.erl
@@ -13,7 +13,7 @@
 -module(couch_httpd_misc_handlers).
 
 -export([handle_welcome_req/2,handle_favicon_req/2,handle_utils_dir_req/2,
-    handle_all_dbs_req/1,handle_restart_req/1,
+    handle_all_dbs_req/1,
     handle_uuids_req/1,handle_config_req/1,
     handle_task_status_req/1, handle_file_req/2]).
 
@@ -79,27 +79,6 @@ handle_task_status_req(#httpd{method='GET'}=Req) ->
     send_json(Req, [{Props} || Props <- couch_task_status:all()]);
 handle_task_status_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
-
-
-handle_restart_req(#httpd{method='GET', path_parts=[_, <<"token">>]}=Req) ->
-    ok = couch_httpd:verify_is_server_admin(Req),
-    Token = case application:get_env(couch, instance_token) of
-        {ok, Tok} ->
-            Tok;
-        _ ->
-            Tok = erlang:phash2(make_ref()),
-            application:set_env(couch, instance_token, Tok),
-            Tok
-    end,
-    send_json(Req, 200, {[{token, Token}]});
-handle_restart_req(#httpd{method='POST'}=Req) ->
-    couch_httpd:validate_ctype(Req, "application/json"),
-    ok = couch_httpd:verify_is_server_admin(Req),
-    Result = send_json(Req, 202, {[{ok, true}]}),
-    couch:restart(),
-    Result;
-handle_restart_req(Req) ->
-    send_method_not_allowed(Req, "POST").
 
 
 handle_uuids_req(#httpd{method='GET'}=Req) ->

--- a/test/javascript/run
+++ b/test/javascript/run
@@ -85,11 +85,7 @@ def run_couchjs(test, fmt):
         if not line:
             break
         line = line.decode()
-        if line.strip() == "restart":
-            sys.stdout.write("reboot_nodes(ctx)" + os.linesep)
-            sys.stdout.flush()
-        else:
-            sys.stderr.write(line)
+        sys.stderr.write(line)
     p.wait()
     fmt(p.returncode == 0)
     return p.returncode

--- a/test/javascript/test_setup.js
+++ b/test/javascript/test_setup.js
@@ -76,6 +76,14 @@ function getUptime() {
   return stats['uptime'];
 }
 
+function restartNodeRequest(node) {
+    var url = "/_node/" + node +"/_restart"
+    var result = JSON.parse(CouchDB.request("POST", url).responseText);
+    if (result.ok != true) {
+        throw(Error('FAILED to restart: ' + node));
+    }
+}
+
 function restartServer() {
   var olduptime = getUptime();
   if (olduptime < 15) {
@@ -83,7 +91,8 @@ function restartServer() {
     sleep(15000);
     olduptime = getUptime();
   }
-  print('restart');
+
+  restartNodeRequest('node1@127.0.0.1');
 
   /* Wait up to 15s for server to restart */
   var start = new Date().getTime();


### PR DESCRIPTION
## Overview

We need to be able to restart CouchDB from integration test suite.
We used to have this feature, but it was removed.
This PR brings this functionality back under `/_node/$node/_restart`.

## Testing recommendations

1. compile and start CouchDB using `dev/run`
```
make && dev/run --admin=adm:pass
```
2. try to access new endpoint as non authenticated user (you shouldn't be able to)
```
curl -s -X POST 127.0.0.1:35984/_node/node1@127.0.0.1/_restart
```
3. note number of ets tables on the node 
```
 curl -s -u adm:pass -X GET 127.0.0.1:35984/_node/node1@127.0.0.1/_system | jq '.ets_table_count'
```
4. trigger restart of the node (the call should succeed)
```
curl -s -u adm:pass -X POST 127.0.0.1:35984/_node/node1@127.0.0.1/_restart
```
5. keep checking the number of ets tables on the node. The call should return `null` few times and then it should increase gradually. 
```
 curl -s -u adm:pass -X GET 127.0.0.1:35984/_node/node1@127.0.0.1/_system | jq '.ets_table_count'
```


## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
