### PR TITLE
Log error when changes forced to rewind to beginning

### DIFF
--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -173,6 +173,9 @@ find_source_seq(SrcDb, TgtNode, TgtUUIDPrefix, TgtSeq) ->
         SrcNode = atom_to_binary(node(), utf8),
         find_source_seq_int(Doc, SrcNode, TgtNode, TgtUUID, TgtSeq);
     {not_found, _} ->
+        couch_log:warning("~p find_source_seq repl doc not_found "
+            "src_db: ~p, tgt_node: ~p, tgt_uuid_prefix: ~p, tgt_seq: ~p",
+            [?MODULE, SrcDb, TgtNode, TgtUUIDPrefix, TgtSeq]),
         0
     end.
 
@@ -202,6 +205,10 @@ find_source_seq_int(#doc{body={Props}}, SrcNode0, TgtNode0, TgtUUID, TgtSeq) ->
         [{Entry} | _] ->
             couch_util:get_value(<<"source_seq">>, Entry);
         [] ->
+            couch_log:warning("~p find_source_seq_int nil useable history "
+                "src_node: ~p, tgt_node: ~p, tgt_uuid: ~p, tgt_seq: ~p, "
+                "src_history: ~p",
+                [?MODULE, SrcNode, TgtNode, TgtUUID, TgtSeq, SrcHistory]),
             0
     end.
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

During a recent rolling upgrade, we observed the changes feed rewinding to a very old version, which caused performance issues for the client since it had to slog through millions of previously seen changes. Unfortunately, there is no logging when the changes endpoint is forced to rewind, so this adds such logging .

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Unfortunately, this is not trivial to test.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
