### PR TITLE
Fix dialyzer warning of shard record construction

### DIFF
--- a/src/mem3/include/mem3.hrl
+++ b/src/mem3/include/mem3.hrl
@@ -12,12 +12,12 @@
 
 % type specification hacked to suppress dialyzer warning re: match spec
 -record(shard, {
-    name :: binary() | '_',
-    node :: node() | '_',
-    dbname :: binary(),
-    range :: [non_neg_integer() | '$1' | '$2'] | '_',
-    ref :: reference() | 'undefined' | '_',
-    opts :: list()
+    name :: binary() | '_' | 'undefined',
+    node :: node() | '_' | 'undefined',
+    dbname :: binary() | 'undefined',
+    range :: [non_neg_integer() | '$1' | '$2'] | '_' | 'undefined',
+    ref :: reference() | '_' | 'undefined',
+    opts :: list() | 'undefined'
 }).
 
 %% Do not reference outside of mem3.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The violation of shard record construction is reported in several files, including  `fabric_doc_open_revs.erl`, `cpse_test_purge_replication.erl`, etc. This PR is aimed to address these warnings.
```
src/fabric_doc_open_revs.erl:0: in fabric_doc_open_revs:check_finish_quorum/0[385-396]:Record construction #shard{node::'node1',range::'undefined'} violates the declared type of field range::'_' | ['$1' | '$2' | non_neg_integer()]

src/cpse_test_purge_replication.erl:0: in cpse_test_purge_replication:make_shard/1[196-201]:Record construction #shard{node::atom(),range::[0 | 4294967295,...],opts::'undefined'} violates the declared type of field opts::[any()]

```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Run dialyzer tool and make sure there are no complains about shard record construction
1. Prepare for analysis:
  ```
make build-plt
  ```
2. Run analysis 
  ```
make dialyze
  ```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/issues/1580

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
