### PR TITLE
Create shard files if missing

### DIFF
--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -179,7 +179,7 @@ get_db(DbName, Options) ->
     Nodes = [node()|erlang:nodes()],
     Live = [S || #shard{node = N} = S <- Shards, lists:member(N, Nodes)],
     Factor = list_to_integer(config:get("fabric", "shard_timeout_factor", "2")),
-    get_shard(Live, Options, 100, Factor).
+    get_shard(Live, [{create_if_missing, true} | Options], 100, Factor).
 
 get_shard([], _Opts, _Timeout, _Factor) ->
     erlang:error({internal_server_error, "No DB shards could be opened."});


### PR DESCRIPTION
## Overview

If, when a database is created, it was not possible to create any of
the shard files, the database cannot be used. All requests return a
"No DB shards could be opened." error.

This commit changes fabric_util:get_db/2 to create the shard file if
missing. This is correct as that function has already called
mem3:shards(DbName) which only returns shards if the database exists.

## Testing recommendations

It's tricky. You need to have max_dbs_open's worth of files open on all nodes when creating the database. This ensures the _dbs doc is created (as this db is opened at startup and stays open) but none of the shards.

The easiest test is as follows;

1. Create the db
2. stop couchdb (all nodes)
3. delete the .couch files under the 'shards' directory
4. start couchdb
5. try to do anything with the database, get "No DB shards could be opened" error.

retry with the patch and step 5 is successful (and the shard files appear on disk).

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
