### PR TITLE
Couch server improvements

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -230,7 +230,13 @@ init([]) ->
     ok = config:listen_for_changes(?MODULE, nil),
     ok = couch_file:init_delete_dir(RootDir),
     hash_admin_passwords(),
-    ets:new(couch_dbs, [set, protected, named_table, {keypos, #entry.name}]),
+    ets:new(couch_dbs, [
+        set,
+        protected,
+        named_table,
+        {keypos, #entry.name},
+        {read_concurrency, true}
+    ]),
     ets:new(couch_dbs_pid_to_name, [set, protected, named_table]),
     process_flag(trap_exit, true),
     {ok, #server{root_dir=RootDir,

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -101,9 +101,14 @@ open(DbName, Options0) ->
     end.
 
 update_lru(DbName, Options) ->
-    case lists:member(sys_db, Options) of
-        false -> gen_server:cast(couch_server, {update_lru, DbName});
-        true -> ok
+    case config:get_boolean("couchdb", "update_lru_on_read", false) of
+        true ->
+            case lists:member(sys_db, Options) of
+                false -> gen_server:cast(couch_server, {update_lru, DbName});
+                true -> ok
+            end;
+        false ->
+            ok
     end.
 
 close_lru() ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This PR provides two performance related improvements to couch_server:

  1. Use `{read_concurrency, true}` for the protected `couch_dbs` ETS table used in couch_server.
  2. Don't send update_lru messages to couch_server when disabled

More details in the corresponding commit messages.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Standard test suite should do the trick.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
