### PR TITLE
Implement couch_file:format_status to log filepath

### DIFF
--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -47,7 +47,7 @@
 -export([last_read/1]).
 
 % gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2, code_change/3, format_status/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 %% helper functions
@@ -526,6 +526,9 @@ handle_info({'DOWN', Ref, process, _Pid, _Info}, #file{db_monitor=Ref}=File) ->
         false -> {noreply, File}
     end.
 
+format_status(_Opt, [PDict, #file{} = File]) ->
+    {_Fd, FilePath} = couch_util:get_value(couch_file_fd, PDict),
+    [{data, [{"State", File}, {"InitialFilePath", FilePath}]}].
 
 find_header(Fd, Block) ->
     case (catch load_header(Fd, Block)) of


### PR DESCRIPTION
## Overview

Erlang OTP logs the fact when gen_server behavior crashes. However in case of couch_file the filename is not part of the state. So it is quite hard to figure out what happened given the current log entry format. This PR adds information about filepath to the log entry. Keep in mind though that the filepath value is captured on couch_file:start_link. It is not representing the current file name if file is renamed or moved.

## Testing recommendations

1. Start couchdb `dev/run --admin=adm:pass`
2. Start remsh session `dev/remsh`
3. Inject failure in one of the couch_file processes (by reading with position greater than the file size) 
```
{_Port, Pid, _Fd, _Name} = hd(couch_debug:opened_files()).
couch_file:pread_binary(Pid, 999999999999999).
```
4. Check logs to make sure the following messages are present:
```
[error] 2018-09-12T20:01:02.957946Z node1@127.0.0.1 <0.390.0> -------- gen_server <0.390.0> terminated with reason: bad return value {read_beyond_eof,"/home/jenkins/dev/lib/node1/data/dbs/nodes.couch"}
  last msg: {pread_iolist,123123123}
     state: [{data,[{"State",{file,{file_descriptor,prim_file,{#Port<0.51359>,29}},true,139454,#Ref<0.0.3.65>,infinity}},{"InitialFilePath","/home/jenkins/dev/lib/node1/data/dbs/nodes.couch"}]}]
```

## Related Issues or Pull Requests

This is a port of PR from https://github.com/apache/couchdb-couch/pull/215 to couchdb repository. 

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
