### PR TITLE
Feature/user partitioned databases

### DIFF
--- a/src/chttpd/src/chttpd_handlers.erl
+++ b/src/chttpd/src/chttpd_handlers.erl
@@ -15,7 +15,9 @@
 -export([
     url_handler/2,
     db_handler/2,
-    design_handler/2
+    design_handler/2,
+    partition_handler/2,
+    partition_design_handler/2
 ]).
 
 -define(SERVICE_ID, chttpd_handlers).
@@ -34,6 +36,12 @@ db_handler(HandlerKey, DefaultFun) ->
 
 design_handler(HandlerKey, DefaultFun) ->
     select(collect(design_handler, [HandlerKey]), DefaultFun).
+
+partition_handler(HandlerKey, DefaultFun) ->
+        select(collect(partition_handler, [HandlerKey]), DefaultFun).
+
+partition_design_handler(HandlerKey, DefaultFun) ->
+        select(collect(partition_design_handler, [HandlerKey]), DefaultFun).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/chttpd/src/chttpd_httpd_handlers.erl
+++ b/src/chttpd/src/chttpd_httpd_handlers.erl
@@ -12,7 +12,7 @@
 
 -module(chttpd_httpd_handlers).
 
--export([url_handler/1, db_handler/1, design_handler/1]).
+-export([url_handler/1, db_handler/1, design_handler/1, partition_design_handler/1, partition_handler/1]).
 
 url_handler(<<>>)                  -> fun chttpd_misc:handle_welcome_req/1;
 url_handler(<<"favicon.ico">>)     -> fun chttpd_misc:handle_favicon_req/1;
@@ -32,6 +32,7 @@ url_handler(_) -> no_match.
 db_handler(<<"_view_cleanup">>) -> fun chttpd_db:handle_view_cleanup_req/2;
 db_handler(<<"_compact">>)      -> fun chttpd_db:handle_compact_req/2;
 db_handler(<<"_design">>)       -> fun chttpd_db:handle_design_req/2;
+db_handler(<<"_partition">>)    -> fun chttpd_db:handle_partition_req/2;
 db_handler(<<"_temp_view">>)    -> fun chttpd_view:handle_temp_view_req/2;
 db_handler(<<"_changes">>)      -> fun chttpd_db:handle_changes_req/2;
 db_handler(_) -> no_match.
@@ -43,3 +44,8 @@ design_handler(<<"_update">>)  -> fun chttpd_show:handle_doc_update_req/3;
 design_handler(<<"_info">>)    -> fun chttpd_db:handle_design_info_req/3;
 design_handler(<<"_rewrite">>) -> fun chttpd_rewrite:handle_rewrite_req/3;
 design_handler(_) -> no_match.
+
+partition_design_handler(<<"_view">>) -> fun chttpd_view:handle_partition_view_req/4;
+partition_design_handler(_) -> no_match.
+
+partition_handler(_) -> no_match.

--- a/src/chttpd/src/chttpd_view.erl
+++ b/src/chttpd/src/chttpd_view.erl
@@ -101,6 +101,36 @@ handle_temp_view_req(Req, _Db) ->
     chttpd:send_error(Req, 410, gone, Msg).
 
 
+handle_partition_view_req(#httpd{method='POST',
+        path_parts=[_, _, _, _, _, _, ViewName]} = Req, Db, DDoc, Partition) ->
+    chttpd:validate_ctype(Req, "application/json"),
+    Props = couch_httpd:json_body_obj(Req),
+    Keys = couch_mrview_util:get_view_keys(Props),
+    case Keys of
+        Keys when is_list(Keys) ->
+            couch_stats:increment_counter([couchdb, httpd, view_reads]),
+            Args0 = couch_mrview_http:parse_params(Req, Keys),
+            Args1 = couch_mrview_util:set_extra(Args0, partition, Partition),
+            Args2 = couch_mrview_util:set_extra(Args1, partitioned, true),
+            design_doc_view_int(Req, Db, DDoc, ViewName, Args2);
+        _ ->
+            throw({
+                bad_request,
+                "POST body must contain `keys` field"
+            })
+    end;
+
+handle_partition_view_req(#httpd{method='GET',
+        path_parts=[_, _, _, _, _, _, ViewName]} = Req, Db, DDoc, Partition) ->
+    Keys = chttpd:qs_json_value(Req, "keys", undefined),
+    Args = couch_mrview_http:parse_params(Req, Keys),
+    Args1 = couch_mrview_util:set_extra(Args, partition, Partition),
+    Args2 = couch_mrview_util:set_extra(Args1, partitioned, true),
+    design_doc_view_int(Req, Db, DDoc, ViewName, Args2);
+
+handle_partition_view_req(Req, _Db, _DDoc, _Pk) ->
+        chttpd:send_method_not_allowed(Req, "GET").
+
 
 -ifdef(TEST).
 

--- a/src/chttpd/test/chttpd_db_bulk_get_test.erl
+++ b/src/chttpd/test/chttpd_db_bulk_get_test.erl
@@ -14,6 +14,7 @@
 
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
+-include_lib("couch/src/couch_db_int.hrl").
 
 -define(TIMEOUT, 3000).
 
@@ -26,6 +27,7 @@ setup() ->
     mock(couch_stats),
     mock(fabric),
     mock(mochireq),
+    mock(mem3),
     Pid = spawn_accumulator(),
     Pid.
 
@@ -38,7 +40,8 @@ teardown(Pid) ->
     meck:unload(couch_httpd),
     meck:unload(couch_stats),
     meck:unload(fabric),
-    meck:unload(mochireq).
+    meck:unload(mochireq),
+    meck:unload(mem3).
 
 
 bulk_get_test_() ->
@@ -95,7 +98,8 @@ should_get_doc_with_all_revs(Pid) ->
     DocRevB = #doc{id = DocId, body = {[{<<"_rev">>, <<"1-CDE">>}]}},
 
     mock_open_revs(all, {ok, [{ok, DocRevA}, {ok, DocRevB}]}),
-    chttpd_db:db_req(Req, nil),
+    Db = fake_db(),
+    chttpd_db:db_req(Req, Db),
 
     [{Result}] = get_results_from_response(Pid),
     ?assertEqual(DocId, couch_util:get_value(<<"id">>, Result)),
@@ -115,7 +119,8 @@ should_validate_doc_with_bad_id(Pid) ->
     DocId = <<"_docudoc">>,
 
     Req = fake_request(DocId),
-    chttpd_db:db_req(Req, nil),
+    Db = fake_db(),
+    chttpd_db:db_req(Req, Db),
 
     [{Result}] = get_results_from_response(Pid),
     ?assertEqual(DocId, couch_util:get_value(<<"id">>, Result)),
@@ -138,7 +143,8 @@ should_validate_doc_with_bad_rev(Pid) ->
     Rev = <<"revorev">>,
 
     Req = fake_request(DocId, Rev),
-    chttpd_db:db_req(Req, nil),
+    Db = fake_db(),
+    chttpd_db:db_req(Req, Db),
 
     [{Result}] = get_results_from_response(Pid),
     ?assertEqual(DocId, couch_util:get_value(<<"id">>, Result)),
@@ -162,7 +168,8 @@ should_validate_missing_doc(Pid) ->
 
     Req = fake_request(DocId, Rev),
     mock_open_revs([{1,<<"revorev">>}], {ok, []}),
-    chttpd_db:db_req(Req, nil),
+    Db = fake_db(),
+    chttpd_db:db_req(Req, Db),
 
     [{Result}] = get_results_from_response(Pid),
     ?assertEqual(DocId, couch_util:get_value(<<"id">>, Result)),
@@ -186,7 +193,8 @@ should_validate_bad_atts_since(Pid) ->
 
     Req = fake_request(DocId, Rev, <<"badattsince">>),
     mock_open_revs([{1,<<"revorev">>}], {ok, []}),
-    chttpd_db:db_req(Req, nil),
+    Db = fake_db(),
+    chttpd_db:db_req(Req, Db),
 
     [{Result}] = get_results_from_response(Pid),
     ?assertEqual(DocId, couch_util:get_value(<<"id">>, Result)),
@@ -210,10 +218,11 @@ should_include_attachments_when_atts_since_specified(_) ->
 
     Req = fake_request(DocId, Rev, [<<"1-abc">>]),
     mock_open_revs([{1,<<"revorev">>}], {ok, []}),
-    chttpd_db:db_req(Req, nil),
+    Db = fake_db(),
+    chttpd_db:db_req(Req, Db),
 
     ?_assert(meck:called(fabric, open_revs,
-                         [nil, DocId, [{1, <<"revorev">>}],
+                         [Db, DocId, [{1, <<"revorev">>}],
                           [{atts_since, [{1, <<"abc">>}]}, attachments]])).
 
 %% helpers
@@ -231,6 +240,10 @@ fake_request(DocId, Rev, AttsSince) ->
     fake_request({[{<<"docs">>, [{[{<<"id">>, DocId},
                                    {<<"rev">>, Rev},
                                    {<<"atts_since">>, AttsSince}]}]}]}).
+
+
+fake_db() ->
+    #db{name = <<"dbName">>}.
 
 
 mock_open_revs(RevsReq0, RevsResp) ->
@@ -276,6 +289,10 @@ mock(fabric) ->
 mock(config) ->
     ok = meck:new(config, [passthrough]),
     ok = meck:expect(config, get, fun(_, _, Default) -> Default end),
+    ok;
+mock(mem3) ->
+    ok = meck:new(mem3, [passthrough]),
+    ok = meck:expect(mem3, is_partitioned, 1, false),
     ok.
 
 

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -44,6 +44,7 @@
     get_prop/2,
     get_prop/3,
     get_size_info/1,
+    get_partition_info/2,
     get_update_seq/1,
     get_uuid/1,
 
@@ -277,6 +278,56 @@ get_size_info(#st{} = St) ->
         {external, ExternalSize},
         {file, FileSize}
     ].
+
+
+partition_size_cb(traverse, Key, {DC, DDC, Sizes}, {Partition, DCAcc, DDCAcc, SizesAcc}) ->
+    case in_partition(Key, Partition) of
+        true ->
+            {skip, {Partition, DC + DCAcc, DDC + DDCAcc, reduce_sizes(Sizes, SizesAcc)}};
+        false ->
+            {ok, {Partition, DCAcc, DDCAcc, SizesAcc}}
+    end;
+
+
+partition_size_cb(visit, FDI, _PrevReds, {Partition, DCAcc, DDCAcc, Acc}) ->
+    InPartition = in_partition(FDI#full_doc_info.id, Partition),
+    Deleted = FDI#full_doc_info.deleted,
+    case {InPartition, Deleted} of
+        {true, true} ->
+            {ok, {Partition, DCAcc, DDCAcc + 1,
+                reduce_sizes(FDI#full_doc_info.sizes, Acc)}};
+        {true, false} ->
+            {ok, {Partition, DCAcc + 1, DDCAcc,
+                reduce_sizes(FDI#full_doc_info.sizes, Acc)}};
+        {false, _} ->
+            {ok, {Partition, DCAcc, DDCAcc, Acc}}
+    end.
+
+
+get_partition_info(#st{} = St, Partition) ->
+    StartKey = <<Partition/binary, ":">>,
+    EndKey = <<Partition/binary, ";">>,
+    Fun = fun partition_size_cb/4,
+    InitAcc = {Partition, 0, 0, #size_info{}},
+    Options = [{start_key, StartKey}, {end_key, EndKey}],
+    {ok, _, OutAcc} = couch_btree:fold(St#st.id_tree, Fun, InitAcc, Options),
+    {Partition, DocCount, DocDelCount, SizeInfo} = OutAcc,
+    [
+        {partition, Partition},
+        {doc_count, DocCount},
+        {doc_del_count, DocDelCount},
+        {sizes,
+            [
+                {active, SizeInfo#size_info.active},
+                {external, SizeInfo#size_info.external}
+            ]
+        }
+    ].
+
+
+in_partition(DocId, Partition0) ->
+    [Partition1, _Id] = binary:split(DocId, <<":">>),
+    Partition0 == Partition1.
 
 
 get_security(#st{header = Header} = St) ->

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -40,6 +40,9 @@
     get_purge_infos_limit/1,
     get_revs_limit/1,
     get_security/1,
+    get_props/1,
+    get_prop/2,
+    get_prop/3,
     get_size_info/1,
     get_update_seq/1,
     get_uuid/1,
@@ -47,6 +50,7 @@
     set_revs_limit/2,
     set_purge_infos_limit/2,
     set_security/2,
+    set_prop/3,
 
     open_docs/2,
     open_local_docs/2,
@@ -104,7 +108,8 @@
 -export([
     set_update_seq/2,
     update_header/2,
-    copy_security/2
+    copy_security/2,
+    copy_props/2
 ]).
 
 
@@ -143,8 +148,9 @@ init(FilePath, Options) ->
         true ->
             delete_compaction_files(FilePath),
             Header0 = couch_bt_engine_header:new(),
-            ok = couch_file:write_header(Fd, Header0),
-            Header0;
+            Header1 = set_initial_props(Fd, Header0, Options),
+            ok = couch_file:write_header(Fd, Header1),
+            Header1;
         false ->
             case couch_file:read_header(Fd) of
                 {ok, Header0} ->
@@ -283,6 +289,31 @@ get_security(#st{header = Header} = St) ->
     end.
 
 
+get_props(#st{header = Header} = St) ->
+    case couch_bt_engine_header:get(Header, props_ptr) of
+        undefined ->
+            [];
+        Pointer ->
+            {ok, Props} = couch_file:pread_term(St#st.fd, Pointer),
+            Props
+    end.
+
+
+get_prop(St, Key) ->
+    Props = get_props(St),
+    case lists:keyfind(Key, 1, Props) of
+        false -> {error, no_value};
+        {Key, Value} -> {ok, Value}
+    end.
+
+
+get_prop(St, Key, DefaultValue) ->
+    case get_prop(St, Key) of
+        {error, no_value} -> DefaultValue;
+        Value -> Value
+    end.
+
+
 get_update_seq(#st{header = Header}) ->
     couch_bt_engine_header:get(Header, update_seq).
 
@@ -317,6 +348,20 @@ set_security(#st{header = Header} = St, NewSecurity) ->
     NewSt = St#st{
         header = couch_bt_engine_header:set(Header, [
             {security_ptr, Ptr}
+        ]),
+        needs_commit = true
+    },
+    {ok, increment_update_seq(NewSt)}.
+
+
+set_prop(#st{header = Header} = St, Key, Value) ->
+    OldProps = get_props(St),
+    NewProps = lists:ukeymerge(1, [{Key, Value}], OldProps),
+    Options = [{compression, St#st.compression}],
+    {ok, Ptr, _} = couch_file:append_term(St#st.fd, NewProps, Options),
+    NewSt = St#st{
+        header = couch_bt_engine_header:set(Header, [
+            {props_ptr, Ptr}
         ]),
         needs_commit = true
     },
@@ -752,6 +797,16 @@ copy_security(#st{header = Header} = St, SecProps) ->
         needs_commit = true
     }}.
 
+copy_props(#st{header = Header} = St, Props) ->
+    Options = [{compression, St#st.compression}],
+    {ok, Ptr, _} = couch_file:append_term(St#st.fd, Props, Options),
+    {ok, St#st{
+        header = couch_bt_engine_header:set(Header, [
+            {props_ptr, Ptr}
+        ]),
+        needs_commit = true
+    }}.
+
 
 open_db_file(FilePath, Options) ->
     case couch_file:open(FilePath, Options) of
@@ -936,6 +991,18 @@ upgrade_purge_info(Fd, Header) ->
                         {purge_seq_tree_state, PurgeSeqTreeSt}
                     ])
             end
+    end.
+
+
+set_initial_props(Fd, Header, Options) ->
+    case couch_util:get_value(initial_props, Options) of
+        undefined ->
+            Header;
+        InitialProps ->
+            Compression = couch_compress:get_compression_method(),
+            AppendOpts = [{compression, Compression}],
+            {ok, Ptr, _} = couch_file:append_term(Fd, InitialProps, AppendOpts),
+            couch_bt_engine_header:set(Header, props_ptr, Ptr)
     end.
 
 

--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -276,9 +276,13 @@ copy_compact(DbName, St, NewSt0, Retry) ->
     SecProps = couch_bt_engine:get_security(St),
     {ok, NewSt4} = couch_bt_engine:copy_security(NewSt3, SecProps),
 
+    % Copy general properties over
+    Props = couch_bt_engine:get_props(St),
+    {ok, NewSt5} = couch_bt_engine:copy_props(NewSt4, Props),
+
     FinalUpdateSeq = couch_bt_engine:get_update_seq(St),
-    {ok, NewSt5} = couch_bt_engine:set_update_seq(NewSt4, FinalUpdateSeq),
-    commit_compaction_data(NewSt5).
+    {ok, NewSt6} = couch_bt_engine:set_update_seq(NewSt5, FinalUpdateSeq),
+    commit_compaction_data(NewSt6).
 
 
 copy_docs(St, #st{} = NewSt, MixedInfos, Retry) ->

--- a/src/couch/src/couch_bt_engine_header.erl
+++ b/src/couch/src/couch_bt_engine_header.erl
@@ -68,7 +68,8 @@
     uuid,
     epochs,
     compacted_seq,
-    purge_infos_limit = 1000
+    purge_infos_limit = 1000,
+    props_ptr
 }).
 
 

--- a/src/couch/src/couch_btree.erl
+++ b/src/couch/src/couch_btree.erl
@@ -133,7 +133,9 @@ make_group_fun(Bt, exact) ->
     end;
 make_group_fun(Bt, GroupLevel) when is_integer(GroupLevel), GroupLevel > 0 ->
     fun
-        ({[_|_] = Key1, _}, {[_|_] = Key2, _}) ->
+        GF({{p, _Partition, Key1}, Val1}, {{p, _Partition, Key2}, Val2}) ->
+            GF({Key1, Val1}, {Key2, Val2});
+        GF({[_|_] = Key1, _}, {[_|_] = Key2, _}) ->
             SL1 = lists:sublist(Key1, GroupLevel),
             SL2 = lists:sublist(Key2, GroupLevel),
             case less(Bt, {SL1, nil}, {SL2, nil}) of
@@ -147,7 +149,7 @@ make_group_fun(Bt, GroupLevel) when is_integer(GroupLevel), GroupLevel > 0 ->
                 _ ->
                     false
             end;
-        ({Key1, _}, {Key2, _}) ->
+        GF({Key1, _}, {Key2, _}) ->
             case less(Bt, {Key1, nil}, {Key2, nil}) of
                 false ->
                     case less(Bt, {Key2, nil}, {Key1, nil}) of

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -46,6 +46,7 @@
     get_pid/1,
     get_revs_limit/1,
     get_security/1,
+    get_props/1,
     get_update_seq/1,
     get_user_ctx/1,
     get_uuid/1,
@@ -60,6 +61,7 @@
     set_revs_limit/2,
     set_purge_infos_limit/2,
     set_security/2,
+    set_prop/3,
     set_user_ctx/2,
 
     ensure_full_commit/1,
@@ -713,6 +715,15 @@ set_security(#db{main_pid=Pid}=Db, {NewSecProps}) when is_list(NewSecProps) ->
     ok;
 set_security(_, _) ->
     throw(bad_request).
+
+get_props(#db{props=Props}) ->
+    Props.
+
+set_prop(#db{main_pid=Pid}=Db, Key, Value) ->
+    check_is_admin(Db),
+    ok = gen_server:call(Pid, {set_prop, Key, Value}, infinity),
+    {ok, _} = ensure_full_commit(Db),
+    ok.
 
 set_user_ctx(#db{} = Db, UserCtx) ->
     {ok, Db#db{user_ctx = UserCtx}}.

--- a/src/couch/src/couch_db_engine.erl
+++ b/src/couch/src/couch_db_engine.erl
@@ -242,6 +242,19 @@
 % the last value that was passed to set_security/2.
 -callback get_security(DbHandle::db_handle()) -> SecProps::any().
 
+% Get the current properties.
+-callback get_props(DbHandle::db_handle()) -> Props::any().
+
+% Get the current properties. This should just return
+% the last value that was passed to set_prop/2.
+-callback get_prop(DbHandle::db_handle(), Prop::atom()) ->
+    {ok, SecProps::json()} | {error, no_value}.
+
+% Get the current properties. If the value isn't set it will return the set default value.
+% This should just return the last value that was passed to set_prop/2.
+-callback get_prop(DbHandle::db_handle(), Prop::atom(), DefaultValue::any()) ->
+    {ok, SecProps::json()}.
+
 
 % This information is displayed in the database info poperties. It
 % should just be a list of {Name::atom(), Size::non_neg_integer()}
@@ -285,6 +298,15 @@
 
 
 -callback set_security(DbHandle::db_handle(), SecProps::any()) ->
+        {ok, NewDbHandle::db_handle()}.
+
+
+% This function is only called by couch_db_updater and
+% as such is guaranteed to be single threaded calls. The
+% database should simply store prop key and value somewhere so
+% they can be returned by the corresponding get_prop calls.
+
+-callback set_prop(DbHandle::db_handle(), PropKey::atom(), PropValue::any()) ->
         {ok, NewDbHandle::db_handle()}.
 
 
@@ -670,6 +692,9 @@
     get_purge_infos_limit/1,
     get_revs_limit/1,
     get_security/1,
+    get_props/1,
+    get_prop/2,
+    get_prop/3,
     get_size_info/1,
     get_update_seq/1,
     get_uuid/1,
@@ -677,6 +702,7 @@
     set_revs_limit/2,
     set_security/2,
     set_purge_infos_limit/2,
+    set_prop/3,
 
     open_docs/2,
     open_local_docs/2,
@@ -836,6 +862,21 @@ get_security(#db{} = Db) ->
     Engine:get_security(EngineState).
 
 
+get_props(#db{} = Db) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    Engine:get_props(EngineState).
+
+
+get_prop(#db{} = Db, Prop) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    Engine:get_prop(EngineState, Prop).
+
+
+get_prop(#db{} = Db, Prop, DefaultValue) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    Engine:get_prop(EngineState, Prop, DefaultValue).
+
+
 get_size_info(#db{} = Db) ->
     #db{engine = {Engine, EngineState}} = Db,
     Engine:get_size_info(EngineState).
@@ -865,6 +906,12 @@ set_purge_infos_limit(#db{} = Db, PurgedDocsLimit) ->
 set_security(#db{} = Db, SecProps) ->
     #db{engine = {Engine, EngineState}} = Db,
     {ok, NewSt} = Engine:set_security(EngineState, SecProps),
+    {ok, Db#db{engine = {Engine, NewSt}}}.
+
+
+set_prop(#db{} = Db, Key, Value) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    {ok, NewSt} = Engine:set_prop(EngineState, Key, Value),
     {ok, Db#db{engine = {Engine, NewSt}}}.
 
 

--- a/src/couch/src/couch_db_int.hrl
+++ b/src/couch/src/couch_db_int.hrl
@@ -35,7 +35,8 @@
     waiting_delayed_commit = nil,
 
     options = [],
-    compression
+    compression,
+    props = []
 }).
 
 

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -88,6 +88,14 @@ handle_call({set_security, NewSec}, _From, #db{} = Db) ->
     ok = gen_server:call(couch_server, {db_updated, NewSecDb}, infinity),
     {reply, ok, NewSecDb, idle_limit()};
 
+handle_call({set_prop, Key, Value}, _From, #db{} = Db) ->
+    {ok, NewDb} = couch_db_engine:set_prop(Db, Key, Value),
+    NewPropDb = commit_data(NewDb#db{
+        props = couch_db_engine:get_props(NewDb)
+    }),
+    ok = gen_server:call(couch_server, {db_updated, NewPropDb}, infinity),
+    {reply, ok, NewPropDb, idle_limit()};
+
 handle_call({set_revs_limit, Limit}, _From, Db) ->
     {ok, Db2} = couch_db_engine:set_revs_limit(Db, Limit),
     Db3 = commit_data(Db2),
@@ -324,7 +332,8 @@ init_db(DbName, FilePath, EngineState, Options) ->
 
     InitDb#db{
         committed_update_seq = couch_db_engine:get_update_seq(InitDb),
-        security = couch_db_engine:get_security(InitDb)
+        security = couch_db_engine:get_security(InitDb),
+        props = couch_db_engine:get_props(InitDb)
     }.
 
 

--- a/src/couch/src/couch_ejson_compare.erl
+++ b/src/couch/src/couch_ejson_compare.erl
@@ -22,6 +22,10 @@ init() ->
     Dir = code:priv_dir(couch),
     ok = erlang:load_nif(filename:join(Dir, ?MODULE), NumScheds).
 
+% partitioned row comparison
+less({p, PA, A}, {p, PB, B}) ->
+    less([PA, A], [PB, B]);
+
 less(A, B) ->
     try
         less_nif(A, B)

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -582,6 +582,9 @@ parse_param(Key, Val, Args, IsDecoded) ->
             Args#mrargs{callback=couch_util:to_binary(Val)};
         "sorted" ->
             Args#mrargs{sorted=parse_boolean(Val)};
+        "partition" ->
+            Partition = couch_util:to_binary(Val),
+            couch_mrview_util:set_extra(Args, partition, Partition);
         _ ->
             BKey = couch_util:to_binary(Key),
             BVal = couch_util:to_binary(Val),

--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -40,10 +40,12 @@ get(update_options, #mrst{design_opts = Opts}) ->
     LocalSeq = couch_util:get_value(<<"local_seq">>, Opts, false),
     SeqIndexed = couch_util:get_value(<<"seq_indexed">>, Opts, false),
     KeySeqIndexed = couch_util:get_value(<<"keyseq_indexed">>, Opts, false),
+    Partitioned = couch_util:get_value(<<"partitioned">>, Opts, false),
     if IncDesign -> [include_design]; true -> [] end
         ++ if LocalSeq -> [local_seq]; true -> [] end
         ++ if KeySeqIndexed -> [keyseq_indexed]; true -> [] end
-        ++ if SeqIndexed -> [seq_indexed]; true -> [] end;
+        ++ if SeqIndexed -> [seq_indexed]; true -> [] end
+        ++ if Partitioned -> [partitioned]; true -> [] end;
 get(fd, #mrst{fd = Fd}) ->
     Fd;
 get(language, #mrst{language = Language}) ->

--- a/src/couch_mrview/src/couch_mrview_updater.erl
+++ b/src/couch_mrview/src/couch_mrview_updater.erl
@@ -315,8 +315,12 @@ write_kvs(State, UpdateSeq, ViewKVs, DocIdKeys, Seqs, Log0) ->
     #mrst{
         id_btree=IdBtree,
         log_btree=LogBtree,
-        first_build=FirstBuild
+        first_build=FirstBuild,
+        design_opts=DesignOpts
     } = State,
+
+    DbPartitioned = mem3:is_partitioned(State#mrst.db_name),
+    Partitioned = couch_util:get_value(<<"partitioned">>, DesignOpts, DbPartitioned),
 
     Revs = dict:from_list(dict:fetch_keys(Log0)),
 
@@ -332,8 +336,9 @@ write_kvs(State, UpdateSeq, ViewKVs, DocIdKeys, Seqs, Log0) ->
         _ -> update_log(LogBtree, Log, Revs, Seqs, FirstBuild)
     end,
 
-    UpdateView = fun(#mrview{id_num=ViewId}=View, {ViewId, {KVs, SKVs}}) ->
+    UpdateView = fun(#mrview{id_num=ViewId}=View, {ViewId, {KVs0, SKVs}}) ->
         #mrview{seq_indexed=SIndexed, keyseq_indexed=KSIndexed} = View,
+        KVs = if Partitioned -> inject_partition(KVs0); true -> KVs0 end,
         ToRem = couch_util:dict_find(ViewId, ToRemByView, []),
         {ok, VBtree2} = couch_btree:add_remove(View#mrview.btree, KVs, ToRem),
         NewUpdateSeq = case VBtree2 =/= View#mrview.btree of
@@ -381,6 +386,13 @@ write_kvs(State, UpdateSeq, ViewKVs, DocIdKeys, Seqs, Log0) ->
         id_btree=IdBtree2,
         log_btree=LogBtree2
     }.
+
+inject_partition(KVs) ->
+    [{{{p, partition(DocId), Key}, DocId}, Value} || {{Key, DocId}, Value} <- KVs].
+
+partition(DocId) ->
+    [Partition, _Rest] = binary:split(DocId, <<":">>),
+    Partition.
 
 update_id_btree(Btree, DocIdKeys, true) ->
     ToAdd = [{Id, DIKeys} || {Id, DIKeys} <- DocIdKeys, DIKeys /= []],

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -642,20 +642,6 @@ validate_args(Args) ->
             mrverror(<<"`partition` parameter is not supported in this view.">>)
     end,
 
-    case {Partitioned, Args#mrargs.conflicts} of
-        {true, true} ->
-            mrverror(<<"`conflicts=true` is not supported in this view.">>);
-        {_, _} ->
-            ok
-    end,
-
-    case {Partitioned, Args#mrargs.stable} of
-        {true, true} ->
-            mrverror(<<"`stable=true` is not supported in this view.">>);
-        {_, _} ->
-            ok
-    end,
-
     Args1 = case {Style, Partitioned, Partition} of
         {all_docs, true, undefined} ->
             Args;

--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -22,7 +22,7 @@
     set_security/2, set_security/3, get_revs_limit/1, get_security/1,
     get_security/2, get_all_security/1, get_all_security/2,
     get_purge_infos_limit/1, set_purge_infos_limit/3,
-    compact/1, compact/2]).
+    compact/1, compact/2, get_partition_info/2]).
 
 % Documents
 -export([open_doc/3, open_revs/4, get_doc_info/3, get_full_doc_info/3,
@@ -84,6 +84,19 @@ all_dbs(Prefix) when is_list(Prefix) ->
     ]}.
 get_db_info(DbName) ->
     fabric_db_info:go(dbname(DbName)).
+
+%% @doc returns the size of a given partition
+-spec get_partition_info(dbname(), Partition::binary()) ->
+    {ok, [
+        {db_name, binary()} |
+        {partition, binary()} |
+        {doc_count, non_neg_integer()} |
+        {doc_del_count, non_neg_integer()} |
+        {sizes, json_obj()}
+    ]}.
+get_partition_info(DbName, Partition) ->
+    fabric_db_partition_info:go(dbname(DbName), Partition).
+
 
 %% @doc the number of docs in a database
 -spec get_doc_count(dbname()) ->

--- a/src/fabric/src/fabric_db_create.erl
+++ b/src/fabric/src/fabric_db_create.erl
@@ -164,6 +164,10 @@ make_document([#shard{dbname=DbName}|_] = Shards, Suffix, Options) ->
         {[[<<"add">>, Range, Node] | Raw], orddict:append(Node, Range, ByNode),
             orddict:append(Range, Node, ByRange)}
     end, {[], [], []}, Shards),
+    InitialProps = case couch_util:get_value(initial_props, Options) of
+        I when is_list(I) -> [{<<"options">>, {I}}];
+        _ -> []
+    end,
     EngineProp = case couch_util:get_value(engine, Options) of
         E when is_binary(E) -> [{<<"engine">>, E}];
         _ -> []
@@ -175,7 +179,7 @@ make_document([#shard{dbname=DbName}|_] = Shards, Suffix, Options) ->
             {<<"changelog">>, lists:sort(RawOut)},
             {<<"by_node">>, {[{K,lists:sort(V)} || {K,V} <- ByNodeOut]}},
             {<<"by_range">>, {[{K,lists:sort(V)} || {K,V} <- ByRangeOut]}}
-        ] ++ EngineProp}
+        ] ++ EngineProp ++ InitialProps}
     }.
 
 db_exists(DbName) -> is_list(catch mem3:shards(DbName)).

--- a/src/fabric/src/fabric_db_info.erl
+++ b/src/fabric/src/fabric_db_info.erl
@@ -112,6 +112,8 @@ merge_results(Info) ->
             [{disk_format_version, lists:max(X)} | Acc];
         (cluster, [X], Acc) ->
             [{cluster, {X}} | Acc];
+        (props, X, Acc) ->
+            [{props, {merge_object(X)}} | Acc];
         (_, _, Acc) ->
             Acc
     end, [{instance_start_time, <<"0">>}], Dict).
@@ -132,9 +134,16 @@ merge_object(Objects) ->
         lists:foldl(fun({K,V},D0) -> orddict:append(K,V,D0) end, D, Props)
     end, orddict:new(), Objects),
     orddict:fold(fun
-        (Key, X, Acc) ->
-            [{Key, lists:sum(X)} | Acc]
+        (Key, [X | _] = Xs, Acc) when is_integer(X) ->
+            [{Key, lists:sum(Xs)} | Acc];
+        (Key, [X | _] = Xs, Acc) when is_boolean(X) ->
+            [{Key, lists:all(fun all_true/1, Xs)} | Acc];
+        (_Key, _X, Acc) ->
+            Acc
     end, [], Dict).
+
+all_true(true) -> true;
+all_true(_)    -> false.
 
 get_cluster_info(Shards) ->
     Dict = lists:foldl(fun(#shard{range = R}, Acc) ->

--- a/src/fabric/src/fabric_db_partition_info.erl
+++ b/src/fabric/src/fabric_db_partition_info.erl
@@ -1,0 +1,98 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric_db_partition_info).
+
+-export([go/2]).
+
+-include_lib("fabric/include/fabric.hrl").
+-include_lib("mem3/include/mem3.hrl").
+
+go(DbName, Partition) ->
+    Shards = mem3:shards(DbName, <<Partition/binary, ":foo">>),
+    Workers = fabric_util:submit_jobs(Shards, get_partition_info, [Partition]),
+    RexiMon = fabric_util:create_monitors(Shards),
+    Fun = fun handle_message/3,
+    Acc0 = {fabric_dict:init(Workers, nil), []},
+    try
+        case fabric_util:recv(Workers, #shard.ref, Fun, Acc0) of
+            {ok, Acc} -> {ok, Acc};
+            {timeout, {WorkersDict, _}} ->
+                DefunctWorkers = fabric_util:remove_done_workers(
+                    WorkersDict,
+                    nil
+                ),
+                fabric_util:log_timeout(
+                    DefunctWorkers,
+                    "get_partition_info"
+                ),
+                {error, timeout};
+            {error, Error} -> throw(Error)
+        end
+    after
+        rexi_monitor:stop(RexiMon)
+    end.
+
+handle_message({rexi_DOWN, _, {_,NodeRef},_}, _Shard, {Counters, Acc}) ->
+    case fabric_util:remove_down_workers(Counters, NodeRef) of
+    {ok, NewCounters} ->
+        {ok, {NewCounters, Acc}};
+    error ->
+        {error, {nodedown, <<"progress not possible">>}}
+    end;
+
+handle_message({rexi_EXIT, Reason}, Shard, {Counters, Acc}) ->
+    NewCounters = fabric_dict:erase(Shard, Counters),
+    case fabric_view:is_progress_possible(NewCounters) of
+    true ->
+        {ok, {NewCounters, Acc}};
+    false ->
+        {error, Reason}
+    end;
+
+handle_message({ok, Sizes}, #shard{dbname=Name} = Shard, {Counters, Acc}) ->
+    Acc2 = [Sizes | Acc],
+    Counters1 = fabric_dict:erase(Shard, Counters),
+    case fabric_dict:size(Counters1) =:= 0 of
+        true ->
+            [FirstInfo | RestInfos] = Acc2,
+            PartitionInfo = get_max_partition_size(FirstInfo, RestInfos),
+            {stop, [{db_name, Name} | format_partition(PartitionInfo)]};
+        false ->
+            {ok, {Counters1, Acc2}}
+    end;
+    
+handle_message(_, _, Acc) ->
+    {ok, Acc}.
+
+get_max_partition_size(Max, []) ->
+    Max;
+get_max_partition_size(MaxInfo, [NextInfo | Rest]) ->
+    {sizes, MaxSize} = lists:keyfind(sizes, 1, MaxInfo),
+    {sizes, NextSize} = lists:keyfind(sizes, 1, NextInfo),
+
+    {external, MaxExtSize} = lists:keyfind(external, 1, MaxSize),
+    {external, NextExtSize} = lists:keyfind(external, 1, NextSize),
+    case NextExtSize > MaxExtSize of 
+        true ->
+            get_max_partition_size(NextInfo, Rest);
+        false ->
+            get_max_partition_size(MaxInfo, Rest)
+    end.
+
+
+% for JS to work nicely we need to convert the size list
+% to a jiffy object
+format_partition(PartitionInfo) ->
+    {value, {sizes, Size}, PartitionInfo1} = lists:keytake(sizes, 1, PartitionInfo),
+    [{sizes, {Size}} | PartitionInfo1].
+

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -97,9 +97,8 @@ changes(DbName, Options, StartVector, DbOptions) ->
 
 all_docs(DbName, Options, Args0) ->
     case fabric_util:upgrade_mrargs(Args0) of
-        #mrargs{keys=undefined} = Args1 ->
+        #mrargs{keys=undefined} = Args ->
             set_io_priority(DbName, Options),
-            Args = fix_skip_and_limit(Args1),
             {ok, Db} = get_or_create_db(DbName, Options),
             CB = get_view_cb(Args),
             couch_mrview:query_all_docs(Db, Args, CB, Args)
@@ -123,7 +122,7 @@ map_view(DbName, {DDocId, Rev}, ViewName, Args0, DbOptions) ->
     map_view(DbName, DDoc, ViewName, Args0, DbOptions);
 map_view(DbName, DDoc, ViewName, Args0, DbOptions) ->
     set_io_priority(DbName, DbOptions),
-    Args = fix_skip_and_limit(fabric_util:upgrade_mrargs(Args0)),
+    Args = fabric_util:upgrade_mrargs(Args0),
     {ok, Db} = get_or_create_db(DbName, DbOptions),
     CB = get_view_cb(Args),
     couch_mrview:query_view(Db, DDoc, ViewName, Args, CB, Args).
@@ -137,15 +136,10 @@ reduce_view(DbName, {DDocId, Rev}, ViewName, Args0, DbOptions) ->
     reduce_view(DbName, DDoc, ViewName, Args0, DbOptions);
 reduce_view(DbName, DDoc, ViewName, Args0, DbOptions) ->
     set_io_priority(DbName, DbOptions),
-    Args = fix_skip_and_limit(fabric_util:upgrade_mrargs(Args0)),
+    Args = fabric_util:upgrade_mrargs(Args0),
     {ok, Db} = get_or_create_db(DbName, DbOptions),
     VAcc0 = #vacc{db=Db},
     couch_mrview:query_view(Db, DDoc, ViewName, Args, fun reduce_cb/2, VAcc0).
-
-fix_skip_and_limit(Args) ->
-    #mrargs{skip=Skip, limit=Limit, extra=Extra}=Args,
-    % the coordinator needs to finalize each row, so make sure the shards don't
-    Args#mrargs{skip=0, limit=Skip+Limit, extra=[{finalizer,null} | Extra]}.
 
 create_db(DbName) ->
     create_db(DbName, []).

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -18,7 +18,7 @@
 -export([all_docs/3, changes/3, map_view/4, reduce_view/4, group_info/2]).
 -export([create_db/1, create_db/2, delete_db/1, reset_validation_funs/1,
     set_security/3, set_revs_limit/3, create_shard_db_doc/2,
-    delete_shard_db_doc/2]).
+    delete_shard_db_doc/2, get_partition_info/2]).
 -export([get_all_security/2, open_shard/2]).
 -export([compact/1, compact/2]).
 -export([get_purge_seq/2, purge_docs/3, set_purge_infos_limit/3]).
@@ -173,6 +173,9 @@ get_db_info(DbName) ->
 
 get_db_info(DbName, DbOptions) ->
     with_db(DbName, DbOptions, {couch_db, get_db_info, []}).
+
+get_partition_info(DbName, Partition) ->
+    with_db(DbName, [], {couch_db, get_partition_info, [Partition]}).
 
 %% equiv get_doc_count(DbName, [])
 get_doc_count(DbName) ->

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -64,7 +64,6 @@ stream_start(Workers0, Keypos, StartFun, Replacements) ->
     Timeout = request_timeout(),
     case rexi_utils:recv(Workers0, Keypos, Fun, Acc, Timeout, infinity) of
         {ok, #stream_acc{workers=Workers}} ->
-            true = fabric_view:is_progress_possible(Workers),
             AckedWorkers = fabric_dict:fold(fun(Worker, From, WorkerAcc) ->
                 rexi:stream_start(From),
                 [Worker | WorkerAcc]

--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -16,6 +16,7 @@
     transform_row/1, keydict/1, extract_view/4, get_shards/2,
     check_down_shards/2, handle_worker_exit/3,
     get_shard_replacements/2, maybe_update_others/5]).
+-export([fix_skip_and_limit/1]).
 
 -include_lib("fabric/include/fabric.hrl").
 -include_lib("mem3/include/mem3.hrl").
@@ -119,8 +120,10 @@ maybe_send_row(State) ->
         counters = Counters,
         skip = Skip,
         limit = Limit,
-        user_acc = AccIn
+        user_acc = AccIn,
+        query_args = QueryArgs
     } = State,
+    Partitioned = couch_mrview_util:get_extra(QueryArgs, partitioned),
     case fabric_dict:any(0, Counters) of
     true ->
         {ok, State};
@@ -128,8 +131,14 @@ maybe_send_row(State) ->
         try get_next_row(State) of
         {_, NewState} when Skip > 0 ->
             maybe_send_row(NewState#collector{skip=Skip-1});
-        {Row, NewState} ->
-            case Callback(transform_row(possibly_embed_doc(NewState,Row)), AccIn) of
+        {Row0, NewState} ->
+            Row1 = possibly_embed_doc(NewState, Row0),
+            Row2 = if
+                Partitioned -> detach_partition(Row1);
+                true -> Row1
+            end,
+            Row3 = transform_row(Row2),
+            case Callback(Row3, AccIn) of
             {stop, Acc} ->
                 {stop, NewState#collector{user_acc=Acc, limit=Limit-1}};
             {ok, Acc} ->
@@ -194,6 +203,10 @@ possibly_embed_doc(#collector{db_name=DbName, query_args=Args},
         _ -> Row
     end.
 
+detach_partition(#view_row{key={p, _Partition, Key}} = Row) ->
+    Row#view_row{key = Key};
+detach_partition(#view_row{} = Row) ->
+    Row.
 
 keydict(undefined) ->
     undefined;
@@ -339,6 +352,7 @@ partition_docid(Args) ->
             <<Partition/binary, ":foo">>
     end.
 
+
 maybe_update_others(DbName, DDoc, ShardsInvolved, ViewName,
     #mrargs{update=lazy} = Args) ->
     ShardsNeedUpdated = mem3:shards(DbName) -- ShardsInvolved,
@@ -376,6 +390,21 @@ get_shard_replacements(DbName, UsedShards0) ->
                 Acc
         end
     end, [], UsedShards).
+
+-spec fix_skip_and_limit(#mrargs{}) -> {CoordArgs::#mrargs{}, WorkerArgs::#mrargs{}}.
+fix_skip_and_limit(#mrargs{} = Args) ->
+    {CoordArgs, WorkerArgs} = case couch_mrview_util:get_extra(Args, partition) of
+        undefined ->
+            #mrargs{skip=Skip, limit=Limit}=Args,
+            {Args, Args#mrargs{skip=0, limit=Skip+Limit}};
+        _Partition ->
+            {Args#mrargs{skip=0}, Args}
+    end,
+    %% the coordinator needs to finalize each row, so make sure the shards don't
+    {CoordArgs, remove_finalizer(WorkerArgs)}.
+
+remove_finalizer(Args) ->
+    couch_mrview_util:set_extra(Args, finalizer, null).
 
 % unit test
 is_progress_possible_test() ->

--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -309,10 +309,35 @@ index_of(X, [X|_Rest], I) ->
 index_of(X, [_|Rest], I) ->
     index_of(X, Rest, I+1).
 
-get_shards(DbName, #mrargs{stable=true}) ->
-    mem3:ushards(DbName);
-get_shards(DbName, #mrargs{stable=false}) ->
-    mem3:shards(DbName).
+
+get_shards(DbName, #mrargs{} = Args) ->
+    Partitioned = couch_mrview_util:get_extra(Args, partitioned),
+    Partition = partition_docid(Args),
+    case {Args#mrargs.stable, Partitioned, Partition} of
+        {true, false, _} ->
+            mem3:ushards(DbName);
+        {true, true, undefined} ->
+            mem3:ushards(DbName);
+        {true, true, Partition} ->
+            mem3:ushards(DbName, Partition);
+        {false, false, _} ->
+            mem3:shards(DbName);
+        {false, true, undefined} ->
+            mem3:shards(DbName);
+        {false, true, Partition} ->
+            mem3:shards(DbName, Partition);
+        {false, undefined, _} ->
+            mem3:shards(DbName)
+    end.
+
+% create a fake docid within the specified partition.
+partition_docid(Args) ->
+    case couch_mrview_util:get_extra(Args, partition) of
+        undefined ->
+            undefined;
+        Partition when is_binary(Partition) ->
+            <<Partition/binary, ":foo">>
+    end.
 
 maybe_update_others(DbName, DDoc, ShardsInvolved, ViewName,
     #mrargs{update=lazy} = Args) ->

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -294,3 +294,89 @@ cancel_read_pids(Pids) ->
         {empty, _} ->
             ok
     end.
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+    shards_for_partition_gets_partitioned_shards_test() ->
+        DbName = <<"db">>,
+        Args = #mrargs{
+            start_key = <<"pk:id">>,
+            end_key = <<"pk:idZ">>,
+            extra = [{partitioned, true}]
+        },
+        meck:expect(mem3, shards, fun(<<"db">>, <<"pk:foo">>) -> [] end),
+        shards(DbName, Args),
+        meck:validate(mem3),
+        meck:unload(mem3).
+
+    shards_for_no_partition_gets_all_shards_test() ->
+        DbName = <<"db">>,
+        Args = #mrargs{
+            start_key = <<"pk:id">>,
+            end_key = <<"pk:idZ">>,
+            extra = [{partitioned, false}]
+        },
+        meck:expect(mem3, shards, fun(<<"db">>) -> [] end),
+        shards(DbName, Args),
+        meck:validate(mem3),
+        meck:unload(mem3).
+    
+    shards_for_different_partitions_gets_all_shards_test() ->
+        DbName = <<"db">>,
+        Args = #mrargs{
+            start_key = <<"pk1:id">>,
+            end_key = <<"pk2:idZ">>,
+            extra = [{partitioned, true}]
+        },
+        meck:expect(mem3, shards, fun(<<"db">>) -> [] end),
+        shards(DbName, Args),
+        meck:validate(mem3),
+        meck:unload(mem3).
+    
+    shards_for_no_startkey_all_shards_test() ->
+        DbName = <<"db">>,
+        Args = #mrargs{
+            end_key = <<"pk:idZ">>,
+            extra = [{partitioned, true}]
+        },
+        meck:expect(mem3, shards, fun(<<"db">>) -> [] end),
+        shards(DbName, Args),
+        meck:validate(mem3),
+        meck:unload(mem3).
+    
+    shards_for_no_endkey_all_shards_test() ->
+        DbName = <<"db">>,
+        Args = #mrargs{
+            start_key = <<"pk:idZ">>,
+            extra = [{partitioned, true}]
+        },
+        meck:expect(mem3, shards, fun(<<"db">>) -> [] end),
+        shards(DbName, Args),
+        meck:validate(mem3),
+        meck:unload(mem3).
+    
+    shards_for_no_keys_all_shards_test() ->
+        DbName = <<"db">>,
+        Args = #mrargs{
+            extra = [{partitioned, true}]
+        },
+        meck:expect(mem3, shards, fun(<<"db">>) -> [] end),
+        shards(DbName, Args),
+        meck:validate(mem3),
+        meck:unload(mem3).
+    
+    shards_for_non_binary_keys_all_shards_test() ->
+        DbName = <<"db">>,
+        Args = #mrargs{
+            start_key = null,
+            end_key = null,
+            extra = [{partitioned, false}]
+        },
+        meck:expect(mem3, shards, fun(<<"db">>) -> [] end),
+        shards(DbName, Args),
+        meck:validate(mem3),
+        meck:unload(mem3).
+
+-endif.

--- a/src/fabric/src/fabric_view_reduce.erl
+++ b/src/fabric/src/fabric_view_reduce.erl
@@ -24,8 +24,9 @@ go(DbName, GroupId, View, Args, Callback, Acc0, VInfo) when is_binary(GroupId) -
     go(DbName, DDoc, View, Args, Callback, Acc0, VInfo);
 
 go(DbName, DDoc, VName, Args, Callback, Acc, VInfo) ->
+    {CoordArgs, WorkerArgs} = fabric_view:fix_skip_and_limit(Args),
     DocIdAndRev = fabric_util:doc_id_and_rev(DDoc),
-    RPCArgs = [DocIdAndRev, VName, Args],
+    RPCArgs = [DocIdAndRev, VName, WorkerArgs],
     Shards = fabric_view:get_shards(DbName, Args),
     fabric_view:maybe_update_others(DbName, DocIdAndRev, Shards, VName, Args),
     Repls = fabric_view:get_shard_replacements(DbName, Shards),
@@ -40,7 +41,7 @@ go(DbName, DDoc, VName, Args, Callback, Acc, VInfo) ->
                 Callback({error, ddoc_updated}, Acc);
             {ok, Workers} ->
                 try
-                    go2(DbName, Workers, VInfo, Args, Callback, Acc)
+                    go2(DbName, Workers, VInfo, CoordArgs, Callback, Acc)
                 after
                     fabric_util:cleanup(Workers)
                 end;

--- a/src/mango/src/mango_app.erl
+++ b/src/mango/src/mango_app.erl
@@ -15,6 +15,7 @@
 -export([start/2, stop/1]).
 
 start(_Type, StartArgs) ->
+    config:enable_feature(partitions),
     mango_sup:start_link(StartArgs).
 
 stop(_State) ->

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -32,6 +32,7 @@
 -include_lib("fabric/include/fabric.hrl").
 
 -include("mango_cursor.hrl").
+-include("mango_idx.hrl").
 -include("mango_idx_view.hrl").
 
 -define(HEARTBEAT_INTERVAL_IN_USEC, 4000000).
@@ -76,7 +77,8 @@ explain(Cursor) ->
         {direction, Args#mrargs.direction},
         {stable, Args#mrargs.stable},
         {update, Args#mrargs.update},
-        {conflicts, Args#mrargs.conflicts}
+        {conflicts, Args#mrargs.conflicts},
+        {partition, couch_mrview_util:get_extra(Args, partition, null)}
     ]}}].
 
 
@@ -98,15 +100,31 @@ maybe_replace_max_json([H | T] = EndKey) when is_list(EndKey) ->
 maybe_replace_max_json(EndKey) ->
     EndKey.
 
-base_args(#cursor{index = Idx, selector = Selector} = Cursor) ->
-    #mrargs{
+base_args(#cursor{index = Idx, opts = Opts, selector = Selector} = Cursor) ->
+    Args1 = #mrargs{
         view_type = map,
         reduce = false,
         start_key = mango_idx:start_key(Idx, Cursor#cursor.ranges),
         end_key = mango_idx:end_key(Idx, Cursor#cursor.ranges),
         include_docs = true,
         extra = [{callback, {?MODULE, view_cb}}, {selector, Selector}]
-    }.
+    },
+
+    DbPartitioned = mem3:is_partitioned(couch_db:name(Cursor#cursor.db)),
+    Partitioned = couch_util:get_value(partitioned, Idx#idx.design_opts, DbPartitioned),
+    Args2 = couch_mrview_util:set_extra(Args1, partitioned, Partitioned),
+    Args3 = case couch_util:get_value(partition, Opts) of
+        <<>> ->
+            Args2;
+        Partition ->
+            couch_mrview_util:set_extra(Args2, partition, Partition)
+    end,
+    add_style(Idx, Args3).
+
+add_style(#idx{def = all_docs}, Args) ->
+    couch_mrview_util:set_extra(Args, style, all_docs);
+add_style(_, Args) ->
+    Args.
 
 
 execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFun, UserAcc) ->

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -73,6 +73,13 @@ info(mango_fields, {invalid_field_json, BadField}) ->
         fmt("Invalid JSON for field spec: ~w", [BadField])
     };
 
+info(mango_httpd, partition_field_error) ->
+    {
+        400,
+        <<"bad request">>,
+        <<"`partition` is not a valid parameter.">>
+    };
+
 info(mango_httpd, error_saving_ddoc) ->
     {
         500,
@@ -255,6 +262,13 @@ info(mango_opts, {multiple_text_operator, {invalid_selector, BadSel}}) ->
         <<"multiple_text_selector">>,
         fmt("Selector cannot contain more than one $text operator: ~w",
             [BadSel])
+    };
+
+info(mango_opts, invalid_partition_read) -> 
+    {
+        400,
+        <<"invalid_partition_read_value">>,
+        <<"`r` value can only be r = 1 for partitions">>
     };
 
 info(mango_selector, {invalid_selector, missing_field_name}) ->

--- a/src/mango/src/mango_httpd_handlers.erl
+++ b/src/mango/src/mango_httpd_handlers.erl
@@ -12,7 +12,7 @@
 
 -module(mango_httpd_handlers).
 
--export([url_handler/1, db_handler/1, design_handler/1]).
+-export([url_handler/1, db_handler/1, design_handler/1, partition_handler/1]).
 
 url_handler(_) -> no_match.
 
@@ -22,3 +22,7 @@ db_handler(<<"_find">>)         -> fun mango_httpd:handle_req/2;
 db_handler(_) -> no_match.
 
 design_handler(_) -> no_match.
+
+partition_handler(<<"_find">>) -> fun mango_httpd:handle_partition_req/3;
+partition_handler(<<"_explain">>) -> fun mango_httpd:handle_partition_req/3;
+partition_handler(_) -> no_match.

--- a/src/mango/src/mango_idx.hrl
+++ b/src/mango/src/mango_idx.hrl
@@ -16,5 +16,6 @@
     name,
     type,
     def,
+    design_opts,
     opts
 }).

--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -51,7 +51,8 @@ add(#doc{body={Props0}}=DDoc, Idx) ->
     Texts2 = lists:keystore(element(1, NewText), 1, Texts1, NewText),
     Props1 = lists:keystore(<<"indexes">>, 1, Props0, {<<"indexes">>,
         {Texts2}}),
-    {ok, DDoc#doc{body={Props1}}}.
+    Props2 = lists:keystore(<<"options">>, 1, Props1, {<<"options">>, {Idx#idx.design_opts}}),
+    {ok, DDoc#doc{body={Props2}}}.
 
 
 remove(#doc{body={Props0}}=DDoc, Idx) ->
@@ -75,6 +76,7 @@ remove(#doc{body={Props0}}=DDoc, Idx) ->
 
 
 from_ddoc({Props}) ->
+    DesignOpts = mango_idx:validate_design_opts(Props),
     case lists:keyfind(<<"indexes">>, 1, Props) of
         {<<"indexes">>, {Texts}} when is_list(Texts) ->
             lists:flatmap(fun({Name, {VProps}}) ->
@@ -85,7 +87,8 @@ from_ddoc({Props}) ->
                         I = #idx{
                         type = <<"text">>,
                         name = Name,
-                        def = Def
+                        def = Def,
+                        design_opts = DesignOpts
                         },
                         [I]
                 end
@@ -257,7 +260,8 @@ opts() ->
 make_text(Idx) ->
     Text= {[
         {<<"index">>, Idx#idx.def},
-        {<<"analyzer">>, construct_analyzer(Idx#idx.def)}
+        {<<"analyzer">>, construct_analyzer(Idx#idx.def)},
+        {<<"options">>, {Idx#idx.opts}}
     ]},
     {Idx#idx.name, Text}.
 

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -54,7 +54,8 @@ add(#doc{body={Props0}}=DDoc, Idx) ->
     NewView = make_view(Idx),
     Views2 = lists:keystore(element(1, NewView), 1, Views1, NewView),
     Props1 = lists:keystore(<<"views">>, 1, Props0, {<<"views">>, {Views2}}),
-    {ok, DDoc#doc{body={Props1}}}.
+    Props2 = lists:keystore(<<"options">>, 1, Props1, {<<"options">>, {Idx#idx.design_opts}}),
+    {ok, DDoc#doc{body={Props2}}}.
 
 
 remove(#doc{body={Props0}}=DDoc, Idx) ->
@@ -78,6 +79,7 @@ remove(#doc{body={Props0}}=DDoc, Idx) ->
 
 
 from_ddoc({Props}) ->
+    DesignOpts = mango_idx:validate_design_opts(Props),
     case lists:keyfind(<<"views">>, 1, Props) of
         {<<"views">>, {Views}} when is_list(Views) ->
             lists:flatmap(fun({Name, {VProps}}) ->
@@ -89,6 +91,7 @@ from_ddoc({Props}) ->
                         type = <<"json">>,
                         name = Name,
                         def = Def,
+                        design_opts = DesignOpts,
                         opts = Opts
                         },
                         [I]
@@ -104,6 +107,7 @@ to_json(Idx) ->
         {ddoc, Idx#idx.ddoc},
         {name, Idx#idx.name},
         {type, Idx#idx.type},
+        {design_opts, {Idx#idx.design_opts}},
         {def, {def_to_json(Idx#idx.def)}}
     ]}.
 

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -40,7 +40,7 @@ class IndexSelectionTests:
 
     def test_with_or(self):
         # index on ["company","manager"]
-        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        ddocid = "_design/company-manager"
 
         resp = self.db.find({
                 "company": {
@@ -56,7 +56,7 @@ class IndexSelectionTests:
 
     def test_use_most_columns(self):
         # ddoc id for the age index
-        ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"
+        ddocid = "_design/age"
         resp = self.db.find({
                 "name.first": "Stephanie",
                 "name.last": "Something or other",
@@ -81,7 +81,7 @@ class IndexSelectionTests:
 
     def test_invalid_use_index(self):
         # ddoc id for the age index
-        ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"
+        ddocid = "_design/age"
         r = self.db.find({}, use_index=ddocid, return_raw=True)
         self.assertEqual(r["warning"], '{0} was not used because it does not contain a valid index for this query.'.format(ddocid))
 
@@ -101,7 +101,7 @@ class IndexSelectionTests:
 
     def test_reject_use_index_invalid_fields(self):
         # index on ["company","manager"] which should not be valid
-        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        ddocid = "_design/company-manager"
         selector = {
             "company": "Pharmex"
         }
@@ -114,8 +114,8 @@ class IndexSelectionTests:
 
     def test_reject_use_index_ddoc_and_name_invalid_fields(self):
         # index on ["company","manager"] which should not be valid
-        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
-        name = "a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        ddocid = "_design/company-manager"
+        name = "company-manager"
         selector = {
             "company": "Pharmex"
         }
@@ -130,7 +130,7 @@ class IndexSelectionTests:
     def test_reject_use_index_sort_order(self):
         # index on ["company","manager"] which should not be valid
         # and there is no valid fallback (i.e. an index on ["company"])
-        ddocid = "_design/a0c425a60cf3c3c09e3c537c9ef20059dcef9198"
+        ddocid = "_design/company-manager"
         selector = {
             "company": {"$gt": None}
         }

--- a/src/mango/test/user_docs.py
+++ b/src/mango/test/user_docs.py
@@ -87,7 +87,8 @@ def add_view_indexes(db, kwargs):
         ["ordered"]
     ]
     for idx in indexes:
-        assert db.create_index(idx) is True
+        name = '-'.join(idx)
+        assert db.create_index(idx, ddoc=name, name=name) is True
 
 
 def add_text_indexes(db, kwargs):

--- a/src/mem3/src/mem3_util.erl
+++ b/src/mem3/src/mem3_util.erl
@@ -162,7 +162,7 @@ build_shards_by_node(DbName, DocProps) ->
                 dbname = DbName,
                 node = to_atom(Node),
                 range = [Beg, End],
-                opts = get_engine_opt(DocProps)
+                opts = get_engine_opt(DocProps) ++ get_opts(DocProps)
             }, Suffix)
         end, Ranges)
     end, ByNode).
@@ -180,7 +180,7 @@ build_shards_by_range(DbName, DocProps) ->
                 node = to_atom(Node),
                 range = [Beg, End],
                 order = Order,
-                opts = get_engine_opt(DocProps)
+                opts = get_engine_opt(DocProps) ++ get_opts(DocProps)
             }, Suffix)
         end, lists:zip(Nodes, lists:seq(1, length(Nodes))))
     end, ByRange).
@@ -196,6 +196,14 @@ to_integer(N) when is_binary(N) ->
     list_to_integer(binary_to_list(N));
 to_integer(N) when is_list(N) ->
     list_to_integer(N).
+
+get_opts(DocProps) ->
+    case couch_util:get_value(<<"options">>, DocProps) of
+        {Opts} ->
+            Opts;
+        _ ->
+            []
+    end.
 
 get_engine_opt(DocProps) ->
     case couch_util:get_value(<<"engine">>, DocProps) of


### PR DESCRIPTION
## Overview

This PR introduces a new feature, user-defined partitioned databases.

A new kind of database can be created with the `?partitioned=true` option. All documents within the database must have document ids of the following format;

  partition_name:doc_id

both partition_name and doc_id must follow the couchdb id format (can't begin with _, etc).

All documents with the same partition_name are guaranteed to be mapped to the same shard range. When querying an index, the new `/db/_partition/$partition/_view` endpoint can query the view more efficiently, by only consulting the single shard range holding the partition. This is much more efficient and scales the same way that primary key lookup (GET /dbname/docid) does (approximately linearly).

## Testing recommendations

The PR contains multiple tests for basic functionality and all existing tests  still pass. When testing the PR, it is important to try the feature yourself, interactively, with docs and views of your choosing, to give us confidence in this new feature.

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
