### PR TITLE
Remove redundant functions

### DIFF
--- a/test/elixir/test/compact_test.exs
+++ b/test/elixir/test/compact_test.exs
@@ -80,18 +80,4 @@ defmodule CompactTest do
     Couch.get("/#{db}").body
   end
 
-  defp rev(doc = %{_id: id}, %{"id" => id, "rev" => rev}) do
-    Map.put(doc, :_rev, rev)
-  end
-
-  defp rev(docs, rows) do
-    for {doc, row} <- Enum.zip(docs, rows), do: rev(doc, row)
-  end
-
-  def create_docs(id_range) do
-    for id <- id_range, str_id = Integer.to_string(id) do
-      %{_id: str_id, integer: id, string: str_id}
-    end
-  end
-
 end

--- a/test/elixir/test/conflicts_test.exs
+++ b/test/elixir/test/conflicts_test.exs
@@ -83,12 +83,6 @@ defmodule RevisionTest do
     Couch.put("/#{db}/#{doc._id}", [body: doc]).body
   end
 
-  # Update doc's _rev entry with request result
-  @spec rev(map(), map()) :: map()
-  defp rev(doc = %{_id: id}, %{"id" => id, "rev" => rev}) do
-    Map.put(doc, :_rev, rev)
-  end
-
   defp suffix(rev) do
     hd(tl(String.split(rev, "-")))
   end

--- a/test/elixir/test/test_helper.exs
+++ b/test/elixir/test/test_helper.exs
@@ -216,10 +216,12 @@ defmodule CouchTestCase do
         div(:erlang.system_time, 100000)
       end
 
+      @spec rev(map(), map()) :: map()
       def rev(doc = %{_id: id}, %{"id" => id, "rev" => rev}) do
         Map.put(doc, :_rev, rev)
       end
 
+      @spec rev([map()], [map()]) :: [map()]
       def rev(docs, rows) when length(docs) == length(rows) do
         for {doc, row} <- Enum.zip(docs, rows), do: rev(doc, row)
       end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This fixes compilation errors from functions duplicated in multiple files by removing the duplicates.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

`make` should now compile without failure

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
