### PR TITLE
Implement replicator forced session refresh

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -211,7 +211,7 @@ authentication_redirect = /_utils/session.html
 require_valid_user = false
 timeout = 600 ; number of seconds before automatic logout
 auth_cache_size = 50 ; size is number of cache entries
-allow_persistent_cookies = false ; set to true to allow persistent cookies
+allow_persistent_cookies = true ; set to false to disallow persistent cookies
 iterations = 10 ; iterations for password hashing
 ; min_iterations = 1
 ; max_iterations = 1000000000
@@ -394,6 +394,15 @@ ssl_certificate_max_depth = 3
 ;auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
 ; To restore the old behaviour, use the following value:
 ;auth_plugins = couch_replicator_auth_noop
+
+; Force couch_replicator_auth_session plugin to refresh the session
+; periodically if max-age is not present in the cookie. This is mostly to
+; handle the case where anonymous writes are allowed to the database and a VDU
+; function is used to forbid writes based on the authenticated user name. In
+; that case this value should be adjusted based on the expected minimum session
+; expiry timeout on replication endpoints. If session expiry results in a 401
+; or 403 response this setting is not needed.
+;session_refresh_interval_sec = 550
 
 [compaction_daemon]
 ; The delay, in seconds, between each check for which database and view indexes

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -436,7 +436,7 @@ cookie_scheme(#httpd{mochi_req=MochiReq}) ->
     end.
 
 max_age() ->
-    case config:get("couch_httpd_auth", "allow_persistent_cookies", "false") of
+    case config:get("couch_httpd_auth", "allow_persistent_cookies", "true") of
         "false" ->
             [];
         "true" ->


### PR DESCRIPTION
Implement replicator session refresh based on cookie max age

Force couch_replicator_auth_session plugin to refresh the session periodically.
Normally it is not needed as the session would be refreshed when requests start
failing with a 401 (authentication) or 403 (authorization) errors. In some
cases when anonymous writes are allowed to the database and a VDU function is
used to forbid writes based on the authenticated in username, requests with an
expired session cookie will not fail with a 401 and the session will not be
refreshed.

To fix the issue using these two approaches:

 1. Use cookie's max-age expiry time to schedule a refresh. To ensure that time
 is provided in the cookie, switch the the option to enable it by default. This
 handles the issue for endpoints which are updated with this commit.

 2. For endpoints which do not put a max-age time in the cookie, use a value
 that's less than CouchDB's default auth timeout. If users changed their
 auth timeout value, and use VDUs in the pattern described above, and don't
 update their endpoints to version which sends max-age by default, they could
 adjust `[replicator] session_refresh_interval_sec` to their auth timeout minus
 some small delay.

Of course refresh based on auth/authz failures should still works as before.

Fixes #1607

[x] Code is written and works correctly;
[x] Changes are covered by tests;
[x] Documentation reflects the changes (comment in default.ini for now, will make a separate docs repo commit)
