### PR TITLE
Explicit Python version in scripts

### DIFF
--- a/build-aux/logfile-uploader.py
+++ b/build-aux/logfile-uploader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/dev/run
+++ b/dev/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/rel/overlay/bin/couchup
+++ b/rel/overlay/bin/couchup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at

--- a/test/javascript/run
+++ b/test/javascript/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
Recent Linux distributions start defaulting to Python 3, and require
ambiguous scripts to be more explicit.
For example building for Fedora 30 (not released yet) fails with:

    ERROR: ambiguous python shebang in /opt/couchdb/bin/couchup:
    #!/usr/bin/env python. Change it to python3 (or python2) explicitly.

So this commit changes the four Python scripts to use `python2`.

Note: They seem to be Python-3-compatible, but I couldn't be sure. If
you know they are, please tell me, I'll change it to `python3`.