### PR TITLE
Switch rexi server_per_node to true by default

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -187,7 +187,7 @@ port = 6984
 
 ; [rexi]
 ; buffer_count = 2000
-; server_per_node = false
+; server_per_node = true
 
 ; [global_changes]
 ; max_event_delay = 25

--- a/src/rexi/src/rexi_server_mon.erl
+++ b/src/rexi/src/rexi_server_mon.erl
@@ -68,6 +68,8 @@ cluster_stable(Server) ->
 init(ChildMod) ->
     {ok, _Mem3Cluster} = mem3_cluster:start_link(?MODULE, self(),
         ?CLUSTER_STABILITY_PERIOD_SEC, ?CLUSTER_STABILITY_PERIOD_SEC),
+    start_servers(ChildMod),
+    couch_log:notice("~s : started servers", [ChildMod]),
     {ok, ChildMod}.
 
 

--- a/src/rexi/src/rexi_utils.erl
+++ b/src/rexi/src/rexi_utils.erl
@@ -16,8 +16,8 @@
 
 %% @doc Return a rexi_server id for the given node.
 server_id(Node) ->
-    case config:get("rexi", "server_per_node", "false") of
-    "true" ->
+    case config:get_boolean("rexi", "server_per_node", true) of
+    true ->
         list_to_atom("rexi_server_" ++ atom_to_list(Node));
     _ ->
         rexi_server


### PR DESCRIPTION
This has been solid for years and when not enabled can be a performance
bottleneck.

Fixes #1625
