### PR TITLE
Don't use CamelCase in format_status

### DIFF
--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -528,7 +528,7 @@ handle_info({'DOWN', Ref, process, _Pid, _Info}, #file{db_monitor=Ref}=File) ->
 
 format_status(_Opt, [PDict, #file{} = File]) ->
     {_Fd, FilePath} = couch_util:get_value(couch_file_fd, PDict),
-    [{data, [{"State", File}, {"InitialFilePath", FilePath}]}].
+    [{data, [{"State", File}, {initial_file_path, FilePath}]}].
 
 find_header(Fd, Block) ->
     case (catch load_header(Fd, Block)) of


### PR DESCRIPTION
## Overview

This changes the term logged into the log file to use erlang notation. There is no functional changes.

## Testing recommendations

1. Start couchdb `dev/run --admin=adm:pass`
2. Start remsh session `dev/remsh`
3. Inject failure in one of the couch_file processes (by reading with position greater than the file size) 
```
{_Port, Pid, _Fd, _Name} = hd(couch_debug:opened_files()).
couch_file:pread_binary(Pid, 999999999999999).
```
4. Check logs to make sure the following messages are present:
```
[error] 2018-09-27T19:43:44.986463Z node1@127.0.0.1 <0.358.0> -------- gen_server <0.358.0> terminated with reason: bad return value {read_beyond_eof,"/home/jenkins/dev/lib/node1/data/dbs/_users.couch"}
  last msg: {pread_iolist,999999999999999}
     state: [{data,[
         {"State",{file,{file_descriptor,prim_file,
              {#Port<0.50773>,26}},true,28868,#Ref<0.0.3.35>,infinity}},
         {initial_file_path,"/home/jenkins/dev/lib/node1/data/dbs/_users.couch"}]}]
```

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/pull/1601

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
