### PR TITLE
[WIP] DONT MERGE YET deps: update ibrowse to support inet6-only hosts

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -63,7 +63,7 @@ DepDescs = [
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.2"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-4"}},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1"}},
+{ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.2"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-2"}},
 {mochiweb,         "mochiweb",         {tag, "v2.17.0"}},
 {meck,             "meck",             {tag, "0.8.8"}}


### PR DESCRIPTION
Pulls in our custom ibrowse with inet6-only host support
from https://github.com/apache/couchdb-ibrowse/pull/1

This will require tagging our ibrowse first with a matching
tag, I've proposed CouchDB-4.0.2 but anything goes.
 
## Testing recommendations

Try replicating from an IPv6-only host.

## Related Issues or Pull Requests

https://github.com/apache/couchdb-ibrowse/pull/1

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;

for docs, I propose to add this to change log only. If there's
another place you'd like it mentioned please let me know.