### PR TITLE
Add document_purges counter for stats

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -50,9 +50,17 @@
     {type, counter},
     {desc, <<"number of document write operations">>}
 ]}.
-{[couchdb, document_purges], [
+{[couchdb, document_purges, total], [
     {type, counter},
-    {desc, <<"number of document purge operations">>}
+    {desc, <<"number of total document purge operations">>}
+]}.
+{[couchdb, document_purges, success], [
+    {type, counter},
+    {desc, <<"number of successful document purge operations">>}
+]}.
+{[couchdb, document_purges, failure], [
+    {type, counter},
+    {desc, <<"number of failed document purge operations">>}
 ]}.
 {[couchdb, local_document_writes], [
     {type, counter},


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Introduce the `couchdb.document_purges` counter

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Using metric to see the newly added counter

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://issues.apache.org/jira/browse/COUCHDB-3326
https://github.com/apache/couchdb/pull/1370


## Checklist

- [X] Code is written and works correctly;
- [ ] Changes are covered by tests;  verified using metrics
- [X] Documentation reflects the changes;
