### PR TITLE
Restrict access to _active_tasks to server admin

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -178,6 +178,7 @@ handle_dbs_info_req(Req) ->
     send_method_not_allowed(Req, "POST").
 
 handle_task_status_req(#httpd{method='GET'}=Req) ->
+    ok = chttpd:verify_is_server_admin(Req),
     {Replies, _BadNodes} = gen_server:multi_call(couch_task_status, all),
     Response = lists:flatmap(fun({Node, Tasks}) ->
         [{[{node,Node} | Task]} || Task <- Tasks]


### PR DESCRIPTION
## Overview

According to [documentation](http://docs.couchdb.org/en/2.2.0/api/server/common.html#active-tasks) CouchDB Server Administrator privileges required to access this end-point. This patch adds the according check.  

## Testing recommendations

Full test suite should pass.

## Related Issues or Pull Requests

Closes #1643 

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
