### PR TITLE
Upgrade disk version to 7/latest for databases generated prior to clustered purge builds

### DIFF
--- a/src/couch/src/couch_bt_engine_header.erl
+++ b/src/couch/src/couch_bt_engine_header.erl
@@ -234,8 +234,8 @@ upgrade_disk_version(#db_header{}=Header) ->
         2 -> throw({database_disk_version_error, ?OLD_DISK_VERSION_ERROR});
         3 -> throw({database_disk_version_error, ?OLD_DISK_VERSION_ERROR});
         4 -> Header#db_header{security_ptr = nil}; % [0.10 - 0.11)
-        5 -> Header; % pre 1.2
-        6 -> Header; % pre clustered purge
+        5 -> Header#db_header{disk_version = ?LATEST_DISK_VERSION}; % pre 1.2
+        6 -> Header#db_header{disk_version = ?LATEST_DISK_VERSION}; % pre clustered purge
         ?LATEST_DISK_VERSION -> Header;
         _ ->
             Reason = "Incorrect disk header version",


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
For databases generated prior to clustered purge builds, the `db_header` record was changed to below, i.e. with purge_tree and purge_seq_tree.
```
-record(db_header, {
    disk_version = ?LATEST_DISK_VERSION,
    update_seq = 0,
    unused = 0,
    id_tree_state = nil,
    seq_tree_state = nil,
    local_tree_state = nil,
    purge_tree_state = nil,
    purge_seq_tree_state = nil, %purge tree: purge_seq -> uuid
    security_ptr = nil,
    revs_limit = 1000,
    uuid,
    epochs,
    compacted_seq,
    purge_infos_limit = 1000
}).
```
However, the disk_version is still not upgraded and this caused mismatch between disk_version and actual `db_header` record, and there is the following error.

```
**throw:{{invalid_header_size,{db_header,6,1,0,
                                 {5681,{1,0,{size_info,1426,5361}},111},
                                 {5792,1,108},
                                 {24780,[],419},
                                 nil,nil,173,1000,<<"3c1bb3e64979227b"...>>,
                                 [{'node1@127.0.0.1',1},
                                  {'dbcore@db1.testy024.cloudant.net',...}],
                                 0,1000}},
 [{couch_bt_engine_header,upgrade_tuple,1,
                          [{file,"src/couch_bt_engine_header.erl"},
                           {line,225}]},
  {lists,foldl,3,[{file,"lists.erl"},{line,1263}]},
  {couch_bt_engine,init_state,4,[{file,"src/couch_bt_engine.erl"},{line,715}]},
  {couch_bt_engine,init,2,[{file,"src/couch_bt_engine.erl"},{line,155}]},
  {couch_db_engine,init,3,[{file,"src/couch_db_engine.erl"},{line,648}]},
  {couch_db_updater,init,1,[{file,"src/couch_db_updater.erl"},{line,32}]},
  {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
```
The aim of this PR is to upgrade disk version 7 or latest so that it can match the db_header with purge_tree and purge_seq_tree.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

make check skip_deps+=couch_epi apps=couch tests=upgrade_test_

```
======================== EUnit ========================
Upgrade tests
Application crypto was left running!
  couchdb_views_tests:189: should_upgrade_legacy_view_files...[2.487 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 2.491 s]
Couch Bt Engine Upgrade tests
  couch_bt_engine_upgrade_tests:64: t_upgrade_without_purge_req...[0.103 s] ok
  couch_bt_engine_upgrade_tests:103: t_upgrade_with_1_purge_req...[0.125 s] ok
  couch_bt_engine_upgrade_tests:143: t_upgrade_with_N_purge_req...[0.111 s] ok
  couch_bt_engine_upgrade_tests:181: t_upgrade_with_1_purge_req_for_2_docs...[0.109 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 0.461 s]
=======================================================
  All 5 tests passed.
==> rel (eunit)
==> db (eunit)
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

COUCHDB-3326

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
