### PR TITLE
Fix test failure on upgrade_v5_test

### DIFF
--- a/src/couch/src/couch_bt_engine_header.erl
+++ b/src/couch/src/couch_bt_engine_header.erl
@@ -368,12 +368,12 @@ upgrade_v3_test() ->
 
 -endif.
 
-upgrade_v5_test() ->
+upgrade_v5_to_v7_test() ->
     Vsn5Header = mk_header(5),
     NewHeader = upgrade_disk_version(upgrade_tuple(Vsn5Header)),
 
     ?assert(is_record(NewHeader, db_header)),
-    ?assertEqual(5, disk_version(NewHeader)),
+    ?assertEqual(7, disk_version(NewHeader)),
 
     % Security ptr isn't changed for v5 headers
     ?assertEqual(bang, security_ptr(NewHeader)).


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Fix test failure on `upgrade_v5_test`.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->


make check skip_deps+=couch_epi apps=couch
```
module 'couch_bt_engine_header'
  couch_bt_engine_header: upgrade_v5_to_v7_test...ok
  couch_bt_engine_header: upgrade_uuid_test...ok
  couch_bt_engine_header: upgrade_epochs_test...ok
  couch_bt_engine_header: get_uuid_from_old_header_test...ok
  couch_bt_engine_header: get_epochs_from_old_header_test...ok
  [done in 0.015 s]
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/1657
COUCHDB-3326
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
