### PR TITLE
Do not crash couch_log application when gen_* servers send extra args

### DIFF
--- a/src/couch_log/src/couch_log_sup.erl
+++ b/src/couch_log/src/couch_log_sup.erl
@@ -26,7 +26,7 @@ start_link() ->
 
 init([]) ->
     ok = couch_log_config:init(),
-    {ok, {{one_for_one, 1, 1}, children()}}.
+    {ok, {{one_for_one, 10, 10}, children()}}.
 
 
 children() ->


### PR DESCRIPTION
`gen_server`, `gen_fsm` and `gen_statem` might send extra args when terminating. This
is a recent behavior, and not handling these extra args could lead to couch_log
application crashing and taking down the whole VM with it.
