### PR TITLE
Avoid crashing if a mango query is reduced

### DIFF
--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -89,11 +89,11 @@ handle_call({prompt, [<<"add_fun">>, IndexInfo]}, _From, St) ->
 handle_call({prompt, [<<"map_doc">>, Doc]}, _From, St) ->
     {reply, map_doc(St, mango_json:to_binary(Doc)), St};
 
-handle_call({prompt, [<<"reduce">>, _, _]}, _From, St) ->
-    {reply, null, St};
+handle_call({prompt, [<<"reduce">>, RedSrcs, _]}, _From, St) ->
+    {reply, [true, [null || _ <- RedSrcs]], St};
 
-handle_call({prompt, [<<"rereduce">>, _, _]}, _From, St) ->
-    {reply, null, St};
+handle_call({prompt, [<<"rereduce">>, RedSrcs, _]}, _From, St) ->
+    {reply, [true, [null || _ <- RedSrcs]], St};
 
 handle_call({prompt, [<<"index_doc">>, Doc]}, _From, St) ->
     Vals = case index_doc(St, mango_json:to_binary(Doc)) of


### PR DESCRIPTION
Previously returning null from mango native proc lead to case clause error in
couch_query_servers. Instead return a proper shape but with null results for
each reduction.
