### PR TITLE
Update snappy dependency to CouchDB-1.0.2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -52,7 +52,7 @@ DepDescs = [
 {b64url,           "b64url",           {tag, "1.0.1"}},
 {ets_lru,          "ets-lru",          {tag, "1.0.0"}},
 {khash,            "khash",            {tag, "1.0.1"}},
-{snappy,           "snappy",           {tag, "CouchDB-1.0.1"}},
+{snappy,           "snappy",           {tag, "CouchDB-1.0.2"}},
 {ioq,              "ioq",              {tag, "1.0.1"}},
 
 %% Non-Erlang deps


### PR DESCRIPTION
This fixes a memory bug:

https://github.com/apache/couchdb-snappy/commit/2038ad13b1d6926468f25adea110028e3c0b4b0c
