### PR TITLE
Fix initial view compaction task status

### DIFF
--- a/src/couch_mrview/src/couch_mrview_compactor.erl
+++ b/src/couch_mrview/src/couch_mrview_compactor.erl
@@ -86,7 +86,9 @@ compact(State) ->
         {type, view_compaction},
         {database, DbName},
         {design_document, IdxName},
-        {progress, 0}
+        {progress, 0},
+        {changes_done, 0},
+        {total_changes, TotalChanges}
     ]),
 
     BufferSize0 = config:get(


### PR DESCRIPTION
This is a minor consistency issue. Currently when a view compaction
starts it doesn't include the `total_changes` and `changes_done` fields
until the first task status update. This is easy to miss as every other
task type includes those fields from the initial task definition.

The obvious trivial fix is both obvious and trivial.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
