### PR TITLE
Remove explicit python version for dev/run (for now)

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
While we wait for #1639, this change will fix the trusty build failures on Jenkins.

They are failing because trusty has Python 2.6 (but the Docker image has python3 in the path as `/usr/local/bin/python` ahead of the 2.6 python):

```
Traceback (most recent call last):
  File "dev/run", line 592, in <module>
    main()
  File "dev/run", line 80, in main
    ctx = setup()
  File "dev/run", line 94, in setup
    setup_configs(ctx)
  File "dev/run", line 65, in wrapper
    res = func(*args, **kwargs)
  File "dev/run", line 203, in setup_configs
    write_config(ctx, node, env)
  File "dev/run", line 239, in write_config
    content = hack_default_ini(ctx, node, content)
  File "dev/run", line 289, in hack_default_ini
    flags=re.MULTILINE)
TypeError: sub() got an unexpected keyword argument 'flags'
```
