### PR TITLE
Fix JS/Python test harness for Python 2.6

### DIFF
--- a/test/javascript/run
+++ b/test/javascript/run
@@ -146,7 +146,7 @@ def main():
     sys.stderr.write("======================================================="
         + os.linesep)
     sys.stderr.write("JavaScript tests complete." + os.linesep)
-    sys.stderr.write("  Failed: {}.  Skipped or passed: {}.".format(
+    sys.stderr.write("  Failed: {0}.  Skipped or passed: {1}.".format(
         failed, passed) + os.linesep)
     exit(failed > 0)
 


### PR DESCRIPTION
A problem on CentOS 6, which is in our Jenkins test setup, stemming from #1622 again :(