### PR TITLE
Allow to return with accepted for mixed nodes in cluster

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -524,8 +524,11 @@ db_req(#httpd{method='POST',path_parts=[_,<<"_purge">>]}=Req, Db) ->
         true -> ok
     end,
     couch_stats:increment_counter([couchdb, document_purges, total], length(IdsRevs2)),
-    {ok, Results} = fabric:purge_docs(Db, IdsRevs2, Options),
-    {Code, Json} = purge_results_to_json(IdsRevs2, Results),
+    Results2 = case fabric:purge_docs(Db, IdsRevs2, Options) of
+        {ok, Results} -> Results;
+        {accepted, Results} -> Results
+    end,
+    {Code, Json} = purge_results_to_json(IdsRevs2, Results2),
     send_json(Req, Code, {[{<<"purge_seq">>, null}, {<<"purged">>, {Json}}]});
 
 db_req(#httpd{path_parts=[_,<<"_purge">>]}=Req, _Db) ->


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Under situation where mixed nodes exist in one cluster, i.e. some nodes are with clustered purge feature while some nodes are without clustered purge feature, the `accepted` result is returned instead of `ok` when purge request is sent. 

This PR is used to address `badmatch` error where "accepted" returned result is not considered. Otherwise, the following error may occur

```
req_err(3038544381) badmatch : {accepted,[{accepted,[{1,<<217,66,240,206,1,100,122,160,244,101,24,178,19,181,98,142>>}]}]}[<<"chttpd_db:db_req/2 L527">>,<<"chttpd:handle_req_after_auth/2 L320">>,<<"chttpd:process_request/1 L303">>,<<"chttpd:handle_request_int/1 L243">>,<<"mochiweb_http:headers/6 L124">>,<<"proc_lib:init_p_do_apply/3 L247">>]
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=chttpd tests=purge_test_

```
======================== EUnit ========================
chttpd db tests
Application crypto was left running!
  chttpd_purge_tests:86: test_empty_purge_request...[0.009 s] ok
  chttpd_purge_tests:103: test_ok_purge_request...[0.176 s] ok
  chttpd_purge_tests:140: test_accepted_purge_request...[0.123 s] ok
  chttpd_purge_tests:172: test_partial_purge_request...[0.094 s] ok
  chttpd_purge_tests:208: test_mixed_purge_request...[0.177 s] ok
  chttpd_purge_tests:256: test_overmany_ids_or_revs_purge_request...[0.128 s] ok
  chttpd_purge_tests:306: test_exceed_limits_on_purge_infos...[0.146 s] ok
  chttpd_purge_tests:349: should_error_set_purged_docs_limit_to0...[0.004 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 2.965 s]
=======================================================
  All 8 tests passed.
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

COUCHDB-3326

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
