### PR TITLE
Use mainline Rebar (v2)

### DIFF
--- a/configure
+++ b/configure
@@ -209,7 +209,7 @@ EOF
 install_local_rebar() {
     if [ ! -x "${rootdir}/bin/rebar" ]; then
         if [ ! -d "${rootdir}/src/rebar" ]; then
-            git clone --depth 1 --branch 2.6.0-couchdb https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
+            git clone --depth 1 --branch master https://github.com/rebar/rebar.git ${rootdir}/src/rebar
         fi
         make -C ${rootdir}/src/rebar
         mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar


### PR DESCRIPTION
This PR uses the latest software provided by the upstream Rebar (v2) repo.

The most significant change allows this version of Rebar to work with compilers which do not support the -m64 flag, as reported in https://github.com/apache/couchdb/issues/892 amongst others.

The latest code base also contains @davisp's `Properly skip apps with a .app.src.script file` patch with CouchDB has been carrying for a while now.

Signed-off-by: Lee Jones <lee.jones@linaro.org>