### PR TITLE
Use CouchDB hosted Mainline Rebar (v2)

### DIFF
--- a/configure
+++ b/configure
@@ -209,7 +209,7 @@ EOF
 install_local_rebar() {
     if [ ! -x "${rootdir}/bin/rebar" ]; then
         if [ ! -d "${rootdir}/src/rebar" ]; then
-            git clone --depth 1 --branch 2.6.0-couchdb https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
+            git clone --depth 1 https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
         fi
         make -C ${rootdir}/src/rebar
         mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar


### PR DESCRIPTION
This PR depends on https://github.com/apache/couchdb-rebar/pull/1.

Signed-off-by: Lee Jones <lee.jones@linaro.org>

