### PR TITLE
Partition feature flag

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -304,6 +304,13 @@ os_process_limit = 100
 [indexers]
 couch_mrview = true
 
+[feature_flags]
+; This enables any database to be created as a partitioned databases (except system db's). 
+; Setting this to false will stop the creation of paritioned databases.
+; paritioned||allowed* = true will scope the creation of partitioned databases
+; to databases with 'allowed' prefix.
+partitioned||* = true
+
 [uuids]
 ; Known algorithms:
 ;   random - 128 bits of random awesome

--- a/src/couch/test/couch_flags_tests.erl
+++ b/src/couch/test/couch_flags_tests.erl
@@ -60,12 +60,16 @@ setup() ->
 
     application:load(couch_epi),
     application:set_env(couch_epi, plugins, [couch_db_epi, ?MODULE]),
-    test_util:start_couch([couch_epi]).
+    meck:expect(config, get, 1, []),
+
+    Ctx = test_util:start_couch([couch_epi]),
+    Ctx. 
 
 
 teardown(Ctx) ->
     test_util:stop_couch(Ctx),
     ok = application:unload(couch_epi),
+    meck:unload(),
     ok.
 
 couch_flags_test_() ->


### PR DESCRIPTION
## Overview

Add partition feature flag based for #1789

## Testing recommendations

Create something like this in `local.ini`:
```
[feature_flags]
partitions||* = false
partitions||allowed* = true
```

Then:
`curl -X PUT http://localhost:5984/not-allowed?partitioned=true` should throw an error
`curl -X PUT http://localhost:5984/allowed-partition?partitioned=true` should be created

## Related Issues or Pull Requests

#1789 

## Checklist

- [x] Code is written and works correctly;
- [x] Tests

