### PR TITLE
Support out-of-sync between db and index in mango

### DIFF
--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -229,6 +229,9 @@ view_cb({row, Row}, #mrargs{extra = Options} = Acc) ->
         doc = couch_util:get_value(doc, Row)
     },
     case ViewRow#view_row.doc of
+        null ->
+            put(mango_docs_examined, get(mango_docs_examined) + 1),
+            maybe_send_mango_ping();
         undefined ->
             ViewRow2 = ViewRow#view_row{
                 value = couch_util:get_value(value, Row)
@@ -427,7 +430,10 @@ doc_member(Cursor, RowProps) ->
                     match_doc(Selector, Doc, ExecutionStats1);
                 Else ->
                     Else
-            end
+            end;
+        null ->
+            ExecutionStats1 = mango_execution_stats:incr_docs_examined(ExecutionStats),
+            {no_match, null, {execution_stats, ExecutionStats1}}
     end.
 
 

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -113,6 +113,12 @@ class Database(object):
         r.raise_for_status()
         return r.json()
 
+    def delete_doc(self, docid):
+        r = self.sess.get(self.path(docid))
+        r.raise_for_status()
+        original_rev = r.json()['_rev']
+        self.sess.delete(self.path(docid), params={"rev": original_rev})
+
     def ddoc_info(self, ddocid):
         r = self.sess.get(self.path([ddocid, "_info"]))
         r.raise_for_status()


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Under situation where the document is deleted while the mrview index for this document is not updated, the returned value from mrview is `{doc,null}`. There is no such consideration in Mango to cause case_clause error. This fix is to consider out-of-sync between documents in database and their index and not to cause 500 when the `_find` endpoint is called.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

```
localhost:mytest jiangph$ curl -u foo:bar -X PUT http://localhost:15984/db01
{"ok":true}
localhost:mytest jiangph$ curl -u foo:bar -X POST -H "Content-Type: application/json"  http://localhost:15984/db01 -d @point2.json
{"ok":true,"id":"point2","rev":"1-d942f0ce01647aa0f46518b213b5628e"}
localhost:mytest jiangph$ more queryindex.json
{
 "index": {
     "fields": ["type"]
 },
 "name" : "type_json_index",
 "type" : "json"
}
localhost:mytest jiangph$ curl -u foo:bar -X POST -H "content-type: application/json" http://localhost:15984/db01/_index -d @queryindex.json
{"result":"created","id":"_design/6ad4c553950364254e1c44a7a10c4fb4343097ae","name":"type_json_index"}
localhost:mytest jiangph$ curl -u foo:bar -X POST -H "content-type: application/json" http://localhost:15984/db01/_find -d @query_without_stale_ok.json|jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   382    0   255  100   127   7730   3850 --:--:-- --:--:-- --:--:--  7968
{
  "docs": [
    {
      "_id": "point2",
      "_rev": "1-d942f0ce01647aa0f46518b213b5628e",
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          0.2,
          0.2
        ]
      }
    }
  ],
  "bookmark": "g1AAAABDeJzLYWBgYMpgSmHgKy5JLCrJTq2MT8lPzkzJBYqzFeRn5pUYgWQ5YLI5QHFGkCS7W2piSWlRalYWAGwgEsE"
}
localhost:mytest jiangph$ more query_without_stale_ok.json
{
  "selector": {
     "type": {
        "$gt": "0"
     }
  },
  "use_index": "_design/6ad4c553950364254e1c44a7a10c4fb4343097ae"
}
localhost:mytest jiangph$ curl -u foo:bar -X PUT http://localhost:15984/db01/point2?rev=1-d942f0ce01647aa0f46518b213b5628e -X DELETE
{"ok":true,"id":"point2","rev":"2-a1d194107753346689f5ed3b44b8bbc7"}
localhost:mytest jiangph$ more query_with_stale_ok.json
{
  "selector": {
     "type": {
        "$gt": "0"
     }
  },
  "stale" : "ok",
  "use_index": "_design/6ad4c553950364254e1c44a7a10c4fb4343097ae"
}
localhost:mytest jiangph$  curl -u foo:bar -X POST -H "content-type: application/json" http://localhost:15984/db01/_find -d @query_with_stale_ok.json|jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   208  100    66  100   142   6329  13617 --:--:-- --:--:-- --:--:-- 14200
{
  "error": "unknown_error",
  "reason": "case_clause",
  "ref": 2113297017
}
```
In latest code base, the error looks:

{
  "error": "badmatch",
  "reason": "{error,\n    {function_clause,nil,\n        [{mango_selector,match,\n             [{[{<<\"type\">>,{[{<<\"$gt\">>,<<\"0\">>}]}}]},null],\n             [{file,\"src/mango_selector.erl\"},{line,57}]},\n         {mango_cursor_view,view_cb,2,\n             [{file,\"src/mango_cursor_view.erl\"},{line,241}]},\n         {couch_mrview,map_fold,3,[{file,\"src/couch_mrview.erl\"},{line,548}]},\n         {couch_mrview_util,fold_fun,4,\n             [{file,\"src/couch_mrview_util.erl\"},{line,437}]},\n         {couch_btree,stream_kv_node2,8,\n             [{file,\"src/couch_btree.erl\"},{line,848}]},\n         {couch_btree,fold,4,[{file,\"src/couch_btree.erl\"},{line,222}]},\n         {couch_mrview_util,fold,4,\n             [{file,\"src/couch_mrview_util.erl\"},{line,432}]},\n         {couch_mrview,'-map_fold/5-fun-1-',3,\n             [{file,\"src/couch_mrview.erl\"},{line,497}]}]}}",
  "ref": 709720816
}

The new test is `test_out_of_sync` in src/mango/test/01-index-crud-test.py

```
[ * ] Setup environment ... ok
[ * ] Ensure CouchDB is built ... ok
[ * ] Prepare configuration files ... ok
[ * ] Start node node1 ... ok
[ * ] Check node at http://127.0.0.1:15984/ ... ok
[ * ] Running cluster setup ... ok
[ * ] Developers cluster is set up at http://127.0.0.1:15984.
Admin username: testuser
Password: testpass
Time to hack! ... {"couchdb":"Welcome","version":"2.2.0-f350d5f-dirty","git_sha":"f350d5f","features":["pluggable-storage-engines","scheduler"],"vendor":{"name":"The Apache Software Foundation"}}
...............SSS...................................................................SSSSSSSSSSSSSSSSSSSSSSSSSS.................SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS.SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS......................................SS.......SSSSSSSS...........
----------------------------------------------------------------------
Ran 284 tests in 51.106s

OK (SKIP=128)
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests; 
- [ ] Documentation reflects the changes;
