### PR TITLE
Don't use $not to validate use of index

### DIFF
--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -628,6 +628,9 @@ has_required_fields_int([{[{<<"$and">>, Args}]} | Rest], RequiredFields)
     Remainder = has_required_fields_int(Args, RequiredFields),
     has_required_fields_int(Rest, Remainder);
 
+has_required_fields_int([{[{_Field, {[{<<"$not">>, _Args}]}}]} | Rest], RequiredFields) ->
+    has_required_fields_int(Rest, RequiredFields);
+
 has_required_fields_int([{[{Field, Cond}]} | Rest], RequiredFields) ->
     case Cond of
         % $exists:false is a special case - this is the only operator

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -251,6 +251,16 @@ class OperatorTests:
             })
         user_ids = [12,13,14]
         self.assertUserIds(user_ids, docs)
+
+    def test_ne_returns_correct_docs(self):
+        selector = {
+            "twitter": {
+                "$ne": "@nonahorton"
+            }
+        }
+        docs = self.db.find(selector, fields=["user_id"])
+        ex = self.db.find(selector, fields=["user_id"], explain=True)
+        self.assertUserIds([0,1,9,13], docs)
         
 
 

--- a/src/mango/test/12-use-correct-index-test.py
+++ b/src/mango/test/12-use-correct-index-test.py
@@ -127,3 +127,27 @@ class ChooseCorrectIndexForDocs(mango.DbPerClass):
         self.db.create_index(["name", "_rev"], ddoc="aaa")
         explain = self.db.find({"name": "Eddie"}, explain=True)
         self.assertEqual(explain["index"]["ddoc"], '_design/aaa')
+
+    def test_not_choose_index_with_not(self):
+        self.db.create_index(["tags"], ddoc="aaa")
+        selector = {
+            "$not": {
+                "tags": {
+                    "$elemMatch": {
+                    "$eq": "tags2"
+                    }
+                }
+            }
+        }
+        explain = self.db.find(selector, explain=True)
+        self.assertEqual(explain["index"]["name"], '_all_docs')
+    
+    def test_ne_chooses_index(self):
+        self.db.create_index(["tags"], ddoc="aaa")
+        selector = {
+            "tags": {
+                "$ne": "tags2"
+            }
+        }
+        explain = self.db.find(selector, explain=True)
+        self.assertEqual(explain["index"]["ddoc"], '_design/aaa')


### PR DESCRIPTION
## Overview

When mango is selecting an index for a query, previously it would consider a field with a $not to be 
acceptable to validate a field and increase the chance of that index being selected. That isn't quite correct. It is better to ignore a field and condition that contains a $not. It isn't proof enough that the index is usable for the query.



## Testing recommendations

All tests should pass. Queries using $not should use _all_docs unless more selectors in the query help select an index.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
