### PR TITLE
Support elixir 1.7

### DIFF
--- a/test/elixir/mix.lock
+++ b/test/elixir/mix.lock
@@ -1,3 +1,5 @@
-%{"httpotion": {:hex, :httpotion, "3.0.3", "17096ea1a7c0b2df74509e9c15a82b670d66fc4d66e6ef584189f63a9759428d", [], [{:ibrowse, "~> 4.4", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
-  "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [], [], "hexpm"},
-  "jiffy": {:hex, :jiffy, "0.14.11", "919a87d491c5a6b5e3bbc27fafedc3a0761ca0b4c405394f121f582fd4e3f0e5", [], [], "hexpm"}}
+%{
+  "httpotion": {:hex, :httpotion, "3.0.3", "17096ea1a7c0b2df74509e9c15a82b670d66fc4d66e6ef584189f63a9759428d", [:mix], [{:ibrowse, "~> 4.4", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
+  "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], [], "hexpm"},
+  "jiffy": {:hex, :jiffy, "0.14.11", "919a87d491c5a6b5e3bbc27fafedc3a0761ca0b4c405394f121f582fd4e3f0e5", [:rebar3], [], "hexpm"},
+}

--- a/test/elixir/test/replication_test.exs
+++ b/test/elixir/test/replication_test.exs
@@ -132,7 +132,7 @@ defmodule ReplicationTest do
     assert task["replication_id"] == repl_id
     repl_body = %{
       "replication_id" => repl_id,
-      "cancel": true
+      cancel: true
     }
     result = Couch.post("/_replicate", body: repl_body)
     assert result.status_code == 200
@@ -175,7 +175,7 @@ defmodule ReplicationTest do
 
     repl_body = %{
       "replication_id" => repl_id,
-      "cancel": true
+      cancel: true
     }
     resp = Couch.Session.post(sess, "/_replicate", body: repl_body)
     assert resp.status_code == 401
@@ -1349,7 +1349,7 @@ defmodule ReplicationTest do
     assert resp["ok"]
     assert resp["_local_id"] == repl_id
 
-    doc = %{"_id" => "foobar", "value": 666}
+    doc = %{"_id" => "foobar", "value" => 666}
     [doc] = save_docs(src_db_name, [doc])
 
     wait_for_repl_stop(repl_id, 30000)
@@ -1395,7 +1395,7 @@ defmodule ReplicationTest do
     assert history["doc_write_failures"] == 0
 
     token = Enum.random(1..1_000_000)
-    query = %{"att_encoding_info": "true", "bypass_cache": token}
+    query = %{att_encoding_info: true, bypass_cache: token}
     resp = Couch.get("/#{tgt_db_name}/#{doc["_id"]}", query: query)
     assert resp.status_code < 300
     assert is_map(resp.body["_attachments"])

--- a/test/elixir/test/test_helper.exs
+++ b/test/elixir/test/test_helper.exs
@@ -175,8 +175,8 @@ defmodule CouchTestCase do
 
       def sample_doc_foo do
         %{
-          "_id": "foo",
-          "bar": "baz"
+          _id: "foo",
+          bar: "baz"
         }
       end
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Reformat mix.lock, and suppress elixir 1.7 warnings.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Using elixir 1.7, `mix test --trace` should not reformat the `mix.lock` file, and should not generate warnings like:
```
warning: found quoted keyword "_id" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
  test/test_helper.exs:178
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
