### PR TITLE
Remove eliminated config options from elixir tests

### DIFF
--- a/test/elixir/test/config_test.exs
+++ b/test/elixir/test/config_test.exs
@@ -69,10 +69,7 @@ defmodule ConfigTest do
 
   test "Standard config options are present", context do
     assert context[:config]["couchdb"]["database_dir"]
-    assert context[:config]["daemons"]["httpd"]
-    assert context[:config]["httpd_global_handlers"]["_config"]
     assert context[:config]["log"]["level"]
-    assert context[:config]["query_servers"]["javascript"]
   end
 
   test "Settings can be altered with undefined whitelist allowing any change", context do


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Remove eliminated config options from elixir tests.

This mirrors [this commit](https://github.com/apache/couchdb/commit/83f4b9faf5241caa8cfffc7788c7b5bcdbde1f64) which removed similar assertions in the JS test.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

`mix test --trace test/config_test.exs`

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
