### PR TITLE
Stop replications on target document write failures

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -395,6 +395,14 @@ ssl_certificate_max_depth = 3
 ; To restore the old behaviour, use the following value:
 ;auth_plugins = couch_replicator_auth_noop
 
+; Stop replication jobs with an error on first document write failure to the
+; target cluster. By default, when false, only a doc_write_failures counter is
+; incremented but the replication continues on. When true the replication will
+; crash and the document id and the reason for doc failure will be reported
+; in the replication state. Replication will then be retried periodically with
+; exponential backoffs like any other replication.
+;stop_on_doc_write_failure = false
+
 [compaction_daemon]
 ; The delay, in seconds, between each check for which database and view indexes
 ; need to be compacted.

--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -304,6 +304,12 @@ open_doc_revs(#httpdb{} = HttpDb, Id, Revs, Options, Fun, Acc) ->
             throw(Stub);
         {'DOWN', Ref, process, Pid, {http_request_failed, _, _, max_backoff}} ->
             exit(max_backoff);
+        {'DOWN', Ref, process, Pid, {http_request_failed, _, _,
+                {shutdown, {doc_write_failure, _, _}} = DocWriteFailure}} ->
+            exit(DocWriteFailure);
+        {'DOWN', Ref, process, Pid, {shutdown, {doc_write_failure, _, _}} =
+                DocWriteFailure} ->
+            exit(DocWriteFailure);
         {'DOWN', Ref, process, Pid, request_uri_too_long} ->
             NewMaxLen = get_value(max_url_len, Options, ?MAX_URL_LEN) div 2,
             case NewMaxLen < ?MIN_URL_LEN of


### PR DESCRIPTION
Previously when target document writes failed, because a VDU prevented the
write, or it exceed size limits on the target cluster, replication continued
and a `doc_write_failures` statistic counter was incremented. The counter was
visible in _active_tasks output for continuous replications and was visible in
the completion record written back to the replication documents.

That behavior might not be suitable in many cases. For instance, when migrating
data, if the counter is ignored by the user, combined with a successful
replication completion could lead to a perceived data loss. Until recently
00b28c265d97df675b725cd68897dc371cbd7168 this was even worse because on
replication scheduler would reset statistics counters on every job start. So if
a job restarted at least once, user might never find out that all their data
didn't copy from the source to the target.

Introduce a replicator config `stop_on_doc_write_failure = true | false` where
the replication crashes if a single document write fails. This will many write
failures visible to the and they would know exactly which document failed and
why.

Replications which crash because of doc write failures would retry periodically
just like any other crashes related to missing source or target connectivity,
for example. They do not fail permanently because users could adjust document
size limit on a target cluster or change the VDU function and then replication
will start working again and complete. Here we rely on exponential backoffs
which were introduced with the scheduling replicator work. At the maximum
backoff interval replications would retry about once every 8 hours.

After the failure is handled and bubbles up to the main replication job process,
there is an attempt to checkpoint before exiting with the error. That is done
in order to reduce change feed reprocessing during each retry attempt.

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
   Will make a separate PR for documentation