### PR TITLE
Test suite fixes for Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -119,6 +119,8 @@ check: all
 	@$(MAKE) -f Makefile.win test-cluster-without-quorum
 	@$(MAKE) -f Makefile.win eunit
 	@$(MAKE) -f Makefile.win javascript
+	@$(MAKE) -f Makefile.win mango-test
+#	@$(MAKE) -f Makefile.win elixir
 
 
 .PHONY: eunit

--- a/Makefile.win
+++ b/Makefile.win
@@ -125,15 +125,21 @@ check: all
 
 .PHONY: eunit
 # target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
+eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
+eunit: export BUILDDIR = $(shell echo %cd%)
 eunit: couch
-	@set ERL_AFLAGS="-config rel/files/eunit.config" && set BUILDDIR = $(shell echo %cd%) && $(REBAR) setup_eunit 2> nul
-	@set ERL_AFLAGS="-config rel/files/eunit.config" && set BUILDDIR = $(shell echo %cd%) && $(REBAR) -r eunit $(EUNIT_OPTS)
+	@$(REBAR) setup_eunit 2> nul
+	@$(REBAR) -r eunit $(EUNIT_OPTS)
 
+setup-eunit: export BUILDDIR = $(shell pwd)
+setup-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 setup-eunit:
-	@set ERL_AFLAGS="-config rel/files/eunit.config" && set BUILDDIR = $(shell echo %cd%) && $(REBAR) setup_eunit 2> nul
+	@$(REBAR) setup_eunit 2> nul
 
+just-eunit: export BUILDDIR = $(shell pwd)
+just-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 just-eunit:
-	@set ERL_AFLAGS="-config rel/files/eunit.config" && set BUILDDIR = $(shell echo %cd%) && $(REBAR) -r eunit $(EUNIT_OPTS)
+	@$(REBAR) -r eunit $(EUNIT_OPTS)
 
 
 .PHONY: elixir

--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+make.exe -f Makefile.win %*

--- a/src/mango/test/15-execution-stats-test.py
+++ b/src/mango/test/15-execution-stats-test.py
@@ -12,6 +12,7 @@
 
 
 import mango
+import os
 import unittest
 
 class ExecutionStatsTests(mango.UserDocsTests):
@@ -23,7 +24,10 @@ class ExecutionStatsTests(mango.UserDocsTests):
         self.assertEqual(resp["execution_stats"]["total_docs_examined"], 3)
         self.assertEqual(resp["execution_stats"]["total_quorum_docs_examined"], 0)
         self.assertEqual(resp["execution_stats"]["results_returned"], 3)
-        self.assertGreater(resp["execution_stats"]["execution_time_ms"], 0)
+        # See https://github.com/apache/couchdb/issues/1732
+        # Erlang os:timestamp() only has ms accuracy on Windows!
+        if os.name != 'nt':
+            self.assertGreater(resp["execution_stats"]["execution_time_ms"], 0)
 
     def test_no_execution_stats(self):
         resp = self.db.find({"age": {"$lt": 35}}, return_raw=True, executionStats=False)
@@ -36,7 +40,10 @@ class ExecutionStatsTests(mango.UserDocsTests):
         self.assertEqual(resp["execution_stats"]["total_docs_examined"], 0)
         self.assertEqual(resp["execution_stats"]["total_quorum_docs_examined"], 3)
         self.assertEqual(resp["execution_stats"]["results_returned"], 3)
-        self.assertGreater(resp["execution_stats"]["execution_time_ms"], 0)
+        # See https://github.com/apache/couchdb/issues/1732
+        # Erlang os:timestamp() only has ms accuracy on Windows!
+        if os.name != 'nt':
+            self.assertGreater(resp["execution_stats"]["execution_time_ms"], 0)
 
     def test_results_returned_limit(self):
         resp = self.db.find({"age": {"$lt": 35}}, limit=2, return_raw=True, executionStats=True)

--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -47,7 +47,7 @@ defmodule Couch do
   """
 
   def process_url(url) do
-    "http://localhost:15984" <> url
+    "http://127.0.0.1:15984" <> url
   end
 
   def process_request_headers(headers, options) do

--- a/test/elixir/mix.exs
+++ b/test/elixir/mix.exs
@@ -23,7 +23,7 @@ defmodule Foo.Mixfile do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       {:httpotion, "~> 3.0"},
-      {:jiffy, "~> 0.14.11"}
+      {:jiffy, "~> 0.15.2"}
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]
   end

--- a/test/elixir/mix.lock
+++ b/test/elixir/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "httpotion": {:hex, :httpotion, "3.0.3", "17096ea1a7c0b2df74509e9c15a82b670d66fc4d66e6ef584189f63a9759428d", [:mix], [{:ibrowse, "~> 4.4", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
-  "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], [], "hexpm"},
-  "jiffy": {:hex, :jiffy, "0.14.11", "919a87d491c5a6b5e3bbc27fafedc3a0761ca0b4c405394f121f582fd4e3f0e5", [:rebar3], [], "hexpm"},
+  "httpotion": {:hex, :httpotion, "3.1.0", "14d20d9b0ce4e86e253eb91e4af79e469ad949f57a5d23c0a51b2f86559f6589", [:mix], [{:ibrowse, "~> 4.4", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
+  "ibrowse": {:hex, :ibrowse, "4.4.1", "2b7d0637b0f8b9b4182de4bd0f2e826a4da2c9b04898b6e15659ba921a8d6ec2", [:rebar3], [], "hexpm"},
+  "jiffy": {:hex, :jiffy, "0.15.2", "de266c390111fd4ea28b9302f0bc3d7472468f3b8e0aceabfbefa26d08cd73b7", [:rebar3], [], "hexpm"},
 }

--- a/test/elixir/run
+++ b/test/elixir/run
@@ -1,4 +1,6 @@
 #!/bin/bash -e
 cd "$(dirname "$0")"
+mix local.hex --force
+mix local.rebar --force
 mix deps.get
 mix test --trace

--- a/test/elixir/run.cmd
+++ b/test/elixir/run.cmd
@@ -1,5 +1,7 @@
 @ECHO OFF
 
 cd %~dp0
+call mix local.hex --force
+call mix local.rebar --force
 call mix deps.get
 call mix test --trace

--- a/test/elixir/test/replication_test.exs
+++ b/test/elixir/test/replication_test.exs
@@ -10,9 +10,9 @@ defmodule ReplicationTest do
   @admin_account "adm:pass"
   @db_pairs_prefixes [
     {"local-to-local", "", ""},
-    {"remote-to-local", "http://localhost:15984/", ""},
-    {"local-to-remote", "", "http://localhost:15984/"},
-    {"remote-to-remote", "http://localhost:15984/", "http://localhost:15984/"}
+    {"remote-to-local", "http://127.0.0.1:15984/", ""},
+    {"local-to-remote", "", "http://127.0.0.1:15984/"},
+    {"remote-to-remote", "http://127.0.0.1:15984/", "http://127.0.0.1:15984/"}
   ]
 
   # This should probably go into `make elixir` like what
@@ -31,7 +31,7 @@ defmodule ReplicationTest do
 
   test "source database not found with host" do
     name = random_db_name()
-    url = "http://localhost:15984/" <> name <> "_src"
+    url = "http://127.0.0.1:15984/" <> name <> "_src"
     check_not_found(url, name <> "_tgt")
   end
 
@@ -53,7 +53,7 @@ defmodule ReplicationTest do
     doc = %{"_id" => "doc1"}
     [doc] = save_docs(src_db_name, [doc])
 
-    result = replicate(src_db_name, "http://localhost:15984/" <> tgt_db_name)
+    result = replicate(src_db_name, "http://127.0.0.1:15984/" <> tgt_db_name)
     assert result["ok"]
     assert is_list(result["history"])
     history = Enum.at(result["history"], 0)
@@ -73,7 +73,7 @@ defmodule ReplicationTest do
     })
     [doc] = save_docs(src_db_name, [doc])
 
-    result = replicate(src_db_name, "http://localhost:15984/" <> tgt_db_name)
+    result = replicate(src_db_name, "http://127.0.0.1:15984/" <> tgt_db_name)
 
     assert result["ok"]
     assert is_list(result["history"])
@@ -157,7 +157,7 @@ defmodule ReplicationTest do
 
     save_docs(src_db_name, make_docs(1..6))
 
-    repl_src = "http://localhost:15984/" <> src_db_name
+    repl_src = "http://127.0.0.1:15984/" <> src_db_name
     repl_body = %{"continuous" => true}
     result = replicate(repl_src, tgt_db_name, body: repl_body)
 


### PR DESCRIPTION
## Overview

`os:timestamp()` on Windows only has millisecond accuracy, leading to the failure of 2 mango tests. This closes #1732 by disabling the `execution_time_ms` check on Windows only, since these 2 tests seem to be completing in <1ms and failing the `> 0` check.

This also fixes the elixir suite by using `127.0.0.1` instead of `localhost`. It's ALWAYS DNS.

The bump to `mix.*` was recommended by @davisp in #1730. Closes #1730.

## Testing recommendations

Trust me on this one - or you can build your own Windows instance if you want...

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- _n/a_ Documentation reflects the changes;