### PR TITLE
Avoid badmatch when getting fabric timeout

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -688,8 +688,12 @@ db_req(#httpd{method='PUT',path_parts=[_,<<"_purged_infos_limit">>]}=Req, Db) ->
     Options = [{user_ctx, Req#httpd.user_ctx}],
     case chttpd:json_body(Req) of
         Limit when is_integer(Limit), Limit > 0 ->
-            ok = fabric:set_purge_infos_limit(Db, Limit, Options),
-            send_json(Req, {[{<<"ok">>, true}]});
+            case fabric:set_purge_infos_limit(Db, Limit, Options) of
+                ok ->
+                    send_json(Req, {[{<<"ok">>, true}]});
+                Error ->
+                    throw(Error)
+            end;
         _->
             throw({bad_request, "`purge_infos_limit` must be positive integer"})
     end;


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Avoid `badmatch` when putting `_set_purge_infos_limit` and getting fabric timeout

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
======================== EUnit ========================
module 'chttpd_purge_tests'
  chttpd db tests
Application crypto was left running!
    chttpd_purge_tests:87: test_empty_purge_request...[0.009 s] ok
    chttpd_purge_tests:104: test_ok_purge_request...[0.285 s] ok
    chttpd_purge_tests:141: test_accepted_purge_request...[0.123 s] ok
    chttpd_purge_tests:173: test_partial_purge_request...[0.084 s] ok
    chttpd_purge_tests:209: test_mixed_purge_request...[0.172 s] ok
    chttpd_purge_tests:257: test_overmany_ids_or_revs_purge_request...[0.130 s] ok
    chttpd_purge_tests:307: test_exceed_limits_on_purge_infos...[0.140 s] ok
    chttpd_purge_tests:350: should_error_set_purged_docs_limit_to0...[0.004 s] ok
    chttpd_purge_tests:358: test_timeout_set_purged_infos_limit...[0.087 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 3.567 s]
  [done in 5.743 s]
=======================================================
  All 9 tests passed.
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

COUCHDB-3326

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
