### PR TITLE
Set query server env variable in Makefile for isolated eunit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ check: all
 # target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
 eunit: export BUILDDIR = $(shell pwd)
 eunit: export ERL_AFLAGS = -config $(shell pwd)/rel/files/eunit.config
+eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell pwd)/bin/couchjs $(shell pwd)/share/server/main.js
 eunit: couch
 	@$(REBAR) setup_eunit 2> /dev/null
 	@$(REBAR) -r eunit $(EUNIT_OPTS)


### PR DESCRIPTION
## Overview

After #1602 we requite env variable `COUCHDB_QUERY_SERVER_JAVASCRIPT` to point to js query server. This patch adds the env var on Makefile's `eunit` target returning ability to run the isolated eunit tests without setting that var in each tests' setup.

## Testing recommendations

Isolated tests with query server, e.g. `make eunit apps=couch_mrview suites=couch_mrview_all_docs_tests` should run locally without throwing "unknown query server" exceptions. 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
