### PR TITLE
Remove unnecessary setting on chttpd_view_test

### DIFF
--- a/src/chttpd/test/chttpd_view_test.erl
+++ b/src/chttpd/test/chttpd_view_test.erl
@@ -31,7 +31,6 @@ setup() ->
     TmpDb = ?tempdb(),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),
-    os:putenv("COUCHDB_QUERY_SERVER_JAVASCRIPT", "../../../bin/couchjs ../../../share/server/main.js"),
     Url = lists:concat(["http://", Addr, ":", Port, "/", ?b2l(TmpDb)]),
     create_db(Url),
     Url.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Remove unnecessary setting `COUCHDB_QUERY_SERVER_JAVASCRIPT` on chttpd_view_test because this was set via https://github.com/cloudant/db/pull/577

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
`make check`

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/1602
https://github.com/cloudant/db/pull/577

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
