### PR TITLE
Fix couch_epi typespec for data provider

### DIFF
--- a/src/couch_epi/src/couch_epi.erl
+++ b/src/couch_epi/src/couch_epi.erl
@@ -58,8 +58,12 @@
 
 -type apply_opts() :: [apply_opt()].
 
+-type data_spec_opt()
+   :: {interval, pos_integer()}.
+
 -type data_spec()
-    :: {module, module()}
+    :: {static_module, module()}
+        | {callback_module, module()}
         | {priv_file, FileName :: string()}
         | {file, FileName :: string()}.
 

--- a/src/couch_epi/src/couch_epi_plugin.erl
+++ b/src/couch_epi/src/couch_epi_plugin.erl
@@ -43,7 +43,10 @@
 -callback providers() -> [{couch_epi:service_id(), module()}].
 -callback services() -> [{couch_epi:service_id(), module()}].
 -callback data_subscriptions() -> [{couch_epi:service_id(), couch_epi:key()}].
--callback data_providers() -> [{couch_epi:service_id(), couch_epi:data_spec()}].
+-callback data_providers() -> [
+    {couch_epi:key(), couch_epi:data_spec()}
+        | {couch_epi:key(), couch_epi:data_spec(), [couch_epi:data_spec_opt()]}
+].
 -callback processes() -> [{couch_epi:plugin_id(), [supervisor:child_spec()]}].
 -callback notify(Key :: term(), Old :: term(), New :: term()) -> ok.
 


### PR DESCRIPTION
## Overview

There are few problems with type specs in couch_epi:
- `module` was renamed into `static_module`
  - https://github.com/apache/couchdb/commit/0fefc859eb9c18120064317da61a30adaeac5f92#diff-d9e3e3c91d4866fe966666619bda7991
- `callback_module` was added
  - https://github.com/apache/couchdb/commit/cf65280466499d652cff1171a2039af49c5677e8#diff-d9e3e3c91d4866fe966666619bda7991
- data provider specification can include options
  - https://github.com/apache/couchdb/blob/master/src/couch_epi/src/couch_epi_plugin.erl#L143

This PR fixes these issues.

## Testing recommendations

```
make dialyze
```

## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
