### PR TITLE
Add Global timeout for map/reduce queries

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -194,6 +194,11 @@ port = 6984
 ; changes_duration = 
 ; shard_timeout_factor = 2
 ; uuid_prefix_len = 7
+; request_timeout = 60000
+; all_docs_timeout = 10000
+; attachments_timeout = 60000
+; view_timeout = 3600000
+; partition_view_timeout = 3600000
 
 ; [rexi]
 ; buffer_count = 2000

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -15,7 +15,7 @@
 -export([submit_jobs/3, submit_jobs/4, cleanup/1, recv/4, get_db/1, get_db/2, error_info/1,
         update_counter/3, remove_ancestors/2, create_monitors/1, kv/2,
         remove_down_workers/2, doc_id_and_rev/1]).
--export([request_timeout/0, attachments_timeout/0, all_docs_timeout/0]).
+-export([request_timeout/0, attachments_timeout/0, all_docs_timeout/0, view_timeout/1]).
 -export([log_timeout/2, remove_done_workers/2]).
 -export([is_users_db/1, is_replicator_db/1]).
 -export([open_cluster_db/1, open_cluster_db/2]).
@@ -64,6 +64,13 @@ all_docs_timeout() ->
 
 attachments_timeout() ->
     timeout("attachments", "600000").
+
+view_timeout(Args) ->
+    PartitionQuery = couch_mrview_util:get_extra(Args, partition, false),
+    case PartitionQuery of
+        false -> timeout("view", "infinity");
+        _ -> timeout("partition_view", "infinity")
+    end.
 
 timeout(Type, Default) ->
     case config:get("fabric", Type ++ "_timeout", Default) of

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -127,7 +127,7 @@ go(DbName, _Options, Workers, QueryArgs, Callback, Acc0) ->
         update_seq = case UpdateSeq of true -> []; false -> nil end
     },
     case rexi_utils:recv(Workers, #shard.ref, fun handle_message/3,
-        State, infinity, 5000) of
+        State, fabric_util:view_timeout(QueryArgs), 5000) of
     {ok, NewState} ->
         {ok, NewState#collector.user_acc};
     {timeout, NewState} ->

--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -81,7 +81,7 @@ go(DbName, Workers, {map, View, _}, Args, Callback, Acc0) ->
         update_seq = case UpdateSeq of true -> []; false -> nil end
     },
     case rexi_utils:recv(Workers, #shard.ref, fun handle_message/3,
-        State, infinity, 1000 * 60 * 60) of
+        State, fabric_util:view_timeout(Args), 1000 * 60 * 60) of
     {ok, NewState} ->
         {ok, NewState#collector.user_acc};
     {timeout, NewState} ->

--- a/src/fabric/src/fabric_view_reduce.erl
+++ b/src/fabric/src/fabric_view_reduce.erl
@@ -87,7 +87,7 @@ go2(DbName, Workers, {red, {_, Lang, View}, _}=VInfo, Args, Callback, Acc0) ->
         update_seq = case UpdateSeq of true -> []; false -> nil end
     },
     try rexi_utils:recv(Workers, #shard.ref, fun handle_message/3,
-        State, infinity, 1000 * 60 * 60) of
+        State, fabric_util:view_timeout(Args), 1000 * 60 * 60) of
     {ok, NewState} ->
         {ok, NewState#collector.user_acc};
     {timeout, NewState} ->


### PR DESCRIPTION
## Overview

This makes the global timeout for a map/reduce and all_docs request
configurable via the config. It separates the config into global queries
and partition queries so that it is possible to make the global timeout
is for partitioned queries

## Testing recommendations

Add the `global_partition_view_timeout` to the `[fabric]` config. You can then make queries and see if they timeout based on the value set.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
