### PR TITLE
Fix function_clause exception on invalid DB security objects

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -750,19 +750,23 @@ validate_security_object(SecProps) ->
 
 % validate user input
 validate_names_and_roles({Props}) when is_list(Props) ->
-    case couch_util:get_value(<<"names">>,Props,[]) of
+    case couch_util:get_value(<<"names">>, Props, []) of
     Ns when is_list(Ns) ->
             [throw("names must be a JSON list of strings") ||N <- Ns, not is_binary(N)],
             Ns;
-    _ -> throw("names must be a JSON list of strings")
+    _ ->
+        throw("names must be a JSON list of strings")
     end,
-    case couch_util:get_value(<<"roles">>,Props,[]) of
+    case couch_util:get_value(<<"roles">>, Props, []) of
     Rs when is_list(Rs) ->
         [throw("roles must be a JSON list of strings") ||R <- Rs, not is_binary(R)],
         Rs;
-    _ -> throw("roles must be a JSON list of strings")
+    _ ->
+        throw("roles must be a JSON list of strings")
     end,
-    ok.
+    ok;
+validate_names_and_roles(_) ->
+    throw("admins or members must be a JSON list of strings").
 
 get_revs_limit(#db{} = Db) ->
     couch_db_engine:get_revs_limit(Db).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

 This PR will fix function_clause error on invalid DB security objects.

for example when the request body of PUT db/_security endpoint is not a correct json format, if you check the log file you will find the function_clause error.
```
[error] 2018-06-13T16:50:50.479454Z node1@127.0.0.1 <0.3642.0> 3108587a16 rpc couch_db:set_security/2 function_clause [{couch_db,validate_names_and_roles,[[<<"role_a">>]],[{file,"src/couch_db.erl"},{line,594}]},{couch_db,validate_security_object,1,[{file,"src/couch_db.erl"},{line,590}]},{couch_db,set_security,2,[{file,"src/couch_db.erl"},{line,574}]},{fabric_rpc,with_db,3,[{file,"src/fabric_rpc.erl"},{line,289}]},{rexi_server,init_p,3,[{file,"src/rexi_server.erl"},{line,139}]}]                                                                              [error] 2018-06-13T16:50:50.479648Z node1@127.0.0.1 <0.3576.0> 3108587a16 Failed to set security object on {'node1@127.0.0.1',<<"shards/40000000-5fffffff/abc.1528908305">>} :: {error,function_clause}                                         [error] 2018-06-13T16:50:50.480220Z node1@127.0.0.1 <0.3647.0> 3108587a16 rpc couch_db:set_security/2 function_clause [{couch_db,validate_names_and_roles,[[<<"role_a">>]],[{file,"src/couch_db.erl"},{line,594}]},{couch_db,validate_security_object,1,[{file,"src/couch_db.erl"},{line,590}]},{couch_db,set_security,2,[{file,"src/couch_db.erl"},{line,574}]},{fabric_rpc,with_db,3,[{file,"src/fabric_rpc.erl"},{line,289}]},{rexi_server,init_p,3,[{file,"src/rexi_server.erl"},{line,139}]}]                                                                              [error] 2018-06-13T16:50:50.480371Z node1@127.0.0.1 <0.3646.0> 3108587a16 rpc couch_db:set_security/2 function_clause [
{couch_db,validate_names_and_roles,[[<<"role_a">>]],[{file,"src/couch_db.erl"},{line,594}]},
{couch_db,validate_security_object,1,[{file,"src/couch_db.erl"},{line,590}]},
{couch_db,set_security,2,[{file,"src/couch_db.erl"},{line,574}]},
{fabric_rpc,with_db,3,[{file,"src/fabric_rpc.erl"},{line,289}]},
{rexi_server,init_p,3,[{file,"src/rexi_server.erl"},{line,139}]}] 
```
after fix it,` function_clause` error full stack trace will disappeared instead of
```
[error] 2018-11-29T02:30:24.013166Z node1@127.0.0.1 <0.2699.0> 985a72f160 Failed to set security object on {'node1@127.0.0.1',<<"shards/e0000000-ffffffff/test.1543202135">>} :: "admins or members must be a JSON list of strings"
```




## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

case 

1. test with incorrect members format
`curl -i -X PUT http://localhost:5984/test/_security -u "adm:pass" -H 'accept: application/json'  -d '{"members":["foo"]}'`
check logs:
```
node2.log:8979:[error] 2018-11-29T14:08:05.480944Z node2@127.0.0.1 <0.550.0> 71a87732c7 Failed to set security object on {'node3@127.0.0.1',<<"shards/c0000000-dfffffff/test.1543202135">>} :: "admins or members must be a JSON list of strings"
```
return 
`{"error":"error","reason":"no_majority"}`

2.  test with incorrect members roles format

`curl -i -X PUT http://localhost:15984/test/_security -u "adm:pass" -H 'accept: application/json'  -d '{"members":{"names": ["user1","user2"],"roles": "developers"}}'`

check log:
```
node1.log:19740:[error] 2018-11-29T14:03:44.740886Z node1@127.0.0.1 <0.5831.0> 76fbe3cd55 Failed to set security object on {'node2@127.0.0.1',<<"shards/e0000000-ffffffff/test.1543202135">>} :: "roles field vallue must be a list of strings"
```
return 
`{"error":"error","reason":"no_majority"}`

3. test with correct members roles and names format
`curl -i -X PUT http://localhost:5984/test/_security -u "adm:pass" -H 'accept: application/json'  -d '{"members":{"names": ["user1","user2"],"roles": ["developers"]}}'`

return 
`{"ok":true}`

4. test with correct admins and members roles and names format
`curl -i -X PUT http://localhost:5984/test/_security -u "adm:pass" -H 'accept: application/json'  -d '{"admins":{"roles":["admins"],"names":["foo"]},"members":{"names": ["user1","user2"],"roles": ["developers"]}}'`

return 
`{"ok":true}`

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

#1384 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
