### PR TITLE
Add `--clean` flag to `dev/run`

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -24,6 +24,7 @@ import optparse
 import os
 import posixpath
 import re
+import shutil
 import subprocess as sp
 import sys
 import time
@@ -77,6 +78,11 @@ def log(msg):
 log.verbose = True
 
 
+def clean_lib(ctx):
+    lib = os.path.join(ctx['devdir'], "lib")
+    shutil.rmtree(lib)
+
+
 def main():
     ctx = setup()
     startup(ctx)
@@ -89,6 +95,8 @@ def main():
 def setup():
     opts, args = setup_argparse()
     ctx = setup_context(opts, args)
+    if opts.clean:
+        clean_lib(ctx)
     setup_logging(ctx)
     setup_dirs(ctx)
     check_beams(ctx)
@@ -135,6 +143,10 @@ def setup_argparse():
                       help='The number of nodes that should be stopped after cluster config')
     parser.add_option('--no-eval', action='store_true', default=False,
                       help='Do not eval subcommand output')
+    parser.add_option("--clean", dest="clean",
+                      default=False, action="store_true",
+                      help="Wipe the dev cluster state before booting nodes")
+
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Overview

Add ability to delete content of `dev/lib` directory when starting development cluster. 

## Testing recommendations

1. start cluster `dev/run`
2. kill the cluster (CTRL+C)
3. create any file `touch dev/lib/node1/etc/flag_file`
4. start cluster with `dev/run --clean`
5. kill the cluster (CTRL+C)
6. make sure flag file doesn't exists `ls dev/lib/node1/etc/flag_file`
 
## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
