### PR TITLE
Bump fauxton, docs, version to 2.3.0

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -57,9 +57,9 @@ DepDescs = [
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
-                   {tag, "2.2.0"}, [raw]},
+                   {tag, "2.3.0"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
-                   {tag, "v1.1.18"}, [raw]},
+                   {tag, "v1.1.19"}, [raw]},
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.2"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-4"}},

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -12,7 +12,7 @@
 
 {sys, [
     {lib_dirs, ["../src"]},
-    {rel, "couchdb", "2.2.0", [
+    {rel, "couchdb", "2.3.0", [
         %% stdlib
         asn1,
         compiler,

--- a/version.mk
+++ b/version.mk
@@ -1,3 +1,3 @@
 vsn_major=2
-vsn_minor=2
+vsn_minor=3
 vsn_patch=0


### PR DESCRIPTION
This is the last step before starting the 2.3.0 release process.

Closes #1749 