### PR TITLE
fix empty queries

### DIFF
--- a/src/mango/src/mango_cursor_special.erl
+++ b/src/mango/src/mango_cursor_special.erl
@@ -41,12 +41,14 @@ create(Db, Indexes, Selector, Opts) ->
     Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
     Skip = couch_util:get_value(skip, Opts, 0),
     Fields = couch_util:get_value(fields, Opts, all_fields),
-    Bookmark = couch_util:get_value(bookmark, Opts), 
+    Bookmark = couch_util:get_value(bookmark, Opts),
+
+    IndexRanges1 = mango_cursor:maybe_noop_range(Selector, IndexRanges),
 
     {ok, #cursor{
         db = Db,
         index = Index,
-        ranges = IndexRanges,
+        ranges = IndexRanges1,
         selector = Selector,
         opts = Opts,
         limit = Limit,
@@ -54,7 +56,6 @@ create(Db, Indexes, Selector, Opts) ->
         fields = Fields,
         bookmark = Bookmark
     }}.
-
 
 explain(Cursor) ->
     mango_cursor_view:explain(Cursor).

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -92,8 +92,9 @@ execute(Cursor, UserFun, UserAcc) ->
         opts = Opts,
         execution_stats = Stats
     } = Cursor,
+    Query = mango_selector_text:convert(Selector),
     QueryArgs = #index_query_args{
-        q = mango_selector_text:convert(Selector),
+        q = Query,
         partition = get_partition(Opts, nil),
         sort = sort_query(Opts, Selector),
         raw_bookmark = true
@@ -113,7 +114,12 @@ execute(Cursor, UserFun, UserAcc) ->
         execution_stats = mango_execution_stats:log_start(Stats)
     },
     try
-        execute(CAcc)
+        case Query of
+            <<>> ->
+                throw({stop, CAcc});
+            _ ->
+                execute(CAcc)
+        end
     catch
         throw:{stop, FinalCAcc} ->
             #cacc{

--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -126,6 +126,8 @@ columns(Idx) ->
     end.
 
 
+is_usable(_, Selector, _) when Selector =:= {[]} ->
+    false;
 is_usable(Idx, Selector, _) ->
     case columns(Idx) of
         all_fields ->

--- a/src/mango/src/mango_util.erl
+++ b/src/mango/src/mango_util.erl
@@ -344,6 +344,8 @@ has_suffix(Bin, Suffix) when is_binary(Bin), is_binary(Suffix) ->
     end.
 
 
+join(_Sep, []) ->
+    [];
 join(_Sep, [Item]) ->
     [Item];
 join(Sep, [Item | Rest]) ->

--- a/src/mango/test/02-basic-find-test.py
+++ b/src/mango/test/02-basic-find-test.py
@@ -13,6 +13,7 @@
 
 
 import mango
+import user_docs
 
 
 class BasicFindTests(mango.UserDocsTests):

--- a/src/mango/test/21-empty-selector-tests.py
+++ b/src/mango/test/21-empty-selector-tests.py
@@ -1,0 +1,66 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import json
+import mango
+import unittest
+import user_docs
+import math
+
+
+def make_empty_selector_suite(klass):
+    class EmptySelectorTestCase(klass):
+        def test_empty(self):
+           resp = self.db.find({}, explain=True)
+           self.assertEqual(resp["index"]["type"], "special")
+
+        def test_empty_array_or(self):
+           resp = self.db.find({"$or": []}, explain=True)
+           self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+           docs = self.db.find({"$or": []})
+           assert len(docs) == 0
+
+        def test_empty_array_or_with_age(self):
+            resp = self.db.find({"age": 22, "$or": []}, explain=True)
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find({"age": 22, "$or": []})
+            assert len(docs) == 1
+
+        def test_empty_array_and_with_age(self):
+            resp = self.db.find({"age": 22, "$and": [{"b": {"$all":[]}}]},
+                explain=True)
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find({"age": 22, "$and": []})
+            assert len(docs) == 1
+
+        def test_empty_arrays_complex(self):
+            resp = self.db.find({"$or": [], "a": {"$in" : []}}, explain=True)
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find({"$or": [], "a": {"$in" : []}})
+            assert len(docs) == 0
+
+        def test_empty_nin(self):
+            resp = self.db.find({"favorites": {"$nin" : []}}, explain=True)
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find({"favorites": {"$nin" : []}})
+            assert len(docs) == len(user_docs.DOCS)
+
+    return EmptySelectorTestCase
+
+class EmptySelectorNoIndexTests(make_empty_selector_suite(mango.UserDocsTestsNoIndexes)): 
+    pass
+
+class EmptySelectorTextTests(make_empty_selector_suite(mango.UserDocsTextTests)):
+    pass
+
+class EmptySelectorUserDocTests(make_empty_selector_suite(mango.UserDocsTests)):
+    pass

--- a/src/mango/test/21-empty-selector-tests.py
+++ b/src/mango/test/21-empty-selector-tests.py
@@ -20,14 +20,14 @@ import math
 def make_empty_selector_suite(klass):
     class EmptySelectorTestCase(klass):
         def test_empty(self):
-           resp = self.db.find({}, explain=True)
-           self.assertEqual(resp["index"]["type"], "special")
+            resp = self.db.find({}, explain=True)
+            self.assertEqual(resp["index"]["type"], "special")
 
         def test_empty_array_or(self):
-           resp = self.db.find({"$or": []}, explain=True)
-           self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-           docs = self.db.find({"$or": []})
-           assert len(docs) == 0
+            resp = self.db.find({"$or": []}, explain=True)
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find({"$or": []})
+            assert len(docs) == 0
 
         def test_empty_array_or_with_age(self):
             resp = self.db.find({"age": 22, "$or": []}, explain=True)
@@ -36,31 +36,37 @@ def make_empty_selector_suite(klass):
             assert len(docs) == 1
 
         def test_empty_array_and_with_age(self):
-            resp = self.db.find({"age": 22, "$and": [{"b": {"$all":[]}}]},
-                explain=True)
+            resp = self.db.find(
+                {"age": 22, "$and": [{"b": {"$all": []}}]}, explain=True
+            )
             self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
             docs = self.db.find({"age": 22, "$and": []})
             assert len(docs) == 1
 
         def test_empty_arrays_complex(self):
-            resp = self.db.find({"$or": [], "a": {"$in" : []}}, explain=True)
+            resp = self.db.find({"$or": [], "a": {"$in": []}}, explain=True)
             self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"$or": [], "a": {"$in" : []}})
+            docs = self.db.find({"$or": [], "a": {"$in": []}})
             assert len(docs) == 0
 
         def test_empty_nin(self):
-            resp = self.db.find({"favorites": {"$nin" : []}}, explain=True)
+            resp = self.db.find({"favorites": {"$nin": []}}, explain=True)
             self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"favorites": {"$nin" : []}})
+            docs = self.db.find({"favorites": {"$nin": []}})
             assert len(docs) == len(user_docs.DOCS)
 
     return EmptySelectorTestCase
 
-class EmptySelectorNoIndexTests(make_empty_selector_suite(mango.UserDocsTestsNoIndexes)): 
+
+class EmptySelectorNoIndexTests(
+    make_empty_selector_suite(mango.UserDocsTestsNoIndexes)
+):
     pass
+
 
 class EmptySelectorTextTests(make_empty_selector_suite(mango.UserDocsTextTests)):
     pass
+
 
 class EmptySelectorUserDocTests(make_empty_selector_suite(mango.UserDocsTests)):
     pass

--- a/src/mango/test/21-empty-selector-tests.py
+++ b/src/mango/test/21-empty-selector-tests.py
@@ -63,7 +63,7 @@ class EmptySelectorNoIndexTests(
 ):
     pass
 
-
+@unittest.skipUnless(mango.has_text_service(), "requires text service")
 class EmptySelectorTextTests(make_empty_selector_suite(mango.UserDocsTextTests)):
     pass
 

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -314,6 +314,8 @@ class DbPerClass(unittest.TestCase):
 
 
 class UserDocsTests(DbPerClass):
+    INDEX_TYPE = "json"
+
     @classmethod
     def setUpClass(klass):
         super(UserDocsTests, klass).setUpClass()
@@ -321,14 +323,19 @@ class UserDocsTests(DbPerClass):
 
 
 class UserDocsTestsNoIndexes(DbPerClass):
+    INDEX_TYPE = "special"
+
     @classmethod
     def setUpClass(klass):
         super(UserDocsTestsNoIndexes, klass).setUpClass()
-        user_docs.setup(klass.db, index_type="_all_docs")
+        user_docs.setup(
+                    klass.db,
+                    index_type=klass.INDEX_TYPE
+            )
 
 
 class UserDocsTextTests(DbPerClass):
-
+    INDEX_TYPE = "text"
     DEFAULT_FIELD = None
     FIELDS = None
 
@@ -338,9 +345,9 @@ class UserDocsTextTests(DbPerClass):
         if has_text_service():
             user_docs.setup(
                 klass.db,
-                index_type="text",
+                index_type=klass.INDEX_TYPE,
                 default_field=klass.DEFAULT_FIELD,
-                fields=klass.FIELDS,
+                fields=klass.FIELDS
             )
 
 

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -328,10 +328,7 @@ class UserDocsTestsNoIndexes(DbPerClass):
     @classmethod
     def setUpClass(klass):
         super(UserDocsTestsNoIndexes, klass).setUpClass()
-        user_docs.setup(
-                    klass.db,
-                    index_type=klass.INDEX_TYPE
-            )
+        user_docs.setup(klass.db, index_type=klass.INDEX_TYPE)
 
 
 class UserDocsTextTests(DbPerClass):
@@ -347,7 +344,7 @@ class UserDocsTextTests(DbPerClass):
                 klass.db,
                 index_type=klass.INDEX_TYPE,
                 default_field=klass.DEFAULT_FIELD,
-                fields=klass.FIELDS
+                fields=klass.FIELDS,
             )
 
 


### PR DESCRIPTION
## Overview

Mango text indexes currently throw function clauses when queries in two
situations:

1) Empty Selector
2) Operators with empty arrays.

We fix this issue and change the behavior as follows:

1) Any empty selector will fall back on _all_docs (like json indexes).
2) $or, $and, $in, $all that specify an empty arrays
will be treated as no-op when combined with other operators.
3) A single no-nop query such as {"$or": []} will not be executed and
return nothing just like json indexes.
4) $nin with an empty array will return all docs that match the field,
just like json indexes.


## Testing recommendations

New tests were added to the python suite and can be run with
MANGO_TEXT_INDEXES=1 nosetests test/21-empty-selector-tests.py

This requires a clouseau setup. 

## Related Issues or Pull Requests

The issue is this PR.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
