### PR TITLE
Use devclean on elixir target for consistency of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,7 @@ soak-eunit: couch
 	while [ $$? -eq 0 ] ; do $(REBAR) -r eunit $(EUNIT_OPTS) ; done
 
 .PHONY: elixir
-elixir: elixir-check-formatted
-	@rm -rf dev/lib
+elixir: elixir-check-formatted devclean
 	@dev/run -a adm:pass --no-eval test/elixir/run
 
 .PHONY: elixir-check-formatted

--- a/Makefile.win
+++ b/Makefile.win
@@ -326,7 +326,7 @@ clean:
 	-@del /f/q/s src\*.dll
 	-@del /f/q src\couch\priv\*.exe
 	-@del /f/q share\server\main.js share\server\main-coffee.js
-	-@rmdir /s/q tmp 
+	-@rmdir /s/q tmp
 	-@rmdir /s/q dev\data
 	-@rmdir /s/q dev\lib
 	-@rmdir /s/q dev\logs

--- a/Makefile.win
+++ b/Makefile.win
@@ -144,8 +144,7 @@ just-eunit:
 
 
 .PHONY: elixir
-elixir: elixir-check-formatted
-	@del /s/q dev\lib 2> nul
+elixir: elixir-check-formatted devclean
 	@dev\run -a adm:pass --no-eval test\elixir\run.cmd
 
 .PHONY: elixir-check-formatted


### PR DESCRIPTION
## Overview

This is a simple change of Makefile for consistency sake. Since `dev/run` overrides etc configs on each run functionally it's the same as earlier `@rm` command.

## Testing recommendations

`make elixir` should pass, apart from common races.

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
