### PR TITLE
dev/run: do not create needless dev/data/ dir

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -163,7 +163,6 @@ def setup_context(opts, args):
 
 @log('Setup environment')
 def setup_dirs(ctx):
-    ensure_dir_exists(ctx['devdir'], 'data')
     ensure_dir_exists(ctx['devdir'], 'logs')
 
 


### PR DESCRIPTION
## Overview

`dev/run` has been creating a `dev/data` directory needlessly. Long ago we moved the data directory under `dev/lib/node#/data` to support multiple clusters. Confuses me every time.

## Testing recommendations

`dev/run`, kill it, make sure `dev/data` is not created.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- Documentation reflects the changes _n/a_
