### PR TITLE
Move tests to suite

### DIFF
--- a/src/couch/src/couch_flags_config.erl
+++ b/src/couch/src/couch_flags_config.erl
@@ -20,6 +20,11 @@
     data_provider/0
 ]).
 
+%% for test suite only
+-export([
+    parse_flags_term/1
+]).
+
 -define(DATA_INTERVAL, 1000).
 -define(MAX_FLAG_NAME_LENGTH, 256).
 
@@ -281,94 +286,3 @@ get_config_section(Section) ->
     catch error:badarg ->
             []
     end.
-
-%% ------------------------------------------------------------------
-%% Tests
-%% ------------------------------------------------------------------
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
-
-all_combinations_return_same_result_test_() ->
-    Config = [
-         {"foo, bar||*", "true"},
-         {"baz, qux||*", "false"},
-         {"baz||shards/test*", "true"},
-         {"baz||shards/blacklist*", "false"},
-         {"bar||shards/test*", "false"},
-         {"bar||shards/test/blacklist*", "true"}
-    ],
-    Expected = [
-        {{<<"shards/test/blacklist*">>},{<<"shards/test/blacklist*">>,22,[bar, foo]}},
-        {{<<"shards/test*">>},{<<"shards/test*">>, 12, [baz, foo]}},
-        {{<<"shards/blacklist*">>},{<<"shards/blacklist*">>, 17, [bar, foo]}},
-        {{<<"*">>},{<<"*">>, 1, [bar, foo]}}
-    ],
-    Combinations = couch_tests_combinatorics:permutations(Config),
-    [{test_id(Items), ?_assertEqual(Expected, data(Items))}
-        || Items <- Combinations].
-
-rules_are_sorted_test() ->
-    Expected = [
-        {{<<"shards/test/exact">>},{<<"shards/test/exact">>, 17, [baz,flag_bar,flag_foo]}},
-        {{<<"shards/test/blacklist*">>},{<<"shards/test/blacklist*">>,22,[flag_foo]}},
-        {{<<"shards/test*">>},{<<"shards/test*">>, 12, [baz,flag_bar,flag_foo]}},
-        {{<<"shards/exact">>},{<<"shards/exact">>, 12, [flag_bar,flag_foo]}},
-        {{<<"shards/blacklist*">>},{<<"shards/blacklist*">>, 17, []}},
-        {{<<"*">>},{<<"*">>, 1, [flag_foo]}}
-    ],
-    ?assertEqual(Expected, data(test_config())).
-
-latest_overide_wins_test_() ->
-    Cases = [
-        {[
-            {"flag||*", "false"}, {"flag||a*", "true"},
-            {"flag||ab*", "true"}, {"flag||abc*", "true"}
-        ], true},
-        {[
-            {"flag||*", "true"}, {"flag||a*", "false"},
-            {"flag||ab*", "true"}, {"flag||abc*", "false"}
-        ], false}
-    ],
-    [{test_id(Rules, Expected),
-        ?_assertEqual(Expected, lists:member(flag, flags(hd(data(Rules)))))}
-            || {Rules, Expected} <- Cases].
-
-flags({{_Pattern}, {_Pattern, _Size, Flags}}) ->
-    Flags.
-
-test_id(Items, ExpectedResult) ->
-    lists:flatten(io_lib:format("~p -> ~p", [[P || {P, _} <- Items], ExpectedResult])).
-
-
-test_id(Items) ->
-    lists:flatten(io_lib:format("~p", [[P || {P, _} <- Items]])).
-
-test_config() ->
-    [
-        {"flag_foo||*", "true"},
-        {"flag_bar||*", "false"},
-        {"flag_bar||shards/test*", "true"},
-        {"flag_foo||shards/blacklist*", "false"},
-        {"baz||shards/test*", "true"},
-        {"baz||shards/test/blacklist*", "false"},
-        {"flag_bar||shards/exact", "true"},
-        {"flag_bar||shards/test/exact", "true"}
-    ].
-
-parse_flags_term_test_() ->
-    LongBinary = binary:copy(<<"a">>, ?MAX_FLAG_NAME_LENGTH + 1),
-    ExpectedError = {error, {"Cannot parse list of tags: ~n~p",
-       [{too_long, LongBinary}]}},
-    ExpectedUnknownError = {error,{"Cannot parse list of tags: ~n~p",
-       [{invalid_flag,<<"dddddddd">>}]}},
-	[
-		{"empty binary", ?_assertEqual([], parse_flags_term(<<>>))},
-		{"single flag", ?_assertEqual([fff], parse_flags_term(<<"fff">>))},
-		{"sorted", ?_assertEqual([aaa,bbb,fff], parse_flags_term(<<"fff,aaa,bbb">>))},
-		{"whitespace", ?_assertEqual([aaa,bbb,fff], parse_flags_term(<<"fff , aaa, bbb ">>))},
-		{"error", ?_assertEqual(ExpectedError, parse_flags_term(LongBinary))},
-		{"unknown_flag", ?_assertEqual(ExpectedUnknownError, parse_flags_term(<<"dddddddd">>))}
-	].
-
--endif.

--- a/src/couch/test/couch_flags_config_tests.erl
+++ b/src/couch/test/couch_flags_config_tests.erl
@@ -1,0 +1,95 @@
+-module(couch_flags_config_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% value copied from couch_flags_config
+-define(MAX_FLAG_NAME_LENGTH, 256).
+
+all_combinations_return_same_result_test_() ->
+    Config = [
+         {"foo, bar||*", "true"},
+         {"baz, qux||*", "false"},
+         {"baz||shards/test*", "true"},
+         {"baz||shards/blacklist*", "false"},
+         {"bar||shards/test*", "false"},
+         {"bar||shards/test/blacklist*", "true"}
+    ],
+    Expected = [
+        {{<<"shards/test/blacklist*">>},{<<"shards/test/blacklist*">>,22,[bar, foo]}},
+        {{<<"shards/test*">>},{<<"shards/test*">>, 12, [baz, foo]}},
+        {{<<"shards/blacklist*">>},{<<"shards/blacklist*">>, 17, [bar, foo]}},
+        {{<<"*">>},{<<"*">>, 1, [bar, foo]}}
+    ],
+    Combinations = couch_tests_combinatorics:permutations(Config),
+    [{test_id(Items), ?_assertEqual(Expected, couch_flags_config:data(Items))}
+        || Items <- Combinations].
+
+rules_are_sorted_test() ->
+    Expected = [
+        {{<<"shards/test/exact">>},{<<"shards/test/exact">>, 17, [baz,flag_bar,flag_foo]}},
+        {{<<"shards/test/blacklist*">>},{<<"shards/test/blacklist*">>,22,[flag_foo]}},
+        {{<<"shards/test*">>},{<<"shards/test*">>, 12, [baz,flag_bar,flag_foo]}},
+        {{<<"shards/exact">>},{<<"shards/exact">>, 12, [flag_bar,flag_foo]}},
+        {{<<"shards/blacklist*">>},{<<"shards/blacklist*">>, 17, []}},
+        {{<<"*">>},{<<"*">>, 1, [flag_foo]}}
+    ],
+    ?assertEqual(Expected, couch_flags_config:data(test_config())).
+
+latest_overide_wins_test_() ->
+    Cases = [
+        {[
+            {"flag||*", "false"}, {"flag||a*", "true"},
+            {"flag||ab*", "true"}, {"flag||abc*", "true"}
+        ], true},
+        {[
+            {"flag||*", "true"}, {"flag||a*", "false"},
+            {"flag||ab*", "true"}, {"flag||abc*", "false"}
+        ], false}
+    ],
+    [{test_id(Rules, Expected),
+        ?_assertEqual(Expected, lists:member(flag,
+            flags(hd(couch_flags_config:data(Rules)))))}
+            || {Rules, Expected} <- Cases].
+
+flags({{_Pattern}, {_Pattern, _Size, Flags}}) ->
+    Flags.
+
+test_id(Items, ExpectedResult) ->
+    lists:flatten(io_lib:format("~p -> ~p", [[P || {P, _} <- Items], ExpectedResult])).
+
+
+test_id(Items) ->
+    lists:flatten(io_lib:format("~p", [[P || {P, _} <- Items]])).
+
+test_config() ->
+    [
+        {"flag_foo||*", "true"},
+        {"flag_bar||*", "false"},
+        {"flag_bar||shards/test*", "true"},
+        {"flag_foo||shards/blacklist*", "false"},
+        {"baz||shards/test*", "true"},
+        {"baz||shards/test/blacklist*", "false"},
+        {"flag_bar||shards/exact", "true"},
+        {"flag_bar||shards/test/exact", "true"}
+    ].
+
+parse_flags_term_test_() ->
+    LongBinary = binary:copy(<<"a">>, ?MAX_FLAG_NAME_LENGTH + 1),
+    ExpectedError = {error, {"Cannot parse list of tags: ~n~p",
+       [{too_long, LongBinary}]}},
+    ExpectedUnknownError = {error,{"Cannot parse list of tags: ~n~p",
+       [{invalid_flag,<<"dddddddd">>}]}},
+	[
+		{"empty binary", ?_assertEqual(
+		    [], couch_flags_config:parse_flags_term(<<>>))},
+		{"single flag", ?_assertEqual(
+		    [fff], couch_flags_config:parse_flags_term(<<"fff">>))},
+		{"sorted", ?_assertEqual(
+		    [aaa,bbb,fff], couch_flags_config:parse_flags_term(<<"fff,aaa,bbb">>))},
+		{"whitespace", ?_assertEqual(
+		    [aaa,bbb,fff], couch_flags_config:parse_flags_term(<<"fff , aaa, bbb ">>))},
+		{"error", ?_assertEqual(
+		    ExpectedError, couch_flags_config:parse_flags_term(LongBinary))},
+		{"unknown_flag", ?_assertEqual(
+		    ExpectedUnknownError, couch_flags_config:parse_flags_term(<<"dddddddd">>))}
+	].
+

--- a/src/couch/test/couch_flags_config_tests.erl
+++ b/src/couch/test/couch_flags_config_tests.erl
@@ -14,7 +14,7 @@ all_combinations_return_same_result_test_() ->
          {"bar||shards/test/blacklist*", "true"}
     ],
     Expected = [
-        {{<<"shards/test/blacklist*">>},{<<"shards/test/blacklist*">>,22,[bar, foo]}},
+        {{<<"shards/test/blacklist*">>},{<<"shards/test/blacklist*">>,22,[bar, baz, foo]}},
         {{<<"shards/test*">>},{<<"shards/test*">>, 12, [baz, foo]}},
         {{<<"shards/blacklist*">>},{<<"shards/blacklist*">>, 17, [bar, foo]}},
         {{<<"*">>},{<<"*">>, 1, [bar, foo]}}


### PR DESCRIPTION
## Overview

Implementation of eunit tests in the same module with the code we are trying to test is not a good idea. The test suites in the module are conditionally compiled using `-ifdef(TEST).`. This means that depending on phase of the moon the tests can be skipped. They are certainly skipped when `eunit` is used in combination with `meck` library. This problem manifested itself in https://github.com/apache/couchdb/pull/1754 where the tests were originally introduced. The PR was merged because Travis was green and it had a `+1`. However close look at test logs (https://travis-ci.org/apache/couchdb/builds/458820868?utm_source=github_status&utm_medium=notification) on Travis reveal that the tests didn't run (search for couch_flags_config):
```
module 'couch_bt_engine_stream'
module 'couch_flags_config'
module 'couch_changes'
  module 'couch_changes_tests'
    Changes feed
      Filter _selector
        couch_changes_tests:368: should_select_basic...[0.055 s] ok
        couch_changes_tests:382: should_select_with_since...[0.001 s] ok
``` 

The only correct solution is to move tests into a suite in `test` directory. In this case compilation will be unconditional so the tests wouldn't be skipped.

This PR moves the tests and updates the expected return value so the test pass.

## Testing recommendations

1. Run `make eunit > eunit.log` without reducing the scope of testing (using apps= or tests=).
2. Consult `eunit.log` to see if tests for couch_flags_config has been run.

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/pull/1754

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
