### PR TITLE
Filter out empty missing_revs results in mem3_rep

### DIFF
--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -426,10 +426,14 @@ find_missing_revs(Acc) ->
         #doc_info{id=Id, revs=RevInfos} = couch_doc:to_doc_info(FDI),
         {Id, [R || #rev_info{rev=R} <- RevInfos]}
     end, Infos),
-    mem3_rpc:get_missing_revs(Node, Name, IdsRevs, [
+    Missing = mem3_rpc:get_missing_revs(Node, Name, IdsRevs, [
         {io_priority, {internal_repl, Name}},
         ?ADMIN_CTX
-    ]).
+    ]),
+    lists:filter(fun
+        ({_Id, [], _Ancestors}) -> false;
+        ({_Id, _Revs, _Ancestors}) -> true
+    end, Missing).
 
 
 chunk_revs(Revs) ->


### PR DESCRIPTION
This avoids needlessly making fabric:update_docs calls with emtpy doc lists.
