### PR TITLE
Port delayed_commits test to Elixir

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -33,7 +33,7 @@ X means done, - means partially
   - [ ] Port conflicts.js
   - [ ] Port cookie_auth.js
   - [ ] Port copy_doc.js
-  - [ ] Port delayed_commits.js
+  - [X] Port delayed_commits.js
   - [ ] Port design_docs.js
   - [ ] Port design_options.js
   - [ ] Port design_paths.js

--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -50,6 +50,10 @@ defmodule Couch do
   CouchDB library to power test suite.
   """
 
+  def process_url("http://" <> _ = url) do
+    url
+  end
+
   def process_url(url) do
     "http://127.0.0.1:15984" <> url
   end

--- a/test/elixir/test/delayed_commits_test.exs
+++ b/test/elixir/test/delayed_commits_test.exs
@@ -1,0 +1,31 @@
+defmodule DelayedCommitsTest do
+  use CouchTestCase
+
+  @moduledoc """
+  Test CouchDB delayed commits
+  This is a port of the delayed_commits.js suite
+
+  Note that delayed_commits is deprecated in 2.0, so this is a minimal
+  test to show it still works. delayed_commits will be removed in 3.0.
+  """
+
+  @tag config: [
+         {"couchdb", "delayed_commits", "true"}
+       ]
+  @tag :with_db
+  test "delayed commit", context do
+    db_name = context[:db_name]
+    doc_id = "doc-1"
+    resp = Couch.put("/#{db_name}/#{doc_id}", body: %{a: 2, b: 4})
+    assert resp.status_code in 201..204
+    assert resp.body["ok"]
+
+    resp = Couch.get("/#{db_name}/#{doc_id}")
+    assert resp.status_code == 200, "The new doc should be in the database"
+
+    restart_cluster()
+
+    resp = Couch.get("/#{db_name}/#{doc_id}")
+    assert resp.status_code == 404, "The new doc should be missing"
+  end
+end


### PR DESCRIPTION
## Overview

This PR adds a new helper function to `test_helper` allowing to restart a node or the whole cluster and ports `delayed_commits` test.

## Testing recommendations

`make elixir` should pass, output log should include:
```
...
DelayedCommitsTest
  * test delayed commit (9208.3ms)
...
```

## Related Issues or Pull Requests

Closes #1704 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
