### PR TITLE
Ignore clang compile commands database file

### DIFF
--- a/src/couch/.gitignore
+++ b/src/couch/.gitignore
@@ -10,6 +10,7 @@ priv/*.lib
 priv/*.dll
 priv/*.exe
 vc120.pdb
+compile_commands.json
 
 test/engines/coverage/
 test/engines/data/


### PR DESCRIPTION
## Overview

New rebar leaves behind a clang compile commands database file after compiling the ports. This is a simple update to include it into `.gitignore`

