### PR TITLE
Support specifying individual Elixir tests to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ COUCHDB_VERSION = $(RELTAG)$(DIRTY)
 endif
 endif
 
+# needed to do text substitutions
+comma:= ,
+empty:=
+space:= $(empty) $(empty)
+
 DESTDIR=
 
 # Rebar options
@@ -80,6 +85,7 @@ DIALYZE_OPTS=$(shell echo "\
 	apps=$(apps) \
 	skip_deps=$(skip_deps) \
 	" | sed -e 's/[a-z]\{1,\}= / /g')
+EXUNIT_OPTS=$(subst $(comma),$(space),$(tests))
 
 #ignore javascript tests
 ignore_js_suites=
@@ -195,7 +201,7 @@ python-black-update: .venv/bin/black
 
 .PHONY: elixir
 elixir: elixir-check-formatted elixir-credo devclean
-	@dev/run -a adm:pass --no-eval test/elixir/run
+	@dev/run -a adm:pass --no-eval test/elixir/run $(EXUNIT_OPTS)
 
 .PHONY: elixir-check-formatted
 elixir-check-formatted:

--- a/Makefile.win
+++ b/Makefile.win
@@ -60,6 +60,11 @@ COUCHDB_VERSION = $(RELTAG)$(DIRTY)
 endif
 endif
 
+# needed to do text substitutions
+comma:= ,
+empty:=
+space:= $(empty) $(empty)
+
 DESTDIR=
 
 # Rebar options
@@ -71,6 +76,8 @@ tests=
 # no sed on Windows, hard code since apps\suites\tests are empty
 EUNIT_OPTS=skip_deps=$(skip_deps)
 DIALYZE_OPTS=skip_deps=$(skip_deps)
+
+EXUNIT_OPTS=$(subst $(comma),$(space),$(tests))
 
 ################################################################################
 # Main commands
@@ -166,7 +173,7 @@ python-black-update: .venv/bin/black
 
 .PHONY: elixir
 elixir: elixir-check-formatted elixir-credo devclean
-	@dev\run -a adm:pass --no-eval test\elixir\run.cmd
+	@dev\run -a adm:pass --no-eval test\elixir\run.cmd $(EXUNIT_OPTS)
 
 .PHONY: elixir-check-formatted
 elixir-check-formatted:

--- a/test/elixir/run
+++ b/test/elixir/run
@@ -3,4 +3,4 @@ cd "$(dirname "$0")"
 mix local.hex --force
 mix local.rebar --force
 mix deps.get
-mix test --trace
+mix test --trace "$@"

--- a/test/elixir/run.cmd
+++ b/test/elixir/run.cmd
@@ -4,4 +4,4 @@ cd %~dp0
 call mix local.hex --force
 call mix local.rebar --force
 call mix deps.get
-call mix test --trace
+call mix test --trace %*


### PR DESCRIPTION
## Overview

Introduction of an Elixir based integration tests is a great thing. This PR adds an ability to run tests individually from a Makefile. Similar to the way we do it with eunit. 

Individual tests can be specified as:

- `make elixir tests=test/basics_test.exs`
- `make elixir tests=test/basics_test.exs,test/config_test.exs`
- `make elixir tests=test/basics_test.exs:17`

## Testing recommendations

### on UNIX

```
make elixir tests=test/basics_test.exs
make elixir tests=test/basics_test.exs,test/config_test.exs
make elixir tests=test/basics_test.exs:17
```

### on Windows

```
make elixir tests=test\basics_test.exs
make elixir tests=test\basics_test.exs,test\config_test.exs
make elixir tests=test\basics_test.exs:17
```

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
