### PR TITLE
Fix running elixir test suite

### DIFF
--- a/test/elixir/lib/couch/db_test.ex
+++ b/test/elixir/lib/couch/db_test.ex
@@ -1,4 +1,6 @@
 defmodule Couch.DBTest do
+  @moduledoc false
+
   import ExUnit.Callbacks, only: [on_exit: 1]
   import ExUnit.Assertions, only: [assert: 1, assert: 2]
 

--- a/test/elixir/test/support/couch_test_case.ex
+++ b/test/elixir/test/support/couch_test_case.ex
@@ -1,4 +1,6 @@
 defmodule CouchTestCase do
+  @moduledoc false
+
   use ExUnit.CaseTemplate
 
   using do


### PR DESCRIPTION
## Overview

`moduledoc` attribute is now mandatory according to credo policy

## Testing recommendations

`make elixir`

## Related Issues or Pull Requests

Fix for PR #1801 

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
