### PR TITLE
Make view query limits configurable

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -293,6 +293,8 @@ os_process_limit = 100
 ; Timeout for how long a response from a busy view group server can take.
 ; "infinity" is also a valid configuration value.
 ;group_info_timeout = 5000
+;query_limit = 268435456
+;partition_query_limit = 268435456
 
 [mango]
 ; Set to true to disable the "index all fields" text index, which can lead

--- a/src/couch_mrview/include/couch_mrview.hrl
+++ b/src/couch_mrview/include/couch_mrview.hrl
@@ -60,6 +60,7 @@
     view_states=nil
 }).
 
+-define(MAX_VIEW_LIMIT, 16#10000000).
 
 -record(mrargs, {
     view_type,
@@ -74,7 +75,7 @@
     keys,
 
     direction = fwd,
-    limit = 16#10000000,
+    limit = ?MAX_VIEW_LIMIT,
     skip = 0,
     group_level = 0,
     group = undefined,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This allows us to set a maximun allowed number of documents
to be returned for a global or a partitioned query.

## Testing recommendations

Set a view limit in the default.ini. 

* A query with a limit larger than the max will error
* A query with the limit value below the max will run the query. A
* A query with no limit will use the max limit set.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
