### PR TITLE
Fix haproxy config file location

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -381,7 +381,7 @@ def write_config(ctx, node, env):
 def boot_haproxy(ctx):
     if not ctx["with_haproxy"]:
         return
-    config = os.path.join(ctx["devdir"], "rel", "haproxy.cfg")
+    config = os.path.join(ctx["devdir"], "lib", "haproxy.cfg")
     cmd = [ctx["haproxy"], "-f", config]
     logfname = os.path.join(ctx["devdir"], "logs", "haproxy.log")
     log = open(logfname, "w")


### PR DESCRIPTION
## Overview

The problem was introduced in https://github.com/apache/couchdb/commit/94eff0d8ddcdb552389b4273f771aba211e4e57c during rebase of https://github.com/apache/couchdb/pull/1774
The location of generated config file is `os.path.join(ctx["devdir"], "lib", "haproxy.cfg")` (see https://github.com/apache/couchdb/commit/94eff0d8ddcdb552389b4273f771aba211e4e57c#diff-d86563699bde00df2cce2613ecbed531R281). We attempt to start haproxy with config located at `os.path.join(ctx["devdir"], "rel", "haproxy.cfg")` (see https://github.com/apache/couchdb/commit/94eff0d8ddcdb552389b4273f771aba211e4e57c#diff-d86563699bde00df2cce2613ecbed531R384). Which is obviously incorrect since we suppose to use generated config file.

## Testing recommendations

Run `dev/run --with-haproxy` and make sure haproxy process is running

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/1774

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
