### PR TITLE
Increase timeout on restart in JS/elixir tests to 30s

### DIFF
--- a/test/elixir/lib/couch/db_test.ex
+++ b/test/elixir/lib/couch/db_test.ex
@@ -273,7 +273,7 @@ defmodule Couch.DBTest do
     # enough to inroduce a race here
     retry_until(fn -> !node_is_running(port) end)
     # wait utill node is back
-    retry_until(fn -> node_is_running(port) end, 500, 10_000)
+    retry_until(fn -> node_is_running(port) end, 500, 30_000)
   end
 
   defp node_is_running(port) do

--- a/test/javascript/test_setup.js
+++ b/test/javascript/test_setup.js
@@ -106,12 +106,12 @@ function restartServer() {
     } catch (e) {}
 
     var now = new Date().getTime();
-    if (now > start + 15000) {
+    if (now > start + 30000) {
       try {
         uptime = getUptime();
         throw(Error('FAILED to restart: ' + uptime + ' not < ' + olduptime));
       } catch (e) {
-        throw(Error('FAILED to restart: server is unresponsive, waited 15s'));
+        throw(Error('FAILED to restart: server is unresponsive, waited 30s'));
       }
     }
   }


### PR DESCRIPTION
## Overview

Currently, when a JS or Elixir test restarts a node, it waits 15 or 10 seconds respectively for it to come back.

CI systems have shown this is not enough. Most recent failure is here:
    https://builds.apache.org/blue/organizations/jenkins/CouchDB/detail/master/448/pipeline
but it's been happening semi-regularly since we reworked the restart code.

This PR bumps the timeout to 30s in both places.