### PR TITLE
Suppress credo TODO suggests

### DIFF
--- a/test/elixir/.credo.exs
+++ b/test/elixir/.credo.exs
@@ -70,7 +70,7 @@
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
         #
-        {Credo.Check.Design.TagTODO, [exit_status: 0]},
+        {Credo.Check.Design.TagTODO, false},
         {Credo.Check.Design.TagFIXME, []},
 
         #
@@ -108,7 +108,10 @@
         {Credo.Check.Refactor.NegatedConditionsWithElse, []},
         {Credo.Check.Refactor.Nesting, false},
         {Credo.Check.Refactor.PipeChainStart,
-         [excluded_argument_types: [:atom, :binary, :fn, :keyword], excluded_functions: []]},
+         [
+           excluded_argument_types: [:atom, :binary, :fn, :keyword],
+           excluded_functions: []
+         ]},
         {Credo.Check.Refactor.UnlessWithElse, []},
 
         #


### PR DESCRIPTION
## Overview

Suppress credo TODO suggests.

## Testing recommendations

Credo output in `make elixir` looks like:
```shell
Analysis took 3.4 seconds (0.04s to load, 3.4s running checks)
135 mods/funs, found no issues.
```

## Related Issues or Pull Requests

Discussed in PR #1812.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
