### PR TITLE
Handle invalid user docid in changes_callback

### DIFF
--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -160,9 +160,12 @@ changes_callback({change, {Change}}, _) ->
         <<"_design/", _/binary>> ->
             ok;
         DocId ->
-            UserName = username(DocId),
-            couch_log:debug("Invalidating cached credentials for ~s", [UserName]),
-            ets_lru:remove(?CACHE, UserName)
+            try
+                UserName = username(DocId),
+                couch_log:debug("Invalidating cached credentials for ~s", [UserName]),
+                ets_lru:remove(?CACHE, UserName)
+            catch _:_ -> couch_log:info("Invalid user document id for ~s", [DocId])
+            end
     end,
     {ok, couch_util:get_value(seq, Change)};
 changes_callback(timeout, Acc) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Handle user document id without correct id. I simply catch any errors and log a debug message (perhaps we want a info or warn level message?)

## Testing recommendations

1. Disable the VDU in _users database (I removed the validate function)
2. Set the log level to Debug
3. Add an valid user without an id (let Couch generate one)
4. Replicate the user database to another database to trigger the changes_callback function.
5. You should see the debug level saying that the id is invalid and the cache reader should not throw a function clause. 

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

#1821 

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
