### PR TITLE
Re-Introduce cpse_test_purge_seqs

### DIFF
--- a/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
@@ -12,7 +12,6 @@
 
 -module(cpse_test_purge_seqs).
 -compile(export_all).
--compile(nowarn_export_all).
 
 
 -include_lib("eunit/include/eunit.hrl").
@@ -99,10 +98,13 @@ cpse_increment_purge_multiple_times(DbName) ->
 
 
 cpse_increment_purge_seq_on_partial_purge(DbName) ->
-    Doc1 = {[{'_id', foo}, {vsn, 1}]},
-    Doc2 = {[{'_id', foo}, {vsn, 2}]},
-    {ok, Rev1} = cpse_util:save_doc(DbName, Doc1),
-    {ok, _Rev2} = cpse_util:save_doc(DbName, Doc2, [replicated_changes]),
+    {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, <<"1.1">>}]}),
+    Update = {[
+        {'_id', foo1},
+        {'_rev', couch_doc:rev_to_str({1, [crypto:hash(md5, <<"1.2">>)]})},
+        {vsn, <<"1.2">>}
+    ]},
+    {ok, [_Rev2]} = cpse_util:save_docs(DbName, [Update], [replicated_changes]),
 
     cpse_util:assert_db_props(?MODULE, ?LINE, DbName, [
         {doc_count, 1},

--- a/src/couch_pse_tests/src/cpse_util.erl
+++ b/src/couch_pse_tests/src/cpse_util.erl
@@ -31,7 +31,8 @@
     cpse_test_purge_replication,
     cpse_test_purge_bad_checkpoints,
     cpse_test_compaction,
-    cpse_test_ref_counting
+    cpse_test_ref_counting,
+    cpse_test_purge_seqs
 ]).
 
 


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
 Re-introduce cpse_test_purge_seqs after fixing issue on `cpse_test_purge_seqs:cpse_increment_purge_seq_on_partial_purge/1` with undef issue.
```
      cpse_gather: make_test_fun (cpse_increment_purge_seq_on_partial_purge)...*failed*
in function cpse_util:save_doc/3
  called as save_doc(<<"db-475a26f2204d6b20d19fc5334d8f4adb">>,{[{'_id',foo},{vsn,2}]},[replicated_changes])
in call from cpse_test_purge_seqs:cpse_increment_purge_seq_on_partial_purge/1 (src/cpse_test_purge_seqs.erl, line 105)
**error:undef
  output:<<"">>
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

```
   cpse_test_purge_seqs
      cpse_gather: make_test_fun (cpse_increment_purge_seq_on_complete_purge)...[0.100 s] ok
      cpse_gather: make_test_fun (cpse_increment_purge_multiple_times)...[0.074 s] ok
      cpse_gather: make_test_fun (cpse_increment_purge_seq_on_partial_purge)...[0.080 s] ok
      [done in 0.377 s]
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/1798

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
