### PR TITLE
Change minimum supported Erlang version to OTP 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ otp_release:
    - 21.1
    - 20.3
    - 19.3
-   - 18.3
-   - 17.5
 
 addons:
   apt:

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -91,7 +91,7 @@ ErlOpts = case os:getenv("ERL_OPTS") of
 end,
 
 AddConfig = [
-    {require_otp_vsn, "17|18|19|20|21"},
+    {require_otp_vsn, "19|20|21"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs)},
     {sub_dirs, SubDirs},

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -146,10 +146,6 @@ PortSpecs = case os:type() of
         BaseSpecs
 end,
 PlatformDefines = [
-   {platform_define, "^R16", 'PRE18TIMEFEATURES'},
-   {platform_define, "^17", 'PRE18TIMEFEATURES'},
-   {platform_define, "^R16", 'NORANDMODULE'},
-   {platform_define, "^17", 'NORANDMODULE'},
    {platform_define, "win32", 'WINDOWS'}
 ],
 AddConfig = [

--- a/src/couch/src/couch_rand.erl
+++ b/src/couch/src/couch_rand.erl
@@ -19,39 +19,9 @@
 ]).
 
 
--ifdef(NORANDMODULE).
-
-
-uniform() ->
-    maybe_set_random_seed(),
-    random:uniform().
-
-
-uniform(N) ->
-    maybe_set_random_seed(),
-    random:uniform(N).
-
-
-maybe_set_random_seed() ->
-    case get(random_seed) of
-        undefined ->
-            {_, Sec, USec} = os:timestamp(),
-            Seed = {erlang:phash2(self()), Sec, USec},
-            random:seed(Seed);
-        _ ->
-            ok
-    end.
-
-
--else.
-
-
 uniform() ->
     rand:uniform().
 
 
 uniform(N) ->
     rand:uniform(N).
-
-
--endif.

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -737,18 +737,9 @@ process_dict_get(Pid, Key, DefaultValue) ->
     end.
 
 
--ifdef(PRE18TIMEFEATURES).
-
-unique_monotonic_integer() ->
-    {Ms, S, Us} = erlang:now(),
-    (Ms * 1000000 + S) * 1000000 + Us.
-
--else.
-
 unique_monotonic_integer() ->
     erlang:unique_integer([monotonic, positive]).
 
--endif.
 
 check_config_blacklist(Section) ->
     case lists:member(Section, ?BLACKLIST_CONFIG_SECTIONS) of


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The informal proposal on the couchdb-dev mailing list to change the minimum supported Erlang version to OTP 19 seems to have passed unanimously.

This removes references to earlier versions from travis and rebar files. It also removes platform defines and ifdefs necessary to compile using earlier versions.

The main benefits are speeding up Travis by not having to run tests against two platforms, and simplifying some code, making it easier to reason about and maintain.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

`make eunit`

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
