### PR TITLE
Add chttpd stats

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -265,6 +265,7 @@ handle_request_int(MochiReq) ->
 
 before_request(HttpReq) ->
     try
+        chttpd_stats:init(),
         chttpd_plugin:before_request(HttpReq)
     catch Tag:Error ->
         {error, catch_error(HttpReq, Tag, Error)}
@@ -280,6 +281,7 @@ after_request(HttpReq, HttpResp0) ->
             {ok, HttpResp0#httpd_resp{status = aborted}}
         end,
     HttpResp2 = update_stats(HttpReq, HttpResp1),
+    chttpd_stats:report(HttpReq, HttpResp2),
     maybe_log(HttpReq, HttpResp2),
     HttpResp2.
 

--- a/src/chttpd/src/chttpd_show.erl
+++ b/src/chttpd/src/chttpd_show.erl
@@ -25,6 +25,7 @@
 maybe_open_doc(Db, DocId, Options) ->
     case fabric:open_doc(Db, DocId, Options) of
     {ok, Doc} ->
+        chttpd_stats:incr_reads(),
         Doc;
     {not_found, _} ->
         nil
@@ -135,6 +136,7 @@ send_doc_update_response(Req, Db, DDoc, UpdateName, Doc, DocId) ->
             NewDoc = couch_db:doc_from_json_obj_validate(Db, {NewJsonDoc}),
             couch_doc:validate_docid(NewDoc#doc.id),
             {UpdateResult, NewRev} = fabric:update_doc(Db, NewDoc, Options),
+            chttpd_stats:incr_writes(),
             NewRevStr = couch_doc:rev_to_str(NewRev),
             case {UpdateResult, NewRev} of
             {ok, _} ->
@@ -201,7 +203,7 @@ handle_view_list(Req, Db, DDoc, LName, {ViewDesignName, ViewName}, Keys) ->
     couch_util:get_nested_json_value(DDoc#doc.body, [<<"lists">>, LName]),
     DbName = couch_db:name(Db),
     {ok, VDoc} = ddoc_cache:open(DbName, <<"_design/", ViewDesignName/binary>>),
-    CB = fun couch_mrview_show:list_cb/2,
+    CB = fun list_cb/2,
     QueryArgs = couch_mrview_http:parse_params(Req, Keys),
     Options = [{user_ctx, Req#httpd.user_ctx}],
     couch_query_servers:with_ddoc_proc(DDoc, fun(QServer) ->
@@ -219,6 +221,19 @@ handle_view_list(Req, Db, DDoc, LName, {ViewDesignName, ViewName}, Keys) ->
                     CB, Acc, QueryArgs)
         end
     end).
+
+
+list_cb({row, Row} = Msg, Acc) ->
+    case lists:keymember(doc, 1, Row) of
+        true -> chttpd_stats:incr_reads();
+        false -> ok
+    end,
+    chttpd_stats:incr_rows(),
+    couch_mrview_show:list_cb(Msg, Acc);
+
+list_cb(Msg, Acc) ->
+    couch_mrview_show:list_cb(Msg, Acc).
+
 
 % Maybe this is in the proplists API
 % todo move to couch_util

--- a/src/chttpd/src/chttpd_stats.erl
+++ b/src/chttpd/src/chttpd_stats.erl
@@ -1,0 +1,107 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License.  You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_stats).
+
+
+-export([
+    init/0,
+    report/2,
+
+    incr_reads/0,
+    incr_reads/1,
+
+    incr_writes/0,
+    incr_writes/1,
+
+    incr_rows/0,
+    incr_rows/1
+]).
+
+
+-record(st, {
+    reads = 0,
+    writes = 0,
+    rows = 0
+}).
+
+
+-define(KEY, chttpd_stats).
+
+
+init() ->
+    put(?KEY, #st{}).
+
+
+report(HttpReq, HttpResp) ->
+    try
+        case get(?KEY) of
+            #st{} = St ->
+                report(HttpReq, HttpResp, St);
+            _ ->
+                ok
+        end
+    catch T:R ->
+        S = erlang:get_stacktrace(),
+        Fmt = "Failed to report chttpd request stats: ~p:~p ~p",
+        couch_log:error(Fmt, [T, R, S])
+    end.
+
+
+report(HttpReq, HttpResp, St) ->
+    case config:get("chttpd", "stats_reporter") of
+        undefined ->
+            ok;
+        ModStr ->
+            Mod = list_to_existing_atom(ModStr),
+            #st{
+                reads = Reads,
+                writes = Writes,
+                rows = Rows
+            } = St,
+            Mod:report(HttpReq, HttpResp, Reads, Writes, Rows)
+    end.
+
+
+incr_reads() ->
+    incr(#st.reads, 1).
+
+
+incr_reads(N) when is_integer(N), N >= 0 ->
+    incr(#st.reads, N).
+
+
+incr_writes() ->
+    incr(#st.writes, 1).
+
+
+incr_writes(N) when is_integer(N), N >= 0 ->
+    incr(#st.writes, N).
+
+
+incr_rows() ->
+    incr(#st.rows, 1).
+
+
+incr_rows(N) when is_integer(N), N >= 0 ->
+    incr(#st.rows, N).
+
+
+incr(Idx, Count) ->
+    case get(?KEY) of
+        #st{} = St ->
+            Total = element(Idx, St) + Count,
+            NewSt = setelement(Idx, St, Total),
+            put(?KEY, NewSt);
+        _ ->
+            ok
+    end.


### PR DESCRIPTION
## Overview

This adds an advanced API for users that want to write some Erlang to be able to collect request level metrics for reporting.

## Testing recommendations

`make check`

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
