### PR TITLE
Fix end_time field in /_replicate response

### DIFF
--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -735,8 +735,8 @@ do_checkpoint(State) ->
     {SrcInstanceStartTime, TgtInstanceStartTime} ->
         couch_log:notice("recording a checkpoint for `~s` -> `~s` at source update_seq ~p",
             [SourceName, TargetName, NewSeq]),
-        UniversalStartTime = calendar:now_to_universal_time(ReplicationStartTime),
-        StartTime = ?l2b(httpd_util:rfc1123_date(UniversalStartTime)),
+        LocalStartTime = calendar:now_to_local_time(ReplicationStartTime),
+        StartTime = ?l2b(httpd_util:rfc1123_date(LocalStartTime)),
         EndTime = ?l2b(httpd_util:rfc1123_date()),
         NewHistoryEntry = {[
             {<<"session_id">>, SessionId},


### PR DESCRIPTION
Previously `end_time` was generated converting the start_time to universal,
then passing that to `httpd_util:rfc1123_date/1`. However, `rfc1123_date/1`
also transates its argument from local to UTC time, that is it accepts input to
be in local time format.

Fixes #1841
