### PR TITLE
Fix read repair in a mixed cluster environment

### DIFF
--- a/src/fabric/src/fabric_doc_open.erl
+++ b/src/fabric/src/fabric_doc_open.erl
@@ -136,7 +136,7 @@ read_repair(#acc{dbname=DbName, replies=Replies, node_revs=NodeRevs}) ->
     [#doc{id = <<?LOCAL_DOC_PREFIX, _/binary>>} | _] ->
         choose_reply(Docs);
     [#doc{id=Id} | _] ->
-        Opts = [?ADMIN_CTX, {read_repair, NodeRevs}],
+        Opts = [?ADMIN_CTX, replicated_changes, {read_repair, NodeRevs}],
         Res = fabric:update_docs(DbName, Docs, Opts),
         case Res of
             {ok, []} ->

--- a/src/fabric/src/fabric_doc_open_revs.erl
+++ b/src/fabric/src/fabric_doc_open_revs.erl
@@ -224,7 +224,7 @@ dict_repair_docs(Replies, ReplyCount) ->
 
 
 read_repair(Db, Docs, NodeRevs) ->
-    Opts = [?ADMIN_CTX, {read_repair, NodeRevs}],
+    Opts = [?ADMIN_CTX, replicated_changes, {read_repair, NodeRevs}],
     Res = fabric:update_docs(Db, Docs, Opts),
     case Res of
         {ok, []} ->


### PR DESCRIPTION
This enables backwards compatbility with nodes still running the old
version of fabric_rpc when a cluster is upgraded to master. This has no
effect once all nodes are upgraded to the latest version.
