### PR TITLE
Support one purge request with more than 100 docid

### DIFF
--- a/src/fabric/src/fabric_doc_purge.erl
+++ b/src/fabric/src/fabric_doc_purge.erl
@@ -191,7 +191,7 @@ format_resps(UUIDs, #acc{} = Acc) ->
                 [{UUID, {Health, AllRevs}} | ReplyAcc]
         end
     end,
-    FinalReplies = dict:fold(FoldFun, {ok, []}, Resps),
+    FinalReplies = dict:fold(FoldFun, [], Resps),
     couch_util:reorder_results(UUIDs, FinalReplies);
 
 format_resps(_UUIDs, Else) ->


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
This PR is aimed to solve the following error when sending one purge request with more than 100 docid.
```
<<"{\"error\":\"unknown_error\",\"reason\":\"function_clause\",\"ref\":1363930458}\n">>
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make check skip_deps+=couch_epi apps=chttpd tests=purge_test_
chttpd db tests
Application crypto was left running!
  chttpd_purge_tests:88: test_empty_purge_request...[0.019 s] ok
  chttpd_purge_tests:105: test_ok_purge_request...[0.232 s] ok
  chttpd_purge_tests:142: test_ok_purge_request_with_101_docid...[3.268 s] ok
  chttpd_purge_tests:162: test_accepted_purge_request...[0.243 s] ok
  chttpd_purge_tests:194: test_partial_purge_request...[0.087 s] ok
  chttpd_purge_tests:230: test_mixed_purge_request...[0.188 s] ok
  chttpd_purge_tests:278: test_overmany_ids_or_revs_purge_request...[0.124 s] ok
  chttpd_purge_tests:328: test_exceed_limits_on_purge_infos...[0.148 s] ok
  chttpd_purge_tests:371: should_error_set_purged_docs_limit_to0...[0.003 s] ok
  chttpd_purge_tests:379: test_timeout_set_purged_infos_limit...[0.188 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 7.484 s]
=======================================================
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
COUCHDB-3226

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
