### PR TITLE
Update couchup

### DIFF
--- a/rel/overlay/bin/couchup
+++ b/rel/overlay/bin/couchup
@@ -22,7 +22,7 @@ import sys
 try:
     from urllib.parse import quote
 except ImportError:
-    from urllib.parse import quote
+    from urllib import quote
 import requests
 
 try:


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The couchup script was not running if using python2, missing the quote from urllib

According to the python3 docuymentation:

>  The urllib module has been split into parts and renamed in Python 3 to urllib.request, urllib.parse, and urllib.error. 

At the couchup script, the 2 alternatives at lines 22 and 24 are both importing the python3 alternative.

## Testing recommendations

To test is just run the script on python2 before and after the change, because the error its just the import statement.


