### PR TITLE
Add a test for a doc read with etag

### DIFF
--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -100,7 +100,9 @@ defmodule Couch do
   end
 
   def process_response_body(headers, body) do
-    if String.match?(headers[:"Content-Type"], ~r/application\/json/) do
+    content_type = headers[:"Content-Type"]
+
+    if !!content_type and String.match?(content_type, ~r/application\/json/) do
       body |> IO.iodata_to_binary() |> :jiffy.decode([:return_maps])
     else
       process_response_body(body)

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -85,6 +85,17 @@ defmodule BasicsTest do
   end
 
   @tag :with_db
+  test "A document read with etag works", context do
+    db_name = context[:db_name]
+    {:ok, resp} = create_doc(db_name, sample_doc_foo())
+    etag = ~s("#{resp.body["rev"]}")
+    resp = Couch.get("/#{db_name}/foo", headers: ["If-None-Match": etag])
+    assert resp.status_code == 304, "Should be 304 Not Modified"
+    assert resp.headers[:"Content-Length"] == "0", "Should have zero content length"
+    assert resp.body == "", "Should have an empty body"
+  end
+
+  @tag :with_db
   test "Make sure you can do a seq=true option", context do
     db_name = context[:db_name]
     {:ok, _} = create_doc(db_name, sample_doc_foo())


### PR DESCRIPTION
## Overview

This is a new test for a doc read with etag (`If-None-Match` header) to confirm that it works properly.

## Testing recommendations

Isolated:
`make elixir tests=test/basics_test.exs:88`

Complete:
`make elixir`

## Related Issues or Pull Requests

Inspired by #1863 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
