### PR TITLE
fix test url to fix test

### DIFF
--- a/test/elixir/test/partition_design_docs_test.exs
+++ b/test/elixir/test/partition_design_docs_test.exs
@@ -9,7 +9,7 @@ defmodule PartitionDesignDocsTest do
   test "/_partition/:pk/_design/doc 404", context do
     db_name = context[:db_name]
 
-    url = "/#{db_name}/_partition/fake-key/_design/mrtest/"
+    url = "/#{db_name}/_partition/fakekey/_design/mrtest/_view/some"
     resp = Couch.get(url)
     assert resp.status_code == 404
   end


### PR DESCRIPTION
## Overview

Fix the url in the test to an actual map/reduce query url. CouchDB then correctly returns a 404.

## Testing recommendations

Run test

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
