### PR TITLE
Update config dependency to 2.1.5

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -85,7 +85,7 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{config,           "config",           {tag, "2.1.4"}},
+{config,           "config",           {tag, "2.1.5"}},
 {b64url,           "b64url",           {tag, "1.0.1"}},
 {ets_lru,          "ets-lru",          {tag, "1.0.0"}},
 {khash,            "khash",            {tag, "1.0.1"}},


### PR DESCRIPTION
This fixes inability to set keys with regex symbols in them
