### PR TITLE
rename partitions feature to partitioned feature

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -223,7 +223,7 @@ init([]) ->
     config:enable_feature('pluggable-storage-engines'),
 
     % Mark partitioned databases as a supported feature
-    config:enable_feature(partitions),
+    config:enable_feature(partitioned),
 
     % read config and register for configuration changes
 


### PR DESCRIPTION
## Overview

Rename the `partitions` feature to `partitioned` feature to be consistent with how the flag is used everywhere else.

## Testing recommendations

Using curl
```
curl http://adm:pass@localhost:15984
{"couchdb":"Welcome","version":"2.3.0-17f05b758-dirty","git_sha":"17f05b758","uuid":"fake_uuid_for_dev","features":["partitioned","pluggable-storage-engines","scheduler"],"vendor":{"name":"The Apache Software Foundation"}}
```
Should say partitioned


## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
