### PR TITLE
Make it possible to override elixir couchdb settings via environmental variables

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -11,7 +11,16 @@ mix deps.get
 mix test --trace
 ```
 
-# Tests to port
+## Set CouchDB credentials
+
+By default the Elixir tests require CouchDB running at http://127.0.0.1:15984 with credentials `adm:pass`.
+You can override those using the following:
+
+```
+$ USER=myusername PASS=password COUCH_URL=http://my-couchdb.com mix test
+```
+
+## Tests to port
 
 X means done, - means partially
 

--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -55,7 +55,8 @@ defmodule Couch do
   end
 
   def process_url(url) do
-    "http://127.0.0.1:15984" <> url
+    baseUrl = System.get_env("COUCH_URL") || "http://127.0.0.1:15984"
+    baseUrl <> url
   end
 
   def process_request_headers(headers, options) do
@@ -84,7 +85,9 @@ defmodule Couch do
       if headers[:basic_auth] != nil or headers[:authorization] != nil do
         options
       else
-        Keyword.put(options, :basic_auth, {"adm", "pass"})
+        username = System.get_env("USER") || "adm"
+        password = System.get_env("PASS") || "pass"
+        Keyword.put(options, :basic_auth, {username, password})
       end
     else
       options


### PR DESCRIPTION
## Overview

Make it possible to override elixir couchdb settings via environmental variables

## Testing recommendations

Spin up a local CouchDB cluster with different settings to what Elixir requires by default.
Run `USER=myusername PASS=password COUCH_URL=http://my-couchdb.com mix test `
and make sure the tests will run.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
