### PR TITLE
Add junit formatter to the elixir tests

### DIFF
--- a/test/elixir/mix.exs
+++ b/test/elixir/mix.exs
@@ -29,7 +29,8 @@ defmodule Foo.Mixfile do
       # {:dep_from_hexpm, "~> 0.3.0"},
       {:httpotion, "~> 3.0"},
       {:jiffy, "~> 0.15.2"},
-      {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false}
+      {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
+      {:junit_formatter, "~> 3.0", only: [:test]}
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]
   end

--- a/test/elixir/mix.lock
+++ b/test/elixir/mix.lock
@@ -5,4 +5,5 @@
   "ibrowse": {:hex, :ibrowse, "4.4.1", "2b7d0637b0f8b9b4182de4bd0f2e826a4da2c9b04898b6e15659ba921a8d6ec2", [:rebar3], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jiffy": {:hex, :jiffy, "0.15.2", "de266c390111fd4ea28b9302f0bc3d7472468f3b8e0aceabfbefa26d08cd73b7", [:rebar3], [], "hexpm"},
+  "junit_formatter": {:hex, :junit_formatter, "3.0.0", "13950d944dbd295da7d8cc4798b8faee808a8bb9b637c88069954eac078ac9da", [:mix], [], "hexpm"},
 }

--- a/test/elixir/test/test_helper.exs
+++ b/test/elixir/test/test_helper.exs
@@ -1,3 +1,7 @@
-ExUnit.configure(exclude: [pending: true], formatters: [JUnitFormatter, ExUnit.CLIFormatter])
+ExUnit.configure(
+  exclude: [pending: true],
+  formatters: [JUnitFormatter, ExUnit.CLIFormatter]
+)
+
 ExUnit.start()
 Code.require_file("partition_helpers.exs", __DIR__)

--- a/test/elixir/test/test_helper.exs
+++ b/test/elixir/test/test_helper.exs
@@ -1,3 +1,3 @@
-ExUnit.configure(exclude: [pending: true])
+ExUnit.configure(exclude: [pending: true], formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()
 Code.require_file("partition_helpers.exs", __DIR__)


### PR DESCRIPTION
## Overview

Adds the junit formatter for the elixir tests so that Jenkins can read the test output nicely

## Testing recommendations
run `mix test` and then look under `_build/test/lib/foo/test-junit-report.xml` for the xml output

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
