### PR TITLE
Force mix rebar/hex/deps get on make elixir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,8 +201,12 @@ python-black-update: .venv/bin/black
 		. dev/run rel/overlay/bin/couchup test/javascript/run
 
 .PHONY: elixir
-elixir: elixir-check-formatted elixir-credo devclean
+elixir: elixir-init elixir-check-formatted elixir-credo devclean
 	@dev/run -a adm:pass --no-eval 'test/elixir/run --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+
+.PHONY: elixir-init
+elixir-init:
+	@cd test/elixir && mix local.rebar --force && mix local.hex --force && mix deps.get
 
 .PHONY: elixir-cluster-without-quorum
 elixir-cluster-without-quorum: elixir-check-formatted elixir-credo devclean
@@ -224,7 +228,7 @@ elixir-check-formatted:
 # We use it in our tests
 .PHONY: elixir-credo
 elixir-credo:
-	@cd test/elixir/ && mix deps.get && mix credo
+	@cd test/elixir/ && mix credo
 
 .PHONY: javascript
 # target: javascript - Run JavaScript test suites or specific ones defined by suites option

--- a/Makefile.win
+++ b/Makefile.win
@@ -172,20 +172,24 @@ python-black-update: .venv/bin/black
 		. dev\run rel\overlay\bin\couchup test\javascript\run
 
 .PHONY: elixir
-elixir: elixir-check-formatted elixir-credo devclean
+elixir: elixir-init elixir-check-formatted elixir-credo devclean
 	@dev\run -a adm:pass --no-eval 'test\elixir\run.cmd --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+
+.PHONY: elixir-init
+elixir-init:
+	@cd test/elixir && mix local.rebar --force && mix local.hex --force && mix deps.get
 
 .PHONY: elixir-cluster-without-quorum
 elixir-cluster-without-quorum: elixir-check-formatted elixir-credo devclean
 	@dev\run -n 3 -q -a adm:pass \
 	         --degrade-cluster 2 \
-                 --no-eval 'test\elixir\run --only without_quorum_test $(EXUNIT_OPTS)'
+                 --no-eval 'test\elixir\run.cmd --only without_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-cluster-with-quorum
 elixir-cluster-with-quorum: elixir-check-formatted elixir-credo devclean
 	@dev\run -n 3 -q -a adm:pass \
 	         --degrade-cluster 1 \
-		 --no-eval 'test\elixir\run --only with_quorum_test $(EXUNIT_OPTS)'
+		 --no-eval 'test\elixir\run.cmd --only with_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-check-formatted
 elixir-check-formatted:
@@ -195,7 +199,7 @@ elixir-check-formatted:
 # We use it in our tests
 .PHONY: elixir-credo
 elixir-credo:
-	@cd test/elixir/ && mix deps.get && mix credo
+	@cd test/elixir/ && mix credo
 
 .PHONY: test-cluster-with-quorum
 test-cluster-with-quorum: devclean


### PR DESCRIPTION
## Overview

Jenkins - and local runs - are failing on `make check` and `make elixir` because `mix` has not yet been set up, and deps have not been installed.

This PR adds a new `elixir-init` target that runs at the start of `make elixir` to do all the necessary setup work.

## Testing recommendations
`make check` on a fresh checkout of CouchDB, on a user account that's never run `mix` or `elixir` before.

## Related Issues or Pull Requests

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- N/A Documentation reflects the changes;
