### PR TITLE
Fix _bulk_docs crash when provided revision can't be parsed

### DIFF
--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -275,9 +275,16 @@ transfer_fields([{<<"_revisions">>, {Props}} | Rest], Doc, DbName) ->
     true ->
         ok
     end,
-    [throw({doc_validation, "RevId isn't a string"}) ||
-            RevId <- RevIds, not is_binary(RevId)],
-    RevIds2 = [parse_revid(RevId) || RevId <- RevIds],
+    RevIds2 = lists:map(fun(RevId) ->
+        try
+            parse_revid(RevId)
+        catch
+            error:function_clause ->
+                throw({doc_validation, "RevId isn't a string"});
+            error:badarg ->
+                throw({doc_validation, "RevId isn't a valid hexadecimal"})
+        end
+    end, RevIds),
     transfer_fields(Rest, Doc#doc{revs={Start, RevIds2}}, DbName);
 
 transfer_fields([{<<"_deleted">>, B} | Rest], Doc, DbName) when is_boolean(B) ->

--- a/src/couch/test/couch_doc_json_tests.erl
+++ b/src/couch/test/couch_doc_json_tests.erl
@@ -270,6 +270,12 @@ from_json_error_cases() ->
             "Revision ids must be strings."
         },
         {
+            {[{<<"_revisions">>, {[{<<"start">>, 0},
+                {<<"ids">>, [<<"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">>]}]}}]},
+            {doc_validation, "RevId isn't a valid hexadecimal"},
+            "Revision ids must be a valid hex."
+        },
+        {
             {[{<<"_something">>, 5}]},
             {doc_validation, <<"Bad special document member: _something">>},
             "Underscore prefix fields are reserved."

--- a/src/couch/test/couch_doc_json_tests.erl
+++ b/src/couch/test/couch_doc_json_tests.erl
@@ -288,18 +288,14 @@ from_json_error_cases() ->
 
     lists:map(fun
         ({Fun, Expect, Msg}) when is_function(Fun, 0) ->
-            Error = (catch couch_doc:from_json_obj_validate(Fun())),
-            {Msg, ?_assertMatch(Expect, Error)};
+            {Msg,
+            ?_assertThrow(Expect, couch_doc:from_json_obj_validate(Fun()))};
         ({EJson, Expect, Msg}) ->
-            Error = (catch couch_doc:from_json_obj_validate(EJson)),
-            {Msg, ?_assertMatch(Expect, Error)};
+            {Msg,
+            ?_assertThrow(Expect, couch_doc:from_json_obj_validate(EJson))};
         ({EJson, Msg}) ->
-            try
-                couch_doc:from_json_obj_validate(EJson),
-                {"Conversion failed to raise an exception", ?_assert(false)}
-            catch
-                _:_ -> {Msg, ?_assert(true)}
-            end
+            {Msg,
+            ?_assertThrow(_, couch_doc:from_json_obj_validate(EJson))}
     end, Cases).
 
 from_json_with_dbname_error_cases() ->


### PR DESCRIPTION
## Overview

If a doc's revision provided with `_bulk_docs` matches the expected length it assumed to be a parsable hexadecimal. When this is not the case `couch_doc:couch_doc:from_json_obj_validate/2` function crashes with `badarg`.

The fix catches the exception and re-throws it as a `doc_validation` exception to raise "400 Bad Request" error.

## Testing recommendations

`make eunit apps=couch suites=couch_doc_json_tests` or the manual stps from case #1895 

## Related Issues or Pull Requests

Closes #1895 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
