### PR TITLE
Fix `badarg` crash on an invalid revision for individual doc update

### DIFF
--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -179,12 +179,12 @@ parse_rev(Rev) when is_list(Rev) ->
     SplitRev = lists:splitwith(fun($-) -> false; (_) -> true end, Rev),
     case SplitRev of
         {Pos, [$- | RevId]} ->
-            IntPos = try list_to_integer(Pos) of
-                Val -> Val
+            try
+                IntPos = list_to_integer(Pos),
+                {IntPos, parse_revid(RevId)}
             catch
                 error:badarg -> throw({bad_request, <<"Invalid rev format">>})
-            end,
-            {IntPos, parse_revid(RevId)};
+            end;
         _Else -> throw({bad_request, <<"Invalid rev format">>})
     end;
 parse_rev(_BadRev) ->


### PR DESCRIPTION
## Overview

A companion of #1897, a missed clause of using `parse_revid/1` outside of `try` block causing `unknown_error` crash on an individual doc update with invalid revision.

## Testing recommendations

` make eunit apps=couch suites=couch_db_doc_tests`

## Related Issues or Pull Requests

Fixes #1895 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
