### PR TITLE
a systemd-journald compatible log output on stderr

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -449,16 +449,25 @@ level = info
 ; max_message_size = 16000
 ;
 ;
-; There are three different log writers that can be configured
+; There are four different log writers that can be configured
 ; to write log messages. The default writes to stderr of the
 ; Erlang VM which is useful for debugging/development as well
 ; as a lot of container deployments.
 ;
-; There's also a file writer that works with logrotate and an
+; There's also a file writer that works with logrotate, a
 ; rsyslog writer for deployments that need to have logs sent
-; over the network.
+; over the network, and a journald writer that's more suitable
+; when using systemd journald.
 ;
 writer = stderr
+; Journald Writer notes:
+;
+; The journald writer doesn't have any options. It still writes
+; the logs to stderr, but without the timestamp prepended, since
+; the journal will add it automatically, and with the log level
+; formated as per
+; https://www.freedesktop.org/software/systemd/man/sd-daemon.html
+;
 ;
 ; File Writer Options:
 ;

--- a/src/couch_log/src/couch_log_writer_journald.erl
+++ b/src/couch_log/src/couch_log_writer_journald.erl
@@ -1,0 +1,69 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_log_writer_journald).
+-behaviour(couch_log_writer).
+
+
+-export([
+    init/0,
+    terminate/2,
+    write/2
+]).
+
+
+-include("couch_log.hrl").
+
+
+init() ->
+    {ok, nil}.
+
+
+terminate(_, _St) ->
+    ok.
+
+
+% log level mapping from sd-daemon(3)
+% https://www.freedesktop.org/software/systemd/man/sd-daemon.html
+-spec level_to_integer(atom() | string() | integer()) -> integer().
+level_to_integer(debug)                 -> 7;
+level_to_integer(info)                  -> 6;
+level_to_integer(notice)                -> 5;
+level_to_integer(warning)               -> 4;
+level_to_integer(warn)                  -> 4;
+level_to_integer(error)                 -> 3;
+level_to_integer(err)                   -> 3;
+level_to_integer(critical)              -> 2;
+level_to_integer(crit)                  -> 2;
+level_to_integer(alert)                 -> 1;
+level_to_integer(emergency)             -> 0;
+level_to_integer(emerg)                 -> 0;
+level_to_integer(none)                  -> 6.
+
+write(Entry, St) ->
+    #log_entry{
+        level = Level,
+        pid = Pid,
+        msg = Msg,
+        msg_id = MsgId
+    } = Entry,
+    Fmt = "<~B>~s ~p ~s ",
+    Args = [
+        level_to_integer(Level),
+        node(),
+        Pid,
+        MsgId
+    ],
+    MsgSize = couch_log_config:get(max_message_size),
+    Data = couch_log_trunc_io:format(Fmt, Args, MsgSize),
+    io:format(standard_error, [Data, Msg, "\n"], []),
+    {ok, St}.

--- a/src/couch_log/src/couch_log_writer_journald.erl
+++ b/src/couch_log/src/couch_log_writer_journald.erl
@@ -32,23 +32,6 @@ terminate(_, _St) ->
     ok.
 
 
-% log level mapping from sd-daemon(3)
-% https://www.freedesktop.org/software/systemd/man/sd-daemon.html
--spec level_to_integer(atom() | string() | integer()) -> integer().
-level_to_integer(debug)                 -> 7;
-level_to_integer(info)                  -> 6;
-level_to_integer(notice)                -> 5;
-level_to_integer(warning)               -> 4;
-level_to_integer(warn)                  -> 4;
-level_to_integer(error)                 -> 3;
-level_to_integer(err)                   -> 3;
-level_to_integer(critical)              -> 2;
-level_to_integer(crit)                  -> 2;
-level_to_integer(alert)                 -> 1;
-level_to_integer(emergency)             -> 0;
-level_to_integer(emerg)                 -> 0;
-level_to_integer(none)                  -> 6.
-
 write(Entry, St) ->
     #log_entry{
         level = Level,
@@ -58,7 +41,7 @@ write(Entry, St) ->
     } = Entry,
     Fmt = "<~B>~s ~p ~s ",
     Args = [
-        level_to_integer(Level),
+        level_for_journald(Level),
         node(),
         Pid,
         MsgId
@@ -67,3 +50,20 @@ write(Entry, St) ->
     Data = couch_log_trunc_io:format(Fmt, Args, MsgSize),
     io:format(standard_error, [Data, Msg, "\n"], []),
     {ok, St}.
+
+
+% log level mapping from sd-daemon(3)
+% https://www.freedesktop.org/software/systemd/man/sd-daemon.html
+-spec level_for_journald(atom()) -> integer().
+level_for_journald(Level) when is_atom(Level) ->
+    case Level of
+        debug       -> 7;
+        info        -> 6;
+        notice      -> 5;
+        warning     -> 4;
+        error       -> 3;
+        critical    -> 2;
+        alert       -> 1;
+        emergency   -> 0;
+        _           -> 3
+    end.


### PR DESCRIPTION
## Overview

based on the stderr logger but changed:
- doesn't output the timestamp, the journal already has a timestamp
- output the log level as <num> where num is defined as in `sd-daemon(3)`

https://www.freedesktop.org/software/systemd/man/sd-daemon.html


## Testing recommendations

in local.ini:
```
[log]
writer = journald
```

run it as a systemd service:
```
systemd-run -E HOME=$HOME ./bin/couchdb
```

Before:
```
Feb 09 22:01:27 archaeopteryx couchdb[186]: [info] 2019-02-09T22:01:27.754346Z couchdb@127.0.0.1 <0.223.0> -------- Apache CouchDB 2.3.0-abafc2bf2 is starting.
Feb 09 22:01:27 archaeopteryx couchdb[186]: [info] 2019-02-09T22:01:27.754545Z couchdb@127.0.0.1 <0.224.0> -------- Starting couch_sup
Feb 09 22:01:27 archaeopteryx couchdb[186]: [notice] 2019-02-09T22:01:27.764981Z couchdb@127.0.0.1 <0.92.0> -------- config: [features] pluggable-storage-engines set to tru
e for reason nil
Feb 09 22:01:27 archaeopteryx couchdb[186]: [notice] 2019-02-09T22:01:27.765222Z couchdb@127.0.0.1 <0.92.0> -------- config: [features] partitioned set to true for reason n
il
Feb 09 22:01:27 archaeopteryx couchdb[186]: [info] 2019-02-09T22:01:27.914163Z couchdb@127.0.0.1 <0.223.0> -------- Apache CouchDB has started. Time to relax.
Feb 09 22:01:27 archaeopteryx couchdb[186]: [info] 2019-02-09T22:01:27.914361Z couchdb@127.0.0.1 <0.223.0> -------- Apache CouchDB has started on http://127.0.0.1:5986/
```

After:
```
Feb 09 21:57:22 archaeopteryx couchdb[101]: couchdb@127.0.0.1 <0.223.0> -------- Apache CouchDB 2.3.0-abafc2bf2 is starting.
Feb 09 21:57:22 archaeopteryx couchdb[101]: couchdb@127.0.0.1 <0.224.0> -------- Starting couch_sup
Feb 09 21:57:22 archaeopteryx couchdb[101]: couchdb@127.0.0.1 <0.92.0> -------- config: [features] pluggable-storage-engines set to true for reason nil
Feb 09 21:57:22 archaeopteryx couchdb[101]: couchdb@127.0.0.1 <0.92.0> -------- config: [features] partitioned set to true for reason nil
Feb 09 21:57:22 archaeopteryx couchdb[101]: couchdb@127.0.0.1 <0.223.0> -------- Apache CouchDB has started. Time to relax.
Feb 09 21:57:22 archaeopteryx couchdb[101]: couchdb@127.0.0.1 <0.223.0> -------- Apache CouchDB has started on http://127.0.0.1:5986/
```
the log level information is not lost, it's available in the `PRIORITY=` field in the journal (and you can easily filter on it)

## Related Issues or Pull Requests

This has once been proposed and got initial approval here:
https://github.com/apache/couchdb-couch-log/pull/16

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
