### PR TITLE
Not set offset with null as default for _all_docs

### DIFF
--- a/src/chttpd/test/chttpd_db_test.erl
+++ b/src/chttpd/test/chttpd_db_test.erl
@@ -234,7 +234,7 @@ should_return_update_seq_when_set_on_all_docs(Url) ->
         {ResultJson} = ?JSON_DECODE(RespBody),
         ?assertNotEqual(undefined,
             couch_util:get_value(<<"update_seq">>, ResultJson)),
-        ?assertNotEqual(undefined,
+        ?assertEqual(undefined,
             couch_util:get_value(<<"offset">>, ResultJson))
     end).
 
@@ -248,7 +248,7 @@ should_not_return_update_seq_when_unset_on_all_docs(Url) ->
         {ResultJson} = ?JSON_DECODE(RespBody),
         ?assertEqual(undefined,
             couch_util:get_value(<<"update_seq">>, ResultJson)),
-        ?assertNotEqual(undefined,
+        ?assertEqual(undefined,
             couch_util:get_value(<<"offset">>, ResultJson))
     end).
 

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -99,9 +99,9 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
         {'DOWN', Ref, _, _, {ok, TotalRows}} ->
             Meta = case UpdateSeq of
                 false ->
-                    [{total, TotalRows}, {offset, null}];
+                    [{total, TotalRows}];
                 true ->
-                    [{total, TotalRows}, {offset, null}, {update_seq, null}]
+                    [{total, TotalRows}, {update_seq, null}]
             end,
             {ok, Acc1} = Callback({meta, Meta}, Acc0),
             {ok, Acc2} = doc_receive_loop(


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Revert the change of setting offset with null for `_all_docs` when `keys` is set in request to avoid compatibility of returned response where offset with 0 is expected.

Background: there is PR #1085 (Return update_seq and offset when update_seq is true and keys is set) used to address issue https://github.com/apache/couchdb/issues/969 (GET /db/_all_docs?update_seq=true missing 'offset' and 'update_seq' when 'keys' also provided).

Recently, new issue #1648(Result contains "offset": null instead of "offset": 0) was reported to complain `"offset": null` instead of `"offset": 0`.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=chttpd tests=all_test_
```
======================== EUnit ========================
chttpd security tests
Application crypto was left running!
  chttpd_security_tests:147: should_allow_admin_db_compaction...[0.004 s] ok
  chttpd_security_tests:163: should_allow_valid_password_to_create_user...ok
  chttpd_security_tests:173: should_disallow_invalid_password_to_create_user...ok
  chttpd_security_tests:181: should_disallow_anonymous_db_compaction...ok
  chttpd_security_tests:189: should_disallow_db_member_db_compaction...ok
  chttpd_security_tests:192: should_allow_db_admin_db_compaction...[0.003 s] ok
  chttpd_security_tests:202: should_allow_admin_view_compaction...[0.017 s] ok
  chttpd_security_tests:217: should_disallow_anonymous_view_compaction...ok
  chttpd_security_tests:220: should_allow_admin_db_view_cleanup...[0.003 s] ok
  chttpd_security_tests:235: should_disallow_anonymous_db_view_cleanup...ok
  chttpd_security_tests:238: should_allow_admin_purge...[0.020 s] ok
  chttpd_security_tests:254: should_disallow_anonymous_purge...ok
  chttpd_security_tests:262: should_disallow_db_member_purge...ok
  chttpd_security_tests:265: should_allow_admin_purged_infos_limit...[0.003 s] ok
  chttpd_security_tests:280: should_disallow_anonymous_purged_infos_limit...ok
  chttpd_security_tests:288: should_disallow_db_member_purged_infos_limit...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 13.188 s]
chttpd db tests
  chttpd_db_test:91: should_return_ok_true_on_bulk_update...[0.063 s] ok
  chttpd_db_test:106: should_return_ok_true_on_ensure_full_commit...[0.005 s] ok
  chttpd_db_test:116: should_return_404_for_ensure_full_commit_on_no_db...[0.006 s] ok
  chttpd_db_test:138: should_accept_live_as_an_alias_for_continuous...[0.044 s] ok
  chttpd_db_test:153: should_return_404_for_delete_att_on_notadoc...[0.007 s] ok
  chttpd_db_test:175: should_return_409_for_del_att_without_rev...[0.107 s] ok
  chttpd_db_test:193: should_return_200_for_del_att_with_rev...[0.084 s] ok
  chttpd_db_test:214: should_return_409_for_put_att_nonexistent_rev...[0.031 s] ok
  chttpd_db_test:229: should_return_update_seq_when_set_on_all_docs...[0.132 s] ok
  chttpd_db_test:243: should_not_return_update_seq_when_unset_on_all_docs...[0.110 s] ok
  chttpd_db_test:257: should_return_correct_id_on_doc_copy...[0.117 s] ok
  chttpd_db_test:288: should_return_400_for_bad_engine...[0.006 s] ok
  chttpd_db_test:300: should_succeed_on_all_docs_with_queries_keys...[0.304 s] ok
  chttpd_db_test:314: should_succeed_on_all_docs_with_queries_limit_skip...[0.307 s] ok
  chttpd_db_test:329: should_succeed_on_all_docs_with_multiple_queries...[0.308 s] ok
  chttpd_db_test:347: should_succeed_on_design_docs_with_queries_keys...[0.307 s] ok
  chttpd_db_test:362: should_succeed_on_design_docs_with_queries_limit_skip...[0.321 s] ok
  chttpd_db_test:377: should_succeed_on_design_docs_with_multiple_queries...[0.315 s] ok
  chttpd_db_test:395: should_succeed_on_local_docs_with_queries_keys...[0.287 s] ok
  chttpd_db_test:410: should_succeed_on_local_docs_with_queries_limit_skip...[0.302 s] ok
  chttpd_db_test:424: should_succeed_on_local_docs_with_multiple_queries...[0.307 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 9.221 s]
chttpd db max_document_size tests
  chttpd_db_doc_size_tests:84: post_single_doc...ok
  chttpd_db_doc_size_tests:92: put_single_doc...ok
  chttpd_db_doc_size_tests:101: bulk_doc...ok
  chttpd_db_doc_size_tests:127: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:128: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:129: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:130: put_post_doc_attach_inline...ok
  chttpd_db_doc_size_tests:152: put_multi_part_related...ok
  chttpd_db_doc_size_tests:153: put_multi_part_related...ok
  chttpd_db_doc_size_tests:177: post_multi_part_form...ok
  chttpd_db_doc_size_tests:178: post_multi_part_form...ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 1.897 s]
=======================================================
  All 48 tests passed.
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

#1648
#1085
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
