### PR TITLE
Introduce Shard Splitting To CouchDB

### DIFF
--- a/src/chttpd/src/chttpd_auth_request.erl
+++ b/src/chttpd/src/chttpd_auth_request.erl
@@ -50,6 +50,8 @@ authorize_request_int(#httpd{path_parts=[<<"_replicator">>,<<"_changes">>|_]}=Re
     require_admin(Req);
 authorize_request_int(#httpd{path_parts=[<<"_replicator">>|_]}=Req) ->
     db_authorization_check(Req);
+authorize_request_int(#httpd{path_parts=[<<"_reshard">>|_]}=Req) ->
+    require_admin(Req);
 authorize_request_int(#httpd{path_parts=[<<"_users">>], method='PUT'}=Req) ->
     require_admin(Req);
 authorize_request_int(#httpd{path_parts=[<<"_users">>], method='DELETE'}=Req) ->

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -51,6 +51,8 @@
     set_security/2,
     set_props/2,
 
+    set_update_seq/2,
+
     open_docs/2,
     open_local_docs/2,
     read_doc_body/2,
@@ -60,6 +62,7 @@
     write_doc_body/2,
     write_doc_infos/3,
     purge_docs/3,
+    copy_purge_infos/2,
 
     commit_data/1,
 
@@ -105,7 +108,6 @@
 
 % Used by the compactor
 -export([
-    set_update_seq/2,
     update_header/2,
     copy_security/2,
     copy_props/2
@@ -545,6 +547,20 @@ purge_docs(#st{} = St, Pairs, PurgeInfos) ->
         purge_tree = PurgeTree2,
         purge_seq_tree = PurgeSeqTree2,
         needs_commit = true
+    }}.
+
+
+copy_purge_infos(#st{} = St, PurgeInfos) ->
+    #st{
+        purge_tree = PurgeTree,
+        purge_seq_tree = PurgeSeqTree
+    } = St,
+    {ok, PurgeTree2} = couch_btree:add(PurgeTree, PurgeInfos),
+    {ok, PurgeSeqTree2} = couch_btree:add(PurgeSeqTree, PurgeInfos),
+    {ok, St#st{
+       purge_tree = PurgeTree2,
+       purge_seq_tree = PurgeSeqTree2,
+       needs_commit = true
     }}.
 
 

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1527,7 +1527,7 @@ calculate_start_seq(Db, Node, {Seq, Uuid}) ->
     % Treat the current node as the epoch node
     calculate_start_seq(Db, Node, {Seq, Uuid, Node});
 calculate_start_seq(Db, _Node, {Seq, Uuid, EpochNode}) ->
-    case is_prefix(Uuid, get_uuid(Db)) of
+    case Uuid =:= split orelse is_prefix(Uuid, get_uuid(Db)) of
         true ->
             case is_owner(EpochNode, Seq, get_epochs(Db)) of
                 true -> Seq;
@@ -1547,7 +1547,7 @@ calculate_start_seq(Db, _Node, {Seq, Uuid, EpochNode}) ->
             0
     end;
 calculate_start_seq(Db, _Node, {replace, OriginalNode, Uuid, Seq}) ->
-    case is_prefix(Uuid, couch_db:get_uuid(Db)) of
+    case Uuid =:= split orelse is_prefix(Uuid, couch_db:get_uuid(Db)) of
         true ->
             start_seq(get_epochs(Db), OriginalNode, Seq);
         false ->

--- a/src/couch/src/couch_db_split.erl
+++ b/src/couch/src/couch_db_split.erl
@@ -1,0 +1,493 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_db_split).
+
+
+-export([
+    split/3,
+    copy_local_docs/3,
+    cleanup_target/2
+]).
+
+
+-include_lib("couch/include/couch_db.hrl").
+
+
+-define(DEFAULT_BUFFER_SIZE, 16777216).
+
+
+-record(state, {
+    source_db,
+    source_uuid,
+    targets,
+    pickfun,
+    max_buffer_size = ?DEFAULT_BUFFER_SIZE,
+    hashfun
+}).
+
+-record(target, {
+    db,
+    uuid,
+    buffer = [],
+    buffer_size = 0
+}).
+
+-record(racc, {
+    id,
+    source_db,
+    target_db,
+    active = 0,
+    external = 0,
+    atts = []
+}).
+
+
+% Public API
+
+split(Source, #{} = Targets, PickFun) when
+        map_size(Targets) >= 2, is_function(PickFun, 3) ->
+    case couch_db:open_int(Source, [?ADMIN_CTX]) of
+        {ok, SourceDb} ->
+            Engine = get_engine(SourceDb),
+            Partitioned = couch_db:is_partitioned(SourceDb),
+            HashFun = mem3_hash:get_hash_fun(couch_db:name(SourceDb)),
+            try
+                split(SourceDb, Partitioned, Engine, Targets, PickFun, HashFun)
+            catch
+                throw:{target_create_error, DbName, Error, TargetDbs} ->
+                    cleanup_targets(TargetDbs, Engine),
+                    {error, {target_create_error, DbName, Error}}
+            after
+                couch_db:close(SourceDb)
+            end;
+        {not_found, _} ->
+            {error, missing_source}
+    end.
+
+
+copy_local_docs(Source, #{} = Targets0, PickFun) when
+        is_binary(Source), is_function(PickFun, 3) ->
+    case couch_db:open_int(Source, [?ADMIN_CTX]) of
+        {ok, SourceDb} ->
+            try
+                Targets = maps:map(fun(_, DbName) ->
+                    {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),
+                    #target{db = Db, uuid = couch_db:get_uuid(Db)}
+                end, Targets0),
+                SourceName = couch_db:name(SourceDb),
+                try
+                    State = #state{
+                        source_db = SourceDb,
+                        source_uuid = couch_db:get_uuid(SourceDb),
+                        targets = Targets,
+                        pickfun = PickFun,
+                        hashfun = mem3_hash:get_hash_fun(SourceName)
+                    },
+                    copy_local_docs(State),
+                    ok
+                after
+                    maps:map(fun(_, #target{db = Db} = T) ->
+                        couch_db:close(Db),
+                        T#target{db = undefined}
+                    end, Targets)
+                end
+            after
+                couch_db:close(SourceDb)
+            end;
+        {not_found, _} ->
+            {error, missing_source}
+    end.
+
+
+cleanup_target(Source, Target) when is_binary(Source), is_binary(Target) ->
+    case couch_db:open_int(Source, [?ADMIN_CTX]) of
+        {ok, SourceDb} ->
+            try
+                delete_target(Target, get_engine(SourceDb))
+            after
+                couch_db:close(SourceDb)
+            end;
+        {not_found, _} ->
+            {error, missing_source}
+    end.
+
+
+% Private Functions
+
+split(SourceDb, Partitioned, Engine, Targets0, PickFun, {M, F, A} = HashFun) ->
+    Targets = maps:fold(fun(Key, DbName, Map) ->
+        case couch_db:validate_dbname(DbName) of
+            ok ->
+                ok;
+            {error, E} ->
+                throw({target_create_error, DbName, E, Map})
+        end,
+        {ok, Filepath} = couch_server:get_engine_path(DbName, Engine),
+        Opts = [create, ?ADMIN_CTX] ++ case Partitioned of
+            true -> [{props, [{partitioned, true}, {hash, [M, F, A]}]}];
+            false -> []
+        end,
+        case couch_db:start_link(Engine, DbName, Filepath, Opts) of
+            {ok, Db} ->
+                Map#{Key => #target{db = Db}};
+            {error, Error} ->
+                throw({target_create_error, DbName, Error, Map})
+        end
+    end, #{}, Targets0),
+    Seq = couch_db:get_update_seq(SourceDb),
+    State1 = #state{
+        source_db = SourceDb,
+        targets = Targets,
+        pickfun = PickFun,
+        hashfun = HashFun,
+        max_buffer_size = get_max_buffer_size()
+    },
+    State2 = copy_docs(State1),
+    State3 = copy_checkpoints(State2),
+    State4 = copy_meta(State3),
+    State5 = copy_purge_info(State4),
+    State6 = set_targets_update_seq(State5),
+    stop_targets(State6#state.targets),
+    {ok, Seq}.
+
+
+cleanup_targets(#{} = Targets, Engine) ->
+    maps:map(fun(_, #target{db = Db} = T) ->
+        stop_target_db(Db),
+        delete_target(couch_db:name(Db), Engine),
+        T
+    end, Targets).
+
+
+stop_targets(#{} = Targets) ->
+    maps:map(fun(_, #target{db = Db} = T) ->
+        {ok, Db1} = couch_db_engine:commit_data(Db),
+        ok = stop_target_db(Db1),
+        T
+    end, Targets).
+
+
+stop_target_db(Db) ->
+    couch_db:close(Db),
+    Pid = couch_db:get_pid(Db),
+    catch unlink(Pid),
+    catch exit(Pid, kill),
+    ok.
+
+
+delete_target(DbName, Engine) ->
+    RootDir = config:get("couchdb", "database_dir", "."),
+    {ok, Filepath} = couch_server:get_engine_path(DbName, Engine),
+    DelOpt = [{context, compaction}, sync],
+    couch_db_engine:delete(Engine, RootDir, Filepath, DelOpt).
+
+
+pick_target(DocId, #state{} = State, #{} = Targets) ->
+    #state{pickfun = PickFun, hashfun = HashFun} = State,
+    Key = PickFun(DocId, maps:keys(Targets), HashFun),
+    {Key, maps:get(Key, Targets)}.
+
+
+set_targets_update_seq(#state{targets = Targets} = State) ->
+    Seq = couch_db:get_update_seq(State#state.source_db),
+    Targets1 = maps:map(fun(_, #target{db = Db} = Target) ->
+        {ok, Db1} = couch_db_engine:set_update_seq(Db, Seq),
+        Target#target{db = Db1}
+    end, Targets),
+    State#state{targets = Targets1}.
+
+
+copy_checkpoints(#state{} = State) ->
+    #state{source_db = Db, source_uuid = SrcUUID, targets = Targets} = State,
+    FoldFun = fun(#doc{id = Id} = Doc, Acc) ->
+        UpdatedAcc = case Id of
+            <<?LOCAL_DOC_PREFIX, "shard-sync-", _/binary>> ->
+                % Transform mem3 internal replicator checkpoints to avoid
+                % rewinding the changes feed when it sees the new shards
+                maps:map(fun(_, #target{uuid = TgtUUID, buffer = Docs} = T) ->
+                    Doc1 = update_checkpoint_doc(SrcUUID, TgtUUID, Doc),
+                    T#target{buffer = [Doc1 | Docs]}
+                end, Acc);
+            <<?LOCAL_DOC_PREFIX, "purge-", _/binary>> ->
+                % Copy purge checkpoints to all shards
+                maps:map(fun(_, #target{buffer = Docs} = T) ->
+                    T#target{buffer = [Doc | Docs]}
+                end, Acc);
+            <<?LOCAL_DOC_PREFIX, _/binary>> ->
+                % Skip copying these that will be done during
+                % local docs top off right before the shards are switched
+                Acc
+        end,
+        {ok, UpdatedAcc}
+    end,
+    {ok, Targets1} = couch_db_engine:fold_local_docs(Db, FoldFun, Targets, []),
+    Targets2 = maps:map(fun(_, #target{db = TDb, buffer = Docs} = T) ->
+        case Docs of
+            [] ->
+                T;
+            [_ | _] ->
+                Docs1 = lists:reverse(Docs),
+                {ok, TDb1} = couch_db_engine:write_doc_infos(TDb, [], Docs1),
+                {ok, TDb2} = couch_db_engine:commit_data(TDb1),
+                T#target{db = TDb2, buffer = []}
+        end
+    end, Targets1),
+    State#state{targets = Targets2}.
+
+
+update_checkpoint_doc(Old, New, #doc{body = {Props}} = Doc) ->
+    NewProps = case couch_util:get_value(<<"target_uuid">>, Props) of
+        Old ->
+            replace_kv(Props, {<<"target_uuid">>, Old, New});
+        Other when is_binary(Other) ->
+            replace_kv(Props, {<<"source_uuid">>, Old, New})
+    end,
+    NewId = update_checkpoint_id(Doc#doc.id, Old, New),
+    Doc#doc{id = NewId, body = {NewProps}}.
+
+
+update_checkpoint_id(Id, Old, New) ->
+    OldHash = mem3_rep:local_id_hash(Old),
+    NewHash = mem3_rep:local_id_hash(New),
+    binary:replace(Id, OldHash, NewHash).
+
+
+replace_kv({[]}, _) ->
+    {[]};
+replace_kv({KVs}, Replacement) ->
+    {[replace_kv(KV, Replacement) || KV <- KVs]};
+replace_kv([], _) ->
+    [];
+replace_kv(List, Replacement) when is_list(List) ->
+    [replace_kv(V, Replacement) || V <- List];
+replace_kv({K, V}, {K, V, NewV}) ->
+    {K, NewV};
+replace_kv({K, V}, Replacement) ->
+    {K, replace_kv(V, Replacement)};
+replace_kv(V, _) ->
+    V.
+
+
+copy_meta(#state{source_db = SourceDb, targets = Targets} = State) ->
+    RevsLimit = couch_db:get_revs_limit(SourceDb),
+    {SecProps} = couch_db:get_security(SourceDb),
+    PurgeLimit = couch_db:get_purge_infos_limit(SourceDb),
+    Targets1 = maps:map(fun(_, #target{db = Db} = T) ->
+        {ok, Db1} = couch_db_engine:set_revs_limit(Db, RevsLimit),
+        {ok, Db2} = couch_db_engine:set_security(Db1, SecProps),
+        {ok, Db3} = couch_db_engine:set_purge_infos_limit(Db2, PurgeLimit),
+        T#target{db = Db3}
+    end, Targets),
+    State#state{targets = Targets1}.
+
+
+copy_purge_info(#state{source_db = Db} = State) ->
+    {ok, NewState} = couch_db:fold_purge_infos(Db, 0, fun purge_cb/2, State),
+    Targets = maps:map(fun(_, #target{} = T) ->
+        commit_purge_infos(T)
+    end, NewState#state.targets),
+    NewState#state{targets = Targets}.
+
+
+purge_cb({_PSeq, _UUID, Id, _Revs} = PI, #state{targets = Targets} = State) ->
+    {Key, Target} = pick_target(Id, State, Targets),
+    #target{buffer = Buffer, buffer_size = BufferSize} = Target,
+    Target1 = Target#target{
+        buffer = [PI | Buffer],
+        buffer_size = BufferSize + ?term_size(PI)
+    },
+    Target2 = case Target1#target.buffer_size > State#state.max_buffer_size of
+        true -> commit_purge_infos(Target1);
+        false -> Target1
+    end,
+    {ok, State#state{targets = Targets#{Key => Target2}}}.
+
+
+commit_purge_infos(#target{buffer = [], db = Db} = Target) ->
+    Target#target{db = Db};
+
+commit_purge_infos(#target{buffer = PIs0, db = Db} = Target) ->
+    PIs = lists:reverse(PIs0),
+    {ok, Db1} = couch_db_engine:copy_purge_infos(Db, PIs),
+    {ok, Db2} = couch_db_engine:commit_data(Db1),
+    Target#target{buffer = [], buffer_size = 0, db = Db2}.
+
+
+copy_docs(#state{source_db = Db} = State) ->
+    {ok, NewState} = couch_db:fold_changes(Db, 0, fun changes_cb/2, State),
+    CommitTargets = maps:map(fun(_, #target{} = T) ->
+        commit_docs(T)
+    end, NewState#state.targets),
+    NewState#state{targets = CommitTargets}.
+
+
+% Backwards compatibility clause. Seq trees used to hold #doc_infos at one time
+changes_cb(#doc_info{id = Id}, #state{source_db = Db} = State) ->
+    [FDI = #full_doc_info{}] = couch_db_engine:open_docs(Db, [Id]),
+    changes_cb(FDI, State);
+
+changes_cb(#full_doc_info{id = Id} = FDI, #state{} = State) ->
+    #state{source_db = SourceDb, targets = Targets} = State,
+    {Key, Target} = pick_target(Id, State, Targets),
+    #target{db = TargetDb, buffer = Buffer} = Target,
+    FDI1 = process_fdi(FDI, SourceDb, TargetDb),
+    Target1 = Target#target{
+        buffer = [FDI1 | Buffer],
+        buffer_size = Target#target.buffer_size + ?term_size(FDI1)
+    },
+    Target2 = case Target1#target.buffer_size > State#state.max_buffer_size of
+        true -> commit_docs(Target1);
+        false -> Target1
+    end,
+    {ok, State#state{targets = Targets#{Key => Target2}}}.
+
+
+commit_docs(#target{buffer = [], db = Db} = Target) ->
+    Target#target{db = Db};
+
+commit_docs(#target{buffer = FDIs, db = Db} = Target) ->
+    Pairs = [{not_found, FDI} || FDI <- lists:reverse(FDIs)],
+    {ok, Db1} = couch_db_engine:write_doc_infos(Db, Pairs, []),
+    {ok, Db2} = couch_db_engine:commit_data(Db1),
+    Target#target{buffer = [], buffer_size = 0, db = Db2}.
+
+
+process_fdi(FDI, SourceDb, TargetDb) ->
+    #full_doc_info{id = Id, rev_tree = RTree} = FDI,
+    Acc = #racc{id = Id, source_db = SourceDb, target_db = TargetDb},
+    {NewRTree, NewAcc} = couch_key_tree:mapfold(fun revtree_cb/4, Acc, RTree),
+    {Active, External} = total_sizes(NewAcc),
+    FDI#full_doc_info{
+        rev_tree = NewRTree,
+        sizes = #size_info{active = Active, external = External}
+    }.
+
+
+revtree_cb(_Rev, _Leaf, branch, Acc) ->
+    {[], Acc};
+
+revtree_cb({Pos, RevId}, Leaf, leaf, Acc) ->
+    #racc{id = Id, source_db = SourceDb, target_db = TargetDb} = Acc,
+    #leaf{deleted = Deleted, ptr = Ptr} = Leaf,
+    Doc0 = #doc{
+        id = Id,
+        revs = {Pos, [RevId]},
+        deleted = Deleted,
+        body = Ptr
+    },
+    Doc1 = couch_db_engine:read_doc_body(SourceDb, Doc0),
+    #doc{body = Body, atts = AttInfos0} = Doc1,
+    External = if not is_binary(Body) -> ?term_size(body); true ->
+        couch_compress:uncompressed_size(Body)
+    end,
+    AttInfos = if not is_binary(AttInfos0) -> AttInfos0; true ->
+        couch_compress:decompress(AttInfos0)
+    end,
+    Atts = [process_attachment(Att, SourceDb, TargetDb) || Att <- AttInfos],
+    Doc2 = Doc1#doc{atts = Atts},
+    Doc3 = couch_db_engine:serialize_doc(TargetDb, Doc2),
+    {ok, Doc4, Active} = couch_db_engine:write_doc_body(TargetDb, Doc3),
+    AttSizes = [{element(3, A), element(4, A)} || A <- Atts],
+    NewLeaf = Leaf#leaf{
+        ptr = Doc4#doc.body,
+        sizes = #size_info{active = Active, external = External},
+        atts = AttSizes
+    },
+    {NewLeaf, add_sizes(Active, External, AttSizes, Acc)}.
+
+
+% This is copied almost verbatim from the compactor
+process_attachment({Name, Type, BinSp, AttLen, RevPos, ExpectedMd5}, SourceDb,
+        TargetDb) ->
+    % 010 upgrade code
+    {ok, SrcStream} = couch_db_engine:open_read_stream(SourceDb, BinSp),
+    {ok, DstStream} = couch_db_engine:open_write_stream(TargetDb, []),
+    ok = couch_stream:copy(SrcStream, DstStream),
+    {NewStream, AttLen, AttLen, ActualMd5, _IdentityMd5} =
+            couch_stream:close(DstStream),
+    {ok, NewBinSp} = couch_stream:to_disk_term(NewStream),
+    couch_util:check_md5(ExpectedMd5, ActualMd5),
+    {Name, Type, NewBinSp, AttLen, AttLen, RevPos, ExpectedMd5, identity};
+
+process_attachment({Name, Type, BinSp, AttLen, DiskLen, RevPos, ExpectedMd5,
+        Enc1}, SourceDb, TargetDb) ->
+    {ok, SrcStream} = couch_db_engine:open_read_stream(SourceDb, BinSp),
+    {ok, DstStream} = couch_db_engine:open_write_stream(TargetDb, []),
+    ok = couch_stream:copy(SrcStream, DstStream),
+    {NewStream, AttLen, _, ActualMd5, _IdentityMd5} =
+            couch_stream:close(DstStream),
+    {ok, NewBinSp} = couch_stream:to_disk_term(NewStream),
+    couch_util:check_md5(ExpectedMd5, ActualMd5),
+    Enc = case Enc1 of
+        true -> gzip;  % 0110 upgrade code
+        false -> identity;  % 0110 upgrade code
+        _ -> Enc1
+    end,
+    {Name, Type, NewBinSp, AttLen, DiskLen, RevPos, ExpectedMd5, Enc}.
+
+
+get_engine(Db) ->
+    {ok, DbInfoProps} = couch_db:get_db_info(Db),
+    proplists:get_value(engine, DbInfoProps).
+
+
+add_sizes(Active, External, Atts, #racc{} = Acc) ->
+    #racc{active = ActiveAcc, external = ExternalAcc, atts = AttsAcc} = Acc,
+    NewActiveAcc = ActiveAcc + Active,
+    NewExternalAcc = ExternalAcc + External,
+    NewAttsAcc = lists:umerge(Atts, AttsAcc),
+    Acc#racc{
+        active = NewActiveAcc,
+        external = NewExternalAcc,
+        atts = NewAttsAcc
+    }.
+
+
+total_sizes(#racc{active = Active, external = External, atts = Atts}) ->
+    TotalAtts = lists:foldl(fun({_, S}, A) -> S + A end, 0, Atts),
+    {Active + TotalAtts, External + TotalAtts}.
+
+
+get_max_buffer_size() ->
+    config:get_integer("shard_splitting", "buffer_size", ?DEFAULT_BUFFER_SIZE).
+
+
+copy_local_docs(#state{source_db = Db, targets = Targets} = State) ->
+    FoldFun = fun(#doc{id = Id} = Doc, Acc) ->
+        UpdatedAcc = case Id of
+            <<?LOCAL_DOC_PREFIX, "shard-sync-", _/binary>> ->
+                Acc;
+            <<?LOCAL_DOC_PREFIX, "purge-", _/binary>> ->
+                Acc;
+            <<?LOCAL_DOC_PREFIX, _/binary>> ->
+                % Users' and replicator app's checkpoints go to their
+                % respective shards based on the general hashing algorithm
+                {Key, Target} = pick_target(Id, State, Acc),
+                #target{buffer = Docs} = Target,
+                Acc#{Key => Target#target{buffer = [Doc | Docs]}}
+        end,
+        {ok, UpdatedAcc}
+    end,
+    {ok, Targets1} = couch_db:fold_local_docs(Db, FoldFun, Targets, []),
+    Targets2 = maps:map(fun(_, #target{db = TDb, buffer = Docs} = T) ->
+        case Docs of
+            [] ->
+                T;
+            [_ | _] ->
+                Docs1 = lists:reverse(Docs),
+                {ok, _} = couch_db:update_docs(TDb, Docs1),
+                {ok, _} = couch_db:ensure_full_commit(TDb),
+                T#target{buffer = []}
+        end
+    end, Targets1),
+    State#state{targets = Targets2}.

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -25,6 +25,7 @@
 -export([delete_compaction_files/1]).
 -export([exists/1]).
 -export([get_engine_extensions/0]).
+-export([get_engine_path/2]).
 
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
@@ -764,6 +765,16 @@ get_engine_extensions() ->
             ["couch"];
         Entries ->
             [Ext || {Ext, _Mod} <- Entries]
+    end.
+
+
+get_engine_path(DbName, Engine) when is_binary(DbName), is_atom(Engine) ->
+    RootDir = config:get("couchdb", "database_dir", "."),
+    case lists:keyfind(Engine, 2, get_configured_engines()) of
+        {Ext, Engine} ->
+            {ok, make_filepath(RootDir, DbName, Ext)};
+        false ->
+            {error, {invalid_engine, Engine}}
     end.
 
 

--- a/src/couch/test/couch_db_split_tests.erl
+++ b/src/couch/test/couch_db_split_tests.erl
@@ -1,0 +1,298 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_db_split_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(RINGTOP, 2 bsl 31).
+
+
+setup() ->
+    DbName = ?tempdb(),
+    {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
+    ok = couch_db:close(Db),
+    DbName.
+
+
+teardown(DbName) ->
+    {ok, Db} = couch_db:open_int(DbName, []),
+    FilePath = couch_db:get_filepath(Db),
+    ok = couch_db:close(Db),
+    ok = file:delete(FilePath).
+
+
+split_test_() ->
+    Cases = [
+        {"Should split an empty shard", 0, 2},
+        {"Should split shard in half", 100, 2},
+        {"Should split shard in three", 99, 3},
+        {"Should split shard in four", 100, 4}
+    ],
+    {
+        setup,
+        fun test_util:start_couch/0, fun test_util:stop/1,
+        [
+            {
+                foreachx,
+                fun(_) -> setup() end, fun(_, St) -> teardown(St) end,
+                [{Case, fun should_split_shard/2} || Case <- Cases]
+            },
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_fail_on_missing_source/1,
+                    fun should_fail_on_existing_target/1,
+                    fun should_fail_on_invalid_target_name/1,
+                    fun should_crash_on_invalid_tmap/1
+                ]
+            }
+        ]
+    }.
+
+
+should_split_shard({Desc, TotalDocs, Q}, DbName) ->
+    {ok, ExpectSeq} = create_docs(DbName, TotalDocs),
+    Ranges = make_ranges(Q),
+    TMap = make_targets(Ranges),
+    DocsPerRange = TotalDocs div Q,
+    PickFun = make_pickfun(DocsPerRange),
+    {Desc, ?_test(begin
+        {ok, UpdateSeq} = couch_db_split:split(DbName, TMap, PickFun),
+        ?assertEqual(ExpectSeq, UpdateSeq),
+        maps:map(fun(Range, Name) ->
+            {ok, Db} = couch_db:open_int(Name, []),
+            FilePath = couch_db:get_filepath(Db),
+            %% target is actually exist
+            ?assertMatch({ok, _}, file:read_file_info(FilePath)),
+            %% target's update seq is the same as source's update seq
+            USeq = couch_db:get_update_seq(Db),
+            ?assertEqual(ExpectSeq, USeq),
+            %% target shard has all the expected in its range docs
+            {ok, DocsInShard} = couch_db:fold_docs(Db, fun(FDI, Acc) ->
+                DocId = FDI#full_doc_info.id,
+                ExpectedRange = PickFun(DocId, Ranges, undefined),
+                ?assertEqual(ExpectedRange, Range),
+                {ok, Acc + 1}
+            end, 0),
+            ?assertEqual(DocsPerRange, DocsInShard),
+            ok = couch_db:close(Db),
+            ok = file:delete(FilePath)
+        end, TMap)
+    end)}.
+
+
+should_fail_on_missing_source(_DbName) ->
+    DbName = ?tempdb(),
+    Ranges = make_ranges(2),
+    TMap = make_targets(Ranges),
+    Response = couch_db_split:split(DbName, TMap, fun fake_pickfun/3),
+    ?_assertEqual({error, missing_source}, Response).
+
+
+should_fail_on_existing_target(DbName) ->
+    Ranges = make_ranges(2),
+    TMap = maps:map(fun(_, _) -> DbName end, make_targets(Ranges)),
+    Response = couch_db_split:split(DbName, TMap, fun fake_pickfun/3),
+    ?_assertMatch({error, {target_create_error, DbName, eexist}}, Response).
+
+
+should_fail_on_invalid_target_name(DbName) ->
+    Ranges = make_ranges(2),
+    TMap = maps:map(fun([B, _], _) ->
+        iolist_to_binary(["_$", couch_util:to_hex(<<B:32/integer>>)])
+    end, make_targets(Ranges)),
+    Expect = {error, {target_create_error, <<"_$00000000">>,
+        {illegal_database_name, <<"_$00000000">>}}},
+    Response = couch_db_split:split(DbName, TMap, fun fake_pickfun/3),
+    ?_assertMatch(Expect, Response).
+
+
+should_crash_on_invalid_tmap(DbName) ->
+    Ranges = make_ranges(1),
+    TMap = make_targets(Ranges),
+    ?_assertError(function_clause,
+        couch_db_split:split(DbName, TMap, fun fake_pickfun/3)).
+
+
+copy_local_docs_test_() ->
+    Cases = [
+        {"Should work with no docs", 0, 2},
+        {"Should copy local docs after split in two", 100, 2},
+        {"Should copy local docs after split in three", 99, 3},
+        {"Should copy local docs after split in four", 100, 4}
+    ],
+    {
+        setup,
+        fun test_util:start_couch/0, fun test_util:stop/1,
+        [
+            {
+                foreachx,
+                fun(_) -> setup() end, fun(_, St) -> teardown(St) end,
+                [{Case, fun should_copy_local_docs/2} || Case <- Cases]
+            },
+            {"Should return error on missing source",
+            fun should_fail_copy_local_on_missing_source/0}
+        ]
+    }.
+
+
+should_copy_local_docs({Desc, TotalDocs, Q}, DbName) ->
+    {ok, ExpectSeq} = create_docs(DbName, TotalDocs),
+    Ranges = make_ranges(Q),
+    TMap = make_targets(Ranges),
+    DocsPerRange = TotalDocs div Q,
+    PickFun = make_pickfun(DocsPerRange),
+    {Desc, ?_test(begin
+        {ok, UpdateSeq} = couch_db_split:split(DbName, TMap, PickFun),
+        ?assertEqual(ExpectSeq, UpdateSeq),
+        Response = couch_db_split:copy_local_docs(DbName, TMap, PickFun),
+        ?assertEqual(ok, Response),
+        maps:map(fun(Range, Name) ->
+            {ok, Db} = couch_db:open_int(Name, []),
+            FilePath = couch_db:get_filepath(Db),
+            %% target shard has all the expected in its range docs
+            {ok, DocsInShard} = couch_db:fold_local_docs(Db, fun(Doc, Acc) ->
+                DocId = Doc#doc.id,
+                ExpectedRange = PickFun(DocId, Ranges, undefined),
+                ?assertEqual(ExpectedRange, Range),
+                {ok, Acc + 1}
+            end, 0, []),
+            ?assertEqual(DocsPerRange, DocsInShard),
+            ok = couch_db:close(Db),
+            ok = file:delete(FilePath)
+        end, TMap)
+    end)}.
+
+
+should_fail_copy_local_on_missing_source() ->
+    DbName = ?tempdb(),
+    Ranges = make_ranges(2),
+    TMap = make_targets(Ranges),
+    PickFun = fun fake_pickfun/3,
+    Response = couch_db_split:copy_local_docs(DbName, TMap, PickFun),
+    ?assertEqual({error, missing_source}, Response).
+
+
+cleanup_target_test_() ->
+    {
+        setup,
+        fun test_util:start_couch/0, fun test_util:stop/1,
+        [
+            {
+                setup,
+                fun setup/0, fun teardown/1,
+                fun should_delete_existing_targets/1
+            },
+            {"Should return error on missing source",
+            fun should_fail_cleanup_target_on_missing_source/0}
+        ]
+    }.
+
+
+should_delete_existing_targets(SourceName) ->
+    {ok, ExpectSeq} = create_docs(SourceName, 100),
+    Ranges = make_ranges(2),
+    TMap = make_targets(Ranges),
+    PickFun = make_pickfun(50),
+    ?_test(begin
+        {ok, UpdateSeq} = couch_db_split:split(SourceName, TMap, PickFun),
+        ?assertEqual(ExpectSeq, UpdateSeq),
+        maps:map(fun(_Range, TargetName) ->
+            FilePath = couch_util:with_db(TargetName, fun(Db) ->
+                couch_db:get_filepath(Db)
+            end),
+            ?assertMatch({ok, _}, file:read_file_info(FilePath)),
+            Response = couch_db_split:cleanup_target(SourceName, TargetName),
+            ?assertEqual(ok, Response),
+            ?assertEqual({error, enoent}, file:read_file_info(FilePath))
+        end, TMap)
+    end).
+
+
+should_fail_cleanup_target_on_missing_source() ->
+    SourceName = ?tempdb(),
+    TargetName = ?tempdb(),
+    Response = couch_db_split:cleanup_target(SourceName, TargetName),
+    ?assertEqual({error, missing_source}, Response).
+
+
+make_pickfun(DocsPerRange) ->
+    fun(DocId, Ranges, _HashFun) ->
+        Id = docid_to_integer(DocId),
+        case {Id div DocsPerRange, Id rem DocsPerRange} of
+            {N, 0} ->
+                lists:nth(N, Ranges);
+            {N, _} ->
+                lists:nth(N + 1, Ranges)
+        end
+    end.
+
+
+fake_pickfun(_, Ranges, _) ->
+    hd(Ranges).
+
+
+make_targets([]) ->
+    maps:new();
+make_targets(Ranges)  ->
+    Targets = lists:map(fun(Range) ->
+        {Range, ?tempdb()}
+    end, Ranges),
+    maps:from_list(Targets).
+
+
+make_ranges(Q) when Q > 0 ->
+    Incr = (2 bsl 31) div Q,
+    lists:map(fun
+        (End) when End >= ?RINGTOP - 1 ->
+            [End - Incr, ?RINGTOP - 1];
+        (End) ->
+            [End - Incr, End - 1]
+    end, lists:seq(Incr, ?RINGTOP, Incr));
+make_ranges(_) ->
+    [].
+
+
+create_docs(DbName, 0) ->
+    couch_util:with_db(DbName, fun(Db) ->
+        UpdateSeq = couch_db:get_update_seq(Db),
+        {ok, UpdateSeq}
+    end);
+create_docs(DbName, DocNum) ->
+    Docs = lists:foldl(fun(I, Acc) ->
+        [create_doc(I), create_local_doc(I) | Acc]
+    end, [], lists:seq(DocNum, 1, -1)),
+    couch_util:with_db(DbName, fun(Db) ->
+        {ok, _Result} = couch_db:update_docs(Db, Docs),
+        {ok, _StartTime} = couch_db:ensure_full_commit(Db),
+        {ok, Db1} = couch_db:reopen(Db),
+        UpdateSeq = couch_db:get_update_seq(Db1),
+        {ok, UpdateSeq}
+    end).
+
+
+create_doc(I) ->
+    Id = iolist_to_binary(io_lib:format("~3..0B", [I])),
+    couch_doc:from_json_obj({[{<<"_id">>, Id}, {<<"value">>, I}]}).
+
+
+create_local_doc(I) ->
+    Id = iolist_to_binary(io_lib:format("_local/~3..0B", [I])),
+    couch_doc:from_json_obj({[{<<"_id">>, Id}, {<<"value">>, I}]}).
+
+docid_to_integer(<<"_local/", DocId/binary>>) ->
+    docid_to_integer(DocId);
+docid_to_integer(DocId) ->
+    list_to_integer(binary_to_list(DocId)).

--- a/src/couch/test/couch_server_tests.erl
+++ b/src/couch/test/couch_server_tests.erl
@@ -108,6 +108,36 @@ t_bad_engine_option() ->
     ?assertEqual(Resp, {error, {invalid_engine_extension, <<"cowabunga!">>}}).
 
 
+get_engine_path_test_() ->
+    {
+        setup,
+        fun start/0, fun test_util:stop/1,
+        {
+            foreach,
+            fun setup/0, fun teardown/1,
+            [
+                fun should_return_engine_path/1,
+                fun should_return_invalid_engine_error/1
+            ]
+        }
+    }.
+
+
+should_return_engine_path(Db) ->
+    DbName = couch_db:name(Db),
+    Engine = couch_db_engine:get_engine(Db),
+    Resp = couch_server:get_engine_path(DbName, Engine),
+    FilePath = couch_db:get_filepath(Db),
+    ?_assertMatch({ok, FilePath}, Resp).
+
+
+should_return_invalid_engine_error(Db) ->
+    DbName = couch_db:name(Db),
+    Engine = fake_engine,
+    Resp = couch_server:get_engine_path(DbName, Engine),
+    ?_assertMatch({error, {invalid_engine, Engine}}, Resp).
+
+
 interleaved_requests_test_() ->
     {
         setup,

--- a/src/couch_pse_tests/src/cpse_test_copy_purge_infos.erl
+++ b/src/couch_pse_tests/src/cpse_test_copy_purge_infos.erl
@@ -1,0 +1,82 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(cpse_test_copy_purge_infos).
+-compile(export_all).
+-compile(nowarn_export_all).
+
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+-define(NUM_DOCS, 100).
+
+
+setup_each() ->
+    {ok, SrcDb} = cpse_util:create_db(),
+    {ok, SrcDb2} = create_and_purge(SrcDb),
+    {ok, TrgDb} = cpse_util:create_db(),
+    {SrcDb2, TrgDb}.
+
+
+teardown_each({SrcDb, TrgDb}) ->
+    ok = couch_server:delete(couch_db:name(SrcDb), []),
+    ok = couch_server:delete(couch_db:name(TrgDb), []).
+
+
+cpse_copy_empty_purged_info({_, Db}) ->
+    {ok, Db1} = couch_db_engine:copy_purge_infos(Db, []),
+    ?assertEqual(ok, cpse_util:assert_each_prop(Db1, [{purge_infos, []}])).
+
+
+cpse_copy_purged_info({SrcDb, TrgDb}) ->
+    {ok, RPIs} = couch_db_engine:fold_purge_infos(SrcDb, 0, fun(PI, Acc) ->
+        {ok, [PI | Acc]}
+    end, [], []),
+    PIs = lists:reverse(RPIs),
+    AEPFold = fun({PSeq, UUID, Id, Revs}, {CPSeq, CPurges}) ->
+        {max(PSeq, CPSeq), [{UUID, Id, Revs} | CPurges]}
+    end,
+    {PurgeSeq, RPurges} = lists:foldl(AEPFold, {0, []}, PIs),
+    Purges = lists:reverse(RPurges),
+    {ok, TrgDb2} = couch_db_engine:copy_purge_infos(TrgDb, PIs),
+    AssertProps = [{purge_seq, PurgeSeq}, {purge_infos, Purges}],
+    ?assertEqual(ok, cpse_util:assert_each_prop(TrgDb2, AssertProps)).
+
+
+create_and_purge(Db) ->
+    {RActions, RIds} = lists:foldl(fun(Id, {CActions, CIds}) ->
+        Id1 = docid(Id),
+        Action = {create, {Id1, {[{<<"int">>, Id}]}}},
+        {[Action| CActions], [Id1| CIds]}
+     end, {[], []}, lists:seq(1, ?NUM_DOCS)),
+    Actions = lists:reverse(RActions),
+    Ids = lists:reverse(RIds),
+    {ok, Db1} = cpse_util:apply_batch(Db, Actions),
+
+    FDIs = couch_db_engine:open_docs(Db1, Ids),
+    RActions2 = lists:foldl(fun(FDI, CActions) ->
+        Id = FDI#full_doc_info.id,
+        PrevRev = cpse_util:prev_rev(FDI),
+        Rev = PrevRev#rev_info.rev,
+        Action = {purge, {Id, Rev}},
+        [Action| CActions]
+     end, [], FDIs),
+    Actions2 = lists:reverse(RActions2),
+    {ok, Db2} = cpse_util:apply_batch(Db1, Actions2),
+    {ok, Db2}.
+
+
+docid(I) ->
+    Str = io_lib:format("~4..0b", [I]),
+    iolist_to_binary(Str).

--- a/src/couch_pse_tests/src/cpse_util.erl
+++ b/src/couch_pse_tests/src/cpse_util.erl
@@ -27,6 +27,7 @@
     cpse_test_fold_docs,
     cpse_test_fold_changes,
     cpse_test_fold_purge_infos,
+    cpse_test_copy_purge_infos,
     cpse_test_purge_docs,
     cpse_test_purge_replication,
     cpse_test_purge_bad_checkpoints,

--- a/src/fabric/include/fabric.hrl
+++ b/src/fabric/include/fabric.hrl
@@ -36,8 +36,10 @@
 
 -record(stream_acc, {
     workers,
+    ready,
     start_fun,
-    replacements
+    replacements,
+    ring_opts
 }).
 
 -record(view_row, {key, id, value, doc, worker}).

--- a/src/fabric/src/fabric_db_doc_count.erl
+++ b/src/fabric/src/fabric_db_doc_count.erl
@@ -22,7 +22,7 @@ go(DbName) ->
     Shards = mem3:shards(DbName),
     Workers = fabric_util:submit_jobs(Shards, get_doc_count, []),
     RexiMon = fabric_util:create_monitors(Shards),
-    Acc0 = {fabric_dict:init(Workers, nil), 0},
+    Acc0 = {fabric_dict:init(Workers, nil), []},
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc0) of
     {timeout, {WorkersDict, _}} ->
         DefunctWorkers = fabric_util:remove_done_workers(WorkersDict, nil),
@@ -34,38 +34,29 @@ go(DbName) ->
         rexi_monitor:stop(RexiMon)
     end.
 
-handle_message({rexi_DOWN, _, {_,NodeRef},_}, _Shard, {Counters, Acc}) ->
-    case fabric_util:remove_down_workers(Counters, NodeRef) of
-    {ok, NewCounters} ->
-        {ok, {NewCounters, Acc}};
-    error ->
-        {error, {nodedown, <<"progress not possible">>}}
+handle_message({rexi_DOWN, _, {_,NodeRef},_}, _Shard, {Counters, Resps}) ->
+    case fabric_ring:node_down(NodeRef, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps}};
+        error -> {error, {nodedown, <<"progress not possible">>}}
     end;
 
-handle_message({rexi_EXIT, Reason}, Shard, {Counters, Acc}) ->
-    NewCounters = lists:keydelete(Shard, #shard.ref, Counters),
-    case fabric_view:is_progress_possible(NewCounters) of
-    true ->
-        {ok, {NewCounters, Acc}};
-    false ->
-        {error, Reason}
+handle_message({rexi_EXIT, Reason}, Shard, {Counters, Resps}) ->
+    case fabric_ring:handle_error(Shard, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps}};
+        error -> {error, Reason}
     end;
 
-handle_message({ok, Count}, Shard, {Counters, Acc}) ->
-    case fabric_dict:lookup_element(Shard, Counters) of
-    undefined ->
-        % already heard from someone else in this range
-        {ok, {Counters, Acc}};
-    nil ->
-        C1 = fabric_dict:store(Shard, ok, Counters),
-        C2 = fabric_view:remove_overlapping_shards(Shard, C1),
-        case fabric_dict:any(nil, C2) of
-        true ->
-            {ok, {C2, Count+Acc}};
-        false ->
-            {stop, Count+Acc}
-        end
+handle_message({ok, Count}, Shard, {Counters, Resps}) ->
+    case fabric_ring:handle_response(Shard, Count, Counters, Resps) of
+        {ok, {Counters1, Resps1}} ->
+            {ok, {Counters1, Resps1}};
+        {stop, Resps1} ->
+            Total = fabric_dict:fold(fun(_, C, A) -> A + C end, 0, Resps1),
+            {stop, Total}
     end;
-handle_message(_, _, Acc) ->
-    {ok, Acc}.
 
+handle_message(Reason, Shard, {Counters, Resps}) ->
+    case fabric_ring:handle_error(Shard, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps}};
+        error -> {error, Reason}
+    end.

--- a/src/fabric/src/fabric_db_info.erl
+++ b/src/fabric/src/fabric_db_info.erl
@@ -23,7 +23,8 @@ go(DbName) ->
     RexiMon = fabric_util:create_monitors(Shards),
     Fun = fun handle_message/3,
     {ok, ClusterInfo} = get_cluster_info(Shards),
-    Acc0 = {fabric_dict:init(Workers, nil), [], [{cluster, ClusterInfo}]},
+    CInfo =  [{cluster, ClusterInfo}],
+    Acc0 = {fabric_dict:init(Workers, nil), [], CInfo},
     try
         case fabric_util:recv(Workers, #shard.ref, Fun, Acc0) of
 
@@ -46,49 +47,47 @@ go(DbName) ->
         rexi_monitor:stop(RexiMon)
     end.
 
-handle_message({rexi_DOWN,
-        _, {_,NodeRef},_}, _Shard, {Counters, PseqAcc, Acc}) ->
-    case fabric_util:remove_down_workers(Counters, NodeRef) of
-    {ok, NewCounters} ->
-        {ok, {NewCounters, PseqAcc, Acc}};
-    error ->
-        {error, {nodedown, <<"progress not possible">>}}
+
+handle_message({rexi_DOWN, _, {_,NodeRef},_}, _, {Counters, Resps, CInfo}) ->
+    case fabric_ring:node_down(NodeRef, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps, CInfo}};
+        error -> {error, {nodedown, <<"progress not possible">>}}
     end;
 
-handle_message({rexi_EXIT, Reason}, Shard, {Counters, PseqAcc, Acc}) ->
-    NewCounters = fabric_dict:erase(Shard, Counters),
-    case fabric_view:is_progress_possible(NewCounters) of
-    true ->
-        {ok, {NewCounters, PseqAcc, Acc}};
-    false ->
-        {error, Reason}
+handle_message({rexi_EXIT, Reason}, Shard, {Counters, Resps, CInfo}) ->
+    case fabric_ring:handle_error(Shard, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps, CInfo}};
+        error -> {error, Reason}
     end;
 
-handle_message({ok, Info}, #shard{dbname=Name} = Shard, {Counters, PseqAcc, Acc}) ->
-    case fabric_dict:lookup_element(Shard, Counters) of
-    undefined ->
-        % already heard from someone else in this range
-        {ok, {Counters, PseqAcc, Acc}};
-    nil ->
+handle_message({ok, Info}, Shard, {Counters, Resps, CInfo}) ->
+    case fabric_ring:handle_response(Shard, Info, Counters, Resps) of
+        {ok, {Counters1, Resps1}} ->
+            {ok, {Counters1, Resps1, CInfo}};
+        {stop, Resps1} ->
+            {stop, build_final_response(CInfo, Shard#shard.dbname, Resps1)}
+    end;
+
+handle_message(Reason, Shard, {Counters, Resps, CInfo}) ->
+    case fabric_ring:handle_error(Shard, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps, CInfo}};
+        error -> {error, Reason}
+    end.
+
+
+build_final_response(CInfo, DbName, Responses) ->
+    AccF = fabric_dict:fold(fun(Shard, Info, {Seqs, PSeqs, Infos}) ->
         Seq = couch_util:get_value(update_seq, Info),
-        C1 = fabric_dict:store(Shard, Seq, Counters),
-        C2 = fabric_view:remove_overlapping_shards(Shard, C1),
         PSeq = couch_util:get_value(purge_seq, Info),
-        NewPseqAcc = [{Shard, PSeq}|PseqAcc],
-        case fabric_dict:any(nil, C2) of
-        true ->
-            {ok, {C2, NewPseqAcc, [Info|Acc]}};
-        false ->
-            {stop, [
-                {db_name,Name},
-                {purge_seq, fabric_view_changes:pack_seqs(NewPseqAcc)},
-                {update_seq, fabric_view_changes:pack_seqs(C2)} |
-                merge_results(lists:flatten([Info|Acc]))
-            ]}
-        end
-    end;
-handle_message(_, _, Acc) ->
-    {ok, Acc}.
+        {[{Shard, Seq} | Seqs], [{Shard, PSeq} | PSeqs], [Info | Infos]}
+    end, {[], [], []}, Responses),
+    {Seqs, PSeqs, Infos} = AccF,
+    PackedSeq =  fabric_view_changes:pack_seqs(Seqs),
+    PackedPSeq = fabric_view_changes:pack_seqs(PSeqs),
+    MergedInfos = merge_results(lists:flatten([CInfo | Infos])),
+    Sequences = [{purge_seq, PackedPSeq}, {update_seq, PackedSeq}],
+    [{db_name, DbName}] ++ Sequences ++ MergedInfos.
+
 
 merge_results(Info) ->
     Dict = lists:foldl(fun({K,V},D0) -> orddict:append(K,V,D0) end,

--- a/src/fabric/src/fabric_db_meta.erl
+++ b/src/fabric/src/fabric_db_meta.erl
@@ -135,9 +135,9 @@ check_sec_set_int(NumWorkers, SetWorkers) ->
         true -> throw(no_majority);
         false -> ok
     end,
-    % Hack to reuse fabric_view:is_progress_possible/1
+    % Hack to reuse fabric_ring:is_progress_possible/1
     FakeCounters = [{S, 0} || S <- SetWorkers],
-    case fabric_view:is_progress_possible(FakeCounters) of
+    case fabric_ring:is_progress_possible(FakeCounters) of
         false -> throw(no_ring);
         true -> ok
     end,

--- a/src/fabric/src/fabric_db_partition_info.erl
+++ b/src/fabric/src/fabric_db_partition_info.erl
@@ -52,7 +52,7 @@ handle_message({rexi_DOWN, _, {_,NodeRef},_}, _Shard, {Counters, Acc}) ->
 
 handle_message({rexi_EXIT, Reason}, Shard, {Counters, Acc}) ->
     NewCounters = fabric_dict:erase(Shard, Counters),
-    case fabric_view:is_progress_possible(NewCounters) of
+    case fabric_ring:is_progress_possible(NewCounters) of
     true ->
         {ok, {NewCounters, Acc}};
     false ->

--- a/src/fabric/src/fabric_db_update_listener.erl
+++ b/src/fabric/src/fabric_db_update_listener.erl
@@ -111,7 +111,7 @@ cleanup_monitor(Parent, Ref, Notifiers) ->
     end.
 
 stop_update_notifiers(Notifiers) ->
-    [rexi:kill(Node, Ref) || #worker{node=Node, ref=Ref} <- Notifiers].
+    rexi:kill_all([{N, Ref} || #worker{node = N, ref = Ref} <- Notifiers]).
 
 stop({Pid, Ref}) ->
     erlang:send(Pid, {Ref, done}).
@@ -169,7 +169,7 @@ handle_message(done, _, _) ->
 
 handle_error(Node, Reason, #acc{shards = Shards} = Acc) ->
     Rest = lists:filter(fun(#shard{node = N}) -> N /= Node end, Shards),
-    case fabric_view:is_progress_possible([{R, nil} || R <- Rest]) of
+    case fabric_ring:is_progress_possible([{R, nil} || R <- Rest]) of
         true ->
             {ok, Acc#acc{shards = Rest}};
         false ->

--- a/src/fabric/src/fabric_dict.erl
+++ b/src/fabric/src/fabric_dict.erl
@@ -56,3 +56,6 @@ fold(Fun, Acc0, Dict) ->
 
 to_list(Dict) ->
     orddict:to_list(Dict).
+
+from_list(KVList) when is_list(KVList) ->
+    orddict:from_list(KVList).

--- a/src/fabric/src/fabric_doc_open.erl
+++ b/src/fabric/src/fabric_doc_open.erl
@@ -322,7 +322,7 @@ t_handle_message_reply() ->
     Acc0 = #acc{workers=Workers, r=2, replies=[]},
 
     ?_test(begin
-        meck:expect(rexi, kill, fun(_, _) -> ok end),
+        meck:expect(rexi, kill_all, fun(_) -> ok end),
 
         % Test that we continue when we haven't met R yet
         ?assertMatch(
@@ -416,7 +416,7 @@ t_store_node_revs() ->
     InitAcc = #acc{workers = [W1, W2, W3], replies = [], r = 2},
 
     ?_test(begin
-        meck:expect(rexi, kill, fun(_, _) -> ok end),
+        meck:expect(rexi, kill_all, fun(_) -> ok end),
 
         % Simple case
         {ok, #acc{node_revs = NodeRevs1}} = handle_message(Foo1, W1, InitAcc),

--- a/src/fabric/src/fabric_group_info.erl
+++ b/src/fabric/src/fabric_group_info.erl
@@ -27,7 +27,8 @@ go(DbName, #doc{id=DDocId}) ->
     Ushards = mem3:ushards(DbName),
     Workers = fabric_util:submit_jobs(Shards, group_info, [DDocId]),
     RexiMon = fabric_util:create_monitors(Shards),
-    Acc = acc_init(Workers, Ushards),
+    USet = sets:from_list([{Id, N} || #shard{name = Id, node = N} <- Ushards]),
+    Acc = {fabric_dict:init(Workers, nil), [], USet},
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc) of
     {timeout, {WorkersDict, _, _}} ->
         DefunctWorkers = fabric_util:remove_done_workers(WorkersDict, nil),
@@ -39,56 +40,42 @@ go(DbName, #doc{id=DDocId}) ->
         rexi_monitor:stop(RexiMon)
     end.
 
-handle_message({rexi_DOWN, _, {_,NodeRef},_}, _Shard,
-        {Counters, Acc, Ushards}) ->
-    case fabric_util:remove_down_workers(Counters, NodeRef) of
-    {ok, NewCounters} ->
-        {ok, {NewCounters, Acc, Ushards}};
-    error ->
-        {error, {nodedown, <<"progress not possible">>}}
+handle_message({rexi_DOWN, _, {_,NodeRef},_}, _, {Counters, Resps, USet}) ->
+    case fabric_ring:node_down(NodeRef, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps, USet}};
+        error -> {error, {nodedown, <<"progress not possible">>}}
     end;
 
-handle_message({rexi_EXIT, Reason}, Shard, {Counters, Acc, Ushards}) ->
-    NewCounters = lists:keydelete(Shard, #shard.ref, Counters),
-    case fabric_view:is_progress_possible(NewCounters) of
-    true ->
-        {ok, {NewCounters, Acc, Ushards}};
-    false ->
-        {error, Reason}
+handle_message({rexi_EXIT, Reason}, Shard, {Counters, Resps, USet}) ->
+    case fabric_ring:handle_error(Shard, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps, USet}};
+        error -> {error, Reason}
     end;
 
-handle_message({ok, Info}, Shard, {Counters0, Acc, Ushards}) ->
-    case fabric_dict:lookup_element(Shard, Counters0) of
-    undefined ->
-        % already heard from other node in this range
-        {ok, {Counters0, Acc, Ushards}};
-    nil ->
-        NewAcc = append_result(Info, Shard, Acc, Ushards),
-        Counters1 = fabric_dict:store(Shard, ok, Counters0),
-        Counters = fabric_view:remove_overlapping_shards(Shard, Counters1),
-        case is_complete(Counters) of
-        false ->
-            {ok, {Counters, NewAcc, Ushards}};
-        true ->
-            Pending = aggregate_pending(NewAcc),
-            Infos = get_infos(NewAcc),
-            Results = [{updates_pending, {Pending}} | merge_results(Infos)],
-            {stop, Results}
-        end
+handle_message({ok, Info}, Shard, {Counters, Resps, USet}) ->
+   case fabric_ring:handle_response(Shard, Info, Counters, Resps) of
+        {ok, {Counters1, Resps1}} ->
+            {ok, {Counters1, Resps1, USet}};
+        {stop, Resps1} ->
+            {stop, build_final_response(USet, Resps1)}
     end;
-handle_message(_, _, Acc) ->
-    {ok, Acc}.
 
-acc_init(Workers, Ushards) ->
-    Set = sets:from_list([{Id, N} || #shard{name = Id, node = N} <- Ushards]),
-    {fabric_dict:init(Workers, nil), dict:new(), Set}.
+handle_message(Reason, Shard, {Counters, Resps, USet}) ->
+    case fabric_ring:handle_error(Shard, Counters, Resps) of
+        {ok, Counters1} -> {ok, {Counters1, Resps, USet}};
+        error -> {error, Reason}
+    end.
 
-is_complete(Counters) ->
-    not fabric_dict:any(nil, Counters).
 
-append_result(Info, #shard{name = Name, node = Node}, Acc, Ushards) ->
-    IsPreferred = sets:is_element({Name, Node}, Ushards),
-    dict:append(Name, {Node, IsPreferred, Info}, Acc).
+build_final_response(USet, Responses) ->
+    AccF = fabric_dict:fold(fun(#shard{name = Id, node = Node}, Info, Acc) ->
+        IsPreferred = sets:is_element({Id, Node}, USet),
+        dict:append(Id, {Node, IsPreferred, Info}, Acc)
+    end, dict:new(), Responses),
+    Pending = aggregate_pending(AccF),
+    Infos = get_infos(AccF),
+    [{updates_pending, {Pending}} | merge_results(Infos)].
+
 
 get_infos(Acc) ->
     Values = [V || {_, V} <- dict:to_list(Acc)],

--- a/src/fabric/src/fabric_ring.erl
+++ b/src/fabric/src/fabric_ring.erl
@@ -1,0 +1,519 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric_ring).
+
+
+-export([
+    is_progress_possible/1,
+    is_progress_possible/2,
+    get_shard_replacements/2,
+    node_down/3,
+    node_down/4,
+    handle_error/3,
+    handle_error/4,
+    handle_response/4,
+    handle_response/5
+]).
+
+
+-include_lib("fabric/include/fabric.hrl").
+-include_lib("mem3/include/mem3.hrl").
+
+
+-type fabric_dict() :: [{#shard{}, any()}].
+-type ring_opts() :: [atom() | tuple()].
+
+
+%% @doc looks for a fully covered keyrange in the list of counters
+-spec is_progress_possible(fabric_dict()) -> boolean().
+is_progress_possible(Counters) ->
+    is_progress_possible(Counters, []).
+
+
+%% @doc looks for a fully covered keyrange in the list of counters
+%% This version take ring option to configure how progress will
+%% be checked. By default, [], checks that the full ring is covered.
+-spec is_progress_possible(fabric_dict(), ring_opts()) -> boolean().
+is_progress_possible(Counters, RingOpts) ->
+    is_progress_possible(Counters, [], 0, ?RING_END, RingOpts).
+
+
+-spec get_shard_replacements(binary(), [#shard{}]) -> [#shard{}].
+get_shard_replacements(DbName, UsedShards0) ->
+    % We only want to generate a replacements list from shards
+    % that aren't already used.
+    AllLiveShards = mem3:live_shards(DbName, [node() | nodes()]),
+    UsedShards = [S#shard{ref=undefined} || S <- UsedShards0],
+    get_shard_replacements_int(AllLiveShards -- UsedShards, UsedShards).
+
+
+-spec node_down(node(), fabric_dict(), fabric_dict()) ->
+    {ok, fabric_dict()} | error.
+node_down(Node, Workers, Responses) ->
+    node_down(Node, Workers, Responses, []).
+
+
+-spec node_down(node(), fabric_dict(), fabric_dict(), ring_opts()) ->
+    {ok, fabric_dict()} | error.
+node_down(Node, Workers, Responses, RingOpts) ->
+    {B, E} = range_bounds(Workers, Responses),
+    Workers1 = fabric_dict:filter(fun(#shard{node = N}, _) ->
+        N =/= Node
+    end, Workers),
+    case is_progress_possible(Workers1, Responses, B, E, RingOpts) of
+        true -> {ok, Workers1};
+        false -> error
+    end.
+
+
+-spec handle_error(#shard{}, fabric_dict(), fabric_dict()) ->
+    {ok, fabric_dict()} | error.
+handle_error(Shard, Workers, Responses) ->
+    handle_error(Shard, Workers, Responses, []).
+
+
+-spec handle_error(#shard{}, fabric_dict(), fabric_dict(), ring_opts()) ->
+    {ok, fabric_dict()} | error.
+handle_error(Shard, Workers, Responses, RingOpts) ->
+    {B, E} = range_bounds(Workers, Responses),
+    Workers1 = fabric_dict:erase(Shard, Workers),
+    case is_progress_possible(Workers1, Responses, B, E, RingOpts) of
+        true -> {ok, Workers1};
+        false -> error
+    end.
+
+
+-spec handle_response(#shard{}, any(), fabric_dict(), fabric_dict()) ->
+    {ok, {fabric_dict(), fabric_dict()}} | {stop, fabric_dict()}.
+handle_response(Shard, Response, Workers, Responses) ->
+    handle_response(Shard, Response, Workers, Responses, []).
+
+
+-spec handle_response(#shard{}, any(), fabric_dict(), fabric_dict(),
+        ring_opts()) ->
+    {ok, {fabric_dict(), fabric_dict()}} | {stop, fabric_dict()}.
+handle_response(Shard, Response, Workers, Responses, RingOpts) ->
+    handle_response(Shard, Response, Workers, Responses, RingOpts,
+        fun stop_workers/1).
+
+
+% Worker response handler. Gets reponses from shard and puts them in the list
+% until they complete a full ring. Then kill unused responses and remaining
+% workers.
+%
+% How a ring "completes" is driven by RingOpts:
+%
+%  * When RingOpts is [] (the default case) responses must form a "clean"
+%    ring, where all copies at the start of the range and end of the range must
+%    have the same boundary values.
+%
+%  * When RingOpts is [{any, [#shard{}]}] responses are accepted from any of
+%    the provided list of shards. This type of ring might be used when querying
+%    a partitioned database. As soon as a result from any of the shards
+%    arrives, result collection stops.
+%
+handle_response(Shard, Response, Workers, Responses, RingOpts, CleanupCb) ->
+    Workers1 = fabric_dict:erase(Shard, Workers),
+    case RingOpts of
+        [] ->
+            #shard{range = [B, E]} = Shard,
+            Responses1 = [{{B, E}, Shard, Response} | Responses],
+            handle_response_ring(Workers1, Responses1, CleanupCb);
+        [{any, Any}] ->
+            handle_response_any(Shard, Response, Workers1, Any, CleanupCb)
+    end.
+
+
+handle_response_ring(Workers, Responses, CleanupCb) ->
+    {MinB, MaxE} = range_bounds(Workers, Responses),
+    Ranges = lists:map(fun({R, _, _}) -> R end, Responses),
+    case mem3_util:get_ring(Ranges, MinB, MaxE) of
+        [] ->
+            {ok, {Workers, Responses}};
+        Ring ->
+            % Return one response per range in the ring. The
+            % response list is reversed before sorting so that the
+            % first shard copy to reply is first. We use keysort
+            % because it is documented as being stable so that
+            % we keep the relative order of duplicate shards
+            SortedResponses = lists:keysort(1, lists:reverse(Responses)),
+            UsedResponses = get_responses(Ring, SortedResponses),
+            % Kill all the remaining workers as well as the redunant responses
+            stop_unused_workers(Workers, Responses, UsedResponses, CleanupCb),
+            {stop, fabric_dict:from_list(UsedResponses)}
+    end.
+
+
+handle_response_any(Shard, Response, Workers, Any, CleanupCb) ->
+    case lists:member(Shard#shard{ref = undefined}, Any) of
+        true ->
+            stop_unused_workers(Workers, [], [], CleanupCb),
+            {stop, fabric_dict:from_list([{Shard, Response}])};
+        false ->
+            {ok, {Workers, []}}
+    end.
+
+
+% Check if workers still waiting and the already received responses could
+% still form a continous range. The range won't always be the full ring, and
+% the bounds are computed based on the minimum and maximum interval beginning
+% and ends.
+%
+% There is also a special case where even if the ring cannot be formed, but
+% there is an overlap between all the shards, then it's considered that
+% progress can still be made. This is essentially to allow for split
+% partitioned shards where one shard copy on a node was split the set of ranges
+% might look like: 00-ff, 00-ff, 07-ff. Even if both 00-ff workers exit,
+% progress can still be made with the remaining 07-ff copy.
+%
+-spec is_progress_possible(fabric_dict(), [{any(), #shard{}, any()}],
+    non_neg_integer(), non_neg_integer(), ring_opts()) -> boolean().
+is_progress_possible([], [], _, _, _) ->
+    false;
+
+is_progress_possible(Counters, Responses, MinB, MaxE, []) ->
+    ResponseRanges = lists:map(fun({{B, E}, _, _}) -> {B, E} end, Responses),
+    Ranges = fabric_util:worker_ranges(Counters) ++ ResponseRanges,
+    mem3_util:get_ring(Ranges, MinB, MaxE) =/= [];
+
+is_progress_possible(Counters, Responses, _, _, [{any, AnyShards}]) ->
+    InAny = fun(S) -> lists:member(S#shard{ref = undefined}, AnyShards) end,
+    case fabric_dict:filter(fun(S, _) -> InAny(S) end, Counters) of
+        [] ->
+            case lists:filter(fun({_, S, _}) -> InAny(S) end, Responses) of
+                [] -> false;
+                [_ | _] -> true
+            end;
+        [_ | _] ->
+            true
+    end.
+
+
+get_shard_replacements_int(UnusedShards, UsedShards) ->
+    % If we have more than one copy of a range then we don't
+    % want to try and add a replacement to any copy.
+    RangeCounts = lists:foldl(fun(#shard{range=R}, Acc) ->
+        dict:update_counter(R, 1, Acc)
+    end, dict:new(), UsedShards),
+
+    % For each seq shard range with a count of 1, find any
+    % possible replacements from the unused shards. The
+    % replacement list is keyed by range.
+    lists:foldl(fun(#shard{range = [B, E] = Range}, Acc) ->
+        case dict:find(Range, RangeCounts) of
+            {ok, 1} ->
+                Repls = mem3_util:non_overlapping_shards(UnusedShards, B, E),
+                % Only keep non-empty lists of replacements
+                if Repls == [] -> Acc; true ->
+                    [{Range, Repls} | Acc]
+                end;
+            _ ->
+                Acc
+        end
+    end, [], UsedShards).
+
+
+range_bounds(Workers, Responses) ->
+    RespRanges = lists:map(fun({R, _, _}) -> R end, Responses),
+    Ranges = fabric_util:worker_ranges(Workers) ++ RespRanges,
+    {Bs, Es} = lists:unzip(Ranges),
+    {lists:min(Bs), lists:max(Es)}.
+
+
+get_responses([], _) ->
+    [];
+
+get_responses([Range | Ranges], [{Range, Shard, Value} | Resps]) ->
+    [{Shard, Value} | get_responses(Ranges, Resps)];
+
+get_responses(Ranges, [_DupeRangeResp | Resps]) ->
+    get_responses(Ranges, Resps).
+
+
+stop_unused_workers(_, _, _, undefined) ->
+    ok;
+
+stop_unused_workers(Workers, AllResponses, UsedResponses, CleanupCb) ->
+    WorkerShards = [S || {S, _} <- Workers],
+    Used  = [S || {S, _} <- UsedResponses],
+    Unused = [S || {_, S, _} <- AllResponses, not lists:member(S, Used)],
+    CleanupCb(WorkerShards ++ Unused).
+
+
+stop_workers(Shards) when is_list(Shards) ->
+    rexi:kill_all([{Node, Ref} || #shard{node = Node, ref = Ref} <- Shards]).
+
+
+% Unit tests
+
+is_progress_possible_full_range_test() ->
+    % a base case
+    ?assertEqual(false, is_progress_possible([], [], 0, 0, [])),
+    T1 = [[0, ?RING_END]],
+    ?assertEqual(true, is_progress_possible(mk_cnts(T1))),
+    T2 = [[0, 10], [11, 20], [21, ?RING_END]],
+    ?assertEqual(true, is_progress_possible(mk_cnts(T2))),
+    % gap
+    T3 = [[0, 10], [12, ?RING_END]],
+    ?assertEqual(false, is_progress_possible(mk_cnts(T3))),
+    % outside range
+    T4 = [[1, 10], [11, 20], [21, ?RING_END]],
+    ?assertEqual(false, is_progress_possible(mk_cnts(T4))),
+    % outside range
+    T5 = [[0, 10], [11, 20], [21, ?RING_END + 1]],
+    ?assertEqual(false, is_progress_possible(mk_cnts(T5))),
+    % possible progress but with backtracking
+    T6 = [[0, 10], [11, 20], [0, 5], [6, 21], [21, ?RING_END]],
+    ?assertEqual(true, is_progress_possible(mk_cnts(T6))),
+    % not possible, overlap is not exact
+    T7 = [[0, 10], [13, 20], [21, ?RING_END], [9, 12]],
+    ?assertEqual(false, is_progress_possible(mk_cnts(T7))).
+
+
+is_progress_possible_with_responses_test() ->
+    C1 = mk_cnts([[0, ?RING_END]]),
+    ?assertEqual(true, is_progress_possible(C1, [], 0, ?RING_END, [])),
+    % check for gaps
+    C2 = mk_cnts([[5, 6], [7, 8]]),
+    ?assertEqual(true, is_progress_possible(C2, [], 5, 8, [])),
+    ?assertEqual(false, is_progress_possible(C2, [], 4, 8, [])),
+    ?assertEqual(false, is_progress_possible(C2, [], 5, 7, [])),
+    ?assertEqual(false, is_progress_possible(C2, [], 4, 9, [])),
+    % check for uneven shard range copies
+    C3 = mk_cnts([[2, 5], [2, 10]]),
+    ?assertEqual(true, is_progress_possible(C3, [], 2, 10, [])),
+    ?assertEqual(false, is_progress_possible(C3, [], 2, 11, [])),
+    ?assertEqual(false, is_progress_possible(C3, [], 3, 10, [])),
+    % they overlap but still not a proper ring
+    C4 = mk_cnts([[2, 4], [3, 7], [6, 10]]),
+    ?assertEqual(false, is_progress_possible(C4, [], 2, 10, [])),
+    % some of the ranges are in responses
+    RS1 = mk_resps([{"n1", 7, 8, 42}]),
+    C5 = mk_cnts([[5, 6]]),
+    ?assertEqual(true, is_progress_possible(C5, RS1, 5, 8, [])),
+    ?assertEqual(false, is_progress_possible([], RS1, 5, 8, [])),
+    ?assertEqual(true, is_progress_possible([], RS1, 7, 8, [])).
+
+
+is_progress_possible_with_ring_opts_test() ->
+    Opts = [{any, [mk_shard("n1", [0, 5]), mk_shard("n2", [3, 10])]}],
+    C1 = [{mk_shard("n1", [0, ?RING_END]), nil}],
+    RS1 = mk_resps([{"n1", 3, 10, 42}]),
+    ?assertEqual(false, is_progress_possible(C1, [], 0, ?RING_END, Opts)),
+    ?assertEqual(false, is_progress_possible([], [], 0, ?RING_END, Opts)),
+    ?assertEqual(false, is_progress_possible([], RS1, 0, ?RING_END, Opts)),
+    % explicitly accept only the shard specified in the ring options
+    ?assertEqual(false, is_progress_possible([], RS1, 3, 10, [{any, []}])),
+    % need to match the node exactly
+    ?assertEqual(false, is_progress_possible([], RS1, 3, 10, Opts)),
+    RS2 = mk_resps([{"n2", 3, 10, 42}]),
+    ?assertEqual(true, is_progress_possible([], RS2, 3, 10, Opts)),
+    % assert that counters can fill the ring not just the response
+    C2 = [{mk_shard("n1", [0, 5]), nil}],
+    ?assertEqual(true, is_progress_possible(C2, [], 0, ?RING_END, Opts)).
+
+
+get_shard_replacements_test() ->
+    Unused = [mk_shard(N, [B, E]) || {N, B, E} <- [
+        {"n1", 11, 20}, {"n1", 21, ?RING_END},
+        {"n2", 0, 4}, {"n2", 5, 10}, {"n2", 11, 20},
+        {"n3", 0, 21, ?RING_END}
+    ]],
+    Used = [mk_shard(N, [B, E]) || {N, B, E} <- [
+        {"n2", 21, ?RING_END},
+        {"n3", 0, 10}, {"n3", 11, 20}
+    ]],
+    Res = lists:sort(get_shard_replacements_int(Unused, Used)),
+    % Notice that [0, 10] range can be replaces by spawning the
+    % [0, 4] and [5, 10] workers on n1
+    Expect = [
+        {[0, 10], [mk_shard("n2", [0, 4]), mk_shard("n2", [5, 10])]},
+        {[11, 20], [mk_shard("n1", [11, 20]), mk_shard("n2", [11, 20])]},
+        {[21, ?RING_END], [mk_shard("n1", [21, ?RING_END])]}
+    ],
+    ?assertEqual(Expect, Res).
+
+
+handle_response_basic_test() ->
+    Shard1 = mk_shard("n1", [0, 1]),
+    Shard2 = mk_shard("n1", [2, ?RING_END]),
+
+    Workers1 = fabric_dict:init([Shard1, Shard2], nil),
+
+    Result1 = handle_response(Shard1, 42, Workers1, [], [], undefined),
+    ?assertMatch({ok, {_, _}}, Result1),
+    {ok, {Workers2, Responses1}} = Result1,
+    ?assertEqual(fabric_dict:erase(Shard1, Workers1), Workers2),
+    ?assertEqual([{{0, 1}, Shard1, 42}], Responses1),
+
+    Result2 = handle_response(Shard2, 43, Workers2, Responses1, [], undefined),
+    ?assertEqual({stop, [{Shard1, 42}, {Shard2, 43}]}, Result2).
+
+
+handle_response_incomplete_ring_test() ->
+    Shard1 = mk_shard("n1", [0, 1]),
+    Shard2 = mk_shard("n1", [2, 10]),
+
+    Workers1 = fabric_dict:init([Shard1, Shard2], nil),
+
+    Result1 = handle_response(Shard1, 42, Workers1, [], [], undefined),
+    ?assertMatch({ok, {_, _}}, Result1),
+    {ok, {Workers2, Responses1}} = Result1,
+    ?assertEqual(fabric_dict:erase(Shard1, Workers1), Workers2),
+    ?assertEqual([{{0, 1}, Shard1, 42}], Responses1),
+
+    Result2 = handle_response(Shard2, 43, Workers2, Responses1, [], undefined),
+    ?assertEqual({stop, [{Shard1, 42}, {Shard2, 43}]}, Result2).
+
+
+handle_response_test_multiple_copies_test() ->
+    Shard1 = mk_shard("n1", [0, 1]),
+    Shard2 = mk_shard("n2", [0, 1]),
+    Shard3 = mk_shard("n1", [2, ?RING_END]),
+
+    Workers1 = fabric_dict:init([Shard1, Shard2, Shard3], nil),
+
+    Result1 = handle_response(Shard1, 42, Workers1, [], [], undefined),
+    ?assertMatch({ok, {_, _}}, Result1),
+    {ok, {Workers2, Responses1}} = Result1,
+
+    Result2 = handle_response(Shard2, 43, Workers2, Responses1, [], undefined),
+    ?assertMatch({ok, {_, _}}, Result2),
+    {ok, {Workers3, Responses2}} = Result2,
+
+    Result3 = handle_response(Shard3, 44, Workers3, Responses2, [], undefined),
+    % Use the value (42) to distinguish between [0, 1] copies. In reality
+    % they should have the same value but here we need to assert that copy
+    % that responded first is included in the ring.
+    ?assertEqual({stop, [{Shard1, 42}, {Shard3, 44}]}, Result3).
+
+
+handle_response_test_backtracking_test() ->
+    Shard1 = mk_shard("n1", [0, 5]),
+    Shard2 = mk_shard("n1", [10, ?RING_END]),
+    Shard3 = mk_shard("n2", [2, ?RING_END]),
+    Shard4 = mk_shard("n3", [0, 1]),
+
+    Workers1 = fabric_dict:init([Shard1, Shard2, Shard3, Shard4], nil),
+
+    Result1 = handle_response(Shard1, 42, Workers1, [], [], undefined),
+    ?assertMatch({ok, {_, _}}, Result1),
+    {ok, {Workers2, Responses1}} = Result1,
+
+    Result2 = handle_response(Shard2, 43, Workers2, Responses1, [], undefined),
+    ?assertMatch({ok, {_, _}}, Result2),
+    {ok, {Workers3, Responses2}} = Result2,
+
+    Result3 = handle_response(Shard3, 44, Workers3, Responses2, [], undefined),
+    ?assertMatch({ok, {_, _}}, Result3),
+    {ok, {Workers4, Responses3}} = Result3,
+
+    Result4 = handle_response(Shard4, 45, Workers4, Responses3, [], undefined),
+    ?assertEqual({stop, [{Shard3, 44}, {Shard4, 45}]}, Result4).
+
+
+handle_response_test_ring_opts_test() ->
+    Shard1 = mk_shard("n1", [0, 5]),
+    Shard2 = mk_shard("n2", [0, 1]),
+    Shard3 = mk_shard("n3", [0, 1]),
+
+    Opts = [{any, [mk_shard("n3", [0, 1])]}],
+
+    ShardList = [Shard1, Shard2, Shard3],
+    WithRefs = [S#shard{ref = make_ref()} || S <- ShardList],
+    Workers1 = fabric_dict:init(WithRefs, nil),
+
+    Result1 = handle_response(Shard1, 42, Workers1, [], Opts, undefined),
+    ?assertMatch({ok, {_, _}}, Result1),
+    {ok, {Workers2, []}} = Result1,
+
+    % Still waiting because the node doesn't match
+    Result2 = handle_response(Shard2, 43, Workers2, [], Opts, undefined),
+    ?assertMatch({ok, {_, _}}, Result2),
+    {ok, {Workers3, []}} = Result2,
+
+    Result3 = handle_response(Shard3, 44, Workers3, [], Opts, undefined),
+    ?assertEqual({stop, [{Shard3, 44}]}, Result3).
+
+
+handle_error_test() ->
+    Shard1 = mk_shard("n1", [0, 5]),
+    Shard2 = mk_shard("n1", [10, ?RING_END]),
+    Shard3 = mk_shard("n2", [2, ?RING_END]),
+    Shard4 = mk_shard("n3", [0, 1]),
+
+    Workers1 = fabric_dict:init([Shard1, Shard2, Shard3, Shard4], nil),
+
+    Result1 = handle_response(Shard1, 42, Workers1, [], [], undefined),
+    ?assertMatch({ok, {_, _}}, Result1),
+    {ok, {Workers2, Responses1}} = Result1,
+
+    Result2 = handle_error(Shard2, Workers2, Responses1),
+    ?assertMatch({ok, _}, Result2),
+    {ok, Workers3} = Result2,
+    ?assertEqual(fabric_dict:erase(Shard2, Workers2), Workers3),
+
+    Result3 = handle_response(Shard3, 44, Workers3, Responses1, [], undefined),
+    ?assertMatch({ok, {_, _}}, Result3),
+    {ok, {Workers4, Responses3}} = Result3,
+    ?assertEqual(error, handle_error(Shard4, Workers4, Responses3)).
+
+
+node_down_test() ->
+    Shard1 = mk_shard("n1", [0, 5]),
+    Shard2 = mk_shard("n1", [10, ?RING_END]),
+    Shard3 = mk_shard("n2", [2, ?RING_END]),
+    Shard4 = mk_shard("n3", [0, 1]),
+
+    Workers1 = fabric_dict:init([Shard1, Shard2, Shard3, Shard4], nil),
+
+    Result1 = handle_response(Shard1, 42, Workers1, [], [], undefined),
+    ?assertMatch({ok, {_, _}}, Result1),
+    {ok, {Workers2, Responses1}} = Result1,
+
+    Result2 = handle_response(Shard2, 43, Workers2, Responses1, [], undefined),
+    ?assertMatch({ok, {_, _}}, Result2),
+    {ok, {Workers3, Responses2}} = Result2,
+
+    Result3 = node_down(n1, Workers3, Responses2),
+    ?assertMatch({ok, _}, Result3),
+    {ok, Workers4} = Result3,
+    ?assertEqual([{Shard3, nil}, {Shard4, nil}], Workers4),
+
+    Result4 = handle_response(Shard3, 44, Workers4, Responses2, [], undefined),
+    ?assertMatch({ok, {_, _}}, Result4),
+    {ok, {Workers5, Responses3}} = Result4,
+
+    % Note: Shard3 was already processed, it's ok if n2 went down after
+    ?assertEqual({ok, [{Shard4, nil}]}, node_down(n2, Workers5, Responses3)),
+
+    ?assertEqual(error, node_down(n3, Workers5, Responses3)).
+
+
+mk_cnts(Ranges) ->
+    Shards = lists:map(fun mk_shard/1, Ranges),
+    fabric_dict:init([S#shard{ref = make_ref()} || S <- Shards], nil).
+
+
+mk_resps(RangeNameVals) ->
+    [{{B, E}, mk_shard(Name, [B, E]), V} || {Name, B, E, V} <- RangeNameVals].
+
+
+mk_shard([B, E]) when is_integer(B), is_integer(E) ->
+    #shard{range = [B, E]}.
+
+
+mk_shard(Name, Range) ->
+    Node = list_to_atom(Name),
+    BName = list_to_binary(Name),
+    #shard{name=BName, node=Node, range=Range}.

--- a/src/fabric/src/fabric_streams.erl
+++ b/src/fabric/src/fabric_streams.erl
@@ -14,7 +14,9 @@
 
 -export([
     start/2,
+    start/3,
     start/4,
+    start/5,
     cleanup/1
 ]).
 
@@ -28,17 +30,28 @@
 start(Workers, Keypos) ->
     start(Workers, Keypos, undefined, undefined).
 
-start(Workers0, Keypos, StartFun, Replacements) ->
+
+start(Workers, Keypos, RingOpts) ->
+    start(Workers, Keypos, undefined, undefined, RingOpts).
+
+
+start(Workers, Keypos, StartFun, Replacements) ->
+    start(Workers, Keypos, StartFun, Replacements, []).
+
+
+start(Workers0, Keypos, StartFun, Replacements, RingOpts) ->
     Fun = fun handle_stream_start/3,
     Acc = #stream_acc{
         workers = fabric_dict:init(Workers0, waiting),
+        ready = [],
         start_fun = StartFun,
-        replacements = Replacements
+        replacements = Replacements,
+        ring_opts = RingOpts
     },
     spawn_worker_cleaner(self(), Workers0),
     Timeout = fabric_util:request_timeout(),
     case rexi_utils:recv(Workers0, Keypos, Fun, Acc, Timeout, infinity) of
-        {ok, #stream_acc{workers=Workers}} ->
+        {ok, #stream_acc{ready = Workers}} ->
             AckedWorkers = fabric_dict:fold(fun(Worker, From, WorkerAcc) ->
                 rexi:stream_start(From),
                 [Worker | WorkerAcc]
@@ -64,69 +77,74 @@ cleanup(Workers) ->
 
 
 handle_stream_start({rexi_DOWN, _, {_, NodeRef}, _}, _, St) ->
-    case fabric_util:remove_down_workers(St#stream_acc.workers, NodeRef) of
-    {ok, Workers} ->
-        {ok, St#stream_acc{workers=Workers}};
-    error ->
-        Reason = {nodedown, <<"progress not possible">>},
-        {error, Reason}
+    #stream_acc{workers = Workers, ready = Ready, ring_opts = RingOpts} = St,
+    case fabric_ring:node_down(NodeRef, Workers, Ready, RingOpts) of
+        {ok, Workers1} ->
+            {ok, St#stream_acc{workers = Workers1}};
+        error ->
+            {error, {nodedown, <<"progress not possible">>}}
     end;
 
 handle_stream_start({rexi_EXIT, Reason}, Worker, St) ->
-    Workers = fabric_dict:erase(Worker, St#stream_acc.workers),
-    Replacements = St#stream_acc.replacements,
-    case {fabric_view:is_progress_possible(Workers), Reason} of
-    {true, _} ->
-        {ok, St#stream_acc{workers=Workers}};
-    {false, {maintenance_mode, _Node}} when Replacements /= undefined ->
-        % Check if we have replacements for this range
-        % and start the new workers if so.
-        case lists:keytake(Worker#shard.range, 1, Replacements) of
-            {value, {_Range, WorkerReplacements}, NewReplacements} ->
-                FinalWorkers = lists:foldl(fun(Repl, NewWorkers) ->
-                    NewWorker = (St#stream_acc.start_fun)(Repl),
-                    add_worker_to_cleaner(self(), NewWorker),
-                    fabric_dict:store(NewWorker, waiting, NewWorkers)
-                end, Workers, WorkerReplacements),
-                % Assert that our replaced worker provides us
-                % the oppurtunity to make progress.
-                true = fabric_view:is_progress_possible(FinalWorkers),
-                NewRefs = fabric_dict:fetch_keys(FinalWorkers),
-                {new_refs, NewRefs, St#stream_acc{
-                    workers=FinalWorkers,
-                    replacements=NewReplacements
-                }};
-            false ->
-                % If we progress isn't possible and we don't have any
-                % replacements then we're dead in the water.
-                Error = {nodedown, <<"progress not possible">>},
-                {error, Error}
-        end;
-    {false, _} ->
-        {error, fabric_util:error_info(Reason)}
+    #stream_acc{
+        workers = Workers,
+        ready = Ready,
+        replacements = Replacements,
+        ring_opts = RingOpts
+    } = St,
+    case {fabric_ring:handle_error(Worker, Workers, Ready, RingOpts), Reason} of
+        {{ok, Workers1}, _Reason} ->
+            {ok, St#stream_acc{workers = Workers1}};
+        {error, {maintenance_mode, _Node}} when Replacements /= undefined ->
+            % Check if we have replacements for this range
+            % and start the new workers if so.
+            case lists:keytake(Worker#shard.range, 1, Replacements) of
+                {value, {_Range, WorkerReplacements}, NewReplacements} ->
+                    FinalWorkers = lists:foldl(fun(Repl, NewWorkers) ->
+                        NewWorker = (St#stream_acc.start_fun)(Repl),
+                        add_worker_to_cleaner(self(), NewWorker),
+                        fabric_dict:store(NewWorker, waiting, NewWorkers)
+                    end, Workers, WorkerReplacements),
+                    % Assert that our replaced worker provides us
+                    % the oppurtunity to make progress.
+                    true = fabric_ring:is_progress_possible(FinalWorkers),
+                    NewRefs = fabric_dict:fetch_keys(FinalWorkers),
+                    {new_refs, NewRefs, St#stream_acc{
+                        workers=FinalWorkers,
+                        replacements=NewReplacements
+                    }};
+                false ->
+                    % If we progress isn't possible and we don't have any
+                    % replacements then we're dead in the water.
+                    {error, {nodedown, <<"progress not possible">>}}
+            end;
+        {error, _} ->
+            {error, fabric_util:error_info(Reason)}
     end;
 
 handle_stream_start(rexi_STREAM_INIT, {Worker, From}, St) ->
-    case fabric_dict:lookup_element(Worker, St#stream_acc.workers) of
+    #stream_acc{workers = Workers, ready = Ready, ring_opts = RingOpts} = St,
+    case fabric_dict:lookup_element(Worker, Workers) of
     undefined ->
         % This worker lost the race with other partition copies, terminate
         rexi:stream_cancel(From),
         {ok, St};
     waiting ->
-        % Don't ack the worker yet so they don't start sending us
-        % rows until we're ready
-        Workers0 = fabric_dict:store(Worker, From, St#stream_acc.workers),
-        Workers1 = fabric_view:remove_overlapping_shards(Worker, Workers0),
-        case fabric_dict:any(waiting, Workers1) of
-            true ->
-                {ok, St#stream_acc{workers=Workers1}};
-            false ->
-                {stop, St#stream_acc{workers=Workers1}}
+        case fabric_ring:handle_response(Worker, From, Workers, Ready, RingOpts) of
+            {ok, {Workers1, Ready1}} ->
+                % Don't have a full ring yet. Keep getting responses
+                {ok, St#stream_acc{workers = Workers1, ready = Ready1}};
+            {stop, Ready1} ->
+                % Have a full ring of workers. But don't ack the worker
+                % yet so they don't start sending us rows until we're ready
+                {stop, St#stream_acc{workers = [], ready = Ready1}}
         end
     end;
 
 handle_stream_start({ok, ddoc_updated}, _, St) ->
-    cleanup(St#stream_acc.workers),
+    WaitingWorkers = [W || {W, _} <- St#stream_acc.workers],
+    ReadyWorkers = [W || {W, _} <- St#stream_acc.ready],
+    cleanup(WaitingWorkers ++ ReadyWorkers),
     {stop, ddoc_updated};
 
 handle_stream_start(Else, _, _) ->
@@ -199,7 +217,7 @@ should_clean_workers() ->
         Ref = erlang:monitor(process, Cleaner),
         Coord ! die,
         receive {'DOWN', Ref, _, Cleaner, _} -> ok end,
-        ?assertEqual(2, meck:num_calls(rexi, kill, 2))
+        ?assertEqual(1, meck:num_calls(rexi, kill_all, 1))
     end).
 
 
@@ -219,7 +237,7 @@ does_not_fire_if_cleanup_called() ->
         receive {'DOWN', Ref, _, _, _} -> ok end,
         % 2 calls would be from cleanup/1 function. If cleanup process fired
         % too it would have been 4 calls total.
-        ?assertEqual(2, meck:num_calls(rexi, kill, 2))
+        ?assertEqual(1, meck:num_calls(rexi, kill_all, 1))
     end).
 
 
@@ -236,12 +254,12 @@ should_clean_additional_worker_too() ->
         Ref = erlang:monitor(process, Cleaner),
         Coord ! die,
         receive {'DOWN', Ref, _, Cleaner, _} -> ok end,
-        ?assertEqual(2, meck:num_calls(rexi, kill, 2))
+        ?assertEqual(1, meck:num_calls(rexi, kill_all, 1))
     end).
 
 
 setup() ->
-    ok = meck:expect(rexi, kill, fun(_, _) -> ok end).
+    ok = meck:expect(rexi, kill_all, fun(_) -> ok end).
 
 
 teardown(_) ->

--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -12,6 +12,7 @@
 
 -module(fabric_view).
 
+
 -export([is_progress_possible/1, remove_overlapping_shards/2, maybe_send_row/1,
     transform_row/1, keydict/1, extract_view/4, get_shards/2,
     check_down_shards/2, handle_worker_exit/3,
@@ -22,6 +23,7 @@
 -include_lib("mem3/include/mem3.hrl").
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch_mrview/include/couch_mrview.hrl").
+
 
 %% @doc Check if a downed node affects any of our workers
 -spec check_down_shards(#collector{}, node()) ->
@@ -48,60 +50,82 @@ handle_worker_exit(Collector, _Worker, Reason) ->
 
 %% @doc looks for a fully covered keyrange in the list of counters
 -spec is_progress_possible([{#shard{}, term()}]) -> boolean().
-is_progress_possible([]) ->
-    false;
 is_progress_possible(Counters) ->
-    Ranges = fabric_dict:fold(fun(#shard{range=[X,Y]}, _, A) -> [{X,Y}|A] end,
-        [], Counters),
-    [{Start, Tail0} | Rest] = lists:ukeysort(1, Ranges),
-    Result = lists:foldl(fun
-    (_, fail) ->
-        % we've already declared failure
-        fail;
-    (_, complete) ->
-        % this is the success condition, we can fast-forward
-        complete;
-    ({X,_}, Tail) when X > (Tail+1) ->
-        % gap in the keyrange, we're dead
-        fail;
-    ({_,Y}, Tail) ->
-        case erlang:max(Tail, Y) of
-        End when (End+1) =:= (2 bsl 31) ->
-            complete;
-        Else ->
-            % the normal condition, adding to the tail
-            Else
-        end
-    end, if (Tail0+1) =:= (2 bsl 31) -> complete; true -> Tail0 end, Rest),
-    (Start =:= 0) andalso (Result =:= complete).
+    fabric_ring:is_progress_possible(Counters).
 
 -spec remove_overlapping_shards(#shard{}, [{#shard{}, any()}]) ->
     [{#shard{}, any()}].
-remove_overlapping_shards(#shard{range=[A,B]} = Shard0, Shards) ->
-    fabric_dict:filter(fun(#shard{range=[X,Y], node=Node, ref=Ref} = Shard, _) ->
-        if Shard =:= Shard0 ->
-            % we can't remove ourselves
+remove_overlapping_shards(#shard{} = Shard, Counters) ->
+    remove_overlapping_shards(Shard, Counters, fun stop_worker/1).
+
+
+-spec remove_overlapping_shards(#shard{}, [{#shard{}, any()}], fun()) ->
+    [{#shard{}, any()}].
+remove_overlapping_shards(#shard{} = Shard, Counters, RemoveCb) ->
+    Counters1 = filter_exact_copies(Shard, Counters, RemoveCb),
+    filter_possible_overlaps(Shard, Counters1, RemoveCb).
+
+
+filter_possible_overlaps(Shard, Counters, RemoveCb) ->
+    Ranges0 = fabric_util:worker_ranges(Counters),
+    #shard{range = [BShard, EShard]} = Shard,
+    Ranges = Ranges0 ++ [{BShard, EShard}],
+    {Bs, Es} = lists:unzip(Ranges),
+    {MinB, MaxE} = {lists:min(Bs), lists:max(Es)},
+    % Use a custom sort function which prioritizes the given shard
+    % range when the start endpoints match.
+    SortFun  = fun
+        ({B, E}, {B, _}) when {B, E} =:= {BShard, EShard} ->
+            % If start matches with the shard's start, shard always wins
             true;
-        A < B, X >= A, X < B ->
-            % lower bound is inside our range
-            rexi:kill(Node, Ref),
+        ({B, _}, {B, E}) when {B, E} =:= {BShard, EShard} ->
+            % If start matches with te shard's start, shard always wins
             false;
-        A < B, Y > A, Y =< B ->
-            % upper bound is inside our range
-            rexi:kill(Node, Ref),
+        ({B, E1}, {B, E2}) ->
+            % If start matches, pick the longest range first
+            E2 >= E1;
+        ({B1, _}, {B2, _}) ->
+            % Then, by default, sort by start point
+            B1 =< B2
+    end,
+    Ring = mem3_util:get_ring(Ranges, SortFun, MinB, MaxE),
+    fabric_dict:filter(fun
+        (S, _) when S =:= Shard ->
+            % Keep the original shard
+            true;
+        (#shard{range = [B, E]} = S, _) ->
+            case lists:member({B, E}, Ring) of
+                true ->
+                    true; % Keep it
+                false ->
+                    % Duplicate range, delete after calling callback function
+                    case is_function(RemoveCb) of
+                        true -> RemoveCb(S);
+                        false -> ok
+                    end,
+                    false
+            end
+    end, Counters).
+
+
+filter_exact_copies(#shard{range = Range0} = Shard0, Shards, Cb) ->
+    fabric_dict:filter(fun
+        (Shard, _) when Shard =:= Shard0 ->
+            true; % Don't remove ourselves
+        (#shard{range = Range} = Shard, _) when Range =:= Range0 ->
+            case is_function(Cb) of
+                true ->  Cb(Shard);
+                false -> ok
+            end,
             false;
-        B < A, X >= A orelse B < A, X < B ->
-            % target shard wraps the key range, lower bound is inside
-            rexi:kill(Node, Ref),
-            false;
-        B < A, Y > A orelse B < A, Y =< B ->
-            % target shard wraps the key range, upper bound is inside
-            rexi:kill(Node, Ref),
-            false;
-        true ->
+        (_, _) ->
             true
-        end
     end, Shards).
+
+
+stop_worker(#shard{ref = Ref, node = Node}) ->
+    rexi:kill(Node, Ref).
+
 
 maybe_send_row(#collector{limit=0} = State) ->
     #collector{counters=Counters, user_acc=AccIn, callback=Callback} = State,
@@ -329,13 +353,15 @@ get_shards(Db, #mrargs{} = Args) ->
     % request.
     case {Args#mrargs.stable, Partition} of
         {true, undefined} ->
-            mem3:ushards(DbName);
+            {mem3:ushards(DbName), []};
         {true, Partition} ->
-            mem3:ushards(DbName, couch_partition:shard_key(Partition));
+            Shards = mem3:ushards(DbName, couch_partition:shard_key(Partition)),
+            {Shards, [{any, Shards}]};
         {false, undefined} ->
-            mem3:shards(DbName);
+            {mem3:shards(DbName), []};
         {false, Partition} ->
-            mem3:shards(DbName, couch_partition:shard_key(Partition))
+            Shards = mem3:shards(DbName, couch_partition:shard_key(Partition)),
+            {Shards, [{any, Shards}]}
     end.
 
 maybe_update_others(DbName, DDoc, ShardsInvolved, ViewName,
@@ -352,8 +378,9 @@ get_shard_replacements(DbName, UsedShards0) ->
     % that aren't already used.
     AllLiveShards = mem3:live_shards(DbName, [node() | nodes()]),
     UsedShards = [S#shard{ref=undefined} || S <- UsedShards0],
-    UnusedShards = AllLiveShards -- UsedShards,
+    get_shard_replacements_int(AllLiveShards -- UsedShards, UsedShards).
 
+get_shard_replacements_int(UnusedShards, UsedShards) ->
     % If we have more than one copy of a range then we don't
     % want to try and add a replacement to any copy.
     RangeCounts = lists:foldl(fun(#shard{range=R}, Acc) ->
@@ -363,10 +390,10 @@ get_shard_replacements(DbName, UsedShards0) ->
     % For each seq shard range with a count of 1, find any
     % possible replacements from the unused shards. The
     % replacement list is keyed by range.
-    lists:foldl(fun(#shard{range=Range}, Acc) ->
+    lists:foldl(fun(#shard{range = [B, E] = Range}, Acc) ->
         case dict:find(Range, RangeCounts) of
             {ok, 1} ->
-                Repls = [S || S <- UnusedShards, S#shard.range =:= Range],
+                Repls = mem3_util:non_overlapping_shards(UnusedShards, B, E),
                 % Only keep non-empty lists of replacements
                 if Repls == [] -> Acc; true ->
                     [{Range, Repls} | Acc]
@@ -391,41 +418,75 @@ fix_skip_and_limit(#mrargs{} = Args) ->
 remove_finalizer(Args) ->
     couch_mrview_util:set_extra(Args, finalizer, null).
 
-% unit test
+% Unit tests
+
 is_progress_possible_test() ->
-    EndPoint = 2 bsl 31,
-    T1 = [[0, EndPoint-1]],
-    ?assertEqual(is_progress_possible(mk_cnts(T1)),true),
-    T2 = [[0,10],[11,20],[21,EndPoint-1]],
-    ?assertEqual(is_progress_possible(mk_cnts(T2)),true),
+    T1 = [[0, ?RING_END]],
+    ?assertEqual(is_progress_possible(mk_cnts(T1)), true),
+    T2 = [[0, 10], [11, 20], [21, ?RING_END]],
+    ?assertEqual(is_progress_possible(mk_cnts(T2)), true),
     % gap
-    T3 = [[0,10],[12,EndPoint-1]],
-    ?assertEqual(is_progress_possible(mk_cnts(T3)),false),
+    T3 = [[0, 10], [12, ?RING_END]],
+    ?assertEqual(is_progress_possible(mk_cnts(T3)), false),
     % outside range
-    T4 = [[1,10],[11,20],[21,EndPoint-1]],
-    ?assertEqual(is_progress_possible(mk_cnts(T4)),false),
+    T4 = [[1, 10], [11, 20], [21, ?RING_END]],
+    ?assertEqual(is_progress_possible(mk_cnts(T4)), false),
     % outside range
-    T5 = [[0,10],[11,20],[21,EndPoint]],
-    ?assertEqual(is_progress_possible(mk_cnts(T5)),false).
+    T5 = [[0, 10], [11, 20], [21, ?RING_END + 1]],
+    ?assertEqual(is_progress_possible(mk_cnts(T5)), false),
+    % possible progress but with backtracking
+    T6 = [[0, 10], [11, 20], [0, 5], [6, 21], [21, ?RING_END]],
+    ?assertEqual(is_progress_possible(mk_cnts(T6)), true),
+    % not possible, overlap is not exact
+    T7 = [[0, 10], [13, 20], [21, ?RING_END], [9, 12]],
+    ?assertEqual(is_progress_possible(mk_cnts(T7)), false).
+
 
 remove_overlapping_shards_test() ->
-    meck:new(rexi),
-    meck:expect(rexi, kill, fun(_, _) -> ok end),
-    EndPoint = 2 bsl 31,
-    T1 = [[0,10],[11,20],[21,EndPoint-1]],
-    Shards = mk_cnts(T1,3),
-    ?assertEqual(orddict:size(
-              remove_overlapping_shards(#shard{name=list_to_atom("node-3"),
-                                               node=list_to_atom("node-3"),
-                                               range=[11,20]},
-                                        Shards)),7),
-    meck:unload(rexi).
+    Cb = undefined,
+
+    Shards = mk_cnts([[0, 10], [11, 20], [21, ?RING_END]], 3),
+
+    % Simple (exact) overlap
+    Shard1 = mk_shard("node-3", [11, 20]),
+    Shards1 = fabric_dict:store(Shard1, nil, Shards),
+    R1 = remove_overlapping_shards(Shard1, Shards1, Cb),
+    ?assertEqual([{0, 10}, {11, 20}, {21, ?RING_END}],
+        fabric_util:worker_ranges(R1)),
+    ?assert(fabric_dict:is_key(Shard1, R1)),
+
+    % Split overlap (shard overlap multiple workers)
+    Shard2 = mk_shard("node-3", [0, 20]),
+    Shards2 = fabric_dict:store(Shard2, nil, Shards),
+    R2 = remove_overlapping_shards(Shard2, Shards2, Cb),
+    ?assertEqual([{0, 20}, {21, ?RING_END}],
+        fabric_util:worker_ranges(R2)),
+    ?assert(fabric_dict:is_key(Shard2, R2)).
+
+
+get_shard_replacements_test() ->
+    Unused = [mk_shard(N, [B, E]) || {N, B, E} <- [
+        {"n1", 11, 20}, {"n1", 21, ?RING_END},
+        {"n2", 0, 4}, {"n2", 5, 10}, {"n2", 11, 20},
+        {"n3", 0, 21, ?RING_END}
+    ]],
+    Used = [mk_shard(N, [B, E]) || {N, B, E} <- [
+        {"n2", 21, ?RING_END},
+        {"n3", 0, 10}, {"n3", 11, 20}
+    ]],
+    Res = lists:sort(get_shard_replacements_int(Unused, Used)),
+    % Notice that [0, 10] range can be replaces by spawning the
+    % [0, 4] and [5, 10] workers on n1
+    Expect = [
+        {[0, 10], [mk_shard("n2", [0, 4]), mk_shard("n2", [5, 10])]},
+        {[11, 20], [mk_shard("n1", [11, 20]), mk_shard("n2", [11, 20])]},
+        {[21, ?RING_END], [mk_shard("n1", [21, ?RING_END])]}
+    ],
+    ?assertEqual(Expect, Res).
+
 
 mk_cnts(Ranges) ->
-    Shards = lists:map(fun(Range) ->
-                               #shard{range=Range}
-                                    end,
-                        Ranges),
+    Shards = lists:map(fun mk_shard/1, Ranges),
     orddict:from_list([{Shard,nil} || Shard <- Shards]).
 
 mk_cnts(Ranges, NoNodes) ->
@@ -440,6 +501,15 @@ mk_cnts(Ranges, NoNodes) ->
 mk_shards(0,_Range,Shards) ->
     Shards;
 mk_shards(NoNodes,Range,Shards) ->
-    NodeName = list_to_atom("node-" ++ integer_to_list(NoNodes)),
-    mk_shards(NoNodes-1,Range,
-              [#shard{name=NodeName, node=NodeName, range=Range} | Shards]).
+    Name ="node-" ++ integer_to_list(NoNodes),
+    mk_shards(NoNodes-1,Range, [mk_shard(Name, Range) | Shards]).
+
+
+mk_shard([B, E]) when is_integer(B), is_integer(E) ->
+    #shard{range = [B, E]}.
+
+
+mk_shard(Name, Range) ->
+    Node = list_to_atom(Name),
+    BName = list_to_binary(Name),
+    #shard{name=BName, node=Node, range=Range}.

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -23,12 +23,12 @@
 go(Db, Options, #mrargs{keys=undefined} = QueryArgs, Callback, Acc) ->
     {CoordArgs, WorkerArgs} = fabric_view:fix_skip_and_limit(QueryArgs),
     DbName = fabric:dbname(Db),
-    Shards = shards(Db, QueryArgs),
+    {Shards, RingOpts} = shards(Db, QueryArgs),
     Workers0 = fabric_util:submit_jobs(
             Shards, fabric_rpc, all_docs, [Options, WorkerArgs]),
     RexiMon = fabric_util:create_monitors(Workers0),
     try
-        case fabric_streams:start(Workers0, #shard.ref) of
+        case fabric_streams:start(Workers0, #shard.ref, RingOpts) of
             {ok, Workers} ->
                 try
                     go(DbName, Options, Workers, CoordArgs, Callback, Acc)

--- a/src/fabric/src/fabric_view_changes.erl
+++ b/src/fabric/src/fabric_view_changes.erl
@@ -127,24 +127,30 @@ keep_sending_changes(DbName, Args, Callback, Seqs, AccIn, Timeout, UpListen, T0)
 send_changes(DbName, ChangesArgs, Callback, PackedSeqs, AccIn, Timeout) ->
     LiveNodes = [node() | nodes()],
     AllLiveShards = mem3:live_shards(DbName, LiveNodes),
-    Seqs = lists:flatmap(fun({#shard{name=Name, node=N} = Shard, Seq}) ->
-        case lists:member(Shard, AllLiveShards) of
-        true ->
-            Ref = rexi:cast(N, {fabric_rpc, changes, [Name,ChangesArgs,Seq]}),
-            [{Shard#shard{ref = Ref}, Seq}];
-        false ->
-            % Find some replacement shards to cover the missing range
-            % TODO It's possible in rare cases of shard merging to end up
-            % with overlapping shard ranges from this technique
-            lists:map(fun(#shard{name=Name2, node=N2} = NewShard) ->
-                Ref = rexi:cast(N2, {fabric_rpc, changes, [Name2, ChangesArgs,
-                    make_replacement_arg(N, Seq)]}),
-                {NewShard#shard{ref = Ref}, 0}
-            end, find_replacement_shards(Shard, AllLiveShards))
-        end
-    end, unpack_seqs(PackedSeqs, DbName)),
+    Seqs0 = unpack_seqs(PackedSeqs, DbName),
+    {WSeqs0, Dead, Reps} = find_replacements(Seqs0, AllLiveShards),
+    % Start workers which didn't need replacements
+    WSeqs = lists:map(fun({#shard{name = Name, node = N} = S, Seq}) ->
+         Ref = rexi:cast(N, {fabric_rpc, changes, [Name, ChangesArgs, Seq]}),
+         {S#shard{ref = Ref}, Seq}
+    end, WSeqs0),
+    % For some dead workers see if they are a result of split shards. In that
+    % case make a replacement argument so that local rexi workers can calculate
+    % (hopefully) a > 0 update sequence.
+    {WSplitSeqs0, Reps1} = find_split_shard_replacements(Dead, Reps),
+    WSplitSeqs = lists:map(fun({#shard{name = Name, node = N} = S, Seq}) ->
+         Arg = make_replacement_arg(N, Seq),
+         Ref = rexi:cast(N, {fabric_rpc, changes, [Name, ChangesArgs, Arg]}),
+         {S#shard{ref = Ref}, Seq}
+    end, WSplitSeqs0),
+    % For ranges that were not split start sequences from 0
+    WReps = lists:map(fun(#shard{name = Name, node = N} = S) ->
+         Ref = rexi:cast(N, {fabric_rpc, changes, [Name, ChangesArgs, 0]}),
+         {S#shard{ref = Ref}, 0}
+    end, Reps1),
+    Seqs = WSeqs ++ WSplitSeqs ++ WReps,
     {Workers0, _} = lists:unzip(Seqs),
-    Repls = fabric_view:get_shard_replacements(DbName, Workers0),
+    Repls = fabric_ring:get_shard_replacements(DbName, Workers0),
     StartFun = fun(#shard{name=Name, node=N, range=R0}=Shard) ->
         %% Find the original shard copy in the Seqs array
         case lists:dropwhile(fun({S, _}) -> S#shard.range =/= R0 end, Seqs) of
@@ -386,6 +392,24 @@ seq({Seq, _Uuid, _Node}) -> Seq;
 seq({Seq, _Uuid}) -> Seq;
 seq(Seq)          -> Seq.
 
+
+unpack_seq_regex_match(Packed) ->
+    NewPattern = "^\\[[0-9]+\s*,\s*\"(?<opaque>.*)\"\\]$",
+    OldPattern = "^\"?([0-9]+-)?(?<opaque>.*?)\"?$",
+    Options = [{capture, [opaque], binary}],
+    case re:run(Packed, NewPattern, Options) of
+    {match, Match} ->
+        Match;
+    nomatch ->
+        {match, Match} = re:run(Packed, OldPattern, Options),
+        Match
+    end.
+
+
+unpack_seq_decode_term(Opaque) ->
+    binary_to_term(couch_util:decodeBase64Url(Opaque)).
+
+
 unpack_seqs(0, DbName) ->
     fabric_dict:init(mem3:shards(DbName), 0);
 
@@ -396,23 +420,14 @@ unpack_seqs([_SeqNum, Opaque], DbName) -> % deprecated
     do_unpack_seqs(Opaque, DbName);
 
 unpack_seqs(Packed, DbName) ->
-    NewPattern = "^\\[[0-9]+\s*,\s*\"(?<opaque>.*)\"\\]$",
-    OldPattern = "^\"?([0-9]+-)?(?<opaque>.*?)\"?$",
-    Options = [{capture, [opaque], binary}],
-    Opaque = case re:run(Packed, NewPattern, Options) of
-    {match, Match} ->
-        Match;
-    nomatch ->
-        {match, Match} = re:run(Packed, OldPattern, Options),
-        Match
-    end,
+    Opaque = unpack_seq_regex_match(Packed),
     do_unpack_seqs(Opaque, DbName).
 
 do_unpack_seqs(Opaque, DbName) ->
     % A preventative fix for FB 13533 to remove duplicate shards.
     % This just picks each unique shard and keeps the largest seq
     % value recorded.
-    Decoded = binary_to_term(couch_util:decodeBase64Url(Opaque)),
+    Decoded = unpack_seq_decode_term(Opaque),
     DedupDict = lists:foldl(fun({Node, [A, B], Seq}, Acc) ->
         dict:append({Node, [A, B]}, Seq, Acc)
     end, dict:new(), Decoded),
@@ -431,28 +446,28 @@ do_unpack_seqs(Opaque, DbName) ->
         end
     end, Deduped),
 
-    % Fill holes in the since sequence. If/when we ever start
-    % using overlapping shard ranges this will need to be updated
-    % to not include shard ranges that overlap entries in Upacked.
-    % A quick and dirty approach would be like such:
-    %
-    %   lists:foldl(fun(S, Acc) ->
-    %       fabric_view:remove_overlapping_shards(S, Acc)
-    %   end, mem3:shards(DbName), Unpacked)
-    %
-    % Unfortunately remove_overlapping_shards isn't reusable because
-    % of its calls to rexi:kill/2. When we get to overlapping
-    % shard ranges and have to rewrite shard range management
-    % we can revisit this simpler algorithm.
-    case fabric_view:is_progress_possible(Unpacked) of
+    % This just handles the case if the ring in the unpacked sequence
+    % received is not complete and in that case tries to fill in the
+    % missing ranges with shards from the shard map
+    case fabric_ring:is_progress_possible(Unpacked) of
         true ->
             Unpacked;
         false ->
-            Extract = fun({Shard, _Seq}) -> Shard#shard.range end,
-            Ranges = lists:usort(lists:map(Extract, Unpacked)),
-            Filter = fun(S) -> not lists:member(S#shard.range, Ranges) end,
-            Replacements = lists:filter(Filter, mem3:shards(DbName)),
-            Unpacked ++ [{R, get_old_seq(R, Deduped)} || R <- Replacements]
+            PotentialWorkers = lists:map(fun({Node, [A, B], Seq}) ->
+                case mem3:get_shard(DbName, Node, [A, B]) of
+                    {ok, Shard} ->
+                        {Shard, Seq};
+                    {error, not_found} ->
+                        {#shard{node = Node, range = [A, B]}, Seq}
+                end
+            end, Deduped),
+            Shards = mem3:shards(DbName),
+            {Unpacked1, Dead, Reps} = find_replacements(PotentialWorkers, Shards),
+            {Splits, Reps1} = find_split_shard_replacements(Dead, Reps),
+            RepSeqs = lists:map(fun(#shard{} = S) ->
+                {S, get_old_seq(S, Deduped)}
+            end, Reps1),
+            Unpacked1 ++ Splits ++ RepSeqs
     end.
 
 
@@ -491,18 +506,119 @@ changes_row(Props0) ->
     Props2 = lists:filter(fun({K,_V}) -> lists:member(K, Allowed) end, Props1),
     {change, {Props2}}.
 
-find_replacement_shards(#shard{range=Range}, AllShards) ->
-    % TODO make this moar betta -- we might have split or merged the partition
-    [Shard || Shard <- AllShards, Shard#shard.range =:= Range].
+
+find_replacements(Workers, AllShards) ->
+    % Build map [B, E] => [Worker1, Worker2, ...] for all workers
+    WrkMap = lists:foldl(fun({#shard{range = [B, E]}, _} = W, Acc) ->
+         maps:update_with({B, E}, fun(Ws) -> [W | Ws] end, [W], Acc)
+    end, #{}, fabric_dict:to_list(Workers)),
+
+    % Build map [B, E] => [Shard1, Shard2, ...] for all shards
+    AllMap = lists:foldl(fun(#shard{range = [B, E]} = S, Acc) ->
+         maps:update_with({B, E}, fun(Ss) -> [S | Ss] end, [S], Acc)
+    end, #{}, AllShards),
+
+    % Custom sort function will prioritize workers over other shards.
+    % The idea is to not unnecessarily kill workers if we don't have to
+    SortFun = fun
+        (R1 = {B, E1}, R2 = {B, E2}) ->
+            case {maps:is_key(R1, WrkMap), maps:is_key(R2, WrkMap)} of
+                {true, true} ->
+                    % Both are workers, larger interval wins
+                    E1 >= E2;
+                {true, false} ->
+                    % First element is a worker range, it wins
+                    true;
+                {false, true} ->
+                    % Second element is a worker range, it wins
+                    false;
+                {false, false} ->
+                    % Neither one is a worker interval, pick larger one
+                    E1 >= E2
+            end;
+        ({B1, _}, {B2, _}) ->
+            B1 =< B2
+    end,
+    Ring = mem3_util:get_ring(maps:keys(AllMap), SortFun),
+
+    % Keep only workers in the ring  and from one of the available nodes
+    Keep = fun(#shard{range = [B, E], node = N}) ->
+        lists:member({B, E}, Ring) andalso lists:keyfind(N, #shard.node,
+            maps:get({B, E}, AllMap)) =/= false
+    end,
+    Workers1 = fabric_dict:filter(fun(S, _) -> Keep(S) end, Workers),
+    Removed = fabric_dict:filter(fun(S, _) -> not Keep(S) end, Workers),
+
+    {Rep, _} = lists:foldl(fun(R, {RepAcc, AllMapAcc}) ->
+        case maps:is_key(R, WrkMap)of
+            true ->
+                % It's a worker and in the map of available shards. Make sure
+                % to keep it only if there is a range available on that node
+                % only (reuse Keep/1 predicate from above)
+                WorkersInRange = maps:get(R, WrkMap),
+                case lists:any(fun({S, _}) -> Keep(S) end, WorkersInRange) of
+                    true ->
+                        {RepAcc, AllMapAcc};
+                    false ->
+                        [Shard | Rest] = maps:get(R, AllMapAcc),
+                        {[Shard | RepAcc], AllMapAcc#{R := Rest}}
+                end;
+             false ->
+                % No worker for this range. Replace from available shards
+                [Shard | Rest] = maps:get(R, AllMapAcc),
+                {[Shard | RepAcc], AllMapAcc#{R := Rest}}
+         end
+    end, {[], AllMap}, Ring),
+
+    % Return the list of workers that are part of ring, list of removed workers
+    % and a list of replacement shards that could be used to make sure the ring
+    % completes.
+    {Workers1, Removed, Rep}.
+
+
+% From the list of dead workers determine if any are a result of a split shard.
+% In that case perhaps there is a way to not rewind the changes feed back to 0.
+% Returns {NewWorkers, Available} where NewWorkers is the list of
+% viable workers Available is the list of still unused input Shards
+find_split_shard_replacements(DeadWorkers, Shards) ->
+    Acc0 = {[], Shards},
+    AccF = fabric_dict:fold(fun(#shard{node = WN, range = R}, Seq, Acc) ->
+        [B, E] = R,
+        {SplitWorkers, Available} = Acc,
+        ShardsOnSameNode = [S || #shard{node = N} = S <- Available, N =:= WN],
+        SplitShards = mem3_util:non_overlapping_shards(ShardsOnSameNode, B, E),
+        RepCount = length(SplitShards),
+        NewWorkers = [{S, make_split_seq(Seq, RepCount)} || S <- SplitShards],
+        NewAvailable = [S || S <- Available, not lists:member(S, SplitShards)],
+        {NewWorkers ++ SplitWorkers, NewAvailable}
+    end, Acc0, DeadWorkers),
+    {Workers, Available} = AccF,
+    {fabric_dict:from_list(Workers), Available}.
+
+
+make_split_seq({Num, _UuidPrefix, Node}, RepCount) when RepCount > 1 ->
+    {Num, split, Node};
+make_split_seq(Seq, _) ->
+    Seq.
+
 
 validate_start_seq(_DbName, "now") ->
     ok;
-validate_start_seq(DbName, Seq) ->
-    try unpack_seqs(Seq, DbName) of _Any ->
+validate_start_seq(_DbName, 0) ->
+    ok;
+validate_start_seq(_DbName, "0") ->
+    ok;
+validate_start_seq(_DbName, Seq) ->
+    try
+        case Seq of
+            [_SeqNum, Opaque] ->
+                unpack_seq_decode_term(Opaque);
+            Seq ->
+                Opaque = unpack_seq_regex_match(Seq),
+                unpack_seq_decode_term(Opaque)
+        end,
         ok
     catch
-        error:database_does_not_exist ->
-            {error, database_does_not_exist};
         _:_ ->
             Reason = <<"Malformed sequence supplied in 'since' parameter.">>,
             {error, {bad_request, Reason}}
@@ -524,7 +640,7 @@ unpack_seqs_test() ->
     meck:new(mem3),
     meck:new(fabric_view),
     meck:expect(mem3, get_shard, fun(_, _, _) -> {ok, #shard{}} end),
-    meck:expect(fabric_view, is_progress_possible, fun(_) -> true end),
+    meck:expect(fabric_ring, is_progress_possible, fun(_) -> true end),
 
     % BigCouch 0.3 style.
     assert_shards("23423-g1AAAAE7eJzLYWBg4MhgTmHgS0ktM3QwND"
@@ -568,3 +684,122 @@ unpack_seqs_test() ->
 
 assert_shards(Packed) ->
     ?assertMatch([{#shard{},_}|_], unpack_seqs(Packed, <<"foo">>)).
+
+
+find_replacements_test() ->
+    % None of the workers are in the live list of shard but there is a
+    % replacement on n3 for the full range. It should get picked instead of
+    % the two smaller one on n2.
+    Workers1 = mk_workers([{"n1", 0, 10}, {"n2", 11, ?RING_END}]),
+    AllShards1 = [
+        mk_shard("n1", 11, ?RING_END),
+        mk_shard("n2", 0, 4),
+        mk_shard("n2", 5, 10),
+        mk_shard("n3", 0, ?RING_END)
+    ],
+    {WorkersRes1, Dead1, Reps1} = find_replacements(Workers1, AllShards1),
+    ?assertEqual([], WorkersRes1),
+    ?assertEqual(Workers1, Dead1),
+    ?assertEqual([mk_shard("n3", 0, ?RING_END)], Reps1),
+
+    % None of the workers are in the live list of shards and there is a
+    % split replacement from n2 (range [0, 10] replaced with [0, 4], [5, 10])
+    Workers2 = mk_workers([{"n1", 0, 10}, {"n2", 11, ?RING_END}]),
+    AllShards2 = [
+        mk_shard("n1", 11, ?RING_END),
+        mk_shard("n2", 0, 4),
+        mk_shard("n2", 5, 10)
+    ],
+    {WorkersRes2, Dead2, Reps2} = find_replacements(Workers2, AllShards2),
+    ?assertEqual([], WorkersRes2),
+    ?assertEqual(Workers2, Dead2),
+    ?assertEqual([
+        mk_shard("n1", 11, ?RING_END),
+        mk_shard("n2", 0, 4),
+        mk_shard("n2", 5, 10)
+    ], lists:sort(Reps2)),
+
+    % One worker is available and one needs to be replaced. Replacement will be
+    % from two split shards
+    Workers3 = mk_workers([{"n1", 0, 10}, {"n2", 11, ?RING_END}]),
+    AllShards3 = [
+        mk_shard("n1", 11, ?RING_END),
+        mk_shard("n2", 0, 4),
+        mk_shard("n2", 5, 10),
+        mk_shard("n2", 11, ?RING_END)
+    ],
+    {WorkersRes3, Dead3, Reps3} = find_replacements(Workers3, AllShards3),
+    ?assertEqual(mk_workers([{"n2", 11, ?RING_END}]), WorkersRes3),
+    ?assertEqual(mk_workers([{"n1", 0, 10}]), Dead3),
+    ?assertEqual([
+        mk_shard("n2", 0, 4),
+        mk_shard("n2", 5, 10)
+    ], lists:sort(Reps3)),
+
+    % All workers are available. Make sure they are not killed even if there is
+    % a longer (single) shard to replace them.
+    Workers4 = mk_workers([{"n1", 0, 10}, {"n1", 11, ?RING_END}]),
+    AllShards4 = [
+        mk_shard("n1", 0, 10),
+        mk_shard("n1", 11, ?RING_END),
+        mk_shard("n2", 0, 4),
+        mk_shard("n2", 5, 10),
+        mk_shard("n3", 0, ?RING_END)
+    ],
+    {WorkersRes4, Dead4, Reps4} = find_replacements(Workers4, AllShards4),
+    ?assertEqual(Workers4, WorkersRes4),
+    ?assertEqual([], Dead4),
+    ?assertEqual([], Reps4).
+
+
+mk_workers(NodesRanges) ->
+    mk_workers(NodesRanges, nil).
+
+mk_workers(NodesRanges, Val) ->
+    orddict:from_list([{mk_shard(N, B, E), Val} || {N, B, E} <- NodesRanges]).
+
+
+mk_shard(Name, B, E) ->
+    Node = list_to_atom(Name),
+    BName = list_to_binary(Name),
+    #shard{name=BName, node=Node, range=[B, E]}.
+
+
+find_split_shard_replacements_test() ->
+    % One worker is can be replaced and one can't
+    Dead1 = mk_workers([{"n1", 0, 10}, {"n2", 11, ?RING_END}], 42),
+    Shards1 = [
+        mk_shard("n1", 0, 4),
+        mk_shard("n1", 5, 10),
+        mk_shard("n3", 11, ?RING_END)
+    ],
+    {Workers1, ShardsLeft1} = find_split_shard_replacements(Dead1, Shards1),
+    ?assertEqual(mk_workers([{"n1", 0, 4}, {"n1", 5, 10}], 42), Workers1),
+    ?assertEqual([mk_shard("n3", 11, ?RING_END)], ShardsLeft1),
+
+    % All workers can be replaced - one by 1 shard, another by 3 smaller shards
+    Dead2 = mk_workers([{"n1", 0, 10}, {"n2", 11, ?RING_END}], 42),
+    Shards2 = [
+        mk_shard("n1", 0, 10),
+        mk_shard("n2", 11, 12),
+        mk_shard("n2", 13, 14),
+        mk_shard("n2", 15, ?RING_END)
+    ],
+    {Workers2, ShardsLeft2} = find_split_shard_replacements(Dead2, Shards2),
+    ?assertEqual(mk_workers([
+       {"n1", 0, 10},
+       {"n2", 11, 12},
+       {"n2", 13, 14},
+       {"n2", 15, ?RING_END}
+    ], 42), Workers2),
+    ?assertEqual([], ShardsLeft2),
+
+    % No workers can be replaced. Ranges match but they are on different nodes
+    Dead3 = mk_workers([{"n1", 0, 10}, {"n2", 11, ?RING_END}], 42),
+    Shards3 = [
+        mk_shard("n2", 0, 10),
+        mk_shard("n3", 11, ?RING_END)
+    ],
+    {Workers3, ShardsLeft3} = find_split_shard_replacements(Dead3, Shards3),
+    ?assertEqual([], Workers3),
+    ?assertEqual(Shards3, ShardsLeft3).

--- a/src/mem3/README.md
+++ b/src/mem3/README.md
@@ -22,9 +22,9 @@ shards total, so 8 nodes will hold none of the data for this database.  Given
 this feature, we even shard use out across the cluster by altering the 'start'
 node for the database's shards.
 
-Splitting and merging shards is an immature feature of the system, and will
-require attention in the near-term. We believe we can implement both
-functions and perform them while the database remains online.
+Shards can be split using the `/_reshard` API endpoint. Refer to a separate
+[README](README_reshard.md) regarding the technical detail on how shard
+splitting works.
 
 ### Getting Started
 

--- a/src/mem3/README_reshard.md
+++ b/src/mem3/README_reshard.md
@@ -1,0 +1,88 @@
+Developer Oriented Resharding Description
+=========================================
+
+This is a technical description of the resharding logic. The discussion will focus on a few aspects such a job's life cycle, data definitions and the state transition mechanism. The main audience is CouchDB developers and assumes knowledge of Erlang/OTP supervision trees as well as CouchDB internals.
+
+
+Job Life-Cycle
+--------------
+
+Job creation happens in the `mem3_reshard_httpd` API handler module. That module uses `mem3_reshard_http_util` to do some validation, and eventually calls `mem3_reshard:start_split_job/2` on one or more nodes in the cluster depending there the new jobs should run.
+
+`mem3_reshard:start_split_job/2` is the main Erlang API entry point.  After some more validation it creates a `#job{}` record and calls the `mem3_reshard` job manager. The manager then will add the job to its jobs ets table, save it to a _local document in the shards db, and most importantly, start a new resharding process. That process will be supervised by the `mem3_reshard_job_sup` supervisor.
+
+Each job will be running in a gen_server implemented in `mem3_reshard_job` module. When splitting a shard a job will go through a series of steps such as `initial_copy`, `build_indices`, `update_shard_map`, etc. Between each stop it will report progress and checkpoint with `mem3_reshard` manager. A checkpoint involved the `mem3_reshard` manager persisting that job's state to disk in `_local/...` document in _dbs db. The the job continues until `competed` state or until it `fails`.
+
+If a user stops shard splitting on the whole cluster then all running job will stop. When shard splitting is resume, they will try to recover from their last checkpoint.
+
+A job can also be individually stopped or resumed. If a job is individually stopped it will stay so even if the global shard splitting state is `running`. A user has to explictly set that job to a `running` state for it to resume.
+
+
+Data Definitions
+----------------
+
+This section focuses on record definition and how data is transformed to and from various formats.
+
+Right below the `mem3_reshard:start_split_job/1` API level a job is converted to a `#job{}` record defined in the `mem3_reshard.hrl` header file. That record is then used throughout most of the resharding code. The job manager `mem3_reshard` stores it in its jobs ets table, then when a job process is spawn it single argument also just a `#job{}` record. As a job process is executing it will periodically report state back to the `mem3_reshard` manager again as an updated `#job{}` record.
+
+Some interesting fields from the `#job{}` record:
+
+ - `id` Uniquely identifies a job in a cluster. It is derived from the source shard name, node and a version (currently = 1).
+ - `type` Currently the only type supported is `split` but `merge` or `rebalance` might be added in the future.
+ - `job_state` The running state of the job. Indicates if the job is `running`, `stopped`, `completed` or `failed`.
+ - `split_state` Once the job is running this indicates how far along it got in the splitting process.
+ - `source` Source shard file
+ - `target` List of target shard files. This is expected to be a list of 2 times currently.
+ - `history` A time-line of state transitions represented as a list of tuples.
+ - `pid` When job is running this will be set to the pid of the process.
+
+
+Because jobs persist across node restarts, this `#job{}` record also has to be saved to disk. That happens in the `mem3_reshard_job_store` module. There a `#job{}` record is transformed to/from an ejson representation. Those transformation functions are dual-purpose and are also used to the HTTP API to return job's state and other information to the user.
+
+Another important piece of data is the global resharding state. Then a user disables resharding on a cluster, a call is made to `mem3_reshard` manager on each node and they store that in a `#state{}` record. This record is defined in the `mem3_reshard.hrl` module, and just like the `#job{}` record can be translated to/from ejson in the `mem3_reshard_store` and stored and loaded from disk.
+
+
+State Transitions
+-----------------
+
+Resharding logic has 3 separate states to keep track of:
+
+1. Global resharding state. This state can be toggled between `running` and `stopped`. That toggle happens via the `mem3_reshard:start/0` and `mem3_reshard:stop/1` function.  This state is kept in the `#state{}` record of the `mem3_reshard` manager gen_server. This state is also persisted to the local shard map database as a `_local/...` document so that it is maintained on a node restart. When the state is `running` then all jobs that are not individually `stopped` and have not failed or completed will be running. When the state is `stopped` all the running jobs will be `stopped`.
+
+2. Job's running state held in the `#job{}` `job_state` field. This is the general running state of a resharding job. It can be `new`, `running`, `stopped`, `completed` or `failed`. This state is most relevant for the `mem3_reshard` manager. In other words, it is the `mem3_reshard` gen_server that starts the job, monitors it to see if it exits successfully on completion or with an error.
+
+3. Job's internal splitting state. This state track the steps taken during shard splitting by each job. This state is mostly relevant for the `mem3_reshard_job` module. This state is kept in `#job{}`'s `split_state` field. The progression of these states is linear going from one state to the next. That's reflected in the code as well, when one state is done, `mem3_reshard_job:next_state/1` is called which returns the next state in the list. The list is defined in `mem3_reshard.hrl` file in `SPLIT_STATES` macro. This simplistic transition is also one of the reasons why a gen_fsm wasn't considered for `mem3_reshard_job` logic.
+
+Another interesting aspect is how`split_state` transitions happen in `mem3_reshard_job` so what follows is an examination of how that works. A job starts running in the `new` state or from a previously checkpointed state. In the later case, the job goes through some recovery logic (see `maybe_recover` in `mem3_reshard_job`) where it tries to resume its work from where it left of. It means, for example, if it was in the `initial_copy` state and was interrupted it might have to reset the target files and copy everything again. After recovery, the state execution logic starts with the `switch_state(#job{}, StateName)` function.
+
+In `mem3_reshard_job:switch_state/2` job's history is updated, any current `state_info` is cleared, job state is switched in the `#job{}` record and then `mem3_reshard` asked to checkpoint this state. That notificaiton is done via gen_server cast message. After that is send the job process sits and waits. In the meantime `mem3_reshard` manager checkpoints, which mean it updates both its ets table with the new `#job{}` record and also persists the state with the `mem3_reshard_store`, and finally it notifies the job process that checkpointing is done by calling `mem3_reshard_job:checkpoint_done/1`.
+
+`mem3_reshard_job:checkpoint_done/1` function call then sends a `do_state` cast to the job's gen_server which proceeds to execute that particular state.
+
+Most states in `mem3_reshard_job` try not to block the gen_server process and instead launch worker processes to perform long running operations. It is usually just one worker process but it could be multiple as well. After that it mostly waits for the workers to finish and inspects their exit signal. If they all exit normal (see `mem_reshard:worker_exited/2`) it calls `switch_state/2` again with the next state and the whole process repeats until completion. Upon completion, the `mem3_reshard_job` gen_server exits normally.
+
+
+Individual Modules Description
+------------------------------
+
+These are mostly random notes about various modules involved in resharding. Most, but not all, are in the mem3 application.
+
+* `mem3_reshard`: Main API entry point and the job manager.
+
+* `mem3_reshard_job` : Individual job logic.
+
+* `mem3_reshard_dbdoc` : Responsible for updating shard doc in the `_db`'s database. Besides just having a bunch of utility function there is a gen_server spawned which is used to update shard documents in a cluster in such a way as to minimize the risk of conflicts. That is accomplished by having each shard updater calling only one such updater for the whole cluster. This coordinator is picked by sorting the list of all the live mem3 nodes and picking the first one in the list.
+
+* `mem3_reshard_httpd` : API endpoint definitions.
+
+* `mem3_reshard_httpd_util` : API endpoint utilities. This module is also responsible for sending requests to all the nodes in a cluster and gathering results.
+
+* `mem3_reshard_index` : This is a helper module used by workers in the `build_indices` state.
+
+* `mem3_reshard_job_sup` : Simple one for one supervisor which keeps track of running jobs.
+
+* `mem3_reshard_store` : State persistence module. It knows how to save/restore `#job{}` and `#state{}` records to/from `_local/...` docs. It is also re-used for serializing `#job{}` into ejson by the HTTP API module.
+
+* `mem3_reshard_validate` : Validate that source exists, target ranges don't have gaps in them, etc.
+
+* `couch_db_split` : This module is not in `mem3` app but it does all the heavy lifting during the initial data copy. Given a source db and some targets, and a function to decide which doc go to which target, it will copy all data from the source to the targets. It's best to think of this module as a form of compactor. Unlike `couch_bt_engine_compactor` this one lives above the `couch_db_engine` API, and instead of copying data to one new file it copies it to 2 or more. Unsurprisingly because of that it uses some lower level `couch_db_engine` API directly, including linking to a couch_db_updater, force setting db update sequences and others.

--- a/src/mem3/include/mem3.hrl
+++ b/src/mem3/include/mem3.hrl
@@ -10,6 +10,11 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
+
+% The last element in the ring
+-define(RING_END, 2 bsl 31 - 1).
+
+
 % type specification hacked to suppress dialyzer warning re: match spec
 -record(shard, {
     name :: binary() | '_' | 'undefined',

--- a/src/mem3/src/mem3.app.src
+++ b/src/mem3/src/mem3.app.src
@@ -20,6 +20,7 @@
         mem3_shards,
         mem3_sync,
         mem3_sync_nodes,
+        mem3_reshard,
         mem3_sup
     ]},
     {applications, [

--- a/src/mem3/src/mem3.erl
+++ b/src/mem3/src/mem3.erl
@@ -150,7 +150,8 @@ ushards(DbName, Shards0, ZoneMap) ->
     % but sort each zone separately to ensure a consistent choice between
     % nodes in the same zone.
     Shards = choose_ushards(DbName, L ++ S) ++ choose_ushards(DbName, D),
-    lists:ukeysort(#shard.range, Shards).
+    OverlappedShards = lists:ukeysort(#shard.range, Shards),
+    mem3_util:non_overlapping_shards(OverlappedShards).
 
 get_shard(DbName, Node, Range) ->
     mem3_shards:get(DbName, Node, Range).

--- a/src/mem3/src/mem3_httpd_handlers.erl
+++ b/src/mem3/src/mem3_httpd_handlers.erl
@@ -15,6 +15,7 @@
 -export([url_handler/1, db_handler/1, design_handler/1]).
 
 url_handler(<<"_membership">>) -> fun mem3_httpd:handle_membership_req/1;
+url_handler(<<"_reshard">>) -> fun mem3_reshard_httpd:handle_reshard_req/1;
 url_handler(_) -> no_match.
 
 db_handler(<<"_shards">>) -> fun mem3_httpd:handle_shards_req/2;

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -17,9 +17,11 @@
     go/2,
     go/3,
     make_local_id/2,
+    make_local_id/3,
     make_purge_id/2,
     verify_purge_checkpoint/2,
-    find_source_seq/4
+    find_source_seq/4,
+    local_id_hash/1
 ]).
 
 -export([
@@ -33,18 +35,24 @@
 -record(acc, {
     batch_size,
     batch_count,
-    revcount = 0,
-    infos = [],
     seq = 0,
-    localid,
-    purgeid,
+    revcount = 0,
     source,
-    target,
+    targets,
     filter,
     db,
-    history = {[]}
+    hashfun
 }).
 
+-record(tgt, {
+    shard,
+    seq = 0,
+    infos = [],
+    localid,
+    purgeid,
+    history = {[]},
+    remaining = 0
+}).
 
 go(Source, Target) ->
     go(Source, Target, []).
@@ -53,36 +61,48 @@ go(Source, Target) ->
 go(DbName, Node, Opts) when is_binary(DbName), is_atom(Node) ->
     go(#shard{name=DbName, node=node()}, #shard{name=DbName, node=Node}, Opts);
 
-
 go(#shard{} = Source, #shard{} = Target, Opts) ->
-    mem3_sync_security:maybe_sync(Source, Target),
-    BatchSize = case proplists:get_value(batch_size, Opts) of
-        BS when is_integer(BS), BS > 0 -> BS;
-        _ -> 100
-    end,
-    BatchCount = case proplists:get_value(batch_count, Opts) of
-        all -> all;
-        BC when is_integer(BC), BC > 0 -> BC;
-        _ -> 1
-    end,
-    Filter = proplists:get_value(filter, Opts),
-    Acc = #acc{
-        batch_size = BatchSize,
-        batch_count = BatchCount,
-        source = Source,
-        target = Target,
-        filter = Filter
-    },
-    go(Acc).
+    go(Source, targets_map(Source, Target), Opts);
+
+go(#shard{} = Source, #{} = Targets0, Opts) when map_size(Targets0) > 0 ->
+    Targets = maps:map(fun(_, T) -> #tgt{shard = T} end, Targets0),
+    case couch_server:exists(Source#shard.name) of
+        true ->
+            sync_security(Source, Targets),
+            BatchSize = case proplists:get_value(batch_size, Opts) of
+                BS when is_integer(BS), BS > 0 -> BS;
+                _ -> 100
+            end,
+            BatchCount = case proplists:get_value(batch_count, Opts) of
+                all -> all;
+                BC when is_integer(BC), BC > 0 -> BC;
+                _ -> 1
+            end,
+            Filter = proplists:get_value(filter, Opts),
+            Acc = #acc{
+                batch_size = BatchSize,
+                batch_count = BatchCount,
+                source = Source,
+                targets = Targets,
+                filter = Filter
+            },
+            go(Acc);
+        false ->
+            {error, missing_source}
+    end.
 
 
 go(#acc{source=Source, batch_count=BC}=Acc) ->
     case couch_db:open(Source#shard.name, [?ADMIN_CTX]) of
     {ok, Db} ->
         Resp = try
-            repl(Acc#acc{db = Db})
-        catch error:{not_found, no_db_file} ->
-            {error, missing_target}
+            HashFun = mem3_hash:get_hash_fun(couch_db:name(Db)),
+            repl(Acc#acc{db = Db, hashfun = HashFun})
+        catch
+            error:{error, missing_source} ->
+                {error, missing_source};
+            error:{not_found, no_db_file} ->
+                {error, missing_target}
         after
             couch_db:close(Db)
         end,
@@ -106,19 +126,29 @@ make_local_id(Source, Target) ->
 make_local_id(#shard{node=SourceNode}, #shard{node=TargetNode}, Filter) ->
     make_local_id(SourceNode, TargetNode, Filter);
 
+make_local_id(SourceThing, TargetThing, F) when is_binary(F) ->
+    S = local_id_hash(SourceThing),
+    T = local_id_hash(TargetThing),
+    <<"_local/shard-sync-", S/binary, "-", T/binary, F/binary>>;
 
 make_local_id(SourceThing, TargetThing, Filter) ->
-    S = couch_util:encodeBase64Url(couch_hash:md5_hash(term_to_binary(SourceThing))),
-    T = couch_util:encodeBase64Url(couch_hash:md5_hash(term_to_binary(TargetThing))),
-    F = case is_function(Filter) of
-        true ->
-            {new_uniq, Hash} = erlang:fun_info(Filter, new_uniq),
-            B = couch_util:encodeBase64Url(Hash),
-            <<"-", B/binary>>;
-        false ->
-            <<>>
-    end,
+    S = local_id_hash(SourceThing),
+    T = local_id_hash(TargetThing),
+    F = filter_hash(Filter),
     <<"_local/shard-sync-", S/binary, "-", T/binary, F/binary>>.
+
+
+filter_hash(Filter) when is_function(Filter) ->
+    {new_uniq, Hash} = erlang:fun_info(Filter, new_uniq),
+    B = couch_util:encodeBase64Url(Hash),
+    <<"-", B/binary>>;
+
+filter_hash(_) ->
+    <<>>.
+
+
+local_id_hash(Thing) ->
+    couch_util:encodeBase64Url(couch_hash:md5_hash(term_to_binary(Thing))).
 
 
 make_purge_id(SourceUUID, TargetUUID) ->
@@ -214,12 +244,12 @@ find_source_seq_int(#doc{body={Props}}, SrcNode0, TgtNode0, TgtUUID, TgtSeq) ->
 
 repl(#acc{db = Db0} = Acc0) ->
     erlang:put(io_priority, {internal_repl, couch_db:name(Db0)}),
-    Acc1 = calculate_start_seq(Acc0),
+    Acc1 = calculate_start_seq_multi(Acc0),
     try
         Acc3 = case config:get_boolean("mem3", "replicate_purges", false) of
             true ->
-                Acc2 = pull_purges(Acc1),
-                push_purges(Acc2);
+                Acc2 = pull_purges_multi(Acc1),
+                push_purges_multi(Acc2);
             false ->
                 Acc1
         end,
@@ -230,90 +260,95 @@ repl(#acc{db = Db0} = Acc0) ->
     end.
 
 
-pull_purges(#acc{} = Acc0) ->
-    #acc{
-        batch_size = Count,
-        seq = UpdateSeq,
-        target = Target
-    } = Acc0,
-    #shard{
-        node = TgtNode,
-        name = TgtDbName
-    } = Target,
-
+pull_purges_multi(#acc{source = Source} = Acc0) ->
+    #acc{batch_size = Count, seq = UpdateSeq, targets = Targets0} = Acc0,
     with_src_db(Acc0, fun(Db) ->
-        SrcUUID = couch_db:get_uuid(Db),
-        {LocalPurgeId, Infos, ThroughSeq, Remaining} =
-                mem3_rpc:load_purge_infos(TgtNode, TgtDbName, SrcUUID, Count),
-
-        if Infos == [] -> ok; true ->
-            {ok, _} = couch_db:purge_docs(Db, Infos, [replicated_edits]),
-            Body = purge_cp_body(Acc0, ThroughSeq),
-            mem3_rpc:save_purge_checkpoint(
-                    TgtNode, TgtDbName, LocalPurgeId, Body)
-        end,
-
-        if Remaining =< 0 -> ok; true ->
+        Targets = maps:map(fun(_, #tgt{} = T) ->
+            pull_purges(Db, Count, Source, T)
+        end, reset_remaining(Targets0)),
+        Remaining = maps:fold(fun(_, #tgt{remaining = R}, Sum) ->
+            Sum + R
+        end, 0, Targets),
+        if Remaining == 0 -> Acc0#acc{targets = Targets}; true ->
             PurgeSeq = couch_db:get_purge_seq(Db),
             OldestPurgeSeq = couch_db:get_oldest_purge_seq(Db),
             PurgesToPush = PurgeSeq - OldestPurgeSeq,
             Changes = couch_db:count_changes_since(Db, UpdateSeq),
-            throw({finished, Remaining + PurgesToPush + Changes})
-        end,
-
-        Acc0#acc{purgeid = LocalPurgeId}
+            Pending = Remaining + PurgesToPush + Changes,
+            throw({finished, Pending})
+        end
     end).
 
 
-push_purges(#acc{} = Acc0) ->
-    #acc{
-        batch_size = BatchSize,
-        purgeid = LocalPurgeId,
-        seq = UpdateSeq,
-        target = Target
-    } = Acc0,
-    #shard{
-        node = TgtNode,
-        name = TgtDbName
-    } = Target,
-
-    with_src_db(Acc0, fun(Db) ->
-        StartSeq = case couch_db:open_doc(Db, LocalPurgeId, []) of
-            {ok, #doc{body = {Props}}} ->
-                couch_util:get_value(<<"purge_seq">>, Props);
-            {not_found, _} ->
-                Oldest = couch_db:get_oldest_purge_seq(Db),
-                erlang:max(0, Oldest - 1)
-        end,
-
-        FoldFun = fun({PSeq, UUID, Id, Revs}, {Count, Infos, _}) ->
-            NewCount = Count + length(Revs),
-            NewInfos = [{UUID, Id, Revs} | Infos],
-            Status = if NewCount < BatchSize -> ok; true -> stop end,
-            {Status, {NewCount, NewInfos, PSeq}}
-        end,
-        InitAcc = {0, [], StartSeq},
-        {ok, {_, Infos, ThroughSeq}} =
-            couch_db:fold_purge_infos(Db, StartSeq, FoldFun, InitAcc),
-
-        if Infos == [] -> ok; true ->
-            ok = purge_on_target(TgtNode, TgtDbName, Infos),
-            Doc = #doc{
-                id = LocalPurgeId,
-                body = purge_cp_body(Acc0, ThroughSeq)
-            },
-            {ok, _} = couch_db:update_doc(Db, Doc, [])
-        end,
-
-        PurgeSeq = couch_db:get_purge_seq(Db),
-        if ThroughSeq >= PurgeSeq -> ok; true ->
-            Remaining = PurgeSeq - ThroughSeq,
+push_purges_multi(#acc{source = SrcShard} = Acc) ->
+    #acc{batch_size = BatchSize, seq = UpdateSeq, targets = Targets0} = Acc,
+    with_src_db(Acc, fun(Db) ->
+        Targets = maps:map(fun(_, #tgt{} = T) ->
+            push_purges(Db, BatchSize, SrcShard, T)
+        end, reset_remaining(Targets0)),
+        Remaining = maps:fold(fun(_, #tgt{remaining = R}, Sum) ->
+            Sum + R
+        end, 0, Targets),
+        if Remaining == 0 -> Acc#acc{targets = Targets}; true ->
             Changes = couch_db:count_changes_since(Db, UpdateSeq),
             throw({finished, Remaining + Changes})
-        end,
-
-        Acc0
+        end
     end).
+
+
+calculate_start_seq_multi(#acc{} = Acc) ->
+    #acc{db = Db, targets = Targets0, filter = Filter} = Acc,
+    FilterHash = filter_hash(Filter),
+    Targets = maps:map(fun(_, #tgt{} = T) ->
+        calculate_start_seq(Db, FilterHash, T)
+    end, Targets0),
+    % There will always be at least one target
+    #tgt{seq = Seq0} = hd(maps:values(Targets)),
+    Seq = maps:fold(fun(_, #tgt{seq = S}, M) -> min(S, M)  end, Seq0, Targets),
+    Acc#acc{seq = Seq, targets = Targets}.
+
+
+pull_purges(Db, Count, SrcShard, #tgt{} = Tgt0) ->
+    #tgt{shard = TgtShard} = Tgt0,
+    SrcUUID = couch_db:get_uuid(Db),
+    #shard{node = TgtNode, name = TgtDbName} = TgtShard,
+    {LocalPurgeId, Infos, ThroughSeq, Remaining} =
+        mem3_rpc:load_purge_infos(TgtNode, TgtDbName, SrcUUID, Count),
+    Tgt = Tgt0#tgt{purgeid = LocalPurgeId},
+    if Infos == [] -> ok; true ->
+        {ok, _} = couch_db:purge_docs(Db, Infos, [replicated_edits]),
+        Body = purge_cp_body(SrcShard, TgtShard, ThroughSeq),
+        mem3_rpc:save_purge_checkpoint(TgtNode, TgtDbName, LocalPurgeId, Body)
+    end,
+    Tgt#tgt{remaining = max(0, Remaining)}.
+
+
+push_purges(Db, BatchSize, SrcShard, Tgt) ->
+    #tgt{shard = TgtShard, purgeid = LocalPurgeId} = Tgt,
+    #shard{node = TgtNode, name = TgtDbName} = TgtShard,
+    StartSeq = case couch_db:open_doc(Db, LocalPurgeId, []) of
+        {ok, #doc{body = {Props}}} ->
+            couch_util:get_value(<<"purge_seq">>, Props);
+        {not_found, _} ->
+            Oldest = couch_db:get_oldest_purge_seq(Db),
+            erlang:max(0, Oldest - 1)
+    end,
+    FoldFun = fun({PSeq, UUID, Id, Revs}, {Count, Infos, _}) ->
+        NewCount = Count + length(Revs),
+        NewInfos = [{UUID, Id, Revs} | Infos],
+        Status = if NewCount < BatchSize -> ok; true -> stop end,
+        {Status, {NewCount, NewInfos, PSeq}}
+    end,
+    InitAcc = {0, [], StartSeq},
+    {ok, {_, Infos, ThroughSeq}} =
+        couch_db:fold_purge_infos(Db, StartSeq, FoldFun, InitAcc),
+    if Infos == [] -> ok; true ->
+        ok = purge_on_target(TgtNode, TgtDbName, Infos),
+        Body = purge_cp_body(SrcShard, TgtShard, ThroughSeq),
+        Doc = #doc{id = LocalPurgeId, body = Body},
+        {ok, _} = couch_db:update_doc(Db, Doc, [])
+    end,
+    Tgt#tgt{remaining = max(0, couch_db:get_purge_seq(Db) - ThroughSeq)}.
 
 
 push_changes(#acc{} = Acc0) ->
@@ -333,21 +368,18 @@ push_changes(#acc{} = Acc0) ->
         Acc1 = Acc0#acc{db = Db},
         Fun = fun ?MODULE:changes_enumerator/2,
         {ok, Acc2} = couch_db:fold_changes(Db, Seq, Fun, Acc1),
-        {ok, #acc{seq = LastSeq}} = replicate_batch(Acc2),
+        {ok, #acc{seq = LastSeq}} = replicate_batch_multi(Acc2),
         {ok, couch_db:count_changes_since(Db, LastSeq)}
     end).
 
 
-calculate_start_seq(Acc) ->
-    #acc{
-        db = Db,
-        target = #shard{node=Node, name=Name}
-    } = Acc,
-    %% Give the target our UUID and ask it to return the checkpoint doc
+calculate_start_seq(Db, FilterHash, #tgt{shard = TgtShard} = Tgt) ->
     UUID = couch_db:get_uuid(Db),
-    {NewDocId, Doc} = mem3_rpc:load_checkpoint(Node, Name, node(), UUID),
+    #shard{node = Node, name = Name} = TgtShard,
+    {NewDocId, Doc} = mem3_rpc:load_checkpoint(Node, Name, node(), UUID,
+        FilterHash),
     #doc{id=FoundId, body={TProps}} = Doc,
-    Acc1 = Acc#acc{localid = NewDocId},
+    Tgt1 = Tgt#tgt{localid = NewDocId},
     % NewDocId and FoundId may be different the first time
     % this code runs to save our newly named internal replication
     % checkpoints. We store NewDocId to use when saving checkpoints
@@ -369,58 +401,78 @@ calculate_start_seq(Acc) ->
                     Seq = TargetSeq,
                     History = couch_util:get_value(<<"history">>, TProps, {[]})
             end,
-            Acc1#acc{seq = Seq, history = History};
+            Tgt1#tgt{seq = Seq, history = History};
         {not_found, _} ->
-            compare_epochs(Acc1)
+            compare_epochs(Db, Tgt1)
     end.
 
-compare_epochs(Acc) ->
-    #acc{
-        db = Db,
-        target = #shard{node=Node, name=Name}
-    } = Acc,
+
+compare_epochs(Db, #tgt{shard = TgtShard} = Tgt) ->
+    #shard{node = Node, name = Name} = TgtShard,
     UUID = couch_db:get_uuid(Db),
     Epochs = couch_db:get_epochs(Db),
     Seq = mem3_rpc:find_common_seq(Node, Name, UUID, Epochs),
-    Acc#acc{seq = Seq, history = {[]}}.
+    Tgt#tgt{seq = Seq, history = {[]}}.
+
 
 changes_enumerator(#doc_info{id=DocId}, #acc{db=Db}=Acc) ->
     {ok, FDI} = couch_db:get_full_doc_info(Db, DocId),
     changes_enumerator(FDI, Acc);
-changes_enumerator(#full_doc_info{}=FDI, #acc{revcount=C, infos=Infos}=Acc0) ->
-    #doc_info{
-        high_seq=Seq,
-        revs=Revs
-    } = couch_doc:to_doc_info(FDI),
-    {Count, NewInfos} = case filter_doc(Acc0#acc.filter, FDI) of
-        keep -> {C + length(Revs), [FDI | Infos]};
-        discard -> {C, Infos}
+changes_enumerator(#full_doc_info{}=FDI, #acc{}=Acc0) ->
+    #acc{revcount = C, targets = Targets0, hashfun = HashFun} = Acc0,
+    #doc_info{high_seq=Seq, revs=Revs} = couch_doc:to_doc_info(FDI),
+    {Count, Targets} = case filter_doc(Acc0#acc.filter, FDI) of
+        keep -> {C + length(Revs), changes_append_fdi(FDI, Targets0, HashFun)};
+        discard -> {C, Targets0}
     end,
-    Acc1 = Acc0#acc{
-        seq=Seq,
-        revcount=Count,
-        infos=NewInfos
-    },
+    Acc1 = Acc0#acc{seq = Seq, revcount = Count, targets = Targets},
     Go = if Count < Acc1#acc.batch_size -> ok; true -> stop end,
     {Go, Acc1}.
 
 
-replicate_batch(#acc{target = #shard{node=Node, name=Name}} = Acc) ->
-    case find_missing_revs(Acc) of
-    [] ->
-        ok;
-    Missing ->
-        lists:map(fun(Chunk) ->
-            Docs = open_docs(Acc, Chunk),
+% First clause is a special case when there is just a single target
+% (the key then has to be `undefined`, see targets_map/1)
+%
+changes_append_fdi(FDI, #{undefined := Target} = Targets, _)
+        when map_size(Targets) == 1 ->
+    #tgt{infos = Infos} = Target,
+    Targets#{undefined :=  Target#tgt{infos = [FDI | Infos]}};
+changes_append_fdi(#full_doc_info{id = Id} = FDI, Targets, HashFun) ->
+    Key = mem3_reshard_job:pickfun(Id, maps:keys(Targets), HashFun),
+    case mem3_reshard_job:pickfun(Id, maps:keys(Targets), HashFun) of
+        not_in_range ->
+            Targets;
+        Key ->
+            maps:update_with(Key, fun(#tgt{infos = Infos} = T) ->
+                T#tgt{infos = [FDI | Infos]}
+            end, Targets)
+    end.
+
+
+replicate_batch_multi(#acc{targets = Targets0, seq = Seq, db = Db} = Acc) ->
+    Targets = maps:map(fun(_, #tgt{} = T) ->
+        replicate_batch(T, Db, Seq)
+    end, Targets0),
+    {ok, Acc#acc{targets = Targets, revcount = 0}}.
+
+
+replicate_batch(#tgt{shard = TgtShard, infos = Infos} = Target, Db, Seq) ->
+    #shard{node = Node, name = Name} = TgtShard,
+    case find_missing_revs(Target) of
+        [] ->
+            ok;
+        Missing ->
+            lists:map(fun(Chunk) ->
+            Docs = open_docs(Db, Infos, Chunk),
             ok = save_on_target(Node, Name, Docs)
         end, chunk_revs(Missing))
     end,
-    update_locals(Acc),
-    {ok, Acc#acc{revcount=0, infos=[]}}.
+    update_locals(Target, Db, Seq),
+    Target#tgt{infos = []}.
 
 
-find_missing_revs(Acc) ->
-    #acc{target = #shard{node=Node, name=Name}, infos = Infos} = Acc,
+find_missing_revs(#tgt{shard = TgtShard, infos = Infos}) ->
+    #shard{node = Node, name = Name} = TgtShard,
     IdsRevs = lists:map(fun(FDI) ->
         #doc_info{id=Id, revs=RevInfos} = couch_doc:to_doc_info(FDI),
         {Id, [R || #rev_info{rev=R} <- RevInfos]}
@@ -461,7 +513,7 @@ chunk_revs([{Id, R, A}|Revs], {Count, Chunk}, Chunks, Limit) ->
     ).
 
 
-open_docs(#acc{db=Db, infos=Infos}, Missing) ->
+open_docs(Db, Infos, Missing) ->
     lists:flatmap(fun({Id, Revs, _}) ->
         FDI = lists:keyfind(Id, #full_doc_info.id, Infos),
         #full_doc_info{rev_tree=RevTree} = FDI,
@@ -491,9 +543,10 @@ purge_on_target(Node, Name, PurgeInfos) ->
     ]),
     ok.
 
-update_locals(Acc) ->
-    #acc{seq=Seq, db=Db, target=Target, localid=Id, history=History} = Acc,
-    #shard{name=Name, node=Node} = Target,
+
+update_locals(Target, Db, Seq) ->
+    #tgt{shard = TgtShard, localid = Id, history = History} = Target,
+    #shard{node = Node, name = Name} = TgtShard,
     NewEntry = [
         {<<"source_node">>, atom_to_binary(node(), utf8)},
         {<<"source_uuid">>, couch_db:get_uuid(Db)},
@@ -504,11 +557,7 @@ update_locals(Acc) ->
     {ok, _} = couch_db:update_doc(Db, #doc{id = Id, body = NewBody}, []).
 
 
-purge_cp_body(#acc{} = Acc, PurgeSeq) ->
-    #acc{
-        source = Source,
-        target = Target
-    } = Acc,
+purge_cp_body(#shard{} = Source, #shard{} = Target, PurgeSeq) ->
     {Mega, Secs, _} = os:timestamp(),
     NowSecs = Mega * 1000000 + Secs,
     {[
@@ -523,7 +572,7 @@ purge_cp_body(#acc{} = Acc, PurgeSeq) ->
 
 find_repl_doc(SrcDb, TgtUUIDPrefix) ->
     SrcUUID = couch_db:get_uuid(SrcDb),
-    S = couch_util:encodeBase64Url(couch_hash:md5_hash(term_to_binary(SrcUUID))),
+    S = local_id_hash(SrcUUID),
     DocIdPrefix = <<"_local/shard-sync-", S/binary, "-">>,
     FoldFun = fun(#doc{id = DocId, body = {BodyProps}} = Doc, _) ->
         TgtUUID = couch_util:get_value(<<"target_uuid">>, BodyProps, <<>>),
@@ -552,11 +601,15 @@ find_repl_doc(SrcDb, TgtUUIDPrefix) ->
 
 
 with_src_db(#acc{source = Source}, Fun) ->
-    {ok, Db} = couch_db:open(Source#shard.name, [?ADMIN_CTX]),
-    try
-        Fun(Db)
-    after
-        couch_db:close(Db)
+    case couch_db:open(Source#shard.name, [?ADMIN_CTX]) of
+        {ok, Db} ->
+            try
+                Fun(Db)
+            after
+                couch_db:close(Db)
+            end;
+         {not_found, _} ->
+            error({error, missing_source})
     end.
 
 
@@ -573,6 +626,45 @@ filter_doc(Filter, FullDocInfo) when is_function(Filter) ->
     end;
 filter_doc(_, _) ->
     keep.
+
+
+sync_security(#shard{} = Source, #{} = Targets) ->
+    maps:map(fun(_, #tgt{shard = Target}) ->
+        mem3_sync_security:maybe_sync(Source, Target)
+    end, Targets).
+
+
+targets_map(#shard{name = <<"shards/", _/binary>> = SrcName} = Src,
+        #shard{name = <<"shards/", _/binary>>, node = TgtNode}) ->
+    % Parse range from name in case the passed shard is build with a name only
+    SrcRange = mem3:range(SrcName),
+    Shards0 = mem3:shards(mem3:dbname(SrcName)),
+    Shards1 = [S || S <- Shards0, not shard_eq(S, Src)],
+    Shards2 = [S || S <- Shards1, check_overlap(SrcRange, TgtNode, S)],
+    maps:from_list([{R, S} || #shard{range = R} = S <- Shards2]);
+
+targets_map(_Src, Tgt) ->
+    #{undefined => Tgt}.
+
+
+shard_eq(#shard{name = Name, node = Node}, #shard{name = Name, node = Node}) ->
+    true;
+
+shard_eq(_, _) ->
+    false.
+
+
+check_overlap(SrcRange, Node, #shard{node = Node, range = TgtRange}) ->
+    mem3_util:range_overlap(SrcRange, TgtRange);
+
+check_overlap([_, _], _, #shard{}) ->
+    false.
+
+
+reset_remaining(#{} = Targets) ->
+    maps:map(fun(_, #tgt{} = T) ->
+        T#tgt{remaining = 0}
+    end, Targets).
 
 
 -ifdef(TEST).
@@ -665,5 +757,107 @@ doc_() ->
     #doc{
         body={[{<<"history">>, History}]}
     }.
+
+
+targets_map_test_() ->
+    {
+        foreach,
+        fun() -> meck:new(mem3, [passthrough]) end,
+        fun(_) -> meck:unload() end,
+        [
+            target_not_a_shard(),
+            source_contained_in_target(),
+            multiple_targets(),
+            uneven_overlap()
+        ]
+    }.
+
+
+target_not_a_shard() ->
+    ?_assertEqual(#{undefined => <<"t">>}, targets_map(<<"s">>, <<"t">>)).
+
+
+source_contained_in_target() ->
+    ?_test(begin
+        R07 = [16#00000000, 16#7fffffff],
+        R8f = [16#80000000, 16#ffffffff],
+        R0f = [16#00000000, 16#ffffffff],
+
+        Shards = [
+            #shard{node = 'n1', range = R07},
+            #shard{node = 'n1', range = R8f},
+            #shard{node = 'n2', range = R07},
+            #shard{node = 'n2', range = R8f},
+            #shard{node = 'n3', range = R0f}
+        ],
+        meck:expect(mem3, shards, 1, Shards),
+
+        SrcName1 = <<"shards/00000000-7fffffff/d.1551893552">>,
+        TgtName1 = <<"shards/00000000-7fffffff/d.1551893552">>,
+
+        Src1 = #shard{name = SrcName1, node = 'n1'},
+        Tgt1 = #shard{name = TgtName1, node = 'n2'},
+        Map1 = targets_map(Src1, Tgt1),
+        ?assertEqual(1, map_size(Map1)),
+        ?assertMatch(#{R07 := #shard{node = 'n2'}}, Map1),
+
+        Tgt2 =  #shard{name = TgtName1, node = 'n3'},
+        Map2 =  targets_map(Src1, Tgt2),
+        ?assertEqual(1, map_size(Map2)),
+        ?assertMatch(#{R0f := #shard{node = 'n3'}}, Map2)
+    end).
+
+
+multiple_targets() ->
+    ?_test(begin
+        R07 = [16#00000000, 16#7fffffff],
+        R8f = [16#80000000, 16#ffffffff],
+        R0f = [16#00000000, 16#ffffffff],
+
+        Shards = [
+            #shard{node = 'n1', range = R07},
+            #shard{node = 'n1', range = R8f},
+            #shard{node = 'n2', range = R0f}
+        ],
+        meck:expect(mem3, shards, 1, Shards),
+
+        SrcName = <<"shards/00000000-ffffffff/d.1551893552">>,
+        TgtName = <<"shards/00000000-7fffffff/d.1551893552">>,
+
+        Src = #shard{name = SrcName, node = 'n2'},
+        Tgt = #shard{name = TgtName, node = 'n1'},
+        Map = targets_map(Src, Tgt),
+        ?assertEqual(2, map_size(Map)),
+        ?assertMatch(#{R07 := #shard{node = 'n1'}}, Map),
+        ?assertMatch(#{R8f := #shard{node = 'n1'}}, Map)
+    end).
+
+
+uneven_overlap() ->
+    ?_test(begin
+        R04 = [16#00000000, 16#4fffffff],
+        R26 = [16#20000000, 16#6fffffff],
+        R58 = [16#50000000, 16#8fffffff],
+        R9f = [16#90000000, 16#ffffffff],
+        Shards = [
+            #shard{node = 'n1', range = R04},
+            #shard{node = 'n1', range = R58},
+            #shard{node = 'n1', range = R9f},
+            #shard{node = 'n2', range = R26}
+        ],
+
+        meck:expect(mem3, shards, 1, Shards),
+
+        SrcName = <<"shards/20000000-6fffffff/d.1551893552">>,
+        TgtName = <<"shards/20000000-6fffffff/d.1551893552">>,
+
+        Src = #shard{name = SrcName, node = 'n2'},
+        Tgt = #shard{name = TgtName, node = 'n1'},
+        Map = targets_map(Src, Tgt),
+        ?assertEqual(2, map_size(Map)),
+        ?assertMatch(#{R04 := #shard{node = 'n1'}}, Map),
+        ?assertMatch(#{R58 := #shard{node = 'n1'}}, Map)
+    end).
+
 
 -endif.

--- a/src/mem3/src/mem3_reshard.erl
+++ b/src/mem3/src/mem3_reshard.erl
@@ -1,0 +1,885 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard).
+
+-behaviour(gen_server).
+
+-export([
+    start/0,
+    stop/1,
+
+    start_split_job/1,
+    stop_job/2,
+    resume_job/1,
+    remove_job/1,
+
+    get_state/0,
+    jobs/0,
+    job/1,
+
+    report/2,
+    checkpoint/2,
+
+    now_sec/0,
+    update_history/4,
+    shard_from_name/1,
+
+    reset_state/0,
+
+    start_link/0,
+
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3
+]).
+
+
+-include("mem3_reshard.hrl").
+
+
+-define(JOB_ID_VERSION, 1).
+-define(JOB_STATE_VERSION, 1).
+-define(DEFAULT_MAX_JOBS, 25).
+-define(DEFAULT_MAX_HISTORY, 20).
+-define(JOB_PREFIX, <<"reshard-job-">>).
+-define(STATE_PREFIX, <<"reshard-state-">>).
+
+
+%% Public API
+
+-spec start() -> ok | {error, any()}.
+start() ->
+    gen_server:call(?MODULE, start, infinity).
+
+
+-spec stop(binary()) -> ok | {error, any()}.
+stop(Reason) ->
+    gen_server:call(?MODULE, {stop, Reason}, infinity).
+
+
+-spec start_split_job(#shard{} | binary()) -> {ok, binary()} | {error, term()}.
+start_split_job(#shard{} = Shard) ->
+    start_split_job(Shard, 2);
+
+start_split_job(ShardName) when is_binary(ShardName) ->
+    start_split_job(shard_from_name(ShardName), 2).
+
+
+-spec start_split_job(#shard{}, split()) -> {ok, binary()} | {error, any()}.
+start_split_job(#shard{} = Source, Split) ->
+    case mem3_reshard_validate:start_args(Source, Split) of
+        ok ->
+            Target = target_shards(Source, Split),
+            case mem3_reshard_validate:targets(Source, Target) of
+                ok ->
+                    TStamp = now_sec(),
+                    Job = #job{
+                        type = split,
+                        job_state = new,
+                        split_state = new,
+                        start_time = TStamp,
+                        update_time = TStamp,
+                        node = node(),
+                        source = Source,
+                        target = Target
+                    },
+                    Job1 = Job#job{id = job_id(Job)},
+                    Job2 = update_job_history(Job1),
+                    gen_server:call(?MODULE, {start_job, Job2}, infinity);
+                {error, Error} ->
+                    {error, Error}
+            end;
+        {error, Error} ->
+            {error, Error}
+    end.
+
+
+-spec stop_job(binary(), binary()) -> ok | {error, any()}.
+stop_job(JobId, Reason) when is_binary(JobId), is_binary(Reason) ->
+    gen_server:call(?MODULE, {stop_job, JobId, Reason}, infinity).
+
+
+-spec resume_job(binary()) -> ok | {error, any()}.
+resume_job(JobId) when is_binary(JobId) ->
+    gen_server:call(?MODULE, {resume_job, JobId}, infinity).
+
+
+-spec remove_job(binary()) -> ok | {error, not_found}.
+remove_job(JobId) when is_binary(JobId) ->
+    gen_server:call(?MODULE, {remove_job, JobId}, infinity).
+
+
+-spec get_state() -> {[_ | _]}.
+get_state() ->
+    gen_server:call(?MODULE, get_state, infinity).
+
+
+-spec jobs() -> [[tuple()]].
+jobs() ->
+    ets:foldl(fun(Job, Acc) ->
+        Opts = [iso8601],
+        Props = mem3_reshard_store:job_to_ejson_props(Job, Opts),
+        [{Props} | Acc]
+    end, [], ?MODULE).
+
+
+-spec job(job_id()) -> {ok, {[_ | _]}} | {error, not_found}.
+job(JobId) ->
+    case job_by_id(JobId) of
+        #job{} = Job ->
+            Opts = [iso8601],
+            Props = mem3_reshard_store:job_to_ejson_props(Job, Opts),
+            {ok, {Props}};
+        not_found ->
+            {error, not_found}
+    end.
+
+
+% State reporting callbacks. Used by mem3_reshard_job module.
+
+-spec report(pid(), #job{}) -> ok.
+report(Server, #job{} = Job) when is_pid(Server) ->
+    gen_server:cast(Server, {report, Job}).
+
+
+-spec checkpoint(pid(), #job{}) -> ok.
+checkpoint(Server, #job{} = Job) ->
+    couch_log:notice("~p checkpointing ~p ~p", [?MODULE, Server, jobfmt(Job)]),
+    gen_server:cast(Server, {checkpoint, Job}).
+
+
+% Utility functions used from other mem3_reshard modules
+
+-spec now_sec() -> non_neg_integer().
+now_sec() ->
+    {Mega, Sec, _Micro} = os:timestamp(),
+    Mega * 1000000 + Sec.
+
+
+-spec update_history(atom(), binary() | null, time_sec(), list()) -> list().
+update_history(State, State, Ts, History) ->
+    % State is the same as detail. Make the detail null to avoid duplication
+    update_history(State, null, Ts, History);
+
+update_history(State, Detail, Ts, History) ->
+    % Reverse, so we can process the last event as the head using
+    % head matches, then after append and trimming, reserse again
+    Rev = lists:reverse(History),
+    UpdatedRev = update_history_rev(State, Detail, Ts, Rev),
+    TrimmedRev = lists:sublist(UpdatedRev, max_history()),
+    lists:reverse(TrimmedRev).
+
+
+-spec shard_from_name(binary()) -> #shard{}.
+shard_from_name(<<"shards/", _:8/binary, "-", _:8/binary, "/",
+        Rest/binary>> = Shard) ->
+    Range = mem3:range(Shard),
+    [DbName, Suffix] = binary:split(Rest, <<".">>),
+    build_shard(Range, DbName, Suffix).
+
+
+% For debugging only
+
+-spec reset_state() -> ok.
+reset_state() ->
+    gen_server:call(?MODULE, reset_state, infinity).
+
+
+% Gen server functions
+
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+
+init(_) ->
+    config:enable_feature('reshard'),
+    couch_log:notice("~p start init()", [?MODULE]),
+    EtsOpts = [named_table, {keypos, #job.id}, {read_concurrency, true}],
+    ?MODULE = ets:new(?MODULE, EtsOpts),
+    ManagerPid = self(),
+    State = #state{
+        state = running,
+        state_info = [],
+        update_time = now_sec(),
+        node = node(),
+        db_monitor = spawn_link(fun() -> db_monitor(ManagerPid) end)
+    },
+    State1 = mem3_reshard_store:init(State, ?JOB_PREFIX, state_id()),
+    State2 = mem3_reshard_store:load_state(State1),
+    State3 = update_config_state(State2),
+    gen_server:cast(self(), reload_jobs),
+    {ok, State3}.
+
+
+terminate(Reason, State) ->
+    couch_log:notice("~p terminate ~p ~p", [?MODULE, Reason, statefmt(State)]),
+    catch unlink(State#state.db_monitor),
+    catch exit(State#state.db_monitor, kill),
+    [kill_job_int(Job) || Job <- running_jobs()],
+    ok.
+
+
+handle_call(start, _From, #state{state = stopped} = State) ->
+    State1 = State#state{
+        state = running,
+        update_time = now_sec(),
+        state_info = info_delete(reason, State#state.state_info)
+    },
+    ok = mem3_reshard_store:store_state(State1),
+    State2 = reload_jobs(State1),
+    State3 = update_config_state(State2),
+    {reply, ok, State3};
+
+handle_call(start, _From, State) ->
+    {reply, ok, State};
+
+handle_call({stop, Reason}, _From, #state{state = running} = State) ->
+    State1 = State#state{
+        state = stopped,
+        update_time = now_sec(),
+        state_info = info_update(reason, Reason, State#state.state_info)
+    },
+    ok = mem3_reshard_store:store_state(State1),
+    [temporarily_stop_job(Job) || Job <- running_jobs()],
+    {reply, ok, State1};
+
+handle_call({stop, _}, _From, State) ->
+    {reply, ok, State};
+
+handle_call({start_job, #job{id = Id, source = Source} = Job}, _From, State) ->
+    couch_log:notice("~p start_job call ~p", [?MODULE, jobfmt(Job)]),
+    Total = ets:info(?MODULE, size),
+    SourceOk = mem3_reshard_validate:source(Source),
+    case {job_by_id(Id), Total + 1 =<  get_max_jobs(), SourceOk} of
+        {not_found, true, ok} ->
+            case State#state.state of
+                running ->
+                    case start_job_int(Job, State) of
+                        ok -> {reply, {ok, Job#job.id}, State};
+                        {error, Error} -> {reply, {error, Error}, State}
+                    end;
+                stopped ->
+                    ok = mem3_reshard_store:store_job(State, Job),
+                    % Since resharding is stop cluster-wide, job is
+                    % temporarily marked as stopped in the ets table so as not
+                    % to return a "running" result which would look odd.
+                    temporarily_stop_job(Job),
+                    {reply, {ok, Job#job.id}, State}
+            end;
+        {#job{}, _, _} ->
+            {reply, {error, job_already_exists}, State};
+        {_, false, _} ->
+            {reply, {error, max_jobs_exceeded}, State};
+        {_, _, {error, _} = SourceError} ->
+            {reply, SourceError, State}
+    end;
+
+handle_call({resume_job, _}, _From, #state{state = stopped} = State) ->
+    case couch_util:get_value(reason, State#state.state_info) of
+        undefined ->
+            {reply, {error, stopped}, State};
+        Reason ->
+            {reply, {error, {stopped, Reason}}, State}
+    end;
+
+handle_call({resume_job, Id}, _From, State) ->
+    couch_log:notice("~p resume_job call ~p", [?MODULE, Id]),
+    case job_by_id(Id) of
+        #job{job_state = stopped} = Job ->
+            case start_job_int(Job, State) of
+                ok ->
+                    {reply, ok, State};
+                {error, Error} ->
+                    {reply, {error, Error}, State}
+            end;
+        #job{} ->
+            {reply, ok, State};
+        not_found ->
+            {reply, {error, not_found}, State}
+    end;
+
+handle_call({stop_job, Id, Reason}, _From, State) ->
+    couch_log:notice("~p stop_job Id:~p Reason:~p", [?MODULE, Id, Reason]),
+    case job_by_id(Id) of
+        #job{job_state = JSt} = Job when JSt =:= running orelse JSt =:= new
+                orelse JSt =:= stopped ->
+            ok = stop_job_int(Job, stopped, Reason, State),
+            {reply, ok, State};
+        #job{} ->
+            {reply, ok, State};
+        not_found ->
+            {reply, {error, not_found}, State}
+    end;
+
+handle_call({remove_job, Id}, _From, State) ->
+    {reply, remove_job_int(Id, State), State};
+
+handle_call(get_state, _From, #state{state = GlobalState} = State) ->
+    StateProps = mem3_reshard_store:state_to_ejson_props(State),
+    Stats0 =  #{running => 0, completed => 0, failed => 0, stopped => 0},
+    StateStats = ets:foldl(fun(#job{job_state = JS}, Acc) ->
+        % When jobs are disabled globally their state is not checkpointed as
+        % "stopped", but it stays as "running". But when returning the state we
+        % don't want to mislead and indicate that there are "N running jobs"
+        % when the global state is "stopped".
+        JS1 = case GlobalState =:= stopped andalso JS =:= running of
+            true -> stopped;
+            false -> JS
+        end,
+        Acc#{JS1 => maps:get(JS1, Acc, 0) + 1}
+    end, Stats0, ?MODULE),
+    Total = ets:info(?MODULE, size),
+    StateStats1 = maps:to_list(StateStats) ++ [{total, Total}],
+    Result = {lists:sort(StateProps ++ StateStats1)},
+    {reply, Result, State};
+
+handle_call(reset_state, _From, State) ->
+    {reply, ok, reset_state(State)};
+
+handle_call(Call, From, State) ->
+    couch_log:error("~p unknown call ~p from: ~p", [?MODULE, Call, From]),
+    {noreply, State}.
+
+
+handle_cast({db_deleted, DbName}, State) ->
+    % Remove only completed jobs. Other running states would `fail` but
+    % job result would stick around so users can inspect them.
+    JobIds = jobs_by_db_and_state(DbName, completed),
+    [remove_job_int(JobId, State) || JobId <- JobIds],
+    {noreply, State};
+
+handle_cast({report, Job}, State) ->
+    report_int(Job),
+    {noreply, State};
+
+handle_cast({checkpoint, Job}, State) ->
+    {noreply, checkpoint_int(Job, State)};
+
+handle_cast(reload_jobs, State) ->
+    couch_log:notice("~p starting reloading jobs", [?MODULE]),
+    State1 = reload_jobs(State),
+    couch_log:notice("~p finished reloading jobs", [?MODULE]),
+    {noreply, State1};
+
+handle_cast(Cast, State) ->
+    couch_log:error("~p unexpected cast ~p", [?MODULE, Cast]),
+    {noreply, State}.
+
+
+handle_info({'DOWN', _Ref, process, Pid, Info}, State) ->
+    case job_by_pid(Pid) of
+        {ok, Job} ->
+            couch_log:notice("~p job ~s exit ~p", [?MODULE, Job#job.id, Info]),
+            ok = handle_job_exit(Job, Info, State);
+        {error, not_found} ->
+            couch_log:error("~p job not found: ~p ~p", [?MODULE, Pid, Info])
+    end,
+    {noreply, State};
+
+handle_info(Info, State) ->
+    couch_log:error("~p unexpected info ~p", [?MODULE, Info]),
+    {noreply, State}.
+
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%% Private API
+
+
+% Insert job in the ets table as a temporarily stopped job. This would happen
+% then job is reloaded or added when cluster-wide resharding is stopped.
+-spec temporarily_stop_job(#job{}) -> #job{}.
+temporarily_stop_job(Job) ->
+    Job1 = kill_job_int(Job),
+    OldInfo = Job1#job.state_info,
+    Reason = <<"Shard splitting disabled">>,
+    Job2 = Job1#job{
+        job_state = stopped,
+        update_time = now_sec(),
+        start_time = 0,
+        state_info = info_update(reason, Reason, OldInfo),
+        pid = undefined,
+        ref = undefined
+    },
+    Job3 = update_job_history(Job2),
+    true = ets:insert(?MODULE, Job3),
+    Job3.
+
+
+-spec reload_jobs(#state{}) -> #state{}.
+reload_jobs(State) ->
+    Jobs = mem3_reshard_store:get_jobs(State),
+    lists:foldl(fun reload_job/2, State, Jobs).
+
+
+% This is a case when main application is stopped but a job is reloaded that
+% was checkpointed in running state. Set that state to stopped to avoid the API
+% results looking odd.
+-spec reload_job(#job{}, #state{}) -> #state{}.
+reload_job(#job{job_state = JS} = Job, #state{state = stopped} = State)
+        when JS =:= running orelse JS =:= new ->
+    temporarily_stop_job(Job),
+    State;
+
+% This is a case when a job process should be spawend
+reload_job(#job{job_state = JS} = Job, #state{state = running} = State)
+        when JS =:= running orelse JS =:= new ->
+    case start_job_int(Job, State) of
+        ok ->
+            State;
+        {error, Error} ->
+            Msg = "~p could not resume ~s error: ~p",
+            couch_log:error(Msg, [?MODULE, jobfmt(Job), Error]),
+            State
+    end;
+
+% If job is disabled individually (stopped by the user), is completed or failed
+% then simply load it into the ets table
+reload_job(#job{job_state = JS} = Job, #state{} = State)
+        when JS =:= failed orelse JS =:= completed orelse JS =:= stopped ->
+    true = ets:insert(?MODULE, Job),
+    State.
+
+
+-spec get_max_jobs() -> integer().
+get_max_jobs() ->
+    config:get_integer("reshard", "max_jobs", ?DEFAULT_MAX_JOBS).
+
+
+-spec start_job_int(#job{}, #state{}) -> ok | {error, term()}.
+start_job_int(Job, State) ->
+    case spawn_job(Job) of
+        {ok, #job{} = Job1} ->
+            Job2 = update_job_history(Job1),
+            ok = mem3_reshard_store:store_job(State, Job2),
+            true = ets:insert(?MODULE, Job2),
+            ok;
+        {error, Error} ->
+            {error, Error}
+    end.
+
+
+-spec spawn_job(#job{}) -> {ok, pid()} | {error, term()}.
+spawn_job(#job{} = Job0) ->
+    Job = Job0#job{
+        job_state = running,
+        start_time = 0,
+        update_time = now_sec(),
+        state_info = info_delete(reason, Job0#job.state_info),
+        manager = self(),
+        workers = [],
+        retries = 0
+    },
+    case mem3_reshard_job_sup:start_child(Job) of
+        {ok, Pid} ->
+            Ref = monitor(process, Pid),
+            {ok, Job#job{pid = Pid, ref = Ref}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+
+-spec stop_job_int(#job{}, job_state(), term(), #state{}) -> ok.
+stop_job_int(#job{} = Job, JobState, Reason, State) ->
+    couch_log:info("~p stop_job_int ~p newstate: ~p reason:~p", [?MODULE,
+        jobfmt(Job), JobState, Reason]),
+    Job1 = kill_job_int(Job),
+    Job2 = Job1#job{
+        job_state = JobState,
+        update_time = now_sec(),
+        state_info = [{reason, Reason}]
+    },
+    ok = mem3_reshard_store:store_job(State, Job2),
+    true = ets:insert(?MODULE, Job2),
+    couch_log:info("~p stop_job_int stopped ~p", [?MODULE, jobfmt(Job2)]),
+    ok.
+
+
+-spec kill_job_int(#job{}) -> #job{}.
+kill_job_int(#job{pid = undefined} = Job) ->
+    Job;
+
+kill_job_int(#job{pid = Pid, ref = Ref} = Job) ->
+    couch_log:info("~p kill_job_int ~p", [?MODULE, jobfmt(Job)]),
+    demonitor(Ref, [flush]),
+    case erlang:is_process_alive(Pid) of
+        true ->
+            ok = mem3_reshard_job_sup:terminate_child(Pid);
+        false ->
+            ok
+    end,
+    Job1 = Job#job{pid = undefined, ref = undefined},
+    true = ets:insert(?MODULE, Job1),
+    Job1.
+
+
+-spec handle_job_exit(#job{}, term(), #state{}) -> ok.
+handle_job_exit(#job{split_state = completed} = Job, normal, State) ->
+    couch_log:notice("~p completed job ~s exited", [?MODULE, Job#job.id]),
+    Job1 = Job#job{
+        pid = undefined,
+        ref = undefined,
+        job_state = completed,
+        update_time = now_sec(),
+        state_info = []
+    },
+    Job2 = update_job_history(Job1),
+    ok = mem3_reshard_store:store_job(State, Job2),
+    true = ets:insert(?MODULE, Job2),
+    ok;
+
+handle_job_exit(#job{job_state = running} = Job, normal, _State) ->
+    couch_log:notice("~p running job ~s stopped", [?MODULE, Job#job.id]),
+    OldInfo = Job#job.state_info,
+    Job1 = Job#job{
+        pid = undefined,
+        ref = undefined,
+        job_state = stopped,
+        update_time = now_sec(),
+        state_info = info_update(reason, <<"Job stopped">>, OldInfo)
+    },
+    true = ets:insert(?MODULE, update_job_history(Job1)),
+    ok;
+
+handle_job_exit(#job{job_state = running} = Job, shutdown, _State) ->
+    couch_log:notice("~p job ~s shutdown", [?MODULE, Job#job.id]),
+    OldInfo = Job#job.state_info,
+    Job1 = Job#job{
+        pid = undefined,
+        ref = undefined,
+        job_state = stopped,
+        update_time = now_sec(),
+        state_info = info_update(reason, <<"Job shutdown">>, OldInfo)
+    },
+    true = ets:insert(?MODULE, update_job_history(Job1)),
+    ok;
+
+handle_job_exit(#job{job_state = running} = Job, {shutdown, Msg}, _State) ->
+    couch_log:notice("~p job ~s shutdown ~p", [?MODULE, Job#job.id, Msg]),
+    OldInfo = Job#job.state_info,
+    Job1 = Job#job{
+        pid = undefined,
+        ref = undefined,
+        job_state = stopped,
+        update_time = now_sec(),
+        state_info = info_update(reason, <<"Job shutdown">>, OldInfo)
+    },
+    true = ets:insert(?MODULE, update_job_history(Job1)),
+    ok;
+
+handle_job_exit(#job{} = Job, Error, State) ->
+    couch_log:notice("~p job ~s failed ~p", [?MODULE, Job#job.id, Error]),
+    OldInfo = Job#job.state_info,
+    Job1 = Job#job{
+        pid = undefined,
+        ref = undefined,
+        job_state = failed,
+        update_time = now_sec(),
+        state_info = info_update(reason, Error, OldInfo)
+    },
+    Job2 = update_job_history(Job1),
+    ok = mem3_reshard_store:store_job(State, Job2),
+    true = ets:insert(?MODULE, Job2),
+    ok.
+
+
+-spec job_by_id(job_id()) -> #job{} | not_found.
+job_by_id(Id) ->
+    case ets:lookup(?MODULE, Id) of
+        [] ->
+            not_found;
+        [#job{}=Job] ->
+            Job
+    end.
+
+
+-spec job_by_pid(pid()) -> {ok, #job{}} | {error, not_found}.
+job_by_pid(Pid) when is_pid(Pid) ->
+    case ets:match_object(?MODULE, #job{pid=Pid, _='_'}) of
+        [] ->
+            {error, not_found};
+        [#job{}=Job] ->
+            {ok, Job}
+    end.
+
+
+-spec state_id() -> binary().
+state_id() ->
+    Ver = iolist_to_binary(io_lib:format("~3..0B", [?JOB_STATE_VERSION])),
+    <<?STATE_PREFIX/binary, Ver/binary>>.
+
+
+-spec job_id(#job{}) -> binary().
+job_id(#job{source = #shard{name = SourceName}}) ->
+    HashInput = [SourceName, atom_to_binary(node(), utf8)],
+    IdHashList = couch_util:to_hex(crypto:hash(sha256, HashInput)),
+    IdHash = iolist_to_binary(IdHashList),
+    Prefix = iolist_to_binary(io_lib:format("~3..0B", [?JOB_ID_VERSION])),
+    <<Prefix/binary, "-", IdHash/binary>>.
+
+
+-spec target_shards(#shard{}, split()) -> [#shard{}].
+target_shards(#shard{name = Name, range = [B, E], dbname = DbName}, Split) when
+        is_integer(Split), Split >= 2, (E - B + 1) >= Split ->
+    Ranges = target_ranges([B, E], Split),
+    <<"shards/", _:8/binary, "-", _:8/binary, "/", DbAndSuffix/binary>> = Name,
+    [DbName, Suffix] = binary:split(DbAndSuffix, <<".">>),
+    [build_shard(R, DbName, Suffix) || R <- Ranges].
+
+
+-spec target_ranges([range_pos()], split()) -> [[range_pos()]].
+target_ranges([Begin, End], Split) when (End - Begin + 1) >= Split,
+        Split >=2 ->
+    Len = End - Begin + 1, % + 1 since intervals are inclusive
+    NewLen = Len div Split,
+    Rem = Len rem Split,
+    Ranges = [[I, I + NewLen - 1] || I <- lists:seq(Begin, End - Rem, NewLen)],
+    % Adjust last end to always match the original end to ensure we always
+    % cover the whole range. In case when remainder is larger this will make
+    % the last range larger. Improve the algorithm later to re-distribute
+    % the remainder equally amonst the chunks.
+    {BeforeLast, [[BeginLast, _]]} = lists:split(Split - 1, Ranges),
+    BeforeLast ++ [[BeginLast, End]].
+
+
+-spec build_shard([non_neg_integer()], binary(), binary()) -> #shard{}.
+build_shard(Range, DbName, Suffix) ->
+    Shard = #shard{dbname = DbName, range = Range, node = node()},
+    mem3_util:name_shard(Shard, <<".", Suffix/binary>>).
+
+
+-spec running_jobs() -> [#job{}].
+running_jobs() ->
+    Pat = #job{job_state = running, _ = '_'},
+    ets:match_object(?MODULE, Pat).
+
+
+-spec info_update(atom(), any(), [tuple()]) -> [tuple()].
+info_update(Key, Val, StateInfo) ->
+    lists:keystore(Key, 1, StateInfo, {Key, Val}).
+
+
+-spec info_delete(atom(), [tuple()]) -> [tuple()].
+info_delete(Key, StateInfo) ->
+    lists:keydelete(Key, 1, StateInfo).
+
+
+-spec checkpoint_int(#job{}, #state{}) -> #state{}.
+checkpoint_int(#job{} = Job, State) ->
+    couch_log:debug("~p checkpoint ~s", [?MODULE, jobfmt(Job)]),
+    case report_int(Job) of
+        ok ->
+            ok = mem3_reshard_store:store_job(State, Job),
+            ok = mem3_reshard_job:checkpoint_done(Job),
+            State;
+        not_found ->
+            couch_log:error("~p checkpoint couldn't find ~p", [?MODULE, Job]),
+            State
+    end.
+
+
+-spec report_int(#job{}) -> ok | not_found.
+report_int(Job) ->
+    case ets:lookup(?MODULE, Job#job.id) of
+        [#job{ref = Ref, pid = OldPid}] ->
+            case Job#job.pid =:= OldPid of
+                true ->
+                    couch_log:debug("~p reported ~s", [?MODULE, jobfmt(Job)]),
+                    % Carry over the reference from ets as the #job{} coming
+                    % from the job process won't have it's own monitor ref.
+                    true = ets:insert(?MODULE, Job#job{ref = Ref}),
+                    ok;
+                false ->
+                    LogMsg = "~p ignoring old job report ~p new job:~p",
+                    couch_log:warning(LogMsg, [?MODULE, jobfmt(Job), OldPid]),
+                    not_found
+            end;
+        _ ->
+            couch_log:error("~p reporting : couldn't find ~p", [?MODULE, Job]),
+            not_found
+    end.
+
+
+-spec remove_job_int(#job{}, #state{}) -> ok | {error, not_found}.
+remove_job_int(Id, State) ->
+    couch_log:notice("~p call remove_job Id:~p", [?MODULE, Id]),
+    case job_by_id(Id) of
+        #job{} = Job ->
+            kill_job_int(Job),
+            ok = mem3_reshard_store:delete_job(State, Id),
+            ets:delete(?MODULE, Job#job.id),
+            ok;
+        not_found ->
+            {error, not_found}
+    end.
+
+
+% This function is for testing and debugging only
+-spec reset_state(#state{}) -> #state{}.
+reset_state(#state{} = State) ->
+    couch_log:warning("~p resetting state", [?MODULE]),
+    ok = mem3_reshard_store:delete_state(State),
+    couch_log:warning("~p killing all running jobs", [?MODULE]),
+    [kill_job_int(Job) || Job <- running_jobs()],
+    ets:delete_all_objects(?MODULE),
+    couch_log:warning("~p resetting all job states", [?MODULE]),
+    Jobs = mem3_reshard_store:get_jobs(State),
+    lists:foldl(fun(#job{id = Id}, StateAcc) ->
+        couch_log:warning("~p resetting job state ~p", [?MODULE, Id]),
+        ok = mem3_reshard_store:delete_job(StateAcc, Id),
+        StateAcc
+    end, State, Jobs),
+    couch_log:warning("~p resetting state done", [?MODULE]),
+    State#state{
+        state = running,
+        state_info = [],
+        update_time = now_sec()
+    }.
+
+
+-spec update_job_history(#job{}) -> #job{}.
+update_job_history(#job{job_state = St, update_time = Ts} = Job) ->
+    Hist = Job#job.history,
+    Reason = case couch_util:get_value(reason, Job#job.state_info) of
+        undefined -> null;
+        Val -> couch_util:to_binary(Val)
+    end,
+    Job#job{history = update_history(St, Reason, Ts, Hist)}.
+
+
+update_history_rev(State, null, Ts, [{_, State, Detail} | Rest]) ->
+    % Just updated the detail, state stays the same, no new entry added
+    [{Ts, State, Detail} | Rest];
+
+update_history_rev(State, Detail, Ts, [{_, State, Detail} | Rest]) ->
+    % State and detail were same as last event, just update the timestamp
+    [{Ts, State, Detail} | Rest];
+
+update_history_rev(State, Detail, Ts, [{_, State, Detail} | Rest]) ->
+    % State and detail were same as last event, just update the timestamp
+    [{Ts, State, Detail} | Rest];
+
+update_history_rev(State, Detail, Ts, History) ->
+    [{Ts, State, Detail} | History].
+
+
+-spec max_history() -> non_neg_integer().
+max_history() ->
+    config:get_integer("reshard", "max_history", ?DEFAULT_MAX_HISTORY).
+
+
+-spec config_state() -> running | stopped.
+config_state() ->
+    case config:get("reshard", "state", "running") of
+        "stopped" -> stopped;
+        _NotStopped -> running
+    end.
+
+
+-spec update_config_state(#state{}) -> #state{}.
+update_config_state(#state{} = State) ->
+    case config_state() of
+        stopped ->
+            Reason = <<"Stopped from config">>,
+            State#state{
+                state = stopped,
+                state_info = info_update(reason, Reason, State#state.state_info)
+            };
+        running ->
+            State
+    end.
+
+
+-spec jobs_by_db_and_state(binary(), split_state() | '_') -> [job_id()].
+jobs_by_db_and_state(Db, State) ->
+    DbName = mem3:dbname(Db),
+    Pat = #job{
+        id = '$1',
+        source =#shard{dbname = DbName, _ = '_'},
+        job_state = State,
+        _ = '_'
+    },
+    [JobId || [JobId] <- ets:match(?MODULE, Pat)].
+
+
+-spec db_exists(binary()) -> boolean().
+db_exists(Name) ->
+    DbName = mem3:dbname(Name),
+    try
+        mem3:shards(mem3:dbname(DbName)),
+        true
+    catch
+        error:database_does_not_exist ->
+            false
+    end.
+
+
+-spec db_monitor(pid()) -> no_return().
+db_monitor(Server) ->
+    couch_log:notice("~p db monitor ~p starting", [?MODULE, self()]),
+    EvtRef = erlang:monitor(process, couch_event_server),
+    couch_event:register_all(self()),
+    db_monitor_loop(Server, EvtRef).
+
+
+-spec db_monitor_loop(pid(), reference()) -> no_return().
+db_monitor_loop(Server, EvtRef) ->
+    receive
+        {'$couch_event', DbName, deleted} ->
+            case db_exists(DbName) of
+                true ->
+                    % Could be source shard being deleted during splitting
+                    ok;
+                false ->
+                    case length(jobs_by_db_and_state(DbName, '_')) > 0 of
+                        true ->
+                            % Notify only if there are jobs with that db
+                            gen_server:cast(Server, {db_deleted, DbName});
+                        false ->
+                            ok
+                    end
+            end,
+            db_monitor_loop(Server, EvtRef);
+        {'$couch_event', _, _} ->
+            db_monitor_loop(Server, EvtRef);
+        {'DOWN', EvtRef, _, _, Info} ->
+            couch_log:error("~p db monitor listener died ~p", [?MODULE, Info]),
+            exit({db_monitor_died, Info});
+        Msg ->
+            couch_log:error("~p db monitor unexpected msg ~p", [?MODULE, Msg]),
+            db_monitor_loop(Server, EvtRef)
+    end.
+
+
+-spec statefmt(#state{} | term()) -> string().
+statefmt(#state{state = StateName}) ->
+    Total = ets:info(?MODULE, size),
+    Active = mem3_reshard_job_sup:count_children(),
+    Msg = "#state{~s total:~B active:~B}",
+    Fmt = io_lib:format(Msg, [StateName, Total, Active]),
+    lists:flatten(Fmt);
+
+statefmt(State) ->
+    Fmt = io_lib:format("<Unknown split state:~p>", [State]),
+    lists:flatten(Fmt).
+
+
+-spec jobfmt(#job{}) -> string().
+jobfmt(#job{} = Job) ->
+    mem3_reshard_job:jobfmt(Job).

--- a/src/mem3/src/mem3_reshard.hrl
+++ b/src/mem3/src/mem3_reshard.hrl
@@ -1,0 +1,89 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-include_lib("mem3/include/mem3.hrl").
+
+
+-type range_pos() :: non_neg_integer().
+-type split() :: pos_integer().  % also power of 2
+-type job_id() :: binary() | undefined.
+-type job_type() :: split.
+-type time_sec() :: non_neg_integer().
+
+-type shard_split_main_state() ::
+    running |
+    stopped.
+
+-type job_state() ::
+    new |
+    running |
+    stopped |
+    failed |
+    completed.
+
+-type split_state() ::
+    new |
+    initial_copy |
+    topoff1 |
+    build_indices |
+    topoff2 |
+    copy_local_docs |
+    update_shardmap |
+    wait_source_close |
+    topoff3 |
+    source_delete |
+    completed.
+
+
+-record(job, {
+    id :: job_id() | '$1' | '_',
+    type :: job_type(),
+    job_state :: job_state(),
+    split_state :: split_state(),
+    state_info = [] :: [{atom(), any()}],
+    source :: #shard{},
+    target :: [#shard{}],
+    history = [] :: [{atom(), time_sec()}],
+    start_time = 0 :: non_neg_integer(),
+    update_time = 0 :: non_neg_integer(),
+    node :: node(),
+    pid :: undefined | pid() | '$1' | '_',
+    ref :: undefined | reference() | '_',
+    manager :: undefined | pid(),
+    workers = [] :: [pid()],
+    retries = 0 :: non_neg_integer()
+}).
+
+-record(state, {
+    state :: shard_split_main_state(),
+    state_info :: [],
+    update_time :: non_neg_integer(),
+    job_prefix :: binary(),
+    state_id :: binary(),
+    node :: node(),
+    db_monitor :: pid()
+}).
+
+
+-define(SPLIT_STATES, [
+    new,
+    initial_copy,
+    topoff1,
+    build_indices,
+    topoff2,
+    copy_local_docs,
+    update_shardmap,
+    wait_source_close,
+    topoff3,
+    source_delete,
+    completed
+]).

--- a/src/mem3/src/mem3_reshard_api.erl
+++ b/src/mem3/src/mem3_reshard_api.erl
@@ -1,0 +1,195 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_api).
+
+-export([
+    create_jobs/5,
+    get_jobs/0,
+    get_job/1,
+    get_summary/0,
+    resume_job/1,
+    stop_job/2,
+    start_shard_splitting/0,
+    stop_shard_splitting/1,
+    get_shard_splitting_state/0
+]).
+
+
+create_jobs(Node, Shard, Db, Range, split) ->
+    lists:map(fun(S) ->
+        N = mem3:node(S),
+        Name = mem3:name(S),
+        case rpc:call(N, mem3_reshard, start_split_job, [Name]) of
+            {badrpc, Error} ->
+                {error, Error, N, Name};
+            {ok, JobId} ->
+                {ok, JobId, N, Name};
+            {error, Error} ->
+                {error, Error, N, Name}
+        end
+    end, pick_shards(Node, Shard, Db, Range)).
+
+
+get_jobs() ->
+    Nodes = mem3_util:live_nodes(),
+    {Replies, _Bad} = rpc:multicall(Nodes, mem3_reshard, jobs, []),
+    lists:flatten(Replies).
+
+
+get_job(JobId) ->
+    Nodes = mem3_util:live_nodes(),
+    {Replies, _Bad} = rpc:multicall(Nodes, mem3_reshard, job, [JobId]),
+    case [JobInfo || {ok, JobInfo} <- Replies] of
+        [JobInfo | _] ->
+            {ok, JobInfo};
+        [] ->
+            {error, not_found}
+    end.
+
+
+get_summary() ->
+    Nodes = mem3_util:live_nodes(),
+    {Replies, _Bad} = rpc:multicall(Nodes, mem3_reshard, get_state, []),
+    Stats0 = #{running => 0, total => 0, completed => 0, failed => 0,
+        stopped => 0},
+    StatsF = lists:foldl(fun({Res}, Stats) ->
+        maps:map(fun(Stat, OldVal) ->
+            OldVal + couch_util:get_value(Stat, Res, 0)
+        end, Stats)
+    end, Stats0, Replies),
+    {State, Reason} = state_and_reason(Replies),
+    StateReasonProps = [{state, State}, {state_reason, Reason}],
+    {StateReasonProps ++ lists:sort(maps:to_list(StatsF))}.
+
+
+resume_job(JobId) ->
+    Nodes = mem3_util:live_nodes(),
+    {Replies, _Bad} = rpc:multicall(Nodes, mem3_reshard, resume_job,
+        [JobId]),
+    WithoutNotFound = [R || R <- Replies, R =/= {error, not_found}],
+    case lists:usort(WithoutNotFound) of
+        [ok] ->
+            ok;
+        [{error, Error} | _] ->
+            {error, {[{error, couch_util:to_binary(Error)}]}};
+        [] ->
+            {error, not_found}
+    end.
+
+
+stop_job(JobId, Reason) ->
+    Nodes = mem3_util:live_nodes(),
+    {Replies, _Bad} = rpc:multicall(Nodes, mem3_reshard, stop_job,
+        [JobId, Reason]),
+    WithoutNotFound = [R || R <- Replies, R =/= {error, not_found}],
+    case lists:usort(WithoutNotFound) of
+        [ok] ->
+            ok;
+        [{error, Error} | _] ->
+            {error, {[{error, couch_util:to_binary(Error)}]}};
+        [] ->
+            {error, not_found}
+    end.
+
+
+start_shard_splitting() ->
+    {Replies, _Bad} = rpc:multicall(mem3_reshard, start, []),
+    case lists:usort(lists:flatten(Replies)) of
+        [ok] ->
+            {ok, {[{ok, true}]}};
+        [Error | _] ->
+            {error, {[{error, couch_util:to_binary(Error)}]}}
+    end.
+
+
+stop_shard_splitting(Reason) ->
+    {Replies, _Bad} = rpc:multicall(mem3_reshard, stop, [Reason]),
+    case lists:usort(lists:flatten(Replies)) of
+        [ok] ->
+            {ok, {[{ok, true}]}};
+        [Error | _] ->
+            {error, {[{error, couch_util:to_binary(Error)}]}}
+    end.
+
+
+get_shard_splitting_state() ->
+    Nodes = mem3_util:live_nodes(),
+    {Replies, _Bad} = rpc:multicall(Nodes, mem3_reshard, get_state, []),
+    state_and_reason(Replies).
+
+
+state_and_reason(StateReplies) ->
+    AccF = lists:foldl(fun({ResProps}, Acc) ->
+        Reason = get_reason(ResProps),
+        case couch_util:get_value(state, ResProps) of
+            <<"running">> -> orddict:append(running, Reason, Acc);
+            <<"stopped">> -> orddict:append(stopped, Reason, Acc);
+            undefined -> Acc
+        end
+    end, orddict:from_list([{running, []}, {stopped, []}]), StateReplies),
+    Running = orddict:fetch(running, AccF),
+    case length(Running) > 0 of
+        true ->
+            Reason = pick_reason(Running),
+            {running, Reason};
+        false ->
+            Reason = pick_reason(orddict:fetch(stopped, AccF)),
+            {stopped, Reason}
+    end.
+
+
+pick_reason(Reasons) ->
+    Reasons1 = lists:usort(Reasons),
+    Reasons2 = [R || R <- Reasons1, R =/= undefined],
+    case Reasons2 of
+        [] -> null;
+        [R1 | _] -> R1
+    end.
+
+
+get_reason(StateProps) when is_list(StateProps) ->
+    case couch_util:get_value(state_info, StateProps) of
+        [] -> undefined;
+        undefined -> undefined;
+        {SInfoProps} -> couch_util:get_value(reason, SInfoProps)
+    end.
+
+
+pick_shards(undefined, undefined, Db, undefined) when is_binary(Db) ->
+    mem3:shards(Db);
+
+pick_shards(Node, undefined, Db, undefined) when is_atom(Node),
+        is_binary(Db) ->
+    [S || S <- mem3:shards(Db), mem3:node(S) == Node];
+
+pick_shards(undefined, undefined, Db, [_B, _E] = Range) when  is_binary(Db) ->
+    [S || S <- mem3:shards(Db), mem3:range(S) == Range];
+
+pick_shards(Node, undefined, Db, [_B, _E] = Range) when is_atom(Node),
+        is_binary(Db) ->
+    [S || S <- mem3:shards(Db), mem3:node(S) == Node, mem3:range(S) == Range];
+
+pick_shards(undefined, Shard, undefined, undefined) when is_binary(Shard) ->
+    Db = mem3:dbname(Shard),
+    [S || S <- mem3:shards(Db), mem3:name(S) == Shard];
+
+pick_shards(Node, Shard, undefined, undefined) when is_atom(Node),
+        is_binary(Shard) ->
+    Db = mem3:dbname(Shard),
+    [S || S <- mem3:shards(Db), mem3:name(S) == Shard, mem3:node(S) == Node];
+
+pick_shards(_, undefined, undefined, _) ->
+    throw({bad_request, <<"Must specify at least `db` or `shard`">>});
+
+pick_shards(_, Db, Shard, _) when is_binary(Db), is_binary(Shard) ->
+    throw({bad_request, <<"`db` and `shard` are mutually exclusive">>}).

--- a/src/mem3/src/mem3_reshard_dbdoc.erl
+++ b/src/mem3/src/mem3_reshard_dbdoc.erl
@@ -1,0 +1,275 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_dbdoc).
+
+-behaviour(gen_server).
+
+-export([
+    update_shard_map/1,
+
+    start_link/0,
+
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3
+]).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include("mem3_reshard.hrl").
+
+
+-spec update_shard_map(#job{}) -> no_return | ok.
+update_shard_map(#job{source = Source, target = Target} = Job) ->
+    Node = hd(mem3_util:live_nodes()),
+    JobStr = mem3_reshard_job:jobfmt(Job),
+    LogMsg1 = "~p : calling update_shard_map on node ~p. ~p",
+    couch_log:notice(LogMsg1, [?MODULE, Node, JobStr]),
+    ServerRef = {?MODULE, Node},
+    CallArg = {update_shard_map, Source, Target},
+    TimeoutMSec = shard_update_timeout_msec(),
+    try
+        case gen_server:call(ServerRef, CallArg, TimeoutMSec) of
+            {ok, _} -> ok;
+            {error, CallError} -> throw({error, CallError})
+        end
+    catch
+        _:Err ->
+            exit(Err)
+    end,
+    LogMsg2 = "~p : update_shard_map on node returned. ~p",
+    couch_log:notice(LogMsg2, [?MODULE, Node]),
+    UntilSec = mem3_reshard:now_sec() + (TimeoutMSec div 1000),
+    case wait_source_removed(Source, 5, UntilSec) of
+        true -> ok;
+        false -> exit(shard_update_did_not_propagate)
+    end.
+
+
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+
+init(_) ->
+    couch_log:notice("~p start init()", [?MODULE]),
+    {ok, nil}.
+
+
+terminate(_Reason, _State) ->
+    ok.
+
+
+handle_call({update_shard_map, Source, Target}, _From, State) ->
+    Res = try
+        update_shard_map(Source, Target)
+    catch
+        throw:{error, Error} ->
+            {error, Error}
+    end,
+    {reply, Res, State};
+
+handle_call(Call, From, State) ->
+    couch_log:error("~p unknown call ~p from: ~p", [?MODULE, Call, From]),
+    {noreply, State}.
+
+
+handle_cast(Cast, State) ->
+    couch_log:error("~p unexpected cast ~p", [?MODULE, Cast]),
+    {noreply, State}.
+
+
+handle_info(Info, State) ->
+    couch_log:error("~p unexpected info ~p", [?MODULE, Info]),
+    {noreply, State}.
+
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+% Private
+
+update_shard_map(Source, Target) ->
+    ok = validate_coordinator(),
+    ok = replicate_from_all_nodes(shard_update_timeout_msec()),
+    #shard{name = SourceName} = Source,
+    DocId = mem3:dbname(SourceName),
+    OldDoc = case mem3_util:open_db_doc(DocId) of
+        {ok, #doc{deleted = true}} ->
+            throw({error, missing_source});
+        {ok, #doc{} = Doc} ->
+            Doc;
+        {not_found, deleted} ->
+            throw({error, missing_source});
+        OpenErr ->
+            throw({error, {shard_doc_open_error, OpenErr}})
+    end,
+    #doc{body = OldBody} = OldDoc,
+    NewBody = update_shard_props(OldBody, Source, Target),
+    {ok, _}  = write_shard_doc(OldDoc, NewBody),
+    ok = replicate_to_all_nodes(shard_update_timeout_msec()),
+    {ok, NewBody}.
+
+
+validate_coordinator() ->
+    case hd(mem3_util:live_nodes()) =:= node() of
+        true -> ok;
+        false -> throw({error, coordinator_changed})
+    end.
+
+
+replicate_from_all_nodes(TimeoutMSec) ->
+    case mem3_util:replicate_dbs_from_all_nodes(TimeoutMSec) of
+        ok -> ok;
+        Error -> throw({error, Error})
+    end.
+
+
+replicate_to_all_nodes(TimeoutMSec) ->
+    case mem3_util:replicate_dbs_to_all_nodes(TimeoutMSec) of
+        ok -> ok;
+        Error -> throw({error, Error})
+    end.
+
+
+write_shard_doc(#doc{id = Id} = Doc, Body) ->
+    DbName = ?l2b(config:get("mem3", "shards_db", "_dbs")),
+    UpdatedDoc = Doc#doc{body = Body},
+    couch_util:with_db(DbName, fun(Db) ->
+        try
+            {ok, _} = couch_db:update_doc(Db, UpdatedDoc, [])
+        catch
+            conflict ->
+                throw({error, {conflict, Id, Doc#doc.body, UpdatedDoc}})
+        end
+    end).
+
+
+update_shard_props({Props0}, #shard{} = Source, [#shard{} | _] = Targets) ->
+    {ByNode0} =  couch_util:get_value(<<"by_node">>, Props0, {[]}),
+    ByNodeKV = {<<"by_node">>, {update_by_node(ByNode0, Source, Targets)}},
+    Props1 = lists:keyreplace(<<"by_node">>, 1, Props0, ByNodeKV),
+
+    {ByRange0} = couch_util:get_value(<<"by_range">>, Props1, {[]}),
+    ByRangeKV = {<<"by_range">>, {update_by_range(ByRange0, Source, Targets)}},
+    Props2 = lists:keyreplace(<<"by_range">>, 1, Props1, ByRangeKV),
+
+    Changelog = couch_util:get_value(<<"changelog">>, Props2, []),
+    {Node, Range} = {node_key(Source), range_key(Source)},
+    ChangelogEntry = [[<<"split">>, Range, length(Targets), Node]],
+    ChangelogKV = {<<"changelog">>, Changelog ++ ChangelogEntry},
+    Props3 = lists:keyreplace(<<"changelog">>, 1, Props2, ChangelogKV),
+
+    {Props3}.
+
+
+update_by_node(ByNode, #shard{} = Source, [#shard{} | _] = Targets) ->
+    {NodeKey, SKey} = {node_key(Source), range_key(Source)},
+    {_, Ranges} = lists:keyfind(NodeKey, 1, ByNode),
+    Ranges1 = Ranges -- [SKey],
+    Ranges2 = Ranges1 ++ [range_key(T) || T <- Targets],
+    lists:keyreplace(NodeKey, 1, ByNode, {NodeKey, lists:sort(Ranges2)}).
+
+
+update_by_range(ByRange, Source, Targets) ->
+    ByRange1 = remove_node_from_source(ByRange, Source),
+    lists:foldl(fun add_node_to_target_foldl/2, ByRange1, Targets).
+
+
+remove_node_from_source(ByRange, Source) ->
+    {NodeKey, SKey} = {node_key(Source), range_key(Source)},
+    {_, SourceNodes} = lists:keyfind(SKey, 1, ByRange),
+    % Double check that source had node to begin with
+    case lists:member(NodeKey, SourceNodes) of
+        true ->
+            ok;
+        false ->
+            throw({source_shard_missing_node, NodeKey, SourceNodes})
+    end,
+    SourceNodes1 = SourceNodes -- [NodeKey],
+    case SourceNodes1 of
+        [] ->
+            % If last node deleted, remove entry
+            lists:keydelete(SKey, 1, ByRange);
+        _ ->
+            lists:keyreplace(SKey, 1, ByRange, {SKey, SourceNodes1})
+    end.
+
+
+add_node_to_target_foldl(#shard{} = Target, ByRange) ->
+    {NodeKey, TKey} = {node_key(Target), range_key(Target)},
+    case lists:keyfind(TKey, 1, ByRange) of
+        {_, Nodes} ->
+            % Double check that target does not have node already
+            case lists:member(NodeKey, Nodes) of
+                false ->
+                    ok;
+                true ->
+                    throw({target_shard_already_has_node, NodeKey, Nodes})
+            end,
+            Nodes1 = lists:sort([NodeKey | Nodes]),
+            lists:keyreplace(TKey, 1, ByRange, {TKey, Nodes1});
+        false ->
+            % fabric_db_create:make_document/3 says they should be sorted
+            lists:sort([{TKey, [NodeKey]} | ByRange])
+    end.
+
+
+node_key(#shard{node = Node}) ->
+    couch_util:to_binary(Node).
+
+
+range_key(#shard{range = [B, E]}) ->
+    BHex = couch_util:to_hex(<<B:32/integer>>),
+    EHex = couch_util:to_hex(<<E:32/integer>>),
+    list_to_binary([BHex, "-", EHex]).
+
+
+shard_update_timeout_msec() ->
+    config:get_integer("reshard", "shard_upate_timeout_msec", 300000).
+
+
+wait_source_removed(#shard{name = Name} = Source, SleepSec, UntilSec) ->
+    case check_source_removed(Source) of
+        true ->
+            true;
+        false ->
+            case mem3_reshard:now_sec() < UntilSec of
+                true ->
+                    LogMsg = "~p : Waiting for shard ~p removal confirmation",
+                    couch_log:notice(LogMsg, [?MODULE, Name]),
+                    timer:sleep(SleepSec * 1000),
+                    wait_source_removed(Source, SleepSec, UntilSec);
+                false ->
+                    false
+            end
+    end.
+
+
+check_source_removed(#shard{name = Name}) ->
+    DbName = mem3:dbname(Name),
+    Live = mem3_util:live_nodes(),
+    ShardNodes = [N || #shard{node = N} <- mem3:shards(DbName)],
+    Nodes = lists:usort([N || N <- ShardNodes, lists:member(N, Live)]),
+    {Responses, _} = rpc:multicall(Nodes, mem3, shards, [DbName]),
+    Shards = lists:usort(lists:flatten(Responses)),
+    SourcePresent = [S || S = #shard{name = S, node = N} <- Shards, S =:= Name,
+        N =:= node()],
+    case SourcePresent of
+        [] ->  true;
+        [_ | _] -> false
+    end.

--- a/src/mem3/src/mem3_reshard_httpd.erl
+++ b/src/mem3/src/mem3_reshard_httpd.erl
@@ -1,0 +1,297 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_httpd).
+
+-export([
+    handle_reshard_req/1
+]).
+
+-import(couch_httpd, [
+    send_json/2,
+    send_json/3,
+    send_method_not_allowed/2
+]).
+
+
+-include_lib("couch/include/couch_db.hrl").
+
+
+-define(JOBS, <<"jobs">>).
+-define(STATE, <<"state">>).
+-define(S_RUNNING, <<"running">>).
+-define(S_STOPPED, <<"stopped">>).
+
+
+% GET /_reshard
+handle_reshard_req(#httpd{method='GET', path_parts=[_]} = Req) ->
+    State = mem3_reshard_api:get_summary(),
+    send_json(Req, State);
+
+handle_reshard_req(#httpd{path_parts=[_]} = Req) ->
+    send_method_not_allowed(Req, "GET,HEAD");
+
+% GET /_reshard/state
+handle_reshard_req(#httpd{method='GET',
+        path_parts=[_, ?STATE]} = Req) ->
+    {State, Reason} = mem3_reshard_api:get_shard_splitting_state(),
+    send_json(Req, {[{state, State}, {reason, Reason}]});
+
+% PUT /_reshard/state
+handle_reshard_req(#httpd{method='PUT',
+        path_parts=[_, ?STATE]} = Req) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
+    {Props} = couch_httpd:json_body_obj(Req),
+    State = couch_util:get_value(<<"state">>, Props),
+    Reason = couch_util:get_value(<<"reason">>, Props),
+    case {State, Reason} of
+        {undefined, _} ->
+            throw({bad_request, <<"Expected a `state` field">>});
+        {?S_RUNNING, _} ->
+            case mem3_reshard_api:start_shard_splitting() of
+                {ok, JsonResult} ->
+                    send_json(Req, 200, JsonResult);
+                {error, JsonError} ->
+                    send_json(Req, 500, JsonError)
+            end;
+        {?S_STOPPED, Reason} ->
+            Reason1 = case Reason =:= undefined of
+                false -> Reason;
+                true -> <<"Cluster-wide resharding stopped by the user">>
+            end,
+            case mem3_reshard_api:stop_shard_splitting(Reason1) of
+                {ok, JsonResult} ->
+                    send_json(Req, 200, JsonResult);
+                {error, JsonError} ->
+                    send_json(Req, 500, JsonError)
+            end;
+        {_, _} ->
+            throw({bad_request, <<"State field not `running` or `stopped`">>})
+    end;
+
+handle_reshard_req(#httpd{path_parts=[_, ?STATE]} = Req) ->
+    send_method_not_allowed(Req, "GET,HEAD,PUT");
+
+handle_reshard_req(#httpd{path_parts=[_, ?STATE | _]} = _Req) ->
+    throw(not_found);
+
+% GET /_reshard/jobs
+handle_reshard_req(#httpd{method='GET', path_parts=[_, ?JOBS]}=Req) ->
+    Jobs = mem3_reshard_api:get_jobs(),
+    Total = length(Jobs),
+    send_json(Req, {[{total_rows, Total}, {offset, 0}, {jobs, Jobs}]});
+
+% POST /_reshard/jobs {"node": "...", "shard": "..."}
+handle_reshard_req(#httpd{method = 'POST',
+        path_parts=[_, ?JOBS]} = Req) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
+    {Props} = couch_httpd:json_body_obj(Req),
+    Node = validate_node(couch_util:get_value(<<"node">>, Props)),
+    Shard = validate_shard(couch_util:get_value(<<"shard">>, Props)),
+    Db = validate_db(couch_util:get_value(<<"db">>, Props)),
+    Range = validate_range(couch_util:get_value(<<"range">>, Props)),
+    Type = validate_type(couch_util:get_value(<<"type">>, Props)),
+    Res = mem3_reshard_api:create_jobs(Node, Shard, Db, Range, Type),
+    case Res of
+        [] -> throw(not_found);
+        _ -> ok
+    end,
+    Oks = length([R || {ok, _, _, _} = R <- Res]),
+    Code = case {Oks, length(Res)} of
+        {Oks, Oks} -> 201;
+        {Oks, _} when Oks > 0 -> 202;
+        {0, _} -> 500
+    end,
+    EJson = lists:map(fun
+        ({ok, Id, N, S}) ->
+            {[{ok, true}, {id, Id}, {node, N}, {shard, S}]};
+        ({error, E, N, S}) ->
+            {[{error, couch_util:to_binary(E)}, {node, N}, {shard, S}]}
+    end, Res),
+    send_json(Req, Code, EJson);
+
+handle_reshard_req(#httpd{path_parts=[_, ?JOBS]} = Req) ->
+    send_method_not_allowed(Req, "GET,HEAD,POST");
+
+handle_reshard_req(#httpd{path_parts=[_, _]}) ->
+    throw(not_found);
+
+% GET /_reshard/jobs/$jobid
+handle_reshard_req(#httpd{method='GET',
+        path_parts=[_, ?JOBS, JobId]}=Req) ->
+    case mem3_reshard_api:get_job(JobId) of
+        {ok, JobInfo} ->
+            send_json(Req, JobInfo);
+        {error, not_found} ->
+            throw(not_found)
+    end;
+
+% DELETE /_reshard/jobs/$jobid
+handle_reshard_req(#httpd{method='DELETE',
+        path_parts=[_, ?JOBS, JobId]}=Req) ->
+    case mem3_reshard_api:get_job(JobId) of
+        {ok, {Props}} ->
+            NodeBin = couch_util:get_value(node, Props),
+            Node = binary_to_atom(NodeBin, utf8),
+            case rpc:call(Node, mem3_reshard, remove_job, [JobId]) of
+                ok ->
+                    send_json(Req, 200, {[{ok, true}]});
+                {error, not_found} ->
+                    throw(not_found)
+            end;
+        {error, not_found} ->
+            throw(not_found)
+    end;
+
+handle_reshard_req(#httpd{path_parts=[_, ?JOBS, _]} = Req) ->
+    send_method_not_allowed(Req, "GET,HEAD,DELETE");
+
+% GET /_reshard/jobs/$jobid/state
+handle_reshard_req(#httpd{method='GET',
+        path_parts=[_, ?JOBS, JobId, ?STATE]} = Req) ->
+    case mem3_reshard_api:get_job(JobId) of
+        {ok, {Props}} ->
+            JobState = couch_util:get_value(job_state, Props),
+            {SIProps} = couch_util:get_value(state_info, Props),
+            Reason = case couch_util:get_value(reason, SIProps) of
+                undefined -> null;
+                Val -> couch_util:to_binary(Val)
+            end,
+            send_json(Req, 200, {[{state, JobState}, {reason, Reason}]});
+        {error, not_found} ->
+            throw(not_found)
+    end;
+
+% PUT /_reshard/jobs/$jobid/state
+handle_reshard_req(#httpd{method='PUT',
+        path_parts=[_, ?JOBS, JobId, ?STATE]} = Req) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
+    {Props} = couch_httpd:json_body_obj(Req),
+    State = couch_util:get_value(<<"state">>, Props),
+    Reason = couch_util:get_value(<<"reason">>, Props),
+    case {State, Reason} of
+        {undefined, _} ->
+            throw({bad_request, <<"Expected a `state` field">>});
+        {?S_RUNNING, _} ->
+            case mem3_reshard_api:resume_job(JobId) of
+                ok ->
+                    send_json(Req, 200, {[{ok, true}]});
+                {error, not_found} ->
+                    throw(not_found);
+                {error, JsonError} ->
+                    send_json(Req, 500, JsonError)
+            end;
+        {?S_STOPPED, Reason} ->
+            Reason1 = case Reason =:= undefined of
+                false -> Reason;
+                true -> <<"Stopped by user">>
+            end,
+            case mem3_reshard_api:stop_job(JobId, Reason1) of
+                ok ->
+                    send_json(Req, 200, {[{ok, true}]});
+                {error, not_found} ->
+                    throw(not_found);
+                {error, JsonError} ->
+                    send_json(Req, 500, JsonError)
+            end;
+        {_, _} ->
+            throw({bad_request, <<"State field not `running` or `stopped`">>})
+    end;
+
+handle_reshard_req(#httpd{path_parts=[_, ?JOBS, _, ?STATE]} = Req) ->
+    send_method_not_allowed(Req, "GET,HEAD,PUT").
+
+
+validate_type(<<"split">>) ->
+    split;
+
+validate_type(_Type) ->
+    throw({bad_request, <<"`job type must be `split`">>}).
+
+
+validate_node(undefined) ->
+    undefined;
+
+validate_node(Node0) when is_binary(Node0) ->
+    Nodes = mem3_util:live_nodes(),
+    try binary_to_existing_atom(Node0, utf8) of
+        N1 ->
+            case lists:member(N1, Nodes) of
+                true -> N1;
+                false -> throw({bad_request, <<"Not connected to `node`">>})
+            end
+    catch
+        error:badarg ->
+            throw({bad_request, <<"`node` is not a valid node name">>})
+    end;
+
+validate_node(_Node) ->
+    throw({bad_request, <<"Invalid `node`">>}).
+
+
+validate_shard(undefined) ->
+    undefined;
+
+validate_shard(Shard) when is_binary(Shard) ->
+    case Shard of
+        <<"shards/", _:8/binary, "-", _:8/binary, "/", _/binary>> ->
+            Shard;
+        _ ->
+            throw({bad_request, <<"`shard` is invalid">>})
+    end;
+
+validate_shard(_Shard) ->
+    throw({bad_request, <<"Invalid `shard`">>}).
+
+
+validate_db(undefined) ->
+    undefined;
+
+validate_db(DbName) when is_binary(DbName) ->
+    try mem3:shards(DbName) of
+        [_ | _] -> DbName;
+        _ ->  throw({bad_request, <<"`No shards in `db`">>})
+    catch
+        _:_ ->
+            throw({bad_request, <<"Invalid `db`">>})
+    end;
+
+validate_db(_bName) ->
+    throw({bad_request, <<"Invalid `db`">>}).
+
+
+validate_range(undefined) ->
+    undefined;
+
+validate_range(<<BBin:8/binary, "-", EBin:8/binary>>) ->
+    {B, E} = try
+        {
+            httpd_util:hexlist_to_integer(binary_to_list(BBin)),
+            httpd_util:hexlist_to_integer(binary_to_list(EBin))
+        }
+    catch
+        _:_ ->
+            throw({bad_request, <<"Invalid `range`">>})
+    end,
+    if
+        B < 0 -> throw({bad_request, <<"Invalid `range`">>});
+        E < 0 -> throw({bad_request, <<"Invalid `range`">>});
+        B > (2 bsl 31) - 1 -> throw({bad_request, <<"Invalid `range`">>});
+        E > (2 bsl 31) - 1 -> throw({bad_request, <<"invalid `range`">>});
+        B >= E -> throw({bad_request, <<"Invalid `range`">>});
+        true -> ok
+    end,
+    % Use a list format here to make it look the same as #shard's range
+    [B, E];
+
+validate_range(_Range) ->
+    throw({bad_request, <<"Invalid `range`">>}).

--- a/src/mem3/src/mem3_reshard_index.erl
+++ b/src/mem3/src/mem3_reshard_index.erl
@@ -1,0 +1,162 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_index).
+
+
+-export([
+    design_docs/1,
+    target_indices/2,
+    spawn_builders/1
+]).
+
+
+-include_lib("mem3/include/mem3.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+%% Public API
+
+design_docs(DbName) ->
+    try
+        case fabric:design_docs(mem3:dbname(DbName)) of
+            {error, {maintenance_mode, _, _Node}} ->
+                {ok, []};
+            {ok, DDocs} ->
+                JsonDocs = [couch_doc:from_json_obj(DDoc) || DDoc <- DDocs],
+                {ok, JsonDocs};
+            Else ->
+                Else
+        end
+    catch error:database_does_not_exist ->
+        {ok, []}
+    end.
+
+
+target_indices(Docs, Targets) ->
+    Indices = [[indices(N, D) || D <- Docs] || #shard{name = N} <- Targets],
+    lists:flatten(Indices).
+
+
+spawn_builders(Indices) ->
+    Results = [build_index(Index) || Index <- Indices],
+    Oks = [{ok, Pid} || {ok, Pid} <- Results, is_pid(Pid)],
+    case Results -- Oks of
+        [] ->
+            {ok, [Pid || {ok, Pid} <- Results]};
+        Error ->
+            % Do a all or nothing pattern, if some indices could not be
+            % spawned, kill the spawned ones and and return the error.
+            ErrMsg = "~p failed to spawn index builders: ~p ~p",
+            couch_log:error(ErrMsg, [?MODULE, Error, Indices]),
+            lists:foreach(fun({ok, Pid}) ->
+                catch unlink(Pid),
+                catch exit(Pid, kill)
+            end, Oks),
+            {error, Error}
+    end.
+
+
+%% Private API
+
+indices(DbName, Doc) ->
+    mrview_indices(DbName, Doc) ++
+            [dreyfus_indices(DbName, Doc) || has_app(dreyfus)] ++
+            [hastings_indices(DbName, Doc) || has_app(hastings)].
+
+
+mrview_indices(DbName, Doc) ->
+    try
+        {ok, MRSt} = couch_mrview_util:ddoc_to_mrst(DbName, Doc),
+        Views = couch_mrview_index:get(views, MRSt),
+        case Views =/= [] of
+            true ->
+                [{mrview, DbName, MRSt}];
+            false ->
+                []
+        end
+    catch
+        Tag:Err ->
+            Msg = "~p couldn't get mrview index ~p ~p ~p:~p",
+            couch_log:error(Msg, [?MODULE, DbName, Doc, Tag, Err]),
+            []
+    end.
+
+
+dreyfus_indices(DbName, Doc) ->
+    try
+        Indices = dreyfus_index:design_doc_to_indexes(Doc),
+        [{dreyfus, DbName, Index} || Index <- Indices]
+    catch
+        Tag:Err ->
+            Msg = "~p couldn't get dreyfus indices ~p ~p ~p:~p",
+            couch_log:error(Msg, [?MODULE, DbName, Doc, Tag, Err]),
+            []
+    end.
+
+
+hastings_indices(DbName, Doc) ->
+    try
+        Indices = hastings_index:design_doc_to_indexes(Doc),
+        [{hastings, DbName, Index} || Index <- Indices]
+    catch
+        Tag:Err ->
+            Msg = "~p couldn't get hasting indices ~p ~p ~p:~p",
+            couch_log:error(Msg, [?MODULE, DbName, Doc, Tag, Err]),
+            []
+    end.
+
+
+build_index({mrview, DbName, MRSt}) ->
+    case couch_index_server:get_index(couch_mrview_index, MRSt) of
+        {ok, Pid} ->
+            Args = [Pid, get_update_seq(DbName)],
+            WPid = spawn_link(couch_index, get_state, Args),
+            {ok, WPid};
+        Error ->
+            Error
+    end;
+
+build_index({dreyfus, DbName, Index})->
+    case dreyfus_index_manager:get_index(DbName, Index) of
+        {ok, Pid} ->
+            Args = [Pid, get_update_seq(DbName)],
+            WPid = spawn_link(dreyfus_index, await, Args),
+            {ok, WPid};
+        Error ->
+            Error
+    end;
+
+build_index({hastings, DbName, Index}) ->
+    case hastings_index_manager:get_index(DbName, Index) of
+        {ok, Pid} ->
+            Args = [Pid, get_update_seq(DbName)],
+            WPid = spawn_link(hastings_index, await, Args),
+            {ok, WPid};
+        Error ->
+            Error
+    end.
+
+
+has_app(App) ->
+    case application:get_application(App) of
+        {ok, _} ->
+            true;
+        _ ->
+            false
+    end.
+
+
+get_update_seq(DbName) ->
+    couch_util:with_db(DbName, fun(Db) ->
+        couch_db:get_update_seq(Db)
+    end).

--- a/src/mem3/src/mem3_reshard_job.erl
+++ b/src/mem3/src/mem3_reshard_job.erl
@@ -1,0 +1,629 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_job).
+
+
+-behaviour(gen_server).
+
+
+-export([
+    start_link/1,
+    checkpoint_done/1,
+    jobfmt/1,
+    pickfun/3,
+
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3,
+
+    initial_copy/1,
+    topoff/2,
+    copy_local_docs/1,
+    wait_source_close/1,
+    source_delete/1
+]).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include("mem3_reshard.hrl").
+
+
+start_link(#job{} = Job) ->
+    gen_server:start_link(?MODULE, [Job], []).
+
+
+% This is called by the main proces after it has checkpointed the progress
+% of the job. After the new state was checkpointed, we signal the job do start
+% executing that state.
+checkpoint_done(#job{pid = Pid} = Job) ->
+    couch_log:notice(" ~p : checkpoint done for ~p", [?MODULE, jobfmt(Job)]),
+    gen_server:cast(Pid, do_state).
+
+
+% Formatting function, used for logging mostly
+jobfmt(#job{} = Job) ->
+    #job{
+        id = Id,
+        source = #shard{name = Source},
+        target = Target,
+        split_state = State,
+        job_state = JobState,
+        pid = Pid
+    } = Job,
+    TargetCount = length(Target),
+    Msg = "#job{~s ~s /~B job_state:~s split_state:~s pid:~p}",
+    Fmt = io_lib:format(Msg, [Id, Source, TargetCount, JobState, State, Pid]),
+    lists:flatten(Fmt).
+
+
+pickfun(DocId, [[B, E] | _] = Ranges, {_M, _F, _A} = HashFun) when
+        is_integer(B), is_integer(E), B =< E ->
+    HashKey = mem3_hash:calculate(HashFun, DocId),
+    Pred = fun([Begin, End]) ->
+        Begin =< HashKey andalso HashKey =< End
+    end,
+    case lists:filter(Pred, Ranges) of
+        [] -> not_in_range;
+        [Key] -> Key
+    end.
+
+
+init([#job{} = Job0]) ->
+    process_flag(trap_exit, true),
+    Job = Job0#job{
+        pid = self(),
+        start_time = mem3_reshard:now_sec(),
+        workers = [],
+        retries = 0
+    },
+    gen_server:cast(self(), maybe_recover),
+    couch_log:notice("~p starting job ~s", [?MODULE, jobfmt(Job)]),
+    {ok, Job}.
+
+
+terminate(normal, _Job) ->
+    ok;
+
+terminate(shutdown, _Job) ->
+    ok;
+
+terminate({shutdown, _}, _Job) ->
+    ok;
+
+terminate(Reason, Job) ->
+    couch_log:error("~p terminate ~p ~p", [?MODULE, Reason, Job]),
+    ok.
+
+
+handle_call(Call, From, Job) ->
+    couch_log:notice("~p call ~p from: ~p", [?MODULE, Call, From]),
+    {noreply, Job}.
+
+
+handle_cast(maybe_recover, Job) ->
+    {noreply, maybe_recover(Job)};
+
+handle_cast(do_state, Job) ->
+    case do_state(Job) of
+        {ok, Job1} ->
+            {noreply, Job1};
+        {stop, Error, Job1} ->
+            {stop, Error, Job1};
+        {retry, Error, Job1} ->
+            {noreply, retry_state(Error, Job1)}
+    end;
+
+handle_cast(Cast, Job) ->
+    couch_log:notice("~p unknown cast ~p", [?MODULE, Cast]),
+    {noreply, Job}.
+
+
+handle_info(retry, #job{split_state = initial_copy} = Job) ->
+    % For initial copy before retrying make sure to reset the target
+    % as initial copy works from newly created copy every time
+    handle_cast(do_state, reset_target(Job));
+
+handle_info(retry, #job{} = Job) ->
+    handle_cast(do_state, Job);
+
+handle_info({'EXIT', Pid, Reason}, #job{workers = Workers} = Job) ->
+    case lists:member(Pid, Workers) of
+        true ->
+            Job1 = Job#job{workers = Workers -- [Pid]},
+            worker_exited(Reason, Job1);
+        false ->
+            ErrMsg = "~p ~p pid exited reason: ~p job: ~s",
+            couch_log:error(ErrMsg, [?MODULE, Pid, Reason, jobfmt(Job)]),
+            {noreply, Job}
+    end;
+
+handle_info(Info, Job) ->
+    couch_log:notice("~p info ~p ~p", [?MODULE, Info, Job]),
+    {noreply, Job}.
+
+
+code_change(_OldVsn, Job, _Extra) ->
+    {ok, Job}.
+
+
+-spec initial_copy(#job{}) -> ok | no_return().
+initial_copy(#job{source = Source, target = Targets0} = Job) ->
+    #shard{name = SourceName} = Source,
+    Targets = [{R, N} || #shard{range = R, name = N} <- Targets0],
+    TMap = maps:from_list(Targets),
+    LogMsg1 = "~p initial_copy started ~s",
+    LogArgs1 = [?MODULE, shardsstr(Source, Targets0)],
+    couch_log:notice(LogMsg1, LogArgs1),
+    case couch_db_split:split(SourceName, TMap, fun pickfun/3) of
+        {ok, Seq} ->
+            LogMsg2 = "~p initial_copy of ~s finished @ seq:~p",
+            LogArgs2 = [?MODULE, shardsstr(Source, Targets0), Seq],
+            couch_log:notice(LogMsg2, LogArgs2),
+            create_artificial_mem3_rep_checkpoints(Job, Seq);
+        {error, Error} ->
+            LogMsg3 = "~p initial_copy of ~p finished @ ~p",
+            LogArgs3 = [?MODULE, shardsstr(Source, Targets0), Error],
+            couch_log:notice(LogMsg3, LogArgs3),
+            exit({error, Error})
+    end.
+
+
+-spec topoff(#shard{}, [#shard{}]) -> ok | no_return().
+topoff(#shard{} = Source, Targets) ->
+    couch_log:notice("~p topoff ~p", [?MODULE, shardsstr(Source, Targets)]),
+    check_source_exists(Source, topoff),
+    check_targets_exist(Targets, topoff),
+    TMap = maps:from_list([{R, T} || #shard{range = R} = T <- Targets]),
+    Opts =  [{batch_size, 2000}, {batch_count, all}],
+    case mem3_rep:go(Source, TMap, Opts) of
+        {ok, Count} ->
+            Args = [?MODULE, shardsstr(Source, Targets), Count],
+            couch_log:notice("~p topoff done ~s, count: ~p", Args),
+            ok;
+        {error, Error} ->
+            Args = [?MODULE, shardsstr(Source, Targets), Error],
+            couch_log:error("~p topoff failed ~s, error: ~p", Args),
+            exit({error, Error})
+    end.
+
+
+-spec copy_local_docs(#job{}) -> ok | no_return().
+copy_local_docs(#job{source = Source, target = Targets0}) ->
+    #shard{name = SourceName} = Source,
+    Targets = [{R, N} || #shard{range = R, name = N} <- Targets0],
+    TMap = maps:from_list(Targets),
+    LogArg1 = [?MODULE, shardsstr(Source, Targets)],
+    couch_log:notice("~p copy local docs start ~s", LogArg1),
+    case couch_db_split:copy_local_docs(SourceName, TMap, fun pickfun/3) of
+        ok ->
+            couch_log:notice("~p copy local docs finished for ~s", LogArg1),
+            ok;
+        {error, Error} ->
+            LogArg2 = [?MODULE, shardsstr(Source, Targets), Error],
+            couch_log:error("~p copy local docs failed for ~s ~p", LogArg2),
+            exit({error, Error})
+    end.
+
+
+-spec wait_source_close(#job{}) -> ok | no_return().
+wait_source_close(#job{source = #shard{name = Name}, target = Targets}) ->
+    Timeout = config:get_integer("reshard",
+        "source_close_timeout_sec", 600),
+    check_targets_exist(Targets, wait_source_close),
+    case couch_db:open_int(Name, [?ADMIN_CTX]) of
+        {ok, Db} ->
+            Now = mem3_reshard:now_sec(),
+            case wait_source_close(Db, 1, Now + Timeout) of
+                true ->
+                    ok;
+                false ->
+                    exit({error, source_db_close_timeout, Name, Timeout})
+            end;
+        {not_found, _} ->
+            couch_log:warning("~p source already deleted ~p", [?MODULE, Name]),
+            ok
+    end.
+
+
+-spec source_delete(#job{}) -> ok | no_return().
+source_delete(#job{source = #shard{name = Name}, target = Targets}) ->
+    check_targets_exist(Targets, source_delete),
+    case config:get_boolean("mem3_reshard", "delete_source", true) of
+        true ->
+            case couch_server:delete(Name, [?ADMIN_CTX]) of
+                ok ->
+                    couch_log:notice("~p : deleted source shard ~p",
+                        [?MODULE, Name]);
+                not_found ->
+                    couch_log:warning("~p : source was already deleted ~p",
+                        [?MODULE, Name])
+            end;
+        false ->
+            LogMsg = "~p : according to configuration not deleting source ~p",
+            couch_log:warning(LogMsg, [?MODULE, Name])
+    end.
+
+
+-spec next_state(split_state()) -> split_state().
+next_state(State) ->
+    next_state(State, ?SPLIT_STATES).
+
+
+next_state(State, [State, Next | _Rest]) ->
+    Next;
+
+next_state(completed, _) ->
+    completed;
+
+next_state(State, [_ | Rest]) ->
+    next_state(State, Rest).
+
+
+-spec maybe_recover(#job{}) -> #job{} | no_return().
+maybe_recover(#job{split_state = new} = Job) ->
+    Job1 = reset_target(Job),
+    switch_state(Job1, initial_copy);
+
+maybe_recover(#job{split_state = initial_copy} = Job) ->
+    Job1 = reset_target(Job),
+    switch_state(Job1, initial_copy);
+
+maybe_recover(#job{split_state = topoff1} = Job) ->
+    switch_state(Job, topoff1);
+
+maybe_recover(#job{split_state = build_indices} = Job) ->
+    switch_state(Job, topoff1);
+
+maybe_recover(#job{split_state = topoff2} = Job) ->
+    switch_state(Job, topoff1);
+
+maybe_recover(#job{split_state = copy_local_docs} = Job) ->
+    switch_state(Job, topoff1);
+
+maybe_recover(#job{split_state = update_shardmap} = Job) ->
+    switch_state(Job, update_shardmap);
+
+maybe_recover(#job{split_state = wait_source_close} = Job) ->
+    switch_state(Job, wait_source_close);
+
+maybe_recover(#job{split_state = topoff3} = Job) ->
+    switch_state(Job, wait_source_close);
+
+maybe_recover(#job{split_state = source_delete} = Job) ->
+    switch_state(Job, wait_source_close);
+
+maybe_recover(#job{split_state = completed} = Job) ->
+    switch_state(Job, completed);
+
+maybe_recover(Job) ->
+    couch_log:error("~p reocver : unknown state ~s", [?MODULE, jobfmt(Job)]),
+    erlang:error({invalid_split_job_recover_state, Job}).
+
+
+-spec retry_state(term(), #job{}) -> #job{}.
+retry_state(Error, #job{retries = Retries, state_info = Info} = Job0) ->
+    Job = Job0#job{
+        retries = Retries + 1,
+        state_info = info_update(error, Error, Info)
+    },
+    couch_log:notice("~p retrying ~p ~p", [?MODULE, jobfmt(Job), Retries]),
+    Job1 = report(Job),
+    erlang:send_after(retry_interval_sec() * 1000, self(), retry),
+    Job1.
+
+
+-spec switch_state(#job{}, split_state()) -> #job{}.
+switch_state(#job{manager = ManagerPid} = Job0, NewState) ->
+    Info = Job0#job.state_info,
+    Info1 = info_delete(error, Info),
+    Info2 = info_delete(reason, Info1),
+    Job = Job0#job{
+        split_state = NewState,
+        update_time = mem3_reshard:now_sec(),
+        retries = 0,
+        state_info = Info2,
+        workers = []
+    },
+    Job1 = update_split_history(Job),
+    % Ask main process to checkpoint. When if it has finished it will notify us
+    % by calling by checkpoint_done/1. The reason not to call the main process
+    % via a gen_server:call is because the main process could be in the middle
+    % of terminating the job and then it would deadlock (after sending us a
+    % shutdown message) and it would end up using the whole supervisor
+    % termination timeout before finally.
+    ok = mem3_reshard:checkpoint(ManagerPid, check_state(Job1)),
+    Job1.
+
+
+-spec do_state(#job{}) -> #job{}.
+do_state(#job{split_state = initial_copy} = Job) ->
+    Pid = spawn_link(?MODULE, initial_copy, [Job]),
+    {ok, report(Job#job{workers = [Pid]})};
+
+do_state(#job{split_state = topoff1} = Job) ->
+    do_state_topoff(Job);
+
+do_state(#job{split_state = build_indices} = Job) ->
+    case build_indices(Job#job.source, Job#job.target) of
+        {ok, []} ->
+            {ok, switch_state(Job, next_state(build_indices))};
+        {ok, Pids} when is_list(Pids) ->
+            {ok, report(Job#job{workers = Pids})};
+        {error, Error} ->
+            maybe_retry(Job, max_retries(), Error)
+    end;
+
+do_state(#job{split_state = topoff2} = Job) ->
+    do_state_topoff(Job);
+
+do_state(#job{split_state = copy_local_docs} = Job) ->
+    Pid = spawn_link(?MODULE, copy_local_docs, [Job]),
+    {ok, report(Job#job{workers = [Pid]})};
+
+do_state(#job{split_state = update_shardmap} = Job) ->
+    Pid = spawn_link(mem3_reshard_dbdoc, update_shard_map, [Job]),
+    {ok, report(Job#job{workers = [Pid]})};
+
+do_state(#job{split_state = wait_source_close} = Job) ->
+    Pid = spawn_link(?MODULE, wait_source_close, [Job]),
+    {ok, report(Job#job{workers = [Pid]})};
+
+do_state(#job{split_state = topoff3} = Job) ->
+    do_state_topoff(Job);
+
+do_state(#job{split_state = source_delete} = Job) ->
+    ok = source_delete(Job),
+    {ok, switch_state(Job, next_state(source_delete))};
+
+do_state(#job{split_state = completed} = Job) ->
+    couch_log:notice("~p : ~p completed, exit normal", [?MODULE, jobfmt(Job)]),
+    {stop, normal, Job};
+
+do_state(#job{split_state = State} = Job) ->
+    couch_log:error("~p do_state NOT IMPLEMENTED ~p", [?MODULE, jobfmt(Job)]),
+    erlang:error({split_state_not_implemented, State, Job}).
+
+
+-spec maybe_retry(#job{}, any(), integer()) ->
+    {stop, any(), #job{}} | {retry, any(), #job{}}.
+maybe_retry(#job{retries = Retries} = Job, Max, Error) when Retries =< Max ->
+    {retry, Error, Job};
+
+maybe_retry(#job{} = Job, _, Error) ->
+    {stop, Error, Job}.
+
+
+-spec report(#job{}) -> #job{}.
+report(#job{manager = ManagerPid} = Job) ->
+    Job1 = Job#job{update_time = mem3_reshard:now_sec()},
+    ok = mem3_reshard:report(ManagerPid, Job1),
+    Job1.
+
+
+-spec worker_exited(any(), #job{}) ->
+    {noreply, #job{}} | {stop, any()} | {retry, any(), #job{}}.
+worker_exited(normal, #job{split_state = State, workers = []} = Job) ->
+    couch_log:notice("~p last worker exited ~p", [?MODULE, jobfmt(Job)]),
+    {noreply, switch_state(Job, next_state(State))};
+
+worker_exited(normal, #job{workers = Workers} = Job) when Workers =/= [] ->
+    {noreply, Job};
+
+worker_exited({error, missing_source}, #job{} = Job) ->
+    Msg1 = "~p stopping worker due to source missing ~p",
+    couch_log:error(Msg1, [?MODULE, jobfmt(Job)]),
+    [begin unlink(Pid), exit(Pid, kill) end || Pid <- Job#job.workers],
+    TargetCleanStates = [initial_copy, topoff1, build_indices, topoff2,
+        copy_local_docs],
+    case lists:member(Job#job.split_state, TargetCleanStates) of
+        true ->
+            Msg2 = "~p cleaning target after db was deleted ~p",
+            couch_log:error(Msg2, [?MODULE, jobfmt(Job)]),
+            {stop, {error, missing_source}, reset_target(Job)};
+        false ->
+            {stop, {error, missing_source}, Job}
+    end;
+
+worker_exited({error, missing_target}, #job{} = Job) ->
+    Msg = "~p stopping worker due to target db missing ~p",
+    couch_log:error(Msg, [?MODULE, jobfmt(Job)]),
+    [begin unlink(Pid), exit(Pid, kill) end || Pid <- Job#job.workers],
+    {stop, {error, missing_target}, Job};
+
+worker_exited(Reason, #job{} = Job0) ->
+    couch_log:error("~p worker error ~p ~p", [?MODULE, jobfmt(Job0), Reason]),
+    [begin unlink(Pid), exit(Pid, kill) end || Pid <- Job0#job.workers],
+    Job = Job0#job{workers = []},
+    case maybe_retry(Job, max_retries(), Reason) of
+        {stop, Error, Job1} ->
+            {stop, Error, Job1};
+        {retry, Error, Job1} ->
+            {noreply, retry_state(Error, Job1)}
+    end.
+
+
+% This is for belt and suspenders really. Call periodically to validate the
+% state is one of the expected states.
+-spec check_state(#job{}) -> #job{} | no_return().
+check_state(#job{split_state = State} = Job) ->
+    case lists:member(State, ?SPLIT_STATES) of
+        true ->
+            Job;
+        false ->
+            erlang:error({invalid_shard_split_state, State, Job})
+    end.
+
+
+create_artificial_mem3_rep_checkpoints(#job{} = Job, Seq) ->
+    #job{source = Source = #shard{name = SourceName}, target = Targets} = Job,
+    check_source_exists(Source, initial_copy),
+    TNames = [TN || #shard{name = TN} <- Targets],
+    Timestamp = list_to_binary(mem3_util:iso8601_timestamp()),
+    couch_util:with_db(SourceName, fun(SDb) ->
+        [couch_util:with_db(TName, fun(TDb) ->
+            Doc = mem3_rep_checkpoint_doc(SDb, TDb, Timestamp, Seq),
+            {ok, _} = couch_db:update_doc(SDb, Doc, []),
+            {ok, _} = couch_db:update_doc(TDb, Doc, []),
+            ok
+        end) || TName <- TNames]
+    end),
+    ok.
+
+
+mem3_rep_checkpoint_doc(SourceDb, TargetDb, Timestamp, Seq) ->
+    Node = atom_to_binary(node(), utf8),
+    SourceUUID =  couch_db:get_uuid(SourceDb),
+    TargetUUID = couch_db:get_uuid(TargetDb),
+    History = {[
+        {<<"source_node">>, Node},
+        {<<"source_uuid">>, SourceUUID},
+        {<<"source_seq">>, Seq},
+        {<<"timestamp">>, Timestamp},
+        {<<"target_node">>, Node},
+        {<<"target_uuid">>, TargetUUID},
+        {<<"target_seq">>, Seq}
+    ]},
+    Body = {[
+        {<<"seq">>, Seq},
+        {<<"target_uuid">>, TargetUUID},
+        {<<"history">>, {[{Node, [History]}]}}
+    ]},
+    Id = mem3_rep:make_local_id(SourceUUID, TargetUUID),
+    #doc{id = Id, body = Body}.
+
+
+do_state_topoff(#job{} = Job) ->
+    #job{source = Source, target = Targets} = Job,
+    Pid = spawn_link(?MODULE, topoff, [Source, Targets]),
+    {ok, report(Job#job{workers = [Pid]})}.
+
+
+check_source_exists(#shard{name = Name}, StateName) ->
+    case couch_server:exists(Name) of
+        true ->
+            ok;
+        false ->
+            ErrMsg = "~p source ~p is unexpectedly missing in ~p",
+            couch_log:error(ErrMsg, [?MODULE, Name, StateName]),
+            exit({error, missing_source})
+    end.
+
+
+check_targets_exist(Targets, StateName) ->
+    lists:foreach(fun(#shard{name = Name}) ->
+        case couch_server:exists(Name) of
+            true ->
+                ok;
+            false ->
+                ErrMsg = "~p target ~p is unexpectedly missing in ~p",
+                couch_log:error(ErrMsg, [?MODULE, Name, StateName]),
+                exit({error, missing_target})
+        end
+    end, Targets).
+
+
+build_indices(#shard{name = SourceName} = Source, Targets) ->
+    check_source_exists(Source, build_indices),
+    {ok, DDocs} = mem3_reshard_index:design_docs(SourceName),
+    Indices = mem3_reshard_index:target_indices(DDocs, Targets),
+    mem3_reshard_index:spawn_builders(Indices).
+
+
+wait_source_close(Db, SleepSec, UntilSec) ->
+    case couch_db:monitored_by(Db) -- [self()] of
+        [] ->
+            true;
+        [_ | _] ->
+            Now = mem3_reshard:now_sec(),
+            case Now < UntilSec of
+                true ->
+                    LogMsg = "~p : Waiting for source shard ~p to be closed",
+                    couch_log:notice(LogMsg, [?MODULE, couch_db:name(Db)]),
+                    timer:sleep(SleepSec * 1000),
+                    wait_source_close(Db, SleepSec, UntilSec);
+                false ->
+                    false
+            end
+    end.
+
+
+-spec max_retries() -> integer().
+max_retries() ->
+    config:get_integer("mem3_reshard", "max_retries", 1).
+
+
+-spec retry_interval_sec() -> integer().
+retry_interval_sec() ->
+    config:get_integer("mem3_reshard", "retry_interval_sec", 10).
+
+
+-spec info_update(atom(), any(), [tuple()]) -> [tuple()].
+info_update(Key, Val, StateInfo) ->
+    lists:keystore(Key, 1, StateInfo, {Key, Val}).
+
+
+-spec info_delete(atom(), [tuple()]) -> [tuple()].
+info_delete(Key, StateInfo) ->
+    lists:keydelete(Key, 1, StateInfo).
+
+
+-spec shardsstr(#shard{}, #shard{} | [#shard{}]) -> string().
+shardsstr(#shard{name = SourceName}, #shard{name = TargetName}) ->
+    lists:flatten(io_lib:format("~s -> ~s", [SourceName, TargetName]));
+
+shardsstr(#shard{name = SourceName}, Targets) ->
+    TNames = [TN || #shard{name = TN} <- Targets],
+    TargetsStr = string:join([binary_to_list(T) || T <- TNames], ","),
+    lists:flatten(io_lib:format("~s -> ~s", [SourceName, TargetsStr])).
+
+
+-spec reset_target(#job{}) -> #job{}.
+reset_target(#job{source = Source, target = Targets} = Job) ->
+    ShardNames = try
+        [N || #shard{name = N} <- mem3:local_shards(mem3:dbname(Source))]
+    catch
+        error:database_does_not_exist ->
+            []
+    end,
+    lists:map(fun(#shard{name = Name}) ->
+        case {couch_server:exists(Name), lists:member(Name, ShardNames)} of
+            {_, true} ->
+                % Should never get here but if we do crash and don't continue
+                LogMsg = "~p : ~p target unexpectedly found in shard map ~p",
+                couch_log:error(LogMsg, [?MODULE, jobfmt(Job), Name]),
+                erlang:error({target_present_in_shard_map, Name});
+            {true, false} ->
+                LogMsg = "~p : ~p resetting ~p target",
+                couch_log:warning(LogMsg, [?MODULE, jobfmt(Job), Name]),
+                couch_db_split:cleanup_target(Source#shard.name, Name);
+            {false, false} ->
+                ok
+        end
+    end, Targets),
+    Job.
+
+
+-spec update_split_history(#job{}) -> #job{}.
+update_split_history(#job{split_state = St, update_time = Ts} = Job) ->
+    Hist = Job#job.history,
+    JobSt = case St of
+        completed -> completed;
+        failed -> failed;
+        new -> new;
+        stopped -> stopped;
+        _ -> running
+    end,
+    Job#job{history = mem3_reshard:update_history(JobSt, St, Ts, Hist)}.

--- a/src/mem3/src/mem3_reshard_job_sup.erl
+++ b/src/mem3/src/mem3_reshard_job_sup.erl
@@ -1,0 +1,55 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_job_sup).
+
+-behaviour(supervisor).
+
+-export([
+    start_link/0,
+    start_child/1,
+    terminate_child/1,
+    count_children/0,
+    init/1
+]).
+
+
+-include("mem3_reshard.hrl").
+
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+
+start_child(Job) ->
+    supervisor:start_child(?MODULE, [Job]).
+
+
+terminate_child(Pid) ->
+    supervisor:terminate_child(?MODULE, Pid).
+
+
+count_children() ->
+    Props = supervisor:count_children(?MODULE),
+    proplists:get_value(active, Props).
+
+
+init(_Args) ->
+    Children = [
+        {mem3_reshard_job,
+            {mem3_reshard_job, start_link, []},
+            temporary,
+            60000,
+            worker,
+            [mem3_reshard_job]}
+    ],
+    {ok, {{simple_one_for_one, 10, 3}, Children}}.

--- a/src/mem3/src/mem3_reshard_store.erl
+++ b/src/mem3/src/mem3_reshard_store.erl
@@ -1,0 +1,288 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_store).
+
+
+-export([
+    init/3,
+
+    store_job/2,
+    load_job/2,
+    delete_job/2,
+    get_jobs/1,
+
+    store_state/1,
+    load_state/1,
+    delete_state/1, % for debugging
+
+    job_to_ejson_props/2,
+    state_to_ejson_props/1
+]).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include("mem3_reshard.hrl").
+
+
+-spec init(#state{}, binary(), binary()) -> #state{}.
+init(#state{} = State, JobPrefix, StateDocId) ->
+    State#state{
+        job_prefix = <<?LOCAL_DOC_PREFIX, JobPrefix/binary>>,
+        state_id = <<?LOCAL_DOC_PREFIX, StateDocId/binary>>
+    }.
+
+
+-spec store_job(#state{}, #job{}) -> ok.
+store_job(#state{job_prefix = Prefix}, #job{id = Id} = Job) ->
+    with_shards_db(fun(Db) ->
+        DocId = <<Prefix/binary, Id/binary>>,
+        ok = update_doc(Db, DocId, job_to_ejson_props(Job))
+    end).
+
+
+-spec load_job(#state{}, binary()) -> {ok, {[_]}} | not_found.
+load_job(#state{job_prefix = Prefix}, Id) ->
+    with_shards_db(fun(Db) ->
+        case load_doc(Db, <<Prefix/binary, Id/binary>>) of
+            {ok, DocBody} ->
+                {ok, job_from_ejson(DocBody)};
+            not_found ->
+                not_found
+        end
+    end).
+
+
+-spec delete_job(#state{}, binary()) -> ok.
+delete_job(#state{job_prefix = Prefix}, Id) ->
+    with_shards_db(fun(Db) ->
+        DocId = <<Prefix/binary, Id/binary>>,
+        ok = delete_doc(Db, DocId)
+    end).
+
+
+-spec get_jobs(#state{}) -> [#job{}].
+get_jobs(#state{job_prefix = Prefix}) ->
+    with_shards_db(fun(Db) ->
+        PrefixLen = byte_size(Prefix),
+        FoldFun = fun(#doc{id = Id, body = Body}, Acc) ->
+            case Id of
+                <<Prefix:PrefixLen/binary, _/binary>> ->
+                    {ok, [job_from_ejson(Body) | Acc]};
+                _ ->
+                    {stop, Acc}
+            end
+        end,
+        Opts = [{start_key, Prefix}],
+        {ok, Jobs} = couch_db:fold_local_docs(Db, FoldFun, [], Opts),
+        lists:reverse(Jobs)
+    end).
+
+
+-spec store_state(#state{}) -> ok.
+store_state(#state{state_id = DocId} = State) ->
+    with_shards_db(fun(Db) ->
+        ok = update_doc(Db, DocId, state_to_ejson_props(State))
+    end).
+
+
+-spec load_state(#state{}) -> #state{}.
+load_state(#state{state_id = DocId} = State) ->
+    with_shards_db(fun(Db) ->
+        case load_doc(Db, DocId) of
+            {ok, DocBody} ->
+                state_from_ejson(State, DocBody);
+            not_found ->
+                State
+        end
+    end).
+
+
+-spec delete_state(#state{}) -> ok.
+delete_state(#state{state_id = DocId}) ->
+    with_shards_db(fun(Db) ->
+        ok = delete_doc(Db, DocId)
+    end).
+
+
+job_to_ejson_props(#job{source = Source, target = Targets} = Job, Opts) ->
+    Iso8601 = proplists:get_value(iso8601, Opts),
+    History = history_to_ejson(Job#job.history, Iso8601),
+    StartTime = case Iso8601 of
+        true -> iso8601(Job#job.start_time);
+        _ -> Job#job.start_time
+    end,
+    UpdateTime = case Iso8601 of
+        true -> iso8601(Job#job.update_time);
+        _ -> Job#job.update_time
+    end,
+    [
+        {id, Job#job.id},
+        {type, Job#job.type},
+        {source, Source#shard.name},
+        {target, [T#shard.name || T <- Targets]},
+        {job_state, Job#job.job_state},
+        {split_state, Job#job.split_state},
+        {state_info, state_info_to_ejson(Job#job.state_info)},
+        {node, atom_to_binary(Job#job.node, utf8)},
+        {start_time, StartTime},
+        {update_time, UpdateTime},
+        {history, History}
+    ].
+
+
+state_to_ejson_props(#state{} = State) ->
+    [
+        {state, atom_to_binary(State#state.state, utf8)},
+        {state_info, state_info_to_ejson(State#state.state_info)},
+        {update_time, State#state.update_time},
+        {node, atom_to_binary(State#state.node, utf8)}
+    ].
+
+
+% Private API
+
+with_shards_db(Fun) ->
+    DbName = config:get("mem3", "shards_db", "_dbs"),
+    case mem3_util:ensure_exists(DbName) of
+        {ok, Db} ->
+            try
+                Fun(Db)
+            after
+                catch couch_db:close(Db)
+            end;
+        Else ->
+            throw(Else)
+    end.
+
+
+delete_doc(Db, DocId) ->
+    case couch_db:open_doc(Db, DocId, []) of
+        {ok, #doc{revs = {_, Revs}}} ->
+            {ok, _} = couch_db:delete_doc(Db, DocId, Revs),
+            {ok, _} = couch_db:ensure_full_commit(Db),
+            ok;
+        {not_found, _} ->
+            ok
+    end.
+
+
+update_doc(Db, DocId, Body) ->
+    DocProps = [{<<"_id">>, DocId}] ++ Body,
+    Body1 = ?JSON_DECODE(?JSON_ENCODE({DocProps})),
+    BaseDoc = couch_doc:from_json_obj(Body1),
+    Doc = case couch_db:open_doc(Db, DocId, []) of
+        {ok, #doc{revs = Revs}} ->
+            BaseDoc#doc{revs = Revs};
+        {not_found, _} ->
+            BaseDoc
+    end,
+    case store_state() of
+        true ->
+            {ok, _} = couch_db:update_doc(Db, Doc, []),
+            couch_log:debug("~p updated doc ~p ~p", [?MODULE, DocId, Body]),
+            {ok, _} = couch_db:ensure_full_commit(Db),
+            ok;
+        false ->
+            couch_log:debug("~p not storing state in ~p", [?MODULE, DocId]),
+            ok
+    end.
+
+
+load_doc(Db, DocId) ->
+    case couch_db:open_doc(Db, DocId, [ejson_body]) of
+        {ok, #doc{body = Body}} ->
+            couch_log:debug("~p loaded doc ~p ~p", [?MODULE, DocId, Body]),
+            {ok, Body};
+        {not_found, _} ->
+            not_found
+    end.
+
+
+job_to_ejson_props(#job{} = Job) ->
+    job_to_ejson_props(Job, []).
+
+
+job_from_ejson({Props}) ->
+    Id = couch_util:get_value(<<"id">>, Props),
+    Type = couch_util:get_value(<<"type">>, Props),
+    Source = couch_util:get_value(<<"source">>, Props),
+    Target = couch_util:get_value(<<"target">>, Props),
+    JobState = couch_util:get_value(<<"job_state">>, Props),
+    SplitState = couch_util:get_value(<<"split_state">>, Props),
+    StateInfo = couch_util:get_value(<<"state_info">>, Props),
+    TStarted = couch_util:get_value(<<"start_time">>, Props),
+    TUpdated = couch_util:get_value(<<"update_time">>, Props),
+    History = couch_util:get_value(<<"history">>, Props),
+    #job{
+        id = Id,
+        type = binary_to_atom(Type, utf8),
+        job_state = binary_to_atom(JobState, utf8),
+        split_state = binary_to_atom(SplitState, utf8),
+        state_info = state_info_from_ejson(StateInfo),
+        node = node(),
+        start_time = TStarted,
+        update_time = TUpdated,
+        source = mem3_reshard:shard_from_name(Source),
+        target = [mem3_reshard:shard_from_name(T) || T <- Target],
+        history = history_from_ejson(History)
+    }.
+
+
+state_from_ejson(#state{} = State, {Props}) ->
+    StateVal = couch_util:get_value(<<"state">>, Props),
+    StateInfo = couch_util:get_value(<<"state_info">>, Props),
+    TUpdated = couch_util:get_value(<<"update_time">>, Props),
+    State#state{
+        state = binary_to_atom(StateVal, utf8),
+        state_info = state_info_from_ejson(StateInfo),
+        node = node(),
+        update_time = TUpdated
+    }.
+
+
+state_info_from_ejson({Props}) ->
+    Props1 = [{binary_to_atom(K, utf8), couch_util:to_binary(V)}
+        || {K, V} <- Props],
+    lists:sort(Props1).
+
+
+history_to_ejson(Hist, true) when is_list(Hist) ->
+    [{[{timestamp, iso8601(T)}, {type, S}, {detail, D}]} || {T, S, D} <- Hist];
+
+history_to_ejson(Hist, _) when is_list(Hist) ->
+    [{[{timestamp, T}, {type, S}, {detail, D}]} || {T, S, D} <- Hist].
+
+
+history_from_ejson(HistoryEJson) when is_list(HistoryEJson) ->
+    lists:map(fun({EventProps}) ->
+        Timestamp = couch_util:get_value(<<"timestamp">>, EventProps),
+        State = couch_util:get_value(<<"type">>, EventProps),
+        Detail = couch_util:get_value(<<"detail">>, EventProps),
+        {Timestamp, binary_to_atom(State, utf8), Detail}
+    end, HistoryEJson).
+
+
+state_info_to_ejson(Props) ->
+    {lists:sort([{K, couch_util:to_binary(V)} || {K, V} <- Props])}.
+
+
+store_state() ->
+    config:get_boolean("reshard", "store_state", true).
+
+
+iso8601(UnixSec) ->
+    Mega = UnixSec div 1000000,
+    Sec = UnixSec rem 1000000,
+    {{Y, M, D}, {H, Min, S}} = calendar:now_to_universal_time({Mega, Sec, 0}),
+    Format = "~B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0BZ",
+    iolist_to_binary(io_lib:format(Format, [Y, M, D, H, Min, S])).

--- a/src/mem3/src/mem3_reshard_sup.erl
+++ b/src/mem3/src/mem3_reshard_sup.erl
@@ -1,0 +1,47 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_sup).
+
+-behaviour(supervisor).
+
+-export([
+    start_link/0,
+    init/1
+]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+
+init(_Args) ->
+    Children = [
+        {mem3_reshard_dbdoc,
+            {mem3_reshard_dbdoc, start_link, []},
+            permanent,
+            infinity,
+            worker,
+            [mem3_reshard_dbdoc]},
+        {mem3_reshard_job_sup,
+            {mem3_reshard_job_sup, start_link, []},
+            permanent,
+            infinity,
+            supervisor,
+            [mem3_reshard_job_sup]},
+        {mem3_reshard,
+            {mem3_reshard, start_link, []},
+            permanent,
+            brutal_kill,
+            worker,
+            [mem3_reshard]}
+    ],
+    {ok, {{one_for_all, 5, 5}, Children}}.

--- a/src/mem3/src/mem3_reshard_validate.erl
+++ b/src/mem3/src/mem3_reshard_validate.erl
@@ -1,0 +1,113 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_validate).
+
+-export([
+    start_args/2,
+    source/1,
+    targets/2
+]).
+
+-include_lib("mem3/include/mem3.hrl").
+
+
+-spec start_args(#shard{}, any()) -> ok | {error, term()}.
+start_args(Source, Split) ->
+    first_error([
+        check_split(Split),
+        check_range(Source, Split),
+        check_node(Source),
+        source(Source)
+    ]).
+
+
+-spec source(#shard{}) ->  ok | {error, term()}.
+source(#shard{name = Name}) ->
+    case couch_server:exists(Name) of
+        true ->
+            ok;
+        false ->
+            {error, {source_shard_not_found, Name}}
+    end.
+
+
+-spec targets(#shard{}, [#shard{}]) -> ok | {error, term()}.
+targets(#shard{} = Source, Targets) ->
+    first_error([
+        target_ranges(Source, Targets)
+    ]).
+
+
+-spec check_split(any()) ->  ok | {error, term()}.
+check_split(Split) when is_integer(Split), Split > 1 ->
+    ok;
+check_split(Split) ->
+    {error, {invalid_split_parameter, Split}}.
+
+
+-spec check_range(#shard{}, any()) ->  ok | {error, term()}.
+check_range(#shard{range = Range = [B, E]}, Split) ->
+    case (E + 1 - B) >= Split of
+        true ->
+            ok;
+        false ->
+            {error, {shard_range_cannot_be_split, Range, Split}}
+    end.
+
+
+-spec check_node(#shard{}) ->  ok | {error, term()}.
+check_node(#shard{node = undefined}) ->
+    ok;
+
+check_node(#shard{node = Node}) when Node =:= node() ->
+    ok;
+
+check_node(#shard{node = Node}) ->
+    {error, {source_shard_node_is_not_current_node, Node}}.
+
+
+-spec target_ranges(#shard{}, [#shard{}]) -> ok | {error, any()}.
+target_ranges(#shard{range = [Begin, End]}, Targets) ->
+    Ranges = [R || #shard{range = R} <- Targets],
+    SortFun = fun([B1, _], [B2, _]) -> B1 =< B2 end,
+    [First | RestRanges] = lists:sort(SortFun, Ranges),
+    try
+        TotalRange = lists:foldl(fun([B2, E2], [B1, E1]) ->
+            case B2 =:= E1 + 1 of
+                true ->
+                    ok;
+                false ->
+                    throw({range_error, {B2, E1}})
+            end,
+            [B1, E2]
+        end, First, RestRanges),
+        case [Begin, End] =:= TotalRange of
+            true ->
+                ok;
+            false ->
+                throw({range_error, {[Begin, End], TotalRange}})
+        end
+    catch
+        throw:{range_error, Error} ->
+            {error, {shard_range_error, Error}}
+    end.
+
+
+-spec first_error([ok | {error, term()}]) -> ok | {error, term()}.
+first_error(Results) ->
+    case [Res || Res <- Results, Res =/= ok] of
+        [] ->
+            ok;
+        [FirstError | _] ->
+            FirstError
+    end.

--- a/src/mem3/src/mem3_rpc.erl
+++ b/src/mem3/src/mem3_rpc.erl
@@ -21,11 +21,14 @@
     update_docs/4,
     pull_replication/1,
     load_checkpoint/4,
+    load_checkpoint/5,
     save_checkpoint/6,
 
     load_purge_infos/4,
     save_purge_checkpoint/4,
-    purge_docs/4
+    purge_docs/4,
+
+    replicate/4
 ]).
 
 % Private RPC callbacks
@@ -33,10 +36,14 @@
     find_common_seq_rpc/3,
     load_checkpoint_rpc/3,
     pull_replication_rpc/1,
+    load_checkpoint_rpc/4,
     save_checkpoint_rpc/5,
 
     load_purge_infos_rpc/3,
-    save_purge_checkpoint_rpc/3
+    save_purge_checkpoint_rpc/3,
+
+    replicate_rpc/2
+
 ]).
 
 
@@ -55,6 +62,11 @@ get_missing_revs(Node, DbName, IdsRevs, Options) ->
 
 update_docs(Node, DbName, Docs, Options) ->
     rexi_call(Node, {fabric_rpc, update_docs, [DbName, Docs, Options]}).
+
+
+load_checkpoint(Node, DbName, SourceNode, SourceUUID, FilterHash) ->
+    Args = [DbName, SourceNode, SourceUUID, FilterHash],
+    rexi_call(Node, {mem3_rpc, load_checkpoint_rpc, Args}).
 
 
 load_checkpoint(Node, DbName, SourceNode, SourceUUID) ->
@@ -86,12 +98,22 @@ purge_docs(Node, DbName, PurgeInfos, Options) ->
     rexi_call(Node, {fabric_rpc, purge_docs, [DbName, PurgeInfos, Options]}).
 
 
+replicate(Source, Target, DbName, Timeout)
+        when is_atom(Source), is_atom(Target), is_binary(DbName) ->
+    Args = [DbName, Target],
+    rexi_call(Source, {mem3_rpc, replicate_rpc, Args}, Timeout).
+
+
 load_checkpoint_rpc(DbName, SourceNode, SourceUUID) ->
+    load_checkpoint_rpc(DbName, SourceNode, SourceUUID, <<>>).
+
+
+load_checkpoint_rpc(DbName, SourceNode, SourceUUID, FilterHash) ->
     erlang:put(io_priority, {internal_repl, DbName}),
     case get_or_create_db(DbName, [?ADMIN_CTX]) of
     {ok, Db} ->
         TargetUUID = couch_db:get_uuid(Db),
-        NewId = mem3_rep:make_local_id(SourceUUID, TargetUUID),
+        NewId = mem3_rep:make_local_id(SourceUUID, TargetUUID, FilterHash),
         case couch_db:open_doc(Db, NewId, []) of
         {ok, Doc} ->
             rexi:reply({ok, {NewId, Doc}});
@@ -206,6 +228,16 @@ save_purge_checkpoint_rpc(DbName, PurgeDocId, Body) ->
         Error ->
             rexi:reply(Error)
     end.
+
+
+replicate_rpc(DbName, Target) ->
+    rexi:reply(try
+        Opts = [{batch_size, 1000}, {batch_count, all}],
+        {ok, mem3_rep:go(DbName, Target, Opts)}
+    catch
+        Tag:Error ->
+            {Tag, Error}
+    end).
 
 
 %% @doc Return the sequence where two files with the same UUID diverged.
@@ -338,6 +370,10 @@ find_bucket(NewSeq, CurSeq, Bucket) ->
 
 
 rexi_call(Node, MFA) ->
+    rexi_call(Node, MFA, 600000).
+
+
+rexi_call(Node, MFA, Timeout) ->
     Mon = rexi_monitor:start([rexi_utils:server_pid(Node)]),
     Ref = rexi:cast(Node, self(), MFA, [sync]),
     try
@@ -347,7 +383,7 @@ rexi_call(Node, MFA) ->
             erlang:error(Error);
         {rexi_DOWN, Mon, _, Reason} ->
             erlang:error({rexi_DOWN, {Node, Reason}})
-        after 600000 ->
+        after Timeout ->
             erlang:error(timeout)
         end
     after

--- a/src/mem3/src/mem3_sup.erl
+++ b/src/mem3/src/mem3_sup.erl
@@ -25,12 +25,16 @@ init(_Args) ->
         child(mem3_sync_nodes), % Order important?
         child(mem3_sync),
         child(mem3_shards),
-        child(mem3_sync_event_listener)
+        child(mem3_sync_event_listener),
+        child(mem3_reshard_sup)
     ],
     {ok, {{one_for_one,10,1}, couch_epi:register_service(mem3_epi, Children)}}.
 
 child(mem3_events) ->
     MFA = {gen_event, start_link, [{local, mem3_events}]},
     {mem3_events, MFA, permanent, 1000, worker, dynamic};
+child(mem3_reshard_sup = Child) ->
+    MFA = {Child, start_link, []},
+    {Child, MFA, permanent, infinity, supervisor, [Child]};
 child(Child) ->
     {Child, {Child, start_link, []}, permanent, 1000, worker, [Child]}.

--- a/src/mem3/src/mem3_util.erl
+++ b/src/mem3/src/mem3_util.erl
@@ -17,7 +17,18 @@
     shard_info/1, ensure_exists/1, open_db_doc/1]).
 -export([is_deleted/1, rotate_list/2]).
 -export([
-    iso8601_timestamp/0
+    iso8601_timestamp/0,
+    live_nodes/0,
+    replicate_dbs_to_all_nodes/1,
+    replicate_dbs_from_all_nodes/1,
+    range_overlap/2,
+    get_ring/1,
+    get_ring/2,
+    get_ring/3,
+    get_ring/4,
+    non_overlapping_shards/1,
+    non_overlapping_shards/3,
+    calculate_max_n/1
 ]).
 
 %% do not use outside mem3.
@@ -286,3 +297,272 @@ iso8601_timestamp() ->
     {{Year,Month,Date},{Hour,Minute,Second}} = calendar:now_to_datetime(Now),
     Format = "~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.~6.10.0BZ",
     io_lib:format(Format, [Year, Month, Date, Hour, Minute, Second, Micro]).
+
+
+live_nodes() ->
+    LiveNodes = [node() | nodes()],
+    Mem3Nodes = lists:sort(mem3:nodes()),
+    [N || N <- Mem3Nodes, lists:member(N, LiveNodes)].
+
+
+% Replicate "dbs" db to all nodes. Basically push the changes to all the live
+% mem3:nodes(). Returns only after all current changes have been replicated,
+% which could be a while.
+%
+replicate_dbs_to_all_nodes(Timeout) ->
+    DbName = ?l2b(config:get("mem3", "shards_db", "_dbs")),
+    Targets= mem3_util:live_nodes() -- [node()],
+    Res =  [start_replication(node(), T, DbName, Timeout) || T <- Targets],
+    collect_replication_results(Res, Timeout).
+
+
+% Replicate "dbs" db from all nodes to this node. Basically make an rpc call
+% to all the nodes an have them push their changes to this node. Then monitor
+% them until they are all done.
+%
+replicate_dbs_from_all_nodes(Timeout) ->
+    DbName = ?l2b(config:get("mem3", "shards_db", "_dbs")),
+    Sources = mem3_util:live_nodes() -- [node()],
+    Res = [start_replication(S, node(), DbName, Timeout) || S <- Sources],
+    collect_replication_results(Res, Timeout).
+
+
+% Spawn and monitor a single replication of a database to a target node.
+% Returns {ok, PidRef}. This function could be called locally or remotely from
+% mem3_rpc, for instance when replicating other nodes' data to this node.
+%
+start_replication(Source, Target, DbName, Timeout) ->
+    spawn_monitor(fun() ->
+        case mem3_rpc:replicate(Source, Target, DbName, Timeout) of
+            {ok, 0} ->
+                exit(ok);
+            Other ->
+                exit(Other)
+        end
+    end).
+
+
+collect_replication_results(Replications, Timeout) ->
+    Res = [collect_replication_result(R, Timeout) || R <- Replications],
+    case [R || R <- Res, R =/= ok] of
+        [] ->
+            ok;
+        Errors ->
+            {error, Errors}
+    end.
+
+
+collect_replication_result({Pid, Ref}, Timeout) when is_pid(Pid) ->
+    receive
+        {'DOWN', Ref, _, _, Res} ->
+            Res
+    after Timeout ->
+        demonitor(Pid, [flush]),
+        exit(Pid, kill),
+        {error, {timeout, Timeout, node(Pid)}}
+    end;
+
+collect_replication_result(Error, _) ->
+    {error, Error}.
+
+
+% Consider these cases:
+%
+%       A-------B
+%
+% overlap:
+%   X--------Y
+%         X-Y
+%          X-------Y
+% X-------------------Y
+%
+% no overlap:
+% X-Y                     because A !=< Y
+%                   X-Y   because X !=< B
+%
+range_overlap([A, B], [X, Y]) when
+        is_integer(A), is_integer(B),
+        is_integer(X), is_integer(Y),
+        A =< B, X =< Y ->
+    A =< Y andalso X =< B.
+
+
+non_overlapping_shards(Shards) ->
+    {Start, End} = lists:foldl(fun(Shard, {Min, Max}) ->
+        [B, E] = mem3:range(Shard),
+        {min(B, Min), max(E, Max)}
+    end, {0, ?RING_END}, Shards),
+    non_overlapping_shards(Shards, Start, End).
+
+
+non_overlapping_shards([], _, _) ->
+    [];
+
+non_overlapping_shards(Shards, Start, End) ->
+    Ranges = lists:map(fun(Shard) ->
+        [B, E] = mem3:range(Shard),
+        {B, E}
+    end, Shards),
+    Ring = get_ring(Ranges, fun sort_ranges_fun/2, Start, End),
+    lists:filter(fun(Shard) ->
+        [B, E] = mem3:range(Shard),
+        lists:member({B, E}, Ring)
+    end, Shards).
+
+
+% Given a list of shards, return the maximum number of copies
+% across all the ranges. If the ring is incomplete it will return 0.
+% If there it is an n = 1 database, it should return 1, etc.
+calculate_max_n(Shards) ->
+    Ranges = lists:map(fun(Shard) ->
+        [B, E] = mem3:range(Shard),
+        {B, E}
+    end, Shards),
+    calculate_max_n(Ranges, get_ring(Ranges), 0).
+
+
+calculate_max_n(_Ranges, [], N) ->
+    N;
+
+calculate_max_n(Ranges, Ring, N) ->
+    NewRanges = Ranges -- Ring,
+    calculate_max_n(NewRanges, get_ring(NewRanges), N + 1).
+
+
+get_ring(Ranges) ->
+    get_ring(Ranges, fun sort_ranges_fun/2, 0, ?RING_END).
+
+
+get_ring(Ranges, SortFun) when is_function(SortFun, 2) ->
+    get_ring(Ranges, SortFun, 0, ?RING_END).
+
+
+get_ring(Ranges, Start, End) when is_integer(Start), is_integer(End),
+        Start >= 0, End >= 0, Start =< End ->
+    get_ring(Ranges, fun sort_ranges_fun/2, Start, End).
+
+% Build a ring out of a list of possibly overlapping ranges. If a ring cannot
+% be built then [] is returned. Start and End supply a custom range such that
+% only intervals in that range will be considered. SortFun is a custom sorting
+% function to sort intervals before the ring is built. The custom sort function
+% can be used to prioritize how the ring is built, for example, whether to use
+% shortest ranges first (and thus have more total shards) or longer or any
+% other scheme.
+%
+get_ring([], _SortFun, _Start, _End) ->
+    [];
+get_ring(Ranges, SortFun, Start, End) when is_function(SortFun, 2),
+        is_integer(Start), is_integer(End),
+        Start >= 0, End >= 0, Start =< End  ->
+    Sorted = lists:usort(SortFun, Ranges),
+    case get_subring_int(Start, End, Sorted) of
+        fail -> [];
+        Ring -> Ring
+    end.
+
+
+get_subring_int(_, _, []) ->
+    fail;
+
+get_subring_int(Start, EndMax, [{Start, End} = Range | Tail]) ->
+    case End =:= EndMax of
+        true ->
+            [Range];
+        false ->
+            case get_subring_int(End + 1, EndMax, Tail) of
+                fail ->
+                    get_subring_int(Start, EndMax, Tail);
+                Acc ->
+                    [Range | Acc]
+            end
+    end;
+
+get_subring_int(Start1, _, [{Start2, _} | _]) when Start2 > Start1 ->
+    % Found a gap, this attempt is done
+    fail;
+
+get_subring_int(Start1, EndMax, [{Start2, _} | Rest]) when Start2 < Start1 ->
+    % We've overlapped the head, skip the shard
+    get_subring_int(Start1, EndMax, Rest).
+
+
+% Sort ranges by starting point, then sort so that
+% the longest range comes first
+sort_ranges_fun({B, E1}, {B, E2}) ->
+    E2 =< E1;
+
+sort_ranges_fun({B1, _}, {B2, _}) ->
+    B1 =< B2.
+
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+range_overlap_test_() ->
+    [?_assertEqual(Res, range_overlap(R1, R2)) || {R1, R2, Res} <- [
+        {[2, 6], [1, 3], true},
+        {[2, 6], [3, 4], true},
+        {[2, 6], [4, 8], true},
+        {[2, 6], [1, 9], true},
+        {[2, 6], [1, 2], true},
+        {[2, 6], [6, 7], true},
+        {[2, 6], [0, 1], false},
+        {[2, 6], [7, 9], false}
+    ]].
+
+
+non_overlapping_shards_test() ->
+    [?_assertEqual(Res, non_overlapping_shards(Shards)) || {Shards, Res} <- [
+        {
+            [shard(0, ?RING_END)],
+            [shard(0, ?RING_END)]
+        },
+        {
+            [shard(0, 1)],
+            [shard(0, 1)]
+        },
+        {
+            [shard(0, 1), shard(0, 1)],
+            [shard(0, 1)]
+        },
+        {
+            [shard(0, 1), shard(3, 4)],
+            []
+        },
+        {
+            [shard(0, 1), shard(1, 2), shard(2, 3)],
+            [shard(0, 1), shard(2, 3)]
+        },
+        {
+            [shard(1, 2), shard(0, 1)],
+            [shard(0, 1), shard(1, 2)]
+        },
+        {
+            [shard(0, 1), shard(0, 2), shard(2, 5), shard(3, 5)],
+            [shard(0, 2), shard(2, 5)]
+        },
+        {
+            [shard(0, 2), shard(4, 5), shard(1, 3)],
+            []
+        }
+
+    ]].
+
+
+calculate_max_n_test_() ->
+     [?_assertEqual(Res, calculate_max_n(Shards)) || {Res, Shards} <- [
+        {0, []},
+        {0, [shard(1, ?RING_END)]},
+        {1, [shard(0, ?RING_END)]},
+        {1, [shard(0, ?RING_END), shard(1, ?RING_END)]},
+        {2, [shard(0, ?RING_END), shard(0, ?RING_END)]},
+        {2, [shard(0, 1), shard(2, ?RING_END), shard(0, ?RING_END)]},
+        {0, [shard(0, 3), shard(5, ?RING_END), shard(1, ?RING_END)]}
+     ]].
+
+
+shard(Begin, End) ->
+    #shard{range = [Begin, End]}.
+
+-endif.

--- a/src/mem3/test/mem3_reshard_api_test.erl
+++ b/src/mem3/test/mem3_reshard_api_test.erl
@@ -1,0 +1,851 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_api_test).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/src/mem3_reshard.hrl").
+
+
+-define(USER, "mem3_reshard_api_test_admin").
+-define(PASS, "pass").
+-define(AUTH, {basic_auth, {?USER, ?PASS}}).
+-define(JSON, {"Content-Type", "application/json"}).
+-define(RESHARD, "_reshard/").
+-define(JOBS, "_reshard/jobs/").
+-define(STATE, "_reshard/state").
+-define(ID, <<"id">>).
+-define(OK, <<"ok">>).
+
+
+setup() ->
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    Url = lists:concat(["http://", Addr, ":", Port, "/"]),
+    {Db1, Db2, Db3} = {?tempdb(), ?tempdb(), ?tempdb()},
+    create_db(Url, Db1, "?q=1&n=1"),
+    create_db(Url, Db2, "?q=1&n=1"),
+    create_db(Url, Db3, "?q=2&n=1"),
+    {Url, {Db1, Db2, Db3}}.
+
+
+teardown({Url, {Db1, Db2, Db3}}) ->
+    mem3_reshard:reset_state(),
+    delete_db(Url, Db1),
+    delete_db(Url, Db2),
+    delete_db(Url, Db3),
+    ok = config:delete("reshard", "max_jobs", _Persist=false),
+    ok = config:delete("reshard", "state", _Persist=false),
+    ok = config:delete("admins", ?USER, _Persist=false),
+    meck:unload().
+
+
+
+start_couch() ->
+    test_util:start_couch(?CONFIG_CHAIN, [mem3, chttpd]).
+
+
+stop_couch(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+
+mem3_reshard_api_test_() ->
+    {
+        "mem3 shard split api tests",
+        {
+            setup,
+            fun start_couch/0, fun stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun basics/1,
+                    fun create_job_basic/1,
+                    fun create_two_jobs/1,
+                    fun create_multiple_jobs_from_one_post/1,
+                    fun start_stop_cluster_basic/1,
+                    fun stopped_from_config/1,
+                    fun start_stop_cluster_with_a_job/1,
+                    fun individual_job_start_stop/1,
+                    fun individual_job_stop_when_cluster_stopped/1,
+                    fun create_job_with_invalid_arguments/1,
+                    fun create_job_with_db/1,
+                    fun create_job_with_shard_name/1,
+                    fun completed_job_handling/1,
+                    fun handle_db_deletion_in_initial_copy/1,
+                    fun handle_db_deletion_in_topoff1/1,
+                    fun handle_db_deletion_in_copy_local_docs/1,
+                    fun handle_db_deletion_in_build_indices/1,
+                    fun handle_db_deletion_in_update_shard_map/1,
+                    fun handle_db_deletion_in_wait_source_close/1,
+                    fun handle_db_deletion_in_topoff3/1,
+                    fun handle_db_deletion_in_source_delete/1,
+                    fun recover_in_initial_copy/1,
+                    fun recover_in_topoff1/1,
+                    fun recover_in_copy_local_docs/1,
+                    fun recover_in_build_indices/1,
+                    fun recover_in_update_shard_map/1,
+                    fun recover_in_wait_source_close/1,
+                    fun recover_in_topoff3/1,
+                    fun recover_in_source_delete/1,
+                    fun check_max_jobs/1,
+                    fun cleanup_completed_jobs/1
+                ]
+            }
+        }
+    }.
+
+
+basics({Top, _}) ->
+    ?_test(begin
+        % GET /_reshard
+        ?assertMatch({200, #{
+            <<"state">> := <<"running">>,
+            <<"state_reason">> := null,
+            <<"completed">> := 0,
+            <<"failed">> := 0,
+            <<"running">> := 0,
+            <<"stopped">> := 0,
+            <<"total">> := 0
+        }}, req(get, Top ++ ?RESHARD)),
+
+        % GET _reshard/state
+        ?assertMatch({200, #{<<"state">> := <<"running">>}},
+            req(get, Top ++ ?STATE)),
+
+        % GET _reshard/jobs
+        ?assertMatch({200, #{
+            <<"jobs">> := [],
+            <<"offset">> := 0,
+            <<"total_rows">> := 0
+        }}, req(get, Top ++ ?JOBS)),
+
+        % Some invalid paths and methods
+        ?assertMatch({404, _}, req(get, Top ++ ?RESHARD ++ "/invalidpath")),
+        ?assertMatch({405, _}, req(put, Top ++ ?RESHARD, #{dont => thinkso})),
+        ?assertMatch({405, _}, req(post, Top ++ ?RESHARD, #{notgonna => happen}))
+    end).
+
+
+create_job_basic({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        % POST /_reshard/jobs
+        {C1, R1} = req(post, Top ++ ?JOBS,  #{type => split, db => Db1}),
+        ?assertEqual(201, C1),
+        ?assertMatch([#{?OK := true, ?ID := J, <<"shard">> :=  S}]
+            when is_binary(J) andalso is_binary(S), R1),
+        [#{?ID := Id, <<"shard">> := Shard}] = R1,
+
+        % GET /_reshard/jobs
+        ?assertMatch({200, #{
+            <<"jobs">> := [#{?ID := Id, <<"type">> := <<"split">>}],
+            <<"offset">> := 0,
+            <<"total_rows">> := 1
+        }}, req(get, Top ++ ?JOBS)),
+
+        % GET /_reshard/job/$jobid
+        {C2, R2} = req(get, Top ++ ?JOBS ++ ?b2l(Id)),
+        ?assertEqual(200, C2),
+        ThisNode = atom_to_binary(node(), utf8),
+        ?assertMatch(#{?ID := Id}, R2),
+        ?assertMatch(#{<<"type">> := <<"split">>}, R2),
+        ?assertMatch(#{<<"source">> := Shard}, R2),
+        ?assertMatch(#{<<"history">> := History} when length(History) > 1, R2),
+        ?assertMatch(#{<<"node">> := ThisNode}, R2),
+        ?assertMatch(#{<<"split_state">> := SSt} when is_binary(SSt), R2),
+        ?assertMatch(#{<<"job_state">> := JSt} when is_binary(JSt), R2),
+        ?assertMatch(#{<<"state_info">> := #{}}, R2),
+        ?assertMatch(#{<<"target">> := Target} when length(Target) == 2, R2),
+
+        % GET  /_reshard/job/$jobid/state
+        ?assertMatch({200, #{<<"state">> := S, <<"reason">> := R}}
+            when is_binary(S) andalso (is_binary(R) orelse R =:= null),
+            req(get, Top ++ ?JOBS ++ ?b2l(Id) ++ "/state")),
+
+        % GET /_reshard
+        ?assertMatch({200, #{<<"state">> := <<"running">>, <<"total">> := 1}},
+            req(get, Top ++ ?RESHARD)),
+
+        % DELETE /_reshard/jobs/$jobid
+        ?assertMatch({200, #{?OK := true}},
+            req(delete, Top ++ ?JOBS ++ ?b2l(Id))),
+
+        % GET _reshard/jobs
+        ?assertMatch({200, #{<<"jobs">> := [], <<"total_rows">> := 0}},
+            req(get, Top ++ ?JOBS)),
+
+        % GET /_reshard/job/$jobid should be a 404
+        ?assertMatch({404, #{}}, req(get, Top ++ ?JOBS ++ ?b2l(Id))),
+
+        % DELETE /_reshard/jobs/$jobid  should be a 404 as well
+        ?assertMatch({404, #{}}, req(delete, Top ++ ?JOBS ++ ?b2l(Id)))
+    end).
+
+
+create_two_jobs({Top, {Db1, Db2, _}}) ->
+    ?_test(begin
+        Jobs = Top ++ ?JOBS,
+
+        ?assertMatch({201, [#{?OK := true}]},
+            req(post, Jobs, #{type => split, db => Db1})),
+        ?assertMatch({201, [#{?OK := true}]},
+            req(post, Jobs, #{type => split, db => Db2})),
+
+        ?assertMatch({200, #{<<"total">> := 2}}, req(get, Top ++ ?RESHARD)),
+
+        ?assertMatch({200, #{
+            <<"jobs">> := [#{?ID := Id1}, #{?ID := Id2}],
+            <<"offset">> := 0,
+            <<"total_rows">> := 2
+        }} when Id1 =/= Id2, req(get, Jobs)),
+
+        {200, #{<<"jobs">> := [#{?ID := Id1}, #{?ID := Id2}]}} = req(get, Jobs),
+
+        {200, #{?OK := true}} = req(delete, Jobs ++ ?b2l(Id1)),
+        ?assertMatch({200, #{<<"total">> := 1}}, req(get, Top ++ ?RESHARD)),
+        {200, #{?OK := true}} = req(delete, Jobs ++ ?b2l(Id2)),
+        ?assertMatch({200, #{<<"total">> := 0}}, req(get, Top ++ ?RESHARD))
+    end).
+
+
+create_multiple_jobs_from_one_post({Top, {_, _, Db3}}) ->
+     ?_test(begin
+        Jobs = Top ++ ?JOBS,
+        {C1, R1} = req(post, Jobs, #{type => split, db => Db3}),
+        ?assertMatch({201, [#{?OK := true}, #{?OK := true}]}, {C1, R1}),
+        ?assertMatch({200, #{<<"total">> := 2}}, req(get, Top ++ ?RESHARD))
+    end).
+
+
+start_stop_cluster_basic({Top, _}) ->
+    ?_test(begin
+        Url = Top ++ ?STATE,
+
+        ?assertMatch({200, #{
+            <<"state">> := <<"running">>,
+            <<"reason">> := null
+        }}, req(get, Url)),
+
+        ?assertMatch({200, _}, req(put, Url, #{state => stopped})),
+        ?assertMatch({200, #{
+            <<"state">> := <<"stopped">>,
+            <<"reason">> := R
+        }} when is_binary(R), req(get, Url)),
+
+        ?assertMatch({200, _}, req(put, Url, #{state => running})),
+
+        % Make sure the reason shows in the state GET request
+        Reason = <<"somereason">>,
+        ?assertMatch({200, _}, req(put, Url, #{state => stopped,
+            reason => Reason})),
+        ?assertMatch({200, #{<<"state">> := <<"stopped">>,
+            <<"reason">> := Reason}}, req(get, Url)),
+
+        % Top level summary also shows the reason
+        ?assertMatch({200, #{
+            <<"state">> := <<"stopped">>,
+            <<"state_reason">> := Reason
+        }}, req(get, Top ++ ?RESHARD)),
+        ?assertMatch({200, _}, req(put, Url, #{state => running})),
+        ?assertMatch({200, #{<<"state">> := <<"running">>}}, req(get, Url))
+    end).
+
+
+stopped_from_config({Top, _}) ->
+    ?_test(begin
+        Url = Top ++ ?STATE,
+
+        ?assertMatch({200, #{
+            <<"state">> := <<"running">>,
+            <<"reason">> := null
+        }}, req(get, Url)),
+
+        ?assertMatch({200, _}, req(put, Url, #{state => stopped})),
+        ?assertMatch({200, #{
+            <<"state">> := <<"stopped">>,
+            <<"reason">> := R
+        }} when is_binary(R), req(get, Url)),
+
+        config:set("reshard", "state", "stopped", _Persist=false),
+
+        req(put, Url, #{state => running}),
+        ExpReason = <<"Stopped from config">>,
+        ?assertMatch({200, #{<<"state">> := <<"stopped">>,
+            <<"reason">> := ExpReason}}, req(get, Url)),
+
+        config:set("reshard", "state", "running", _Persist=false),
+
+        req(put, Url, #{state => running}),
+        ?assertMatch({200, #{
+            <<"state">> := <<"running">>,
+            <<"reason">> := null
+        }}, req(get, Url))
+    end).
+
+
+start_stop_cluster_with_a_job({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        Url = Top ++ ?STATE,
+
+        ?assertMatch({200, _}, req(put, Url, #{state => stopped})),
+        ?assertMatch({200, #{<<"state">> := <<"stopped">>}}, req(get, Url)),
+
+        % Can add jobs with global state stopped, they just won't be running
+        {201, R1} = req(post, Top ++ ?JOBS, #{type => split, db => Db1}),
+        ?assertMatch([#{?OK := true}], R1),
+        [#{?ID := Id1}] = R1,
+        {200, J1} = req(get, Top ++ ?JOBS ++ ?b2l(Id1)),
+        ?assertMatch(#{?ID := Id1, <<"job_state">> := <<"stopped">>}, J1),
+        % Check summary stats
+        ?assertMatch({200, #{
+            <<"state">> := <<"stopped">>,
+            <<"running">> := 0,
+            <<"stopped">> := 1,
+            <<"total">> := 1
+        }}, req(get, Top ++ ?RESHARD)),
+
+        % Can delete the job when stopped
+        {200, #{?OK := true}} = req(delete, Top ++ ?JOBS ++ ?b2l(Id1)),
+        ?assertMatch({200, #{
+            <<"state">> := <<"stopped">>,
+            <<"running">> := 0,
+            <<"stopped">> := 0,
+            <<"total">> := 0
+        }}, req(get, Top ++ ?RESHARD)),
+
+        % Add same job again
+        {201, [#{?ID := Id2}]} = req(post, Top ++ ?JOBS, #{type => split,
+            db => Db1}),
+        ?assertMatch({200, #{?ID := Id2, <<"job_state">> := <<"stopped">>}},
+            req(get, Top ++ ?JOBS ++ ?b2l(Id2))),
+
+        % Job should start after resharding is started on the cluster
+        ?assertMatch({200, _}, req(put, Url, #{state => running})),
+        ?assertMatch({200, #{?ID := Id2, <<"job_state">> := JSt}}
+            when JSt =/= <<"stopped">>, req(get, Top ++ ?JOBS ++ ?b2l(Id2)))
+     end).
+
+
+individual_job_start_stop({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        intercept_state(topoff1),
+
+        Body = #{type => split, db => Db1},
+        {201, [#{?ID := Id}]} = req(post, Top ++ ?JOBS, Body),
+
+        JobUrl = Top ++ ?JOBS ++ ?b2l(Id),
+        StUrl =  JobUrl ++ "/state",
+
+        % Wait for the the job to start running and intercept it in topoff1 state
+        receive {JobPid, topoff1} -> ok end,
+        % Tell the intercept to never finish checkpointing so job is left hanging
+        % forever in running state
+        JobPid ! cancel,
+        ?assertMatch({200, #{<<"state">> := <<"running">>}}, req(get, StUrl)),
+
+        {200, _} = req(put, StUrl, #{state => stopped}),
+        wait_state(StUrl, <<"stopped">>),
+
+        % Stop/start resharding globally and job should still stay stopped
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => stopped})),
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => running})),
+        ?assertMatch({200, #{<<"state">> := <<"stopped">>}}, req(get, StUrl)),
+
+        % Start the job again
+        ?assertMatch({200, _}, req(put, StUrl, #{state => running})),
+        % Wait for the the job to start running and intercept it in topoff1 state
+        receive {JobPid2, topoff1} -> ok end,
+        ?assertMatch({200, #{<<"state">> := <<"running">>}}, req(get, StUrl)),
+        % Let it continue running and it should complete eventually
+        JobPid2 ! continue,
+        wait_state(StUrl, <<"completed">>)
+    end).
+
+
+individual_job_stop_when_cluster_stopped({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        intercept_state(topoff1),
+
+        Body = #{type => split, db => Db1},
+        {201, [#{?ID := Id}]} = req(post, Top ++ ?JOBS, Body),
+
+        JobUrl = Top ++ ?JOBS ++ ?b2l(Id),
+        StUrl =  JobUrl ++ "/state",
+
+        % Wait for the the job to start running and intercept it in topoff1 state
+        receive {JobPid, topoff1} -> ok end,
+        % Tell the intercept to never finish checkpointing so job is left hanging
+        % forever in running state
+        JobPid ! cancel,
+        ?assertMatch({200, #{<<"state">> := <<"running">>}}, req(get, StUrl)),
+
+        % Stop resharding globally
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => stopped})),
+        wait_state(StUrl, <<"stopped">>),
+
+        % Stop the job specifically
+        {200, _} = req(put, StUrl, #{state => stopped}),
+        % Job stays stopped
+        ?assertMatch({200, #{<<"state">> := <<"stopped">>}}, req(get, StUrl)),
+
+        % Set cluster to running again
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => running})),
+
+        % The job should stay stopped
+        ?assertMatch({200, #{<<"state">> := <<"stopped">>}}, req(get, StUrl)),
+
+        % The it should be possible to resume the job and it should complete
+        ?assertMatch({200, _}, req(put, StUrl, #{state => running})),
+        % Wait for the the job to start running and intercept it in topoff1 state
+        receive {JobPid2, topoff1} -> ok end,
+        ?assertMatch({200, #{<<"state">> := <<"running">>}}, req(get, StUrl)),
+        % Let it continue running and it should complete eventually
+        JobPid2 ! continue,
+        wait_state(StUrl, <<"completed">>)
+    end).
+
+
+create_job_with_invalid_arguments({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        Jobs = Top ++ ?JOBS,
+
+        % Nothing in the body
+        ?assertMatch({400, _}, req(post, Jobs, #{})),
+
+        % Missing type
+        ?assertMatch({400, _}, req(post, Jobs, #{db => Db1})),
+
+        % Have type but no db and no shard
+        ?assertMatch({400, _}, req(post, Jobs, #{type => split})),
+
+        % Have type and db but db is invalid
+        ?assertMatch({400, _}, req(post, Jobs,  #{db => <<"baddb">>,
+            type => split})),
+
+        % Have type and shard but shard is not an existing database
+        ?assertMatch({404, _}, req(post, Jobs, #{type => split,
+            shard => <<"shards/80000000-ffffffff/baddb.1549492084">>})),
+
+        % Bad range values, too large, different types, inverted
+        ?assertMatch({400, _}, req(post, Jobs, #{db => Db1, range => 42,
+            type => split})),
+        ?assertMatch({400, _}, req(post, Jobs, #{db => Db1,
+            range => <<"x">>, type => split})),
+        ?assertMatch({400, _}, req(post, Jobs, #{db => Db1,
+            range => <<"ffffffff-80000000">>, type => split})),
+        ?assertMatch({400, _}, req(post, Jobs, #{db => Db1,
+            range => <<"00000000-fffffffff">>, type => split})),
+
+        % Can't have both db and shard
+        ?assertMatch({400, _}, req(post, Jobs, #{type => split, db => Db1,
+             shard => <<"blah">>}))
+    end).
+
+
+create_job_with_db({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        Jobs = Top ++ ?JOBS,
+        Body1 = #{type => split, db => Db1},
+
+        % Node with db
+        N = atom_to_binary(node(), utf8),
+        {C1, R1} = req(post, Jobs, Body1#{node => N}),
+        ?assertMatch({201, [#{?OK := true}]}, {C1, R1}),
+        wait_to_complete_then_cleanup(Top, R1),
+
+        % Range and db
+        {C2, R2} = req(post, Jobs, Body1#{range => <<"00000000-7fffffff">>}),
+        ?assertMatch({201, [#{?OK := true}]}, {C2, R2}),
+        wait_to_complete_then_cleanup(Top, R2),
+
+        % Node, range and db
+        Range = <<"80000000-ffffffff">>,
+        {C3, R3} = req(post, Jobs, Body1#{range => Range, node => N}),
+        ?assertMatch({201, [#{?OK := true}]}, {C3, R3}),
+        wait_to_complete_then_cleanup(Top, R3),
+
+        ?assertMatch([
+            [16#00000000, 16#3fffffff],
+            [16#40000000, 16#7fffffff],
+            [16#80000000, 16#bfffffff],
+            [16#c0000000, 16#ffffffff]
+        ], [mem3:range(S) || S <- lists:sort(mem3:shards(Db1))])
+    end).
+
+
+create_job_with_shard_name({Top, {_, _, Db3}}) ->
+    ?_test(begin
+        Jobs = Top ++ ?JOBS,
+        [S1, S2] = [mem3:name(S) || S <- lists:sort(mem3:shards(Db3))],
+
+        % Shard only
+        {C1, R1} = req(post, Jobs, #{type => split, shard => S1}),
+        ?assertMatch({201, [#{?OK := true}]}, {C1, R1}),
+        wait_to_complete_then_cleanup(Top, R1),
+
+        % Shard with a node
+        N = atom_to_binary(node(), utf8),
+        {C2, R2} = req(post, Jobs, #{type => split, shard => S2, node => N}),
+        ?assertMatch({201, [#{?OK := true}]}, {C2, R2}),
+        wait_to_complete_then_cleanup(Top, R2),
+
+        ?assertMatch([
+            [16#00000000, 16#3fffffff],
+            [16#40000000, 16#7fffffff],
+            [16#80000000, 16#bfffffff],
+            [16#c0000000, 16#ffffffff]
+        ], [mem3:range(S) || S <- lists:sort(mem3:shards(Db3))])
+    end).
+
+
+completed_job_handling({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        Jobs = Top ++ ?JOBS,
+
+        % Run job to completion
+        {C1, R1} = req(post, Jobs, #{type => split, db => Db1}),
+        ?assertMatch({201, [#{?OK := true}]}, {C1, R1}),
+        [#{?ID := Id}] = R1,
+        wait_to_complete(Top, R1),
+
+        % Check top level stats
+        ?assertMatch({200, #{
+            <<"state">> := <<"running">>,
+            <<"state_reason">> := null,
+            <<"completed">> := 1,
+            <<"failed">> := 0,
+            <<"running">> := 0,
+            <<"stopped">> := 0,
+            <<"total">> := 1
+        }}, req(get, Top ++ ?RESHARD)),
+
+        % Job state itself
+        JobUrl = Jobs ++ ?b2l(Id),
+        ?assertMatch({200, #{
+            <<"split_state">> := <<"completed">>,
+            <<"job_state">> := <<"completed">>
+        }}, req(get, JobUrl)),
+
+        % Job's state endpoint
+        StUrl = Jobs ++ ?b2l(Id) ++ "/state",
+        ?assertMatch({200, #{<<"state">> := <<"completed">>}}, req(get, StUrl)),
+
+        % Try to stop it and it should stay completed
+        {200, _} = req(put, StUrl, #{state => stopped}),
+        ?assertMatch({200, #{<<"state">> := <<"completed">>}}, req(get, StUrl)),
+
+        % Try to resume it and it should stay completed
+        {200, _} = req(put, StUrl, #{state => running}),
+        ?assertMatch({200, #{<<"state">> := <<"completed">>}}, req(get, StUrl)),
+
+        % Stop resharding globally and job should still stay completed
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => stopped})),
+        ?assertMatch({200, #{<<"state">> := <<"completed">>}}, req(get, StUrl)),
+
+        % Start resharding and job stays completed
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => running})),
+        ?assertMatch({200, #{<<"state">> := <<"completed">>}}, req(get, StUrl)),
+
+        ?assertMatch({200, #{?OK := true}}, req(delete, JobUrl))
+    end).
+
+
+handle_db_deletion_in_topoff1({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, topoff1),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+handle_db_deletion_in_initial_copy({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, initial_copy),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+handle_db_deletion_in_copy_local_docs({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, copy_local_docs),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+handle_db_deletion_in_build_indices({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, build_indices),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+handle_db_deletion_in_update_shard_map({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, update_shardmap),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+handle_db_deletion_in_wait_source_close({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, wait_source_close),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+handle_db_deletion_in_topoff3({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, topoff3),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+handle_db_deletion_in_source_delete({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = delete_source_in_state(Top, Db1, source_delete),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"failed">>)
+    end).
+
+
+recover_in_topoff1({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = recover_in_state(Top, Db1, topoff1),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end).
+
+
+recover_in_initial_copy({Top, {Db1, _, _}}) ->
+    {timeout, 60, ?_test(begin
+        JobId = recover_in_state(Top, Db1, initial_copy),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end)}.
+
+
+recover_in_copy_local_docs({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = recover_in_state(Top, Db1, copy_local_docs),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end).
+
+
+recover_in_build_indices({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = recover_in_state(Top, Db1, build_indices),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end).
+
+
+recover_in_update_shard_map({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = recover_in_state(Top, Db1, update_shardmap),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end).
+
+
+recover_in_wait_source_close({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = recover_in_state(Top, Db1, wait_source_close),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end).
+
+
+recover_in_topoff3({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = recover_in_state(Top, Db1, topoff3),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end).
+
+
+recover_in_source_delete({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        JobId = recover_in_state(Top, Db1, source_delete),
+        wait_state(Top ++ ?JOBS ++ ?b2l(JobId) ++ "/state", <<"completed">>)
+    end).
+
+
+check_max_jobs({Top, {Db1, Db2, _}}) ->
+    ?_test(begin
+        Jobs = Top ++ ?JOBS,
+
+        config:set("reshard", "max_jobs", "0", _Persist=false),
+        {C1, R1} = req(post, Jobs, #{type => split, db => Db1}),
+        ?assertMatch({500, [#{<<"error">> := <<"max_jobs_exceeded">>}]}, {C1, R1}),
+
+        config:set("reshard", "max_jobs", "1", _Persist=false),
+        {201, R2} = req(post, Jobs,  #{type => split, db => Db1}),
+        wait_to_complete(Top, R2),
+
+        % Stop clustering so jobs are not started anymore and ensure max jobs is
+        % is enforced even if jobs are stopped
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => stopped})),
+
+        {C3, R3} = req(post, Jobs,  #{type => split, db => Db2}),
+        ?assertMatch({500, [#{<<"error">> := <<"max_jobs_exceeded">>}]}, {C3, R3}),
+
+        % Allow the job to be created by raising max_jobs
+        config:set("reshard", "max_jobs", "2", _Persist=false),
+
+        {C4, R4} = req(post, Jobs,  #{type => split, db => Db2}),
+        ?assertEqual(201, C4),
+
+        % Lower max_jobs after job is created but it's not running
+        config:set("reshard", "max_jobs", "1", _Persist=false),
+
+        % Start resharding again
+        ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => running})),
+
+        % Jobs that have been created already are not removed if max jobs is lowered
+        % so make sure the job completes
+        wait_to_complete(Top, R4)
+    end).
+
+
+cleanup_completed_jobs({Top, {Db1, _, _}}) ->
+    ?_test(begin
+        Body = #{type => split, db => Db1},
+        {201, [#{?ID := Id}]} = req(post, Top ++ ?JOBS, Body),
+        JobUrl = Top ++ ?JOBS ++ ?b2l(Id),
+        wait_state(JobUrl ++ "/state", <<"completed">>),
+        delete_db(Top, Db1),
+        wait_for_http_code(JobUrl, 404)
+    end).
+
+
+% Test help functions
+
+wait_to_complete_then_cleanup(Top, Jobs) ->
+    JobsUrl = Top ++ ?JOBS,
+    lists:foreach(fun(#{?ID := Id}) ->
+        wait_state(JobsUrl ++ ?b2l(Id) ++ "/state", <<"completed">>),
+        {200, _} = req(delete, JobsUrl ++ ?b2l(Id))
+    end, Jobs).
+
+
+wait_to_complete(Top, Jobs) ->
+    JobsUrl = Top ++ ?JOBS,
+    lists:foreach(fun(#{?ID := Id}) ->
+        wait_state(JobsUrl ++ ?b2l(Id) ++ "/state", <<"completed">>)
+    end, Jobs).
+
+
+intercept_state(State) ->
+    TestPid = self(),
+    meck:new(mem3_reshard_job, [passthrough]),
+    meck:expect(mem3_reshard_job, checkpoint_done, fun(Job) ->
+            case Job#job.split_state of
+                State ->
+                    TestPid ! {self(), State},
+                    receive
+                        continue -> meck:passthrough([Job]);
+                        cancel -> ok
+                    end;
+                _ ->
+                   meck:passthrough([Job])
+            end
+        end).
+
+
+cancel_intercept() ->
+     meck:expect(mem3_reshard_job, checkpoint_done, fun(Job) ->
+         meck:passthrough([Job])
+     end).
+
+
+wait_state(Url, State) ->
+    test_util:wait(fun() ->
+            case req(get, Url) of
+                {200, #{<<"state">> := State}} -> ok;
+                {200, #{}} -> timer:sleep(100), wait
+            end
+    end, 30000).
+
+
+wait_for_http_code(Url, Code) when is_integer(Code) ->
+    test_util:wait(fun() ->
+            case req(get, Url) of
+                {Code, _} -> ok;
+                {_, _} -> timer:sleep(100), wait
+            end
+    end, 30000).
+
+
+delete_source_in_state(Top, Db, State) when is_atom(State), is_binary(Db) ->
+    intercept_state(State),
+    Body = #{type => split, db => Db},
+    {201, [#{?ID := Id}]} = req(post, Top ++ ?JOBS, Body),
+    receive {JobPid, State} -> ok end,
+    sync_delete_db(Top, Db),
+    JobPid ! continue,
+    Id.
+
+
+recover_in_state(Top, Db, State) when is_atom(State) ->
+    intercept_state(State),
+    Body = #{type => split, db => Db},
+    {201, [#{?ID := Id}]} = req(post, Top ++ ?JOBS, Body),
+    receive {JobPid, State} -> ok end,
+    % Job is now stuck in running we prevented it from executing
+    % the given state
+    JobPid ! cancel,
+    % Now restart resharding
+    ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => stopped})),
+    cancel_intercept(),
+    ?assertMatch({200, _}, req(put, Top ++ ?STATE, #{state => running})),
+    Id.
+
+
+create_db(Top, Db, QArgs) when is_binary(Db) ->
+    Url = Top ++ binary_to_list(Db) ++ QArgs,
+    {ok, Status, _, _} = test_request:put(Url, [?JSON, ?AUTH], "{}"),
+    ?assert(Status =:= 201 orelse Status =:= 202).
+
+
+delete_db(Top, Db) when is_binary(Db) ->
+    Url = Top ++ binary_to_list(Db),
+    case test_request:get(Url, [?AUTH]) of
+        {ok, 404, _, _} ->
+            not_found;
+        {ok, 200, _, _} ->
+            {ok, 200, _, _} = test_request:delete(Url, [?AUTH]),
+            ok
+    end.
+
+
+sync_delete_db(Top, Db) when is_binary(Db) ->
+    delete_db(Top, Db),
+    try
+        Shards = mem3:local_shards(Db),
+        ShardNames = [mem3:name(S) || S <- Shards],
+        [couch_server:delete(N, [?ADMIN_CTX]) || N <- ShardNames],
+        ok
+    catch
+        error:database_does_not_exist ->
+            ok
+    end.
+
+
+req(Method, Url) ->
+    Headers = [?AUTH],
+    {ok, Code, _, Res} = test_request:request(Method, Url, Headers),
+    {Code, jiffy:decode(Res, [return_maps])}.
+
+
+req(Method, Url, #{} = Body) ->
+    req(Method, Url, jiffy:encode(Body));
+
+req(Method, Url, Body) ->
+    Headers = [?JSON, ?AUTH],
+    {ok, Code, _, Res} = test_request:request(Method, Url, Headers, Body),
+    {Code, jiffy:decode(Res, [return_maps])}.

--- a/src/mem3/test/mem3_reshard_changes_feed_test.erl
+++ b/src/mem3/test/mem3_reshard_changes_feed_test.erl
@@ -1,0 +1,447 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_changes_feed_test).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/src/mem3_reshard.hrl").
+
+
+-define(assertChanges(Expected, Received),
+    begin
+        ((fun() ->
+            ExpectedIDs = lists:sort([I || #{id := I} <- Expected]),
+            ReceivedIDs = lists:sort([I || #{id := I} <- Received]),
+            ?assertEqual(ExpectedIDs, ReceivedIDs)
+        end)())
+    end).
+
+
+setup() ->
+    Db1 = ?tempdb(),
+    create_db(Db1, [{q, 1}, {n, 1}]),
+    #{db1 => Db1}.
+
+
+teardown(#{} = Dbs) ->
+    mem3_reshard:reset_state(),
+    maps:map(fun(_, Db) -> delete_db(Db) end, Dbs).
+
+
+start_couch() ->
+    test_util:start_couch(?CONFIG_CHAIN, [mem3, fabric]).
+
+
+stop_couch(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+
+mem3_reshard_changes_feed_test_() ->
+    {
+        "mem3 shard split changes feed tests",
+        {
+            setup,
+            fun start_couch/0, fun stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun normal_feed_should_work_after_split/1
+                    %fun continuous_feed_should_work_during_split/1
+                ]
+            }
+        }
+    }.
+
+
+normal_feed_should_work_after_split(#{db1 := Db}) ->
+    ?_test(begin
+        DocSpec = #{
+            docs => [1, 10],
+            delete => [5, 6]
+        },
+        add_test_docs(Db, DocSpec),
+
+        % gather pre-shard changes
+        BaseArgs = #changes_args{feed = "normal", dir = fwd, since = 0},
+        {ok, OldChanges, OldEndSeq} = get_changes_feed(Db, BaseArgs),
+
+        % Split the shard
+        split_and_wait(Db),
+
+        % verify changes list consistent for all the old seqs
+        lists:foldl(fun(#{seq := Seq} = C, ExpectedChanges) ->
+            Args = BaseArgs#changes_args{since = Seq},
+            {ok, Changes, _EndSeq} = get_changes_feed(Db, Args),
+            ?assertChanges(ExpectedChanges, Changes),
+            [C | ExpectedChanges]
+        end, [], OldChanges),
+
+        % confirm that old LastSeq respected
+        Args1 = BaseArgs#changes_args{since = OldEndSeq},
+        {ok, Changes1, EndSeq1} = get_changes_feed(Db, Args1),
+        ?assertChanges([], Changes1),
+
+        % confirm that new LastSeq also respected
+        Args2 = BaseArgs#changes_args{since = EndSeq1},
+        {ok, Changes2, EndSeq2} = get_changes_feed(Db, Args2),
+        ?assertChanges([], Changes2),
+        ?assertEqual(EndSeq2, EndSeq1),
+
+        % confirm we didn't lost any changes and have consistent last seq
+        {ok, Changes3, EndSeq3} = get_changes_feed(Db, BaseArgs),
+        ?assertChanges(OldChanges, Changes3),
+        %% FIXME. last_seq should be consistent
+        % ?assertEqual(EndSeq3, EndSeq2),
+
+        % add some docs
+        add_test_docs(Db, #{docs => [11, 15]}),
+        Args4 = BaseArgs#changes_args{since = EndSeq3},
+        {ok, Changes4, EndSeq4} = get_changes_feed(Db, Args4),
+        AddedChanges = [#{id => ID} || #doc{id = ID} <- docs([11, 15])],
+        ?assertChanges(AddedChanges, Changes4),
+
+        % confirm include_docs and deleted works
+        Args5 = BaseArgs#changes_args{include_docs = true},
+        {ok, Changes5, EndSeq5} = get_changes_feed(Db, Args5),
+        ?assertEqual(EndSeq4, EndSeq5),
+        [SampleChange] = [C || #{id := ID} = C <- Changes5, ID == <<"00005">>],
+        ?assertMatch(#{deleted := true}, SampleChange),
+        ?assertMatch(#{doc := {Body}} when is_list(Body), SampleChange),
+
+        % update and delete some pre and post split docs
+        AllDocs = [couch_doc:from_json_obj(Doc) || #{doc := Doc} <- Changes5],
+        UpdateDocs = lists:filtermap(fun
+            (#doc{id = <<"00002">>}) -> true;
+            (#doc{id = <<"00012">>}) -> true;
+            (#doc{id = <<"00004">>} = Doc) -> {true, Doc#doc{deleted = true}};
+            (#doc{id = <<"00014">>} = Doc) -> {true, Doc#doc{deleted = true}};
+            (_) -> false
+        end, AllDocs),
+        update_docs(Db, UpdateDocs),
+
+        Args6 = BaseArgs#changes_args{since = EndSeq5},
+        {ok, Changes6, EndSeq6} = get_changes_feed(Db, Args6),
+        UpdatedChanges = [#{id => ID} || #doc{id = ID} <- UpdateDocs],
+        ?assertChanges(UpdatedChanges, Changes6),
+        [#{seq := Seq6} | _] = Changes6,
+        ?assertEqual(EndSeq6, Seq6),
+
+        Args7 = Args6#changes_args{dir = rev, limit = 4},
+        {ok, Changes7, EndSeq7} = get_changes_feed(Db, Args7),
+        %% FIXME - I believe rev is just conceptually broken in Couch 2.x
+        % ?assertChanges(lists:reverse(Changes6), Changes7),
+        ?assertEqual(4, length(Changes7)),
+        [#{seq := Seq7} | _] = Changes7,
+        ?assertEqual(EndSeq7, Seq7)
+    end).
+
+
+continuous_feed_should_work_during_split(#{db1 := Db}) ->
+    ?_test(begin
+        {UpdaterPid, UpdaterRef} = spawn_monitor(fun() ->
+            Updater = fun U({State, I}) ->
+                receive
+                    {get_state, {Pid, Ref}} ->
+                        Pid ! {state, Ref, State},
+                        U({State, I});
+                    add ->
+                        DocSpec = #{docs => [I, I]},
+                        add_test_docs(Db, DocSpec),
+                        U({State, I + 1});
+                    split ->
+                        spawn_monitor(fun() -> split_and_wait(Db) end),
+                        U({"in_process", I});
+                    stop ->
+                        ok;
+                    {'DOWN', _, process, _, normal} ->
+                        U({"after", I})
+                end
+            end,
+            Updater({"before", 1})
+        end),
+
+        Callback = fun
+            (start, Acc) ->
+                {ok, Acc};
+            (waiting_for_updates, Acc) ->
+                Ref = make_ref(),
+                UpdaterPid ! {get_state, {self(), Ref}},
+                receive {state, Ref, State} -> ok end,
+                case {State, length(Acc)} of
+                    {"before", N} when N < 5 ->
+                        UpdaterPid ! add;
+                    {"before", _} ->
+                        UpdaterPid ! split;
+                    {"in_process", N} when N < 10 ->
+                        UpdaterPid ! add;
+                    {"in_process", _} ->
+                        wait;
+                    {"after", N} when N < 15 ->
+                        UpdaterPid ! add;
+                    {"after", _} ->
+                        UpdaterPid ! stop,
+                        %% nfc why simple return of {stop, Acc} doesn't work
+                        exit({with_proc_res, {ok, Acc}})
+                end,
+                {ok, Acc};
+            (timeout, Acc) ->
+                {ok, Acc};
+            ({change, {Change}}, Acc) ->
+                CM = maps:from_list(Change),
+                {ok, [CM | Acc]};
+            ({stop, EndSeq, _Pending}, _Acc) ->
+                UpdaterPid ! stop,
+                Error = {assertion_fail, [
+                    {module, ?MODULE},
+                    {line, ?LINE},
+                    {value, {last_seq, EndSeq}},
+                    {reason, "Changes feed stopped on shard split"}
+                ]},
+                exit({with_proc_res, {error, Error}})
+        end,
+        BaseArgs = #changes_args{
+            feed = "continuous",
+            heartbeat = 100,
+            timeout = 1000
+        },
+        Result = get_changes_feed(Db, BaseArgs, Callback),
+
+        receive
+            {'DOWN', UpdaterRef, process, UpdaterPid, normal} ->
+                ok;
+            {'DOWN', UpdaterRef, process, UpdaterPid, Error} ->
+                erlang:error({test_context_failed, [
+                    {module, ?MODULE},
+                    {line, ?LINE},
+                    {value, Error},
+                    {reason, "Updater died"}]})
+        end,
+
+        case Result of
+            {ok, Changes} ->
+                Expected = [#{id => ID} || #doc{id = ID} <- docs([1, 15])],
+                ?assertChanges(Expected, Changes);
+            {error, Err} ->
+                erlang:error(Err)
+        end
+    end).
+
+
+split_and_wait(Db) ->
+    [#shard{name = Shard}] = lists:sort(mem3:local_shards(Db)),
+    {ok, JobId} = mem3_reshard:start_split_job(Shard),
+    wait_state(JobId, completed),
+    ResultShards = lists:sort(mem3:local_shards(Db)),
+    ?assertEqual(2, length(ResultShards)).
+
+
+wait_state(JobId, State) ->
+    test_util:wait(fun() ->
+        case mem3_reshard:job(JobId) of
+            {ok, {Props}} ->
+                case couch_util:get_value(job_state, Props) of
+                    State -> ok;
+                    _ -> timer:sleep(100), wait
+                end;
+            {error, not_found} -> timer:sleep(100), wait
+        end
+    end, 30000).
+
+
+get_changes_feed(Db, Args) ->
+    get_changes_feed(Db, Args, fun changes_callback/2).
+
+get_changes_feed(Db, Args, Callback) ->
+    with_proc(fun() ->
+        fabric:changes(Db, Callback, [], Args)
+    end).
+
+
+changes_callback(start, Acc) ->
+    {ok, Acc};
+changes_callback({change, {Change}}, Acc) ->
+    CM = maps:from_list(Change),
+    {ok, [CM | Acc]};
+changes_callback({stop, EndSeq, _Pending}, Acc) ->
+    {ok, Acc, EndSeq}.
+
+
+%% common helpers from here
+
+
+create_db(DbName, Opts) ->
+    GL = erlang:group_leader(),
+    with_proc(fun() -> fabric:create_db(DbName, Opts) end, GL).
+
+
+delete_db(DbName) ->
+    GL = erlang:group_leader(),
+    with_proc(fun() -> fabric:delete_db(DbName, [?ADMIN_CTX]) end, GL).
+
+
+with_proc(Fun) ->
+    with_proc(Fun, undefined, 30000).
+
+
+with_proc(Fun, GroupLeader) ->
+    with_proc(Fun, GroupLeader, 30000).
+
+
+with_proc(Fun, GroupLeader, Timeout) ->
+    {Pid, Ref} = spawn_monitor(fun() ->
+        case GroupLeader of
+            undefined -> ok;
+            _ -> erlang:group_leader(GroupLeader, self())
+        end,
+        exit({with_proc_res, Fun()})
+    end),
+    receive
+        {'DOWN', Ref, process, Pid, {with_proc_res, Res}} ->
+            Res;
+        {'DOWN', Ref, process, Pid, Error} ->
+            error(Error)
+    after Timeout ->
+        erlang:demonitor(Ref, [flush]),
+        exit(Pid, kill),
+        error({with_proc_timeout, Fun, Timeout})
+   end.
+
+
+add_test_docs(DbName, #{} = DocSpec) ->
+    Docs = docs(maps:get(docs, DocSpec, []))
+        ++ ddocs(mrview, maps:get(mrview, DocSpec, []))
+        ++ ddocs(search, maps:get(search, DocSpec, []))
+        ++ ddocs(geo, maps:get(geo, DocSpec, []))
+        ++ ldocs(maps:get(local, DocSpec, [])),
+    Res = update_docs(DbName, Docs),
+    Docs1 = lists:map(fun({Doc, {ok, {RevPos, Rev}}}) ->
+        Doc#doc{revs = {RevPos, [Rev]}}
+    end, lists:zip(Docs, Res)),
+    case delete_docs(maps:get(delete, DocSpec, []), Docs1) of
+        [] -> ok;
+        [_ | _] = Deleted -> update_docs(DbName, Deleted)
+    end,
+    ok.
+
+
+update_docs(DbName, Docs) ->
+    with_proc(fun() ->
+        case fabric:update_docs(DbName, Docs, [?ADMIN_CTX]) of
+            {accepted, Res} -> Res;
+            {ok, Res} -> Res
+        end
+    end).
+
+
+delete_docs([S, E], Docs) when E >= S ->
+    ToDelete = [doc_id(<<"">>, I) || I <- lists:seq(S, E)],
+    lists:filtermap(fun(#doc{id = Id} = Doc) ->
+        case lists:member(Id, ToDelete) of
+            true -> {true, Doc#doc{deleted = true}};
+            false -> false
+        end
+    end, Docs);
+delete_docs(_, _) ->
+    [].
+
+
+docs([S, E]) when E >= S ->
+    [doc(<<"">>, I) || I <- lists:seq(S, E)];
+docs(_) ->
+    [].
+
+
+ddocs(Type, [S, E]) when E >= S ->
+    Body = ddprop(Type),
+    BType = atom_to_binary(Type, utf8),
+    [doc(<<"_design/", BType/binary>>, I, Body, 0) || I <- lists:seq(S, E)];
+ddocs(_, _) ->
+    [].
+
+
+ldocs([S, E]) when E >= S ->
+    [doc(<<"_local/">>, I, bodyprops(), 0) || I <- lists:seq(S, E)];
+ldocs(_) ->
+    [].
+
+
+
+doc(Pref, Id) ->
+    Body = bodyprops(),
+    doc(Pref, Id, Body, 42).
+
+
+doc(Pref, Id, BodyProps, AttSize) ->
+    #doc{
+        id = doc_id(Pref, Id),
+        body = {BodyProps},
+        atts = atts(AttSize)
+    }.
+
+
+doc_id(Pref, Id) ->
+    IdBin = iolist_to_binary(io_lib:format("~5..0B", [Id])),
+    <<Pref/binary, IdBin/binary>>.
+
+
+ddprop(mrview) ->
+    [
+        {<<"views">>, {[
+             {<<"v1">>, {[
+                 {<<"map">>, <<"function(d){emit(d);}">>}
+             ]}}
+        ]}}
+    ];
+
+ddprop(geo) ->
+    [
+        {<<"st_indexes">>, {[
+            {<<"area">>, {[
+                {<<"analyzer">>, <<"standard">>},
+                {<<"index">>, <<"function(d){if(d.g){st_index(d.g)}}">> }
+            ]}}
+        ]}}
+    ];
+
+ddprop(search) ->
+    [
+        {<<"indexes">>, {[
+            {<<"types">>, {[
+                {<<"index">>, <<"function(d){if(d.g){st_index(d.g.type)}}">>}
+            ]}}
+        ]}}
+   ].
+
+
+bodyprops() ->
+    [
+        {<<"g">>, {[
+            {<<"type">>, <<"Polygon">>},
+            {<<"coordinates">>, [[[-71.0, 48.4], [-70.0, 48.4], [-71.0, 48.4]]]}
+        ]}}
+   ].
+
+
+atts(0) ->
+    [];
+
+atts(Size) when is_integer(Size), Size >= 1 ->
+    Data = << <<"x">> || _ <- lists:seq(1, Size) >>,
+    [couch_att:new([
+        {name, <<"att">>},
+        {type, <<"app/binary">>},
+        {att_len, Size},
+        {data, Data}
+    ])].

--- a/src/mem3/test/mem3_reshard_test.erl
+++ b/src/mem3/test/mem3_reshard_test.erl
@@ -1,0 +1,662 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_reshard_test).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/src/mem3_reshard.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl"). % for all_docs function
+
+-define(ID, <<"_id">>).
+
+setup() ->
+    {Db1, Db2} = {?tempdb(), ?tempdb()},
+    create_db(Db1, [{q, 1}, {n, 1}]),
+    PartProps = [{partitioned, true}, {hash, [couch_partition, hash, []]}],
+    create_db(Db2, [{q, 1}, {n, 1}, {props, PartProps}]),
+    #{db1 => Db1, db2 => Db2}.
+
+
+teardown(#{} = Dbs) ->
+    mem3_reshard:reset_state(),
+    maps:map(fun(_, Db) -> delete_db(Db) end, Dbs),
+    meck:unload().
+
+
+start_couch() ->
+    test_util:start_couch(?CONFIG_CHAIN, [mem3, fabric]).
+
+
+stop_couch(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+
+mem3_reshard_db_test_() ->
+    {
+        "mem3 shard split db tests",
+        {
+            setup,
+            fun start_couch/0, fun stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun split_one_shard/1,
+                    fun update_docs_before_topoff1/1,
+                    fun indices_are_built/1,
+                    fun split_partitioned_db/1,
+                    fun split_twice/1
+                ]
+            }
+        }
+    }.
+
+
+% This is a basic test to check that shard splitting preserves documents, and
+% db meta props like revs limits and security.
+split_one_shard(#{db1 := Db}) ->
+    ?_test(begin
+        DocSpec = #{docs => 10, delete => [5, 9], mrview => 1, local => 1},
+        add_test_docs(Db, DocSpec),
+
+        % Save documents before the split
+        Docs0 = get_all_docs(Db),
+        Local0 = get_local_docs(Db),
+
+        % Set some custom metadata properties
+        set_revs_limit(Db, 942),
+        set_purge_infos_limit(Db, 943),
+        SecObj = {[{<<"foo">>, <<"bar">>}]},
+        set_security(Db, SecObj),
+
+        % DbInfo is saved after setting metadata bits
+        % as those could bump the update sequence
+        DbInfo0 = get_db_info(Db),
+
+        % Split the one shard
+        [#shard{name=Shard}] = lists:sort(mem3:local_shards(Db)),
+        {ok, JobId} = mem3_reshard:start_split_job(Shard),
+        wait_state(JobId, completed),
+
+        % Perform some basic checks that the shard was split
+        Shards1 = lists:sort(mem3:local_shards(Db)),
+        ?assertEqual(2, length(Shards1)),
+        [#shard{range = R1}, #shard{range = R2}] = Shards1,
+        ?assertEqual([16#00000000, 16#7fffffff], R1),
+        ?assertEqual([16#80000000, 16#ffffffff], R2),
+
+        % Check metadata bits after the split
+        ?assertEqual(942, get_revs_limit(Db)),
+        ?assertEqual(943, get_purge_infos_limit(Db)),
+        ?assertEqual(SecObj, get_security(Db)),
+
+        DbInfo1 = get_db_info(Db),
+        Docs1 = get_all_docs(Db),
+        Local1 = get_local_docs(Db),
+
+        % When comparing db infos, ignore update sequences they won't be the
+        % same since they are more shards involved after the split
+        ?assertEqual(without_seqs(DbInfo0), without_seqs(DbInfo1)),
+
+        % Update seq prefix number is a sum of all shard update sequences
+        #{<<"update_seq">> := UpdateSeq0} = update_seq_to_num(DbInfo0),
+        #{<<"update_seq">> := UpdateSeq1} = update_seq_to_num(DbInfo1),
+        ?assertEqual(UpdateSeq0 * 2, UpdateSeq1),
+
+        % Finally compare that the documents are still there after the split
+        ?assertEqual(Docs0, Docs1),
+
+        % Don't forget about the local but don't include internal checkpoints
+        % as some of those are munged and transformed during the split
+        ?assertEqual(without_meta_locals(Local0), without_meta_locals(Local1))
+    end).
+
+
+% This test checks that document added while the shard is being split are not
+% lost. Topoff1 state happens before indices are built
+update_docs_before_topoff1(#{db1 := Db}) ->
+    ?_test(begin
+        add_test_docs(Db, #{docs => 10}),
+
+        intercept_state(topoff1),
+
+        [#shard{name=Shard}] = lists:sort(mem3:local_shards(Db)),
+        {ok, JobId} = mem3_reshard:start_split_job(Shard),
+
+        receive {JobPid, topoff1} -> ok end,
+        add_test_docs(Db, #{docs => [10, 19], local => 1}),
+        Docs0 = get_all_docs(Db),
+        Local0 = get_local_docs(Db),
+        DbInfo0 = get_db_info(Db),
+        JobPid ! continue,
+
+        wait_state(JobId, completed),
+
+        % Perform some basic checks that the shard was split
+        Shards1 = lists:sort(mem3:local_shards(Db)),
+        ?assertEqual(2, length(Shards1)),
+
+        DbInfo1 = get_db_info(Db),
+        Docs1 = get_all_docs(Db),
+        Local1 = get_local_docs(Db),
+
+        ?assertEqual(without_seqs(DbInfo0), without_seqs(DbInfo1)),
+
+        % Update sequence after initial copy with 10 docs would be 10 on each
+        % target shard (to match the source) and the total update sequence
+        % would have been 20. But then 10 more docs were added (3 might have
+        % ended up on one target and 7 on another) so the final update sequence
+        % would then be 20 + 10 = 30.
+        ?assertMatch(#{<<"update_seq">> := 30}, update_seq_to_num(DbInfo1)),
+
+        ?assertEqual(Docs0, Docs1),
+        ?assertEqual(without_meta_locals(Local0), without_meta_locals(Local1))
+    end).
+
+
+% This test that indices are built during shard splitting.
+indices_are_built(#{db1 := Db}) ->
+    ?_test(begin
+        add_test_docs(Db, #{docs => 10, mrview => 2, search => 2, geo => 2}),
+        [#shard{name=Shard}] = lists:sort(mem3:local_shards(Db)),
+        {ok, JobId} = mem3_reshard:start_split_job(Shard),
+        wait_state(JobId, completed),
+        Shards1 = lists:sort(mem3:local_shards(Db)),
+        ?assertEqual(2, length(Shards1)),
+        MRViewGroupInfo =  get_group_info(Db, <<"_design/mrview00000">>),
+        ?assertMatch(#{<<"update_seq">> := 32}, MRViewGroupInfo)
+    end).
+
+
+% Split partitioned database
+split_partitioned_db(#{db2 := Db}) ->
+    ?_test(begin
+        DocSpec = #{
+            pdocs => #{
+                <<"PX">> => 5,
+                <<"PY">> => 5
+            },
+            mrview => 1,
+            local => 1
+        },
+        add_test_docs(Db, DocSpec),
+
+        % Save documents before the split
+        Docs0 = get_all_docs(Db),
+        Local0 = get_local_docs(Db),
+
+        % Set some custom metadata properties
+        set_revs_limit(Db, 942),
+        set_purge_infos_limit(Db, 943),
+        SecObj = {[{<<"foo">>, <<"bar">>}]},
+        set_security(Db, SecObj),
+
+        % DbInfo is saved after setting metadata bits
+        % as those could bump the update sequence
+        DbInfo0 = get_db_info(Db),
+        PX0 = get_partition_info(Db, <<"PX">>),
+        PY0 = get_partition_info(Db, <<"PY">>),
+
+        % Split the one shard
+        [#shard{name=Shard}] = lists:sort(mem3:local_shards(Db)),
+        {ok, JobId} = mem3_reshard:start_split_job(Shard),
+        wait_state(JobId, completed),
+
+        % Perform some basic checks that the shard was split
+        Shards1 = lists:sort(mem3:local_shards(Db)),
+        ?assertEqual(2, length(Shards1)),
+        [#shard{range = R1}, #shard{range = R2}] = Shards1,
+        ?assertEqual([16#00000000, 16#7fffffff], R1),
+        ?assertEqual([16#80000000, 16#ffffffff], R2),
+
+        % Check metadata bits after the split
+        ?assertEqual(942, get_revs_limit(Db)),
+        ?assertEqual(943, get_purge_infos_limit(Db)),
+        ?assertEqual(SecObj, get_security(Db)),
+
+        DbInfo1 = get_db_info(Db),
+        Docs1 = get_all_docs(Db),
+        Local1 = get_local_docs(Db),
+
+        % When comparing db infos, ignore update sequences they won't be the
+        % same since they are more shards involved after the split
+        ?assertEqual(without_seqs(DbInfo0), without_seqs(DbInfo1)),
+
+        % Update seq prefix number is a sum of all shard update sequences
+        #{<<"update_seq">> := UpdateSeq0} = update_seq_to_num(DbInfo0),
+        #{<<"update_seq">> := UpdateSeq1} = update_seq_to_num(DbInfo1),
+        ?assertEqual(UpdateSeq0 * 2, UpdateSeq1),
+
+        % Finally compare that documents are still there after the split
+        ?assertEqual(Docs0, Docs1),
+
+        ?assertEqual(PX0, get_partition_info(Db, <<"PX">>)),
+        ?assertEqual(PY0, get_partition_info(Db, <<"PY">>)),
+
+        % Don't forget about the local but don't include internal checkpoints
+        % as some of those are munged and transformed during the split
+        ?assertEqual(without_meta_locals(Local0), without_meta_locals(Local1))
+    end).
+
+
+% Make sure a shard can be split again after it was split one. This checks that
+% too many got added to some range, such that on next split they'd fail to fit
+% in to any of the new target ranges.
+split_twice(#{db1 := Db}) ->
+    ?_test(begin
+        DocSpec = #{docs => 100, delete => [80, 99], mrview => 2, local => 100},
+        add_test_docs(Db, DocSpec),
+
+        % Save documents before the split
+        Docs0 = get_all_docs(Db),
+        Local0 = get_local_docs(Db),
+
+        % Set some custom metadata properties
+        set_revs_limit(Db, 942),
+        set_purge_infos_limit(Db, 943),
+        SecObj = {[{<<"foo">>, <<"bar">>}]},
+        set_security(Db, SecObj),
+
+        % DbInfo is saved after setting metadata bits
+        % as those could bump the update sequence
+        DbInfo0 = get_db_info(Db),
+
+        % Split the one shard
+        [#shard{name=Shard1}] = lists:sort(mem3:local_shards(Db)),
+        {ok, JobId1} = mem3_reshard:start_split_job(Shard1),
+        wait_state(JobId1, completed),
+
+        % Perform some basic checks that the shard was split
+        Shards1 = lists:sort(mem3:local_shards(Db)),
+        ?assertEqual(2, length(Shards1)),
+        [#shard{range = R1}, #shard{range = R2}] = Shards1,
+        ?assertEqual([16#00000000, 16#7fffffff], R1),
+        ?assertEqual([16#80000000, 16#ffffffff], R2),
+
+        % Check metadata bits after the split
+        ?assertEqual(942, get_revs_limit(Db)),
+        ?assertEqual(943, get_purge_infos_limit(Db)),
+        ?assertEqual(SecObj, get_security(Db)),
+
+        DbInfo1 = get_db_info(Db),
+        Docs1 = get_all_docs(Db),
+        Local1 = get_local_docs(Db),
+
+        % When comparing db infos, ignore update sequences they won't be the
+        % same since they are more shards involved after the split
+        ?assertEqual(without_seqs(DbInfo0), without_seqs(DbInfo1)),
+
+        % Update seq prefix number is a sum of all shard update sequences
+        #{<<"update_seq">> := UpdateSeq0} = update_seq_to_num(DbInfo0),
+        #{<<"update_seq">> := UpdateSeq1} = update_seq_to_num(DbInfo1),
+        ?assertEqual(UpdateSeq0 * 2, UpdateSeq1),
+
+        ?assertEqual(Docs0, Docs1),
+        ?assertEqual(without_meta_locals(Local0), without_meta_locals(Local1)),
+
+        % Split the first range again
+        [#shard{name=Shard2}, _] = lists:sort(mem3:local_shards(Db)),
+        {ok, JobId2} = mem3_reshard:start_split_job(Shard2),
+        wait_state(JobId2, completed),
+
+        Shards2 = lists:sort(mem3:local_shards(Db)),
+        ?assertEqual(3, length(Shards2)),
+        [R3, R4, R5] = [R || #shard{range = R} <- Shards2],
+        ?assertEqual([16#00000000, 16#3fffffff], R3),
+        ?assertEqual([16#40000000, 16#7fffffff], R4),
+        ?assertEqual([16#80000000, 16#ffffffff], R5),
+
+        % Check metadata bits after the second split
+        ?assertEqual(942, get_revs_limit(Db)),
+        ?assertEqual(943, get_purge_infos_limit(Db)),
+        ?assertEqual(SecObj, get_security(Db)),
+
+        DbInfo2 = get_db_info(Db),
+        Docs2 = get_all_docs(Db),
+        Local2 = get_local_docs(Db),
+
+        ?assertEqual(without_seqs(DbInfo1), without_seqs(DbInfo2)),
+        % Update seq prefix number is a sum of all shard update sequences
+        % But only 1 shard out of 2 was split
+        #{<<"update_seq">> := UpdateSeq2} = update_seq_to_num(DbInfo2),
+        ?assertEqual(trunc(UpdateSeq1 * 1.5), UpdateSeq2),
+        ?assertEqual(Docs1, Docs2),
+        ?assertEqual(without_meta_locals(Local1), without_meta_locals(Local2))
+    end).
+
+
+intercept_state(State) ->
+    TestPid = self(),
+    meck:new(mem3_reshard_job, [passthrough]),
+    meck:expect(mem3_reshard_job, checkpoint_done, fun(Job) ->
+            case Job#job.split_state of
+                State ->
+                    TestPid ! {self(), State},
+                    receive
+                        continue -> meck:passthrough([Job]);
+                        cancel -> ok
+                    end;
+                _ ->
+                   meck:passthrough([Job])
+            end
+        end).
+
+
+wait_state(JobId, State) ->
+    test_util:wait(fun() ->
+            case mem3_reshard:job(JobId) of
+                {ok, {Props}} ->
+                    case couch_util:get_value(job_state, Props) of
+                        State -> ok;
+                        _ -> timer:sleep(100), wait
+                    end;
+                {error, not_found} -> timer:sleep(100), wait
+            end
+    end, 30000).
+
+
+set_revs_limit(DbName, Limit) ->
+    with_proc(fun() -> fabric:set_revs_limit(DbName, Limit, [?ADMIN_CTX]) end).
+
+
+get_revs_limit(DbName) ->
+    with_proc(fun() -> fabric:get_revs_limit(DbName) end).
+
+
+get_purge_infos_limit(DbName) ->
+    with_proc(fun() -> fabric:get_purge_infos_limit(DbName) end).
+
+
+set_purge_infos_limit(DbName, Limit) ->
+    with_proc(fun() ->
+        fabric:set_purge_infos_limit(DbName, Limit, [?ADMIN_CTX])
+    end).
+
+
+set_security(DbName, SecObj) ->
+    with_proc(fun() -> fabric:set_security(DbName, SecObj) end).
+
+
+get_security(DbName) ->
+    with_proc(fun() -> fabric:get_security(DbName, [?ADMIN_CTX]) end).
+
+
+get_db_info(DbName) ->
+    with_proc(fun() ->
+        {ok, Info} = fabric:get_db_info(DbName),
+        maps:with([
+            <<"db_name">>, <<"doc_count">>, <<"props">>,  <<"doc_del_count">>,
+            <<"update_seq">>, <<"purge_seq">>, <<"disk_format_version">>
+        ], to_map(Info))
+    end).
+
+
+get_group_info(DbName, DesignId) ->
+    with_proc(fun() ->
+        {ok, GInfo} = fabric:get_view_group_info(DbName, DesignId),
+        maps:with([
+            <<"language">>, <<"purge_seq">>, <<"signature">>, <<"update_seq">>
+        ], to_map(GInfo))
+    end).
+
+
+get_partition_info(DbName, Partition) ->
+    with_proc(fun() ->
+        {ok, PInfo} = fabric:get_partition_info(DbName, Partition),
+        maps:with([
+            <<"db_name">>, <<"doc_count">>, <<"doc_del_count">>, <<"partition">>
+        ], to_map(PInfo))
+    end).
+
+
+get_all_docs(DbName) ->
+    get_all_docs(DbName, #mrargs{}).
+
+
+get_all_docs(DbName, #mrargs{} = QArgs0) ->
+    GL = erlang:group_leader(),
+    with_proc(fun() ->
+        Cb = fun
+            ({row, Props}, Acc) ->
+                Doc = to_map(couch_util:get_value(doc, Props)),
+                #{?ID := Id} = Doc,
+                {ok, Acc#{Id => Doc}};
+            ({meta, _}, Acc) -> {ok, Acc};
+            (complete, Acc) -> {ok, Acc}
+        end,
+        QArgs = QArgs0#mrargs{include_docs = true},
+        {ok, Docs} = fabric:all_docs(DbName, Cb, #{}, QArgs),
+        Docs
+    end, GL).
+
+
+get_local_docs(DbName) ->
+    LocalNS = {namespace, <<"_local">>},
+    maps:map(fun(_, Doc) ->
+        maps:without([<<"_rev">>], Doc)
+    end, get_all_docs(DbName, #mrargs{extra = [LocalNS]})).
+
+
+without_seqs(#{} = InfoMap) ->
+    maps:without([<<"update_seq">>, <<"purge_seq">>], InfoMap).
+
+
+without_meta_locals(#{} = Local) ->
+    maps:filter(fun
+        (<<"_local/purge-mrview-", _/binary>>, _) -> false;
+        (<<"_local/shard-sync-", _/binary>>, _) -> false;
+        (_, _) -> true
+   end, Local).
+
+
+update_seq_to_num(#{} = InfoMap) ->
+    maps:map(fun
+        (<<"update_seq">>, Seq) -> seq_to_num(Seq);
+        (<<"purge_seq">>, PSeq) -> seq_to_num(PSeq);
+        (_, V) -> V
+    end, InfoMap).
+
+
+seq_to_num(Seq) ->
+    [SeqNum, _] = binary:split(Seq, <<"-">>),
+    binary_to_integer(SeqNum).
+
+
+to_map([_ | _] = Props) ->
+    to_map({Props});
+
+to_map({[_ | _]} = EJson) ->
+     jiffy:decode(jiffy:encode(EJson), [return_maps]).
+
+
+create_db(DbName, Opts) ->
+    GL = erlang:group_leader(),
+    with_proc(fun() -> fabric:create_db(DbName, Opts) end, GL).
+
+
+delete_db(DbName) ->
+    GL = erlang:group_leader(),
+    with_proc(fun() -> fabric:delete_db(DbName, [?ADMIN_CTX]) end, GL).
+
+
+with_proc(Fun) ->
+    with_proc(Fun, undefined, 30000).
+
+
+with_proc(Fun, GroupLeader) ->
+    with_proc(Fun, GroupLeader, 30000).
+
+
+with_proc(Fun, GroupLeader, Timeout) ->
+    {Pid, Ref} = spawn_monitor(fun() ->
+        case GroupLeader of
+            undefined -> ok;
+            _ -> erlang:group_leader(GroupLeader, self())
+        end,
+        exit({with_proc_res, Fun()})
+    end),
+    receive
+        {'DOWN', Ref, process, Pid, {with_proc_res, Res}} ->
+            Res;
+        {'DOWN', Ref, process, Pid, Error} ->
+            error(Error)
+    after Timeout ->
+        erlang:demonitor(Ref, [flush]),
+        exit(Pid, kill),
+        error({with_proc_timeout, Fun, Timeout})
+   end.
+
+
+add_test_docs(DbName, #{} = DocSpec) ->
+    Docs = docs(maps:get(docs, DocSpec, []))
+        ++ pdocs(maps:get(pdocs, DocSpec, #{}))
+        ++ ddocs(mrview, maps:get(mrview, DocSpec, []))
+        ++ ddocs(search, maps:get(search, DocSpec, []))
+        ++ ddocs(geo, maps:get(geo, DocSpec, []))
+        ++ ldocs(maps:get(local, DocSpec, [])),
+    Res = update_docs(DbName, Docs),
+    Docs1 = lists:map(fun({Doc, {ok, {RevPos, Rev}}}) ->
+        Doc#doc{revs = {RevPos, [Rev]}}
+    end, lists:zip(Docs, Res)),
+    case delete_docs(maps:get(delete, DocSpec, []), Docs1) of
+        [] -> ok;
+        [_ | _] = Deleted -> update_docs(DbName, Deleted)
+    end,
+    ok.
+
+
+update_docs(DbName, Docs) ->
+    with_proc(fun() ->
+        case fabric:update_docs(DbName, Docs, [?ADMIN_CTX]) of
+            {accepted, Res} -> Res;
+            {ok, Res} -> Res
+        end
+    end).
+
+
+delete_docs([S, E], Docs) when E >= S ->
+    ToDelete = [doc_id(<<"">>, I) || I <- lists:seq(S, E)],
+    lists:filtermap(fun(#doc{id = Id} = Doc) ->
+        case lists:member(Id, ToDelete) of
+            true -> {true, Doc#doc{deleted = true}};
+            false -> false
+        end
+    end, Docs);
+delete_docs(_, _) ->
+    [].
+
+
+pdocs(#{} = PMap) ->
+    maps:fold(fun(Part, DocSpec, DocsAcc) ->
+        docs(DocSpec, <<Part/binary, ":">>) ++ DocsAcc
+    end, [], PMap).
+
+
+docs(DocSpec) ->
+    docs(DocSpec, <<"">>).
+
+
+docs(N, Prefix) when is_integer(N), N > 0 ->
+    docs([0, N - 1], Prefix);
+docs([S, E], Prefix) when E >= S ->
+    [doc(Prefix, I) || I <- lists:seq(S, E)];
+docs(_, _) ->
+    [].
+
+ddocs(Type, N) when is_integer(N), N > 0 ->
+    ddocs(Type, [0, N - 1]);
+ddocs(Type, [S, E]) when E >= S ->
+    Body = ddprop(Type),
+    BType = atom_to_binary(Type, utf8),
+    [doc(<<"_design/", BType/binary>>, I, Body, 0) || I <- lists:seq(S, E)];
+ddocs(_, _) ->
+    [].
+
+
+ldocs(N) when is_integer(N), N > 0 ->
+    ldocs([0, N - 1]);
+ldocs([S, E]) when E >= S ->
+    [doc(<<"_local/">>, I, bodyprops(), 0) || I <- lists:seq(S, E)];
+ldocs(_) ->
+    [].
+
+
+
+doc(Pref, Id) ->
+    Body = bodyprops(),
+    doc(Pref, Id, Body, 42).
+
+
+doc(Pref, Id, BodyProps, AttSize) ->
+    #doc{
+        id = doc_id(Pref, Id),
+        body = {BodyProps},
+        atts = atts(AttSize)
+    }.
+
+
+doc_id(Pref, Id) ->
+    IdBin = iolist_to_binary(io_lib:format("~5..0B", [Id])),
+    <<Pref/binary, IdBin/binary>>.
+
+
+ddprop(mrview) ->
+    [
+        {<<"views">>, {[
+             {<<"v1">>, {[
+                 {<<"map">>, <<"function(d){emit(d);}">>}
+             ]}}
+        ]}}
+    ];
+
+ddprop(geo) ->
+    [
+        {<<"st_indexes">>, {[
+            {<<"area">>, {[
+                {<<"analyzer">>, <<"standard">>},
+                {<<"index">>, <<"function(d){if(d.g){st_index(d.g)}}">> }
+            ]}}
+        ]}}
+    ];
+
+ddprop(search) ->
+    [
+        {<<"indexes">>, {[
+            {<<"types">>, {[
+                {<<"index">>, <<"function(d){if(d.g){st_index(d.g.type)}}">>}
+            ]}}
+        ]}}
+   ].
+
+
+bodyprops() ->
+    [
+        {<<"g">>, {[
+            {<<"type">>, <<"Polygon">>},
+            {<<"coordinates">>, [[[-71.0, 48.4], [-70.0, 48.4], [-71.0, 48.4]]]}
+        ]}}
+   ].
+
+
+atts(0) ->
+    [];
+
+atts(Size) when is_integer(Size), Size >= 1 ->
+    Data = << <<"x">> || _ <- lists:seq(1, Size) >>,
+    [couch_att:new([
+        {name, <<"att">>},
+        {type, <<"app/binary">>},
+        {att_len, Size},
+        {data, Data}
+    ])].

--- a/src/mem3/test/mem3_ring_prop_tests.erl
+++ b/src/mem3/test/mem3_ring_prop_tests.erl
@@ -1,0 +1,84 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_ring_prop_tests).
+
+
+-include_lib("triq/include/triq.hrl").
+-triq(eunit).
+
+-compile(export_all).
+
+
+% Properties
+
+prop_get_ring_with_connected_intervals() ->
+    ?FORALL({Start, End}, oneof(ranges()),
+        ?FORALL(Intervals, g_connected_intervals(Start, End),
+            mem3_util:get_ring(Intervals, Start, End) =:= Intervals
+        )
+    ).
+
+
+prop_get_ring_with_disconnected_intervals() ->
+    ?FORALL({Start, End}, oneof(ranges()),
+        ?FORALL(Intervals, g_disconnected_intervals(Start, End),
+            mem3_util:get_ring(Intervals, Start, End) =:= []
+        )
+    ).
+
+
+% Generators
+
+ranges() ->
+    [{0,1}, {1, 10}, {0, 2 bsl 31 - 1}, {2 bsl 31 - 10, 2 bsl 31 - 1}].
+
+
+g_connected_intervals(Begin, End) ->
+    ?SIZED(Size, g_connected_intervals(Begin, End, 10 * Size)).
+
+
+g_connected_intervals(Begin, End, Split) when Begin =< End ->
+    ?LET(N, choose(0, Split),
+    begin
+        if
+            N == 0 ->
+                [{Begin, End}];
+            N > 0 ->
+                Ns = lists:seq(1, N - 1),
+                Bs = lists:usort([rand_range(Begin, End) || _ <- Ns]),
+                Es = [B - 1 || B <- Bs],
+                lists:zip([Begin] ++ Bs, Es ++ [End])
+        end
+    end).
+
+
+g_non_trivial_connected_intervals(Begin, End, Split) ->
+    ?SUCHTHAT(Connected, g_connected_intervals(Begin, End, Split),
+        length(Connected) > 1).
+
+
+g_disconnected_intervals(Begin, End) ->
+    ?SIZED(Size, g_disconnected_intervals(Begin, End, Size)).
+
+
+g_disconnected_intervals(Begin, End, Split) when Begin =< End ->
+    ?LET(Connected, g_non_trivial_connected_intervals(Begin, End, Split),
+    begin
+        I = triq_rnd:uniform(length(Connected)) - 1,
+        {Before, [_ | After]} = lists:split(I, Connected),
+        Before ++ After
+    end).
+
+
+rand_range(B, E) ->
+    B + triq_rnd:uniform(E - B).

--- a/src/rexi/src/rexi.erl
+++ b/src/rexi/src/rexi.erl
@@ -12,7 +12,7 @@
 
 -module(rexi).
 -export([start/0, stop/0, restart/0]).
--export([cast/2, cast/3, cast/4, kill/2]).
+-export([cast/2, cast/3, cast/4, kill/2, kill_all/1]).
 -export([reply/1, sync_reply/1, sync_reply/2]).
 -export([async_server_call/2, async_server_call/3]).
 -export([stream_init/0, stream_init/1]).
@@ -74,6 +74,18 @@ cast(Node, Caller, MFA, Options) ->
 -spec kill(node(), reference()) -> ok.
 kill(Node, Ref) ->
     rexi_utils:send(rexi_utils:server_pid(Node), cast_msg({kill, Ref})),
+    ok.
+
+%% @doc Sends an async kill signal to the remote processes associated with Refs.
+%% No rexi_EXIT message will be sent.
+-spec kill_all([{node(), reference()}]) -> ok.
+kill_all(NodeRefs) when is_list(NodeRefs) ->
+    PerNodeMap = lists:foldl(fun({Node, Ref}, Acc) ->
+        maps:update_with(Node, fun(Refs) -> [Ref | Refs] end, [Ref], Acc)
+    end, #{}, NodeRefs),
+    maps:map(fun(Node, Refs) ->
+        rexi_utils:send(rexi_utils:server_pid(Node), cast_msg({kill_all, Refs}))
+    end, PerNodeMap),
     ok.
 
 %% @equiv async_server_call(Server, self(), Request)


### PR DESCRIPTION
This PR implements shard splitting [1] for CouchDB as discussed in RFC #1920.

The work is organized as a series of commits in the following order:

* Uneven shard copy handling in mem3 and fabric. That's a preparatory step to
  make sure mem3 and fabric knows how to handle uneven shard copies on the
  cluster.

* Main job manager and supervisor. This commit defines the supervision tree and
  the main job manager. The job manager is a central component which starts,
  stops and monitors jobs.

* Individual shard splitting job implementation and associated helper module.
  Here the logic for a single shard splitting job is defined along with the
  needed helpers, some of which were separated in different modules. The
  couch_db_split module, specifically is in its own commit as it lives in the
  `couch` application, operates on db files (instead of shards) and general is
  large and separate enough from the rest to warrant its own commit.

* Internal replicator update to handle split shards. Internal replicator and
  some associated helpers in mem3_rep were updated to handle split shard
  sources and targets. Internal replicator involved in resharding in two main
  ways 1) during the normal cluster operation replicating between possibly
  split shards and 2) as part of the shard splitting job logic where it is used
  to topoff updates from the source to the targets.

* HTTP API implementation and functional tests. This commit implements the HTTP
  API and adds behavior and other tests as discussed in the RFC.

[1] Shard splitting and resharding is used interchangeably in the PR and the
commits. Initially the work had started with implementing just shard splitting
and the API reflected that, however after a fruitful discussion in the couchdb
dev mailing list, it was agreed to generalize the work to potentially allow
shard merging or other shard map operations in the future. So closer to the
HTTP API level "resharding" will be used more often and in the job
implementation discussions and comments shard splitting will be used, since
currently only shard splitting is supported.

