### PR TITLE
Send correct 400 for missing partition with _find

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -274,6 +274,11 @@ handle_partition_req(#httpd{method='GET', path_parts=[_,_,PartId]}=Req, Db) ->
             throw({bad_request, <<"database is not partitioned">>})
     end;
 
+handle_partition_req(#httpd{method='POST',
+    path_parts=[_, <<"_partition">>, <<"_", _/binary>>]}, _Db) ->
+    Msg = <<"Partition must not start with an underscore">>,
+    throw({illegal_partition, Msg});
+
 handle_partition_req(#httpd{path_parts = [_, _, _]}=Req, _Db) ->
     send_method_not_allowed(Req, "GET");
 


### PR DESCRIPTION
## Overview

When sending an incorrect partition query e.g:
/parition/_find, send a 400 with the message:

Partition must not start with an underscore

This makes it consistent with all the other partition requests

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Tests should pass and correct message should be returned for `_explain` and `_find`



## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
