### PR TITLE
Update folsom to support newer erlang

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -101,7 +101,7 @@ DepDescs = [
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.1.19"}, [raw]},
 %% Third party deps
-{folsom,           "folsom",           {tag, "CouchDB-0.8.2"}},
+{folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-4"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-2"}},


### PR DESCRIPTION
## Overview

Update folsom to stop using deprecated erlang APIs

## Testing recommendations

```
make eunit
```

## Related Issues or Pull Requests

- https://github.com/apache/couchdb-folsom/pull/1

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
