### PR TITLE
upgrade ken to 1.0.3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -93,7 +93,7 @@ DepDescs = [
 {ioq,              "ioq",              {tag, "2.0.0"}},
 {hqueue,           "hqueue",           {tag, "1.0.0"}},
 {smoosh,           "smoosh",           {tag, "1.0.0"}},
-{ken,              "ken",              {tag, "1.0.0"}},
+{ken,              "ken",              {tag, "1.0.3"}},
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Upgrade Latest couchdb-ken to use version 1.0.3

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
