### PR TITLE
Fix chttpd auth cache log errors

### DIFF
--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -23,6 +23,12 @@
 
 -define(CACHE, chttpd_auth_cache_lru).
 
+-ifdef(TEST).
+-define(LISTENER_RESTART_CHECK_INTERVAL_MS, 5).
+-else.
+-define(LISTENER_RESTART_CHECK_INTERVAL_MS, 5000).
+-endif.
+
 -record(state, {
     changes_pid,
     last_seq="0"

--- a/src/chttpd/test/chttpd_auth_cache_test.erl
+++ b/src/chttpd/test/chttpd_auth_cache_test.erl
@@ -1,0 +1,80 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_auth_cache_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+setup() ->
+    DbName = ?tempdb(),
+    ok = fabric:create_db(DbName),
+    DbName.
+
+
+teardown(DbName) ->
+    fabric:delete_db(DbName).
+
+
+auth_db_change_listener_lifecycle_test_() ->
+    {
+        "auth db and change listener lifecycle tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun change_listener_should_not_start_if_auth_db_missing/1,
+                    fun change_listener_should_start_if_auth_db_exists/1
+                ]
+            }
+        }
+    }.
+
+
+
+change_listener_should_not_start_if_auth_db_missing(_DbName) ->
+    ?_test(begin
+        %% ok = restart_app(chttpd),
+        AuthCachePid = whereis(chttpd_auth_cache),
+        ?assert(is_pid(AuthCachePid)),
+        Expected = {state, undefined, "0"},
+        ?assertEqual(Expected, sys:get_state(AuthCachePid)),
+        ok
+    end).
+
+
+change_listener_should_start_if_auth_db_exists(DbName) ->
+    ?_test(begin
+        config:set("chttpd_auth", "authentication_db", ?b2l(DbName), false),
+        ok = restart_app(chttpd),
+        AuthCachePid = whereis(chttpd_auth_cache),
+        ?assert(is_pid(AuthCachePid)),
+        ListenerPid = test_util:wait(fun() ->
+            case sys:get_state(AuthCachePid) of
+                {state, undefined, "0"} -> wait;
+                {state, Pid, "0"} when is_pid(Pid) -> Pid
+            end
+        end, 1000, 10),
+        ?assert(is_pid(ListenerPid) andalso is_process_alive(ListenerPid)),
+        config:set("chttpd_auth", "authentication_db", "_users", false),
+        ok
+    end).
+
+
+restart_app(App) ->
+    ok = application:stop(App),
+    ok = application:start(App).

--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -75,7 +75,8 @@ is_single_node_enabled(Dbs) ->
     end.
 
 cluster_system_dbs() ->
-    ["_users", "_replicator", "_global_changes"].
+    %% ["_users", "_replicator", "_global_changes"].
+    [].
 
 
 has_cluster_system_dbs([]) ->


### PR DESCRIPTION
## Overview

In situations where the chttpd authenticaion db (usually named "_users")
does not get created, or gets deleted, the auth cache still attempts
to start the change listener, which results in notice and error level
logs in the system like:

```
[notice] 2018-12-03T22:04:44.299392Z node1@127.0.0.1 <0.374.0> -------- chttpd_auth_cache changes listener died database_does_not_exist at mem3_shards:load_shards_from_db/6(line:395) <= mem3_shards:load_shards_from_disk/1(line:370) <= mem3_shards:load_shards_from_disk/2(line:399) <= mem3_shards:for_docid/3(line:86) <= fabric_doc_open:go/3(line:39) <= chttpd_auth_cache:ensure_auth_ddoc_exists/2(line:195) <= chttpd_auth_cache:listen_for_changes/1(line:142)
```
```
[error] 2018-12-03T22:04:44.299585Z node1@127.0.0.1 emulator -------- Error in process <0.3180.0> on node 'node1@127.0.0.1' with exit value:
{database_does_not_exist,[{mem3_shards,load_shards_from_db,"_users",[{file,"src/mem3_shards.erl"},{line,395}]},{mem3_shards,load_shards_from_disk,1,[{file,"src/mem3_shards.erl"},{line,370}]},{mem3_shards,load_shards_from_disk,2,[{file,"src/mem3_shards.erl"},{line,399}]},{mem3_shards,for_docid,3,[{file,"src/mem3_shards.erl"},{line,86}]},{fabric_doc_open,go,3,[{file,"src/fabric_doc_open.erl"},{line,39}]},{chttpd_auth_cache,ensure_auth_ddoc_exists,2,[{file,"src/chttpd_auth_cache.erl"},{line,195}]},{chttpd_auth_cache,listen_for_changes,1,[{file,"src/chttpd_auth_cache.erl"},{line,142}]}]}
```
This changes the auth cache so that it

• Only starts change listener if auth db exists
• Only retains EndSeq if auth db still exists

Fixes https://github.com/apache/couchdb/issues/1354
Fixes https://github.com/apache/couchdb/issues/1949

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=chttpd suites=chttpd_auth_cache_test
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
