### PR TITLE
Added more info for a mango sort error

### DIFF
--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -25,13 +25,15 @@ info(mango_idx, {no_usable_index, missing_sort_index}) ->
     {
         400,
         <<"no_usable_index">>,
-        <<"No index exists for this sort, try indexing by the sort fields.">>
+        <<"No index exists for this sort, "
+            "try indexing by the sort fields.">>
     };
 info(mango_idx, {no_usable_index, missing_sort_index_partitioned}) ->
     {
         400,
         <<"no_usable_index">>,
-        <<"No partitioned index exists for this sort, try indexing by the sort fields.">>
+        <<"No partitioned index exists for this sort, "
+            "try indexing by the sort fields.">>
     };
 info(mango_idx, {no_usable_index, missing_sort_index_global}) ->
     {

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -27,6 +27,18 @@ info(mango_idx, {no_usable_index, missing_sort_index}) ->
         <<"no_usable_index">>,
         <<"No index exists for this sort, try indexing by the sort fields.">>
     };
+info(mango_idx, {no_usable_index, missing_sort_index_partitioned}) ->
+    {
+        400,
+        <<"no_usable_index">>,
+        <<"No partitioned index exists for this sort, try indexing by the sort fields.">>
+    };
+info(mango_idx, {no_usable_index, missing_sort_index_global}) ->
+    {
+        400,
+        <<"no_usable_index">>,
+        <<"No global index exists for this sort, try indexing by the sort fields.">>
+    };
 info(mango_json_bookmark, {invalid_bookmark, BadBookmark}) ->
     {
         400,

--- a/src/mango/src/mango_idx.erl
+++ b/src/mango/src/mango_idx.erl
@@ -422,7 +422,7 @@ get_idx_partitioned(Db, DDocProps) ->
     end.
 
 is_opts_partitioned(Opts) ->
-    case couch_util:get_value(partition, Opts) of
+    case couch_util:get_value(partition, Opts, <<>>) of
         <<>> ->
             false;
         Partition when is_binary(Partition) ->


### PR DESCRIPTION
## Overview

The mango sort error can be a bit confusing with using a partitioned
database this gives a little more detail on why mango could not find
a specific index when a sort is used.

## Testing recommendations

Elixir and python mango tests should pass. Create a partitioned database, have a selector that has a sort in it:

```
selector = %{
      selector: %{
        some: "field"
      },
      sort: ["some"],
      limit: 50
    }
```

You should get back different errors depending on a normal database, partitioned database with a partitioned query or a global query on a partitioned database.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
