### PR TITLE
Ignore weak ETag part

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -693,9 +693,15 @@ etag_match(Req, CurrentEtag) when is_binary(CurrentEtag) ->
     etag_match(Req, binary_to_list(CurrentEtag));
 
 etag_match(Req, CurrentEtag) ->
-    EtagsToMatch = string:tokens(
+    EtagsToMatch0 = string:tokens(
         chttpd:header_value(Req, "If-None-Match", ""), ", "),
+    EtagsToMatch = lists:map(fun strip_weak_prefix/1, EtagsToMatch0),
     lists:member(CurrentEtag, EtagsToMatch).
+
+strip_weak_prefix([$W, $/ | Etag]) ->
+    Etag;
+strip_weak_prefix(Etag) ->
+    Etag.
 
 etag_respond(Req, CurrentEtag, RespFun) ->
     case etag_match(Req, CurrentEtag) of

--- a/test/javascript/tests/etags_head.js
+++ b/test/javascript/tests/etags_head.js
@@ -63,6 +63,10 @@ couchTests.etags_head = function(debug) {
     headers: {"if-none-match": etag}
   });
   T(xhr.status == 304);
+  xhr = CouchDB.request("GET", "/" + db_name + "/1", {
+    headers: {"if-none-match": "W/" + etag}
+  });
+  T(xhr.status == 304);
 
   // fail to delete a doc
   xhr = CouchDB.request("DELETE", "/" + db_name + "/1", {


### PR DESCRIPTION
## Overview

Some load balancer configurations (HAproxy with compression enabled is
the motivating example) will add W/ to our response ETags if they
modify the response before sending it to the client.

as per rfc7232 section 3.2;

"A recipient MUST use the weak comparison function when comparing
entity-tags for If-None-Match (Section 2.3.2), since weak entity-tags
can be used for cache validation even if there have been changes to
the representation data."

This change improves our ETag checking toward RFC compliance.

## Testing recommendations

1)
create a document

2)

fetch it like;

curl 'foo:bar@localhost:15984/db1/doc1' -i -H'If-None-Match:"1-967a00dff5e02add41819138abb3284d"'

and verify a 304 response

3)

fetch it like;

curl 'foo:bar@localhost:15984/db1/doc1' -i -H'If-None-Match:W/"1-967a00dff5e02add41819138abb3284d"'

and verify a 304 response (prior to this change it would be a 200).

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;

No doc change seems necessary?