### PR TITLE
Update ioq to 2.1.1

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -98,7 +98,7 @@ DepDescs = [
 {ets_lru,          "ets-lru",          {tag, "1.0.0"}},
 {khash,            "khash",            {tag, "1.0.1"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.2"}},
-{ioq,              "ioq",              {tag, "2.1.0"}},
+{ioq,              "ioq",              {tag, "2.1.1"}},
 {hqueue,           "hqueue",           {tag, "1.0.1"}},
 {smoosh,           "smoosh",           {tag, "1.0.1"}},
 {ken,              "ken",              {tag, "1.0.3"}},


### PR DESCRIPTION
## Overview

Update ioq to version 2.1.1. The update includes a fix for a test case.

## Testing recommendations

```
make eunit apps=ioq
```

## Related Issues or Pull Requests

- https://github.com/apache/couchdb-ioq/pull/12

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
