### PR TITLE
Improve elixir test stability

### DIFF
--- a/test/elixir/test/partition_all_docs_test.exs
+++ b/test/elixir/test/partition_all_docs_test.exs
@@ -182,6 +182,7 @@ defmodule PartitionAllDocsTest do
 
   # This test is timing based so it could be a little flaky.
   # If that turns out to be the case we should probably just skip it
+  @tag :pending
   test "partition _all_docs with timeout", context do
     set_config({"fabric", "partition_view_timeout", "1"})
 

--- a/test/elixir/test/partition_ddoc_test.exs
+++ b/test/elixir/test/partition_ddoc_test.exs
@@ -160,16 +160,20 @@ defmodule PartitionDDocTest do
   test "GET /dbname/_design_docs", context do
     db_name = context[:db_name]
 
-    retry_until(fn ->
-      resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
-      assert resp.status_code == 201
+    retry_until(
+      fn ->
+        resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
+        assert resp.status_code == 201
 
-      resp = Couch.get("/#{db_name}/_design_docs")
-      assert resp.status_code == 200
-      %{body: body} = resp
+        resp = Couch.get("/#{db_name}/_design_docs")
+        assert resp.status_code == 200
+        %{body: body} = resp
 
-      assert length(body["rows"]) == 1
-      %{"rows" => [%{"id" => "_design/foo"}]} = body
-    end)
+        assert length(body["rows"]) == 1
+        %{"rows" => [%{"id" => "_design/foo"}]} = body
+      end,
+      500,
+      10_000
+    )
   end
 end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

• Disable self-admitted flaky "partition _all_docs with timeout" test
• Double timeout for "GET /dbname/_design_docs" test

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make elixir
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
