### PR TITLE
Skip running PropEr's own unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ DESTDIR=
 
 # Rebar options
 apps=
-skip_deps=folsom,meck,mochiweb,triq,snappy,bcrypt,hyper
+skip_deps=folsom,meck,mochiweb,triq,proper,snappy,bcrypt,hyper
 suites=
 tests=
 


### PR DESCRIPTION
We skip mochiweb, snappy and others already.
