### PR TITLE
Fix #1988 - Validate attachment names on POST /db/doc

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -412,6 +412,7 @@ db_req(#httpd{method='POST', path_parts=[DbName]}=Req, Db) ->
 
     Doc0 = chttpd:json_body(Req),
     Doc1 = couch_doc:from_json_obj_validate(Doc0, fabric2_db:name(Db)),
+    validate_attachment_names(Doc1),
     Doc2 = case Doc1#doc.id of
         <<"">> ->
             Doc1#doc{id=couch_uuids:new(), revs={0, []}};

--- a/test/elixir/test/all_docs_test.exs
+++ b/test/elixir/test/all_docs_test.exs
@@ -445,4 +445,22 @@ defmodule AllDocsTest do
 
     assert resp.status_code == 200
   end
+
+  @tag :with_db
+  test "POST boolean", context do
+    db_name = context[:db_name]
+
+    resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
+    assert resp.status_code in [201, 202]
+
+    resp = Couch.post(
+      "/#{db_name}/_all_docs",
+      body: %{
+        :stable => true,
+        :update => true
+      }
+    )
+
+    assert resp.status_code == 200
+  end
 end

--- a/test/elixir/test/all_docs_test.exs
+++ b/test/elixir/test/all_docs_test.exs
@@ -445,22 +445,4 @@ defmodule AllDocsTest do
 
     assert resp.status_code == 200
   end
-
-  @tag :with_db
-  test "POST boolean", context do
-    db_name = context[:db_name]
-
-    resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
-    assert resp.status_code in [201, 202]
-
-    resp = Couch.post(
-      "/#{db_name}/_all_docs",
-      body: %{
-        :stable => true,
-        :update => true
-      }
-    )
-
-    assert resp.status_code == 200
-  end
 end

--- a/test/elixir/test/attachment_names_test.exs
+++ b/test/elixir/test/attachment_names_test.exs
@@ -94,5 +94,20 @@ defmodule AttachmentNamesTest do
 
     assert resp.body["reason"] ==
              "Attachment name '_foo.txt' starts with prohibited character '_'"
+
+    resp =
+      Couch.post(
+        "/#{db_name}",
+        body: @leading_underscores_att
+      )
+
+    assert resp.status_code == 400
+
+    assert resp.body["reason"] ==
+             "Attachment name '_foo.txt' starts with prohibited character '_'"
+
+    resp = Couch.get("/#{db_name}/bin_doc2/_foo.txt")
+
+    assert resp.status_code == 404
   end
 end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
 This PR solves the problem described at the issue #1988 

PUT & POST operations for creating documents in a database enforce different validation rules over the attachment names of the new document.

When a document is created with a PUT operation "_foo.txt" is not accepted as a valid attachment name. If the document is created by a POST operation the "_foo.txt" attachment name is accepted.

This is an inconsistent behavoiur in the API as not accepted attachment names can be created. 

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make elixir tests=test/attachment_names_test.exs
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
 This PR fixes #1988 
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
