### PR TITLE
Ioq per shard or user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell pwd)/bin/couchjs $(shell
 eunit: couch
 	@$(REBAR) setup_eunit 2> /dev/null
 	@for dir in $(subdirs); do \
-	  $(REBAR) -r eunit $(EUNIT_OPTS) apps=$$dir; \
+	  $(REBAR) -r eunit $(EUNIT_OPTS) apps=$$dir || exit 1; \
 	done
 
 setup-eunit: export BUILDDIR = $(shell pwd)

--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -139,7 +139,9 @@ spawn_changes(Since) ->
     Pid.
 
 listen_for_changes(Since) ->
-    ensure_auth_ddoc_exists(dbname(), <<"_design/_auth">>),
+    DbName = dbname(),
+    erlang:put(io_priority, {system, DbName}),
+    ensure_auth_ddoc_exists(DbName, <<"_design/_auth">>),
     CBFun = fun ?MODULE:changes_callback/2,
     Args = #changes_args{
         feed = "continuous",
@@ -147,7 +149,7 @@ listen_for_changes(Since) ->
         heartbeat = true,
         filter = {default, main_only}
     },
-    fabric:changes(dbname(), CBFun, Since, Args).
+    fabric:changes(DbName, CBFun, Since, Args).
 
 changes_callback(waiting_for_updates, Acc) ->
     {ok, Acc};

--- a/src/couch/src/couch_auth_cache.erl
+++ b/src/couch/src/couch_auth_cache.erl
@@ -150,6 +150,7 @@ init(_) ->
     ?BY_USER = ets:new(?BY_USER, [set, protected, named_table]),
     ?BY_ATIME = ets:new(?BY_ATIME, [ordered_set, private, named_table]),
     AuthDbName = config:get("couch_httpd_auth", "authentication_db"),
+    erlang:put(io_priority, {system, AuthDbName}),
     process_flag(trap_exit, true),
     ok = config:listen_for_changes(?MODULE, nil),
     {ok, Listener} = couch_event:link_listener(

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -1130,6 +1130,9 @@ active_size(#st{} = St, #size_info{} = SI) ->
 
 
 fold_docs_int(St, Tree, UserFun, UserAcc, Options) ->
+    case erlang:get(io_priority) of
+        Priority when Priority =/= undefined -> ok
+    end,
     Fun = case lists:member(include_deleted, Options) of
         true -> fun include_deleted/4;
         false -> fun skip_deleted/4

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -45,6 +45,7 @@
     get_partition_info/2,
     get_update_seq/1,
     get_uuid/1,
+    get_fd_pid/1,
 
     set_revs_limit/2,
     set_purge_infos_limit/2,
@@ -346,6 +347,10 @@ get_update_seq(#st{header = Header}) ->
 
 get_uuid(#st{header = Header}) ->
     couch_bt_engine_header:get(Header, uuid).
+
+
+get_fd_pid(#st{fd = Fd}) ->
+    Fd.
 
 
 set_revs_limit(#st{header = Header} = St, RevsLimit) ->

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -45,6 +45,7 @@
     get_filepath/1,
     get_instance_start_time/1,
     get_pid/1,
+    get_fd_pid/1,
     get_revs_limit/1,
     get_security/1,
     get_update_seq/1,
@@ -249,7 +250,8 @@ monitored_by(Db) ->
     case couch_db_engine:monitored_by(Db) of
         Pids when is_list(Pids) ->
             PidTracker = whereis(couch_stats_process_tracker),
-            Pids -- [Db#db.main_pid, PidTracker];
+            IOQOpener = whereis(ioq_opener),
+            Pids -- [Db#db.main_pid, PidTracker, IOQOpener];
         undefined ->
             []
     end.
@@ -555,6 +557,9 @@ get_purge_infos_limit(#db{}=Db) ->
 
 get_pid(#db{main_pid = Pid}) ->
     Pid.
+
+get_fd_pid(#db{}=Db) ->
+    couch_db_engine:get_fd_pid(Db).
 
 get_del_doc_count(Db) ->
     {ok, couch_db_engine:get_del_doc_count(Db)}.

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -248,7 +248,9 @@ is_idle(_Db) ->
 
 monitored_by(Db) ->
     case couch_db_engine:monitored_by(Db) of
-        Pids when is_list(Pids) ->
+        Pids0 when is_list(Pids0) ->
+            %% Remove duplicate ioq_opener monitors
+            Pids = lists:usort(Pids0),
             PidTracker = whereis(couch_stats_process_tracker),
             IOQOpener = whereis(ioq_opener),
             Pids -- [Db#db.main_pid, PidTracker, IOQOpener];

--- a/src/couch/src/couch_db_engine.erl
+++ b/src/couch/src/couch_db_engine.erl
@@ -925,6 +925,10 @@ set_props(#db{} = Db, Props) ->
 
 
 open_docs(#db{} = Db, DocIds) ->
+    _IOP = case erlang:get(io_priority) of
+        {_C, E} when E =/= undefined -> E;
+        {_C, E, _} when E =/= undefined -> E
+    end,
     #db{engine = {Engine, EngineState}} = Db,
     Engine:open_docs(EngineState, DocIds).
 

--- a/src/couch/src/couch_db_engine.erl
+++ b/src/couch/src/couch_db_engine.erl
@@ -706,6 +706,7 @@
     get_partition_info/2,
     get_update_seq/1,
     get_uuid/1,
+    get_fd_pid/1,
 
     set_revs_limit/2,
     set_security/2,
@@ -892,6 +893,11 @@ get_update_seq(#db{} = Db) ->
 get_uuid(#db{} = Db) ->
     #db{engine = {Engine, EngineState}} = Db,
     Engine:get_uuid(EngineState).
+
+
+get_fd_pid(#db{} = Db) ->
+    #db{engine = {Engine, EngineState}} = Db,
+    Engine:get_fd_pid(EngineState).
 
 
 set_revs_limit(#db{} = Db, RevsLimit) ->

--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -433,6 +433,13 @@ len_doc_to_multi_part_stream(Boundary, JsonBytes, Atts, SendEncodedAtts) ->
 
 doc_to_multi_part_stream(Boundary, JsonBytes, Atts, WriteFun,
     SendEncodedAtts) ->
+    case erlang:get(io_priority) of
+        undefined ->
+            %% TODO: use proper dbname here
+            erlang:put(interactive, <<"asdf">>);
+        _ ->
+            ok
+    end,
     AttsToInclude = lists:filter(fun(Att)-> couch_att:fetch(data, Att) /= stub end, Atts),
     AttsDecoded = decode_attributes(AttsToInclude, SendEncodedAtts),
     AttFun = case SendEncodedAtts of

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -229,6 +229,8 @@ handle_request(MochiReq, DefaultFun, UrlHandlers, DbUrlHandlers,
 
 handle_request_int(MochiReq, DefaultFun,
             UrlHandlers, DbUrlHandlers, DesignUrlHandlers) ->
+    %% TODO: find appropriate value for internal API
+    erlang:put(io_priority, {interactive, <<"asdf">>}),
     Begin = os:timestamp(),
     % for the path, use the raw path with the query string and fragment
     % removed, but URL quoting left intact

--- a/src/couch/src/couch_httpd_db.erl
+++ b/src/couch/src/couch_httpd_db.erl
@@ -39,6 +39,8 @@
 % Database request handlers
 handle_request(#httpd{path_parts=[DbName|RestParts],method=Method,
         db_url_handlers=DbUrlHandlers}=Req)->
+    %% TODO: set proper io_priority value here
+    erlang:put(io_priority, {interactive, DbName}),
     case {Method, RestParts} of
     {'PUT', []} ->
         create_db_req(Req, DbName);

--- a/src/couch/src/couch_server_int.hrl
+++ b/src/couch/src/couch_server_int.hrl
@@ -15,6 +15,7 @@
     name,
     db,
     pid,
+    ioq_pid,
     lock,
     waiters,
     req_type,

--- a/src/couch/test/couch_auth_cache_tests.erl
+++ b/src/couch/test/couch_auth_cache_tests.erl
@@ -140,6 +140,7 @@ should_get_nil_on_missed_cache(_) ->
 
 should_get_right_password_hash(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         PasswordHash = hash_password("pass1"),
         {ok, _} = update_user_doc(DbName, "joe", "pass1"),
         {ok, Creds, _} = couch_auth_cache:get_user_creds("joe"),
@@ -149,6 +150,7 @@ should_get_right_password_hash(DbName) ->
 
 should_ensure_doc_hash_equals_cached_one(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         {ok, _} = update_user_doc(DbName, "joe", "pass1"),
         {ok, Creds, _} = couch_auth_cache:get_user_creds("joe"),
 
@@ -159,6 +161,7 @@ should_ensure_doc_hash_equals_cached_one(DbName) ->
 
 should_update_password(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         PasswordHash = hash_password("pass2"),
         {ok, Rev} = update_user_doc(DbName, "joe", "pass1"),
         {ok, _} = update_user_doc(DbName, "joe", "pass2", Rev),
@@ -169,6 +172,7 @@ should_update_password(DbName) ->
 
 should_cleanup_cache_after_userdoc_deletion(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         {ok, _} = update_user_doc(DbName, "joe", "pass1"),
         delete_user_doc(DbName, "joe"),
         ?assertEqual(nil, couch_auth_cache:get_user_creds("joe"))
@@ -176,6 +180,7 @@ should_cleanup_cache_after_userdoc_deletion(DbName) ->
 
 should_restore_cache_after_userdoc_recreation(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         PasswordHash = hash_password("pass5"),
         {ok, _} = update_user_doc(DbName, "joe", "pass1"),
         delete_user_doc(DbName, "joe"),
@@ -190,6 +195,7 @@ should_restore_cache_after_userdoc_recreation(DbName) ->
 
 should_drop_cache_on_auth_db_change(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         {ok, _} = update_user_doc(DbName, "joe", "pass1"),
         full_commit(DbName),
         config:set("couch_httpd_auth", "authentication_db",
@@ -199,6 +205,7 @@ should_drop_cache_on_auth_db_change(DbName) ->
 
 should_restore_cache_on_auth_db_change(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         PasswordHash = hash_password("pass1"),
         {ok, _} = update_user_doc(DbName, "joe", "pass1"),
         {ok, Creds, _} = couch_auth_cache:get_user_creds("joe"),
@@ -221,6 +228,7 @@ should_restore_cache_on_auth_db_change(DbName) ->
 
 should_recover_cache_after_shutdown(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         PasswordHash = hash_password("pass2"),
         {ok, Rev0} = update_user_doc(DbName, "joe", "pass1"),
         {ok, Rev1} = update_user_doc(DbName, "joe", "pass2", Rev0),
@@ -232,6 +240,7 @@ should_recover_cache_after_shutdown(DbName) ->
 
 should_close_old_db_on_auth_db_change(DbName) ->
     {timeout, ?DB_TIMEOUT, ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         ?assertEqual(ok, wait_db(DbName, fun is_opened/1)),
         config:set("couch_httpd_auth", "authentication_db",
                          ?b2l(?tempdb()), false),

--- a/src/couch/test/couch_bt_engine_compactor_tests.erl
+++ b/src/couch/test/couch_bt_engine_compactor_tests.erl
@@ -23,6 +23,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {db_compact, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     create_docs(DbName),
@@ -52,6 +53,7 @@ compaction_resume_test_() ->
 
 compaction_resume(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {db_update, DbName}),
         check_db_validity(DbName),
         compact_db(DbName),
         check_db_validity(DbName),

--- a/src/couch/test/couch_bt_engine_upgrade_tests.erl
+++ b/src/couch/test/couch_bt_engine_upgrade_tests.erl
@@ -68,6 +68,7 @@ t_upgrade_without_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
         % db with zero purge entries
         DbName = ?l2b("db_v"  ++ integer_to_list(VersionFrom)
             ++ "_without_purge_req"),
+        erlang:put(io_priority, {db_update, DbName}),
 
         ?assertEqual(VersionFrom, get_disk_version_from_header(DbName)),
         {ok, UpgradedPurged} = couch_util:with_db(DbName, fun(Db) ->
@@ -108,6 +109,7 @@ t_upgrade_with_1_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
         % with a single purge entry
         DbName = ?l2b("db_v"  ++ integer_to_list(VersionFrom)
             ++ "_with_1_purge_req"),
+        erlang:put(io_priority, {db_update, DbName}),
 
         ?assertEqual(VersionFrom, get_disk_version_from_header(DbName)),
         {ok, UpgradedPurged} = couch_util:with_db(DbName, fun(Db) ->
@@ -149,6 +151,7 @@ t_upgrade_with_N_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
         % with two docs that have been purged
         DbName = ?l2b("db_v"  ++ integer_to_list(VersionFrom)
             ++ "_with_2_purge_req"),
+        erlang:put(io_priority, {db_update, DbName}),
 
         ?assertEqual(VersionFrom, get_disk_version_from_header(DbName)),
         {ok, UpgradedPurged} = couch_util:with_db(DbName, fun(Db) ->
@@ -189,6 +192,7 @@ t_upgrade_with_1_purge_req_for_2_docs(VersionFrom, {_Ctx, _NewPaths}) ->
         % with one purge req for Doc1 and another purge req for Doc 2 and Doc3
         DbName = ?l2b("db_v"  ++ integer_to_list(VersionFrom)
             ++ "_with_1_purge_req_for_2_docs"),
+        erlang:put(io_priority, {db_update, DbName}),
 
         ?assertEqual(VersionFrom, get_disk_version_from_header(DbName)),
         {ok, UpgradedPurged} = couch_util:with_db(DbName, fun(Db) ->

--- a/src/couch/test/couch_btree_tests.erl
+++ b/src/couch/test/couch_btree_tests.erl
@@ -19,6 +19,7 @@
 
 
 setup() ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     {ok, Fd} = couch_file:open(?tempfile(), [create, overwrite]),
     {ok, Btree} = couch_btree:open(nil, Fd, [{compression, none},
                                              {reduce, fun reduce_fun/2}]),
@@ -448,6 +449,7 @@ should_not_be_empty(Btree) ->
     ?_assert(couch_btree:size(Btree) > 0).
 
 fold_reduce(Btree, Opts) ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     GroupFun = fun({K1, _}, {K2, _}) ->
         K1 == K2
     end,
@@ -484,6 +486,7 @@ randomize(List) ->
     D1.
 
 test_btree(Btree, KeyValues) ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     ok = test_key_access(Btree, KeyValues),
     ok = test_lookup_access(Btree, KeyValues),
     ok = test_final_reductions(Btree, KeyValues),
@@ -491,6 +494,7 @@ test_btree(Btree, KeyValues) ->
     true.
 
 test_add_remove(Btree, OutKeyValues, RemainingKeyValues) ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     Btree2 = lists:foldl(
         fun({K, _}, BtAcc) ->
             {ok, BtAcc2} = couch_btree:add_remove(BtAcc, [], [K]),
@@ -506,6 +510,7 @@ test_add_remove(Btree, OutKeyValues, RemainingKeyValues) ->
     true = test_btree(Btree3, OutKeyValues ++ RemainingKeyValues).
 
 test_key_access(Btree, List) ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     FoldFun = fun(Element, {[HAcc|TAcc], Count}) ->
         case Element == HAcc of
             true -> {ok, {TAcc, Count + 1}};
@@ -520,6 +525,7 @@ test_key_access(Btree, List) ->
     ok.
 
 test_lookup_access(Btree, KeyValues) ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     FoldFun = fun({Key, Value}, {Key, Value}) -> {stop, true} end,
     lists:foreach(
         fun({Key, Value}) ->
@@ -529,6 +535,7 @@ test_lookup_access(Btree, KeyValues) ->
         end, KeyValues).
 
 test_final_reductions(Btree, KeyValues) ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     KVLen = length(KeyValues),
     FoldLFun = fun(_X, LeadingReds, Acc) ->
         CountToStart = KVLen div 3 + Acc,
@@ -556,6 +563,7 @@ test_final_reductions(Btree, KeyValues) ->
     ok.
 
 test_traversal_callbacks(Btree, _KeyValues) ->
+    erlang:put(io_priority, {db_update, ?tempdb()}),
     FoldFun = fun
         (visit, _GroupedKey, _Unreduced, Acc) ->
             {ok, Acc andalso false};

--- a/src/couch/test/couch_changes_tests.erl
+++ b/src/couch/test/couch_changes_tests.erl
@@ -27,6 +27,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = create_db(DbName),
     Revs = [R || {ok, R} <- [
         save_doc(Db, {[{<<"_id">>, <<"doc1">>}]}),
@@ -178,6 +179,7 @@ continuous_feed() ->
 should_filter_by_specific_doc_ids({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{
                 filter = "_doc_ids"
             },
@@ -197,6 +199,7 @@ should_filter_by_specific_doc_ids({DbName, _}) ->
 should_filter_by_specific_doc_ids_descending({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{
                 filter = "_doc_ids",
                 dir = rev
@@ -217,6 +220,7 @@ should_filter_by_specific_doc_ids_descending({DbName, _}) ->
 should_filter_by_specific_doc_ids_with_since({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{
                 filter = "_doc_ids",
                 since = 5
@@ -235,6 +239,7 @@ should_filter_by_specific_doc_ids_with_since({DbName, _}) ->
 should_filter_by_specific_doc_ids_no_result({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{
                 filter = "_doc_ids",
                 since = 6
@@ -250,6 +255,7 @@ should_filter_by_specific_doc_ids_no_result({DbName, _}) ->
 should_handle_deleted_docs({DbName, Revs}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             Rev3_2 = element(6, Revs),
             {ok, Db} = couch_db:open_int(DbName, []),
             {ok, _} = save_doc(
@@ -277,6 +283,7 @@ should_handle_deleted_docs({DbName, Revs}) ->
 should_filter_continuous_feed_by_specific_doc_ids({DbName, Revs}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             {ok, Db} = couch_db:open_int(DbName, []),
             ChangesArgs = #changes_args{
                 filter = "_doc_ids",
@@ -347,6 +354,7 @@ should_filter_continuous_feed_by_specific_doc_ids({DbName, Revs}) ->
 
 should_end_changes_when_db_deleted({DbName, _Revs}) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, DbName}),
         {ok, _Db} = couch_db:open_int(DbName, []),
         ChangesArgs = #changes_args{
             filter = "_doc_ids",
@@ -367,6 +375,7 @@ should_end_changes_when_db_deleted({DbName, _Revs}) ->
 should_select_basic({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{filter = "_selector"},
             Selector = {[{<<"_id">>, <<"doc3">>}]},
             Req = {json_req, {[{<<"selector">>, Selector}]}},
@@ -381,6 +390,7 @@ should_select_basic({DbName, _}) ->
 should_select_with_since({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{filter = "_selector", since = 9},
             GteDoc2 = {[{<<"$gte">>, <<"doc1">>}]},
             Selector = {[{<<"_id">>, GteDoc2}]},
@@ -396,6 +406,7 @@ should_select_with_since({DbName, _}) ->
 should_select_when_no_result({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{filter = "_selector"},
             Selector = {[{<<"_id">>, <<"nopers">>}]},
             Req = {json_req, {[{<<"selector">>, Selector}]}},
@@ -407,6 +418,7 @@ should_select_when_no_result({DbName, _}) ->
 should_select_with_deleted_docs({DbName, Revs}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             Rev3_2 = element(6, Revs),
             {ok, Db} = couch_db:open_int(DbName, []),
             {ok, _} = save_doc(
@@ -428,6 +440,7 @@ should_select_with_deleted_docs({DbName, Revs}) ->
 should_select_with_continuous({DbName, Revs}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             {ok, Db} = couch_db:open_int(DbName, []),
             ChArgs = #changes_args{filter = "_selector", feed = "continuous"},
             GteDoc8 = {[{<<"$gte">>, <<"doc8">>}]},
@@ -468,6 +481,7 @@ should_select_with_continuous({DbName, Revs}) ->
 should_stop_selector_when_db_deleted({DbName, _Revs}) ->
     ?_test(
        begin
+           erlang:put(io_priority, {interactive, DbName}),
            {ok, _Db} = couch_db:open_int(DbName, []),
            ChArgs = #changes_args{filter = "_selector", feed = "continuous"},
            Selector = {[{<<"_id">>, <<"doc3">>}]},
@@ -485,6 +499,7 @@ should_stop_selector_when_db_deleted({DbName, _Revs}) ->
 should_select_with_empty_fields({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{filter = "_selector", include_docs=true},
             Selector = {[{<<"_id">>, <<"doc3">>}]},
             Req = {json_req, {[{<<"selector">>, Selector},
@@ -501,6 +516,7 @@ should_select_with_empty_fields({DbName, _}) ->
 should_select_with_fields({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{filter = "_selector", include_docs=true},
             Selector = {[{<<"_id">>, <<"doc3">>}]},
             Req = {json_req, {[{<<"selector">>, Selector},
@@ -518,6 +534,7 @@ should_select_with_fields({DbName, _}) ->
 should_emit_only_design_documents({DbName, Revs}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             ChArgs = #changes_args{
                 filter = "_design"
             },
@@ -617,6 +634,7 @@ should_emit_only_design_documents({DbName, Revs}) ->
 should_filter_by_doc_attribute({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             DDocId = <<"_design/app">>,
             DDoc = couch_doc:from_json_obj({[
                 {<<"_id">>, DDocId},
@@ -642,6 +660,7 @@ should_filter_by_doc_attribute({DbName, _}) ->
 should_filter_by_user_ctx({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             DDocId = <<"_design/app">>,
             DDoc = couch_doc:from_json_obj({[
                 {<<"_id">>, DDocId},
@@ -671,6 +690,7 @@ should_filter_by_user_ctx({DbName, _}) ->
 should_filter_by_view({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             DDocId = <<"_design/app">>,
             DDoc = couch_doc:from_json_obj({[
                 {<<"_id">>, DDocId},
@@ -702,6 +722,7 @@ should_filter_by_view({DbName, _}) ->
 should_filter_by_fast_view({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             DDocId = <<"_design/app">>,
             DDoc = couch_doc:from_json_obj({[
                 {<<"_id">>, DDocId},
@@ -739,6 +760,7 @@ should_filter_by_fast_view({DbName, _}) ->
 should_filter_by_erlang_view({DbName, _}) ->
     ?_test(
         begin
+            erlang:put(io_priority, {interactive, DbName}),
             DDocId = <<"_design/app">>,
             DDoc = couch_doc:from_json_obj({[
                 {<<"_id">>, DDocId},
@@ -904,6 +926,7 @@ wait_row_notifications(N) ->
 spawn_consumer(DbName, ChangesArgs0, Req) ->
     Parent = self(),
     spawn_monitor(fun() ->
+        erlang:put(io_priority, {interactive, DbName}),
         put(heartbeat_count, 0),
         Callback = fun
             ({change, {Change}, _}, _, Acc) ->

--- a/src/couch/test/couch_db_doc_tests.erl
+++ b/src/couch/test/couch_db_doc_tests.erl
@@ -21,6 +21,7 @@ start() ->
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {db_update, DbName}),
     config:set("couchdb", "stem_interactive_updates", "false", false),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     couch_db:close(Db),
@@ -108,6 +109,11 @@ add_revision(Db0, DocId, Rev) ->
 
 
 add_revisions(Db, DocId, Rev, N) ->
+    DbName = couch_db:name(Db),
+    case erlang:get(io_priority) of
+        undefined -> erlang:put(io_priority, {db_update, DbName});
+        _ -> ok
+    end,
     lists:foldl(fun(_, OldRev) ->
         add_revision(Db, DocId, OldRev)
     end, Rev, lists:seq(1, N)).

--- a/src/couch/test/couch_server_tests.erl
+++ b/src/couch/test/couch_server_tests.erl
@@ -251,7 +251,7 @@ wait_for_open_async_result(CouchServer, Opener) ->
         {_, Messages} = erlang:process_info(CouchServer, messages),
         Found = lists:foldl(fun(Msg, Acc) ->
             case Msg of
-                {'$gen_call', {Opener, _}, {open_result, _, _, {ok, _}}} ->
+                {'$gen_call', {Opener, _}, {open_result, _, _, {ok, _}, _}} ->
                     true;
                 _ ->
                     Acc

--- a/src/couch/test/couchdb_design_doc_tests.erl
+++ b/src/couch/test/couchdb_design_doc_tests.erl
@@ -17,6 +17,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     create_design_doc(DbName, <<"_design/foo">>),

--- a/src/couch/test/couchdb_update_conflicts_tests.erl
+++ b/src/couch/test/couchdb_update_conflicts_tests.erl
@@ -28,6 +28,7 @@ start() ->
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {db_update, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX, overwrite]),
     Doc = couch_doc:from_json_obj({[{<<"_id">>, ?DOC_ID},
                                     {<<"value">>, 0}]}),
@@ -104,6 +105,7 @@ should_ignore_invalid_local_doc({DbName, _})->
 
 
 concurrent_doc_update(NumClients, DbName, InitRev) ->
+    erlang:put(io_priority, {db_update, DbName}),
     Clients = lists:map(
         fun(Value) ->
             ClientDoc = couch_doc:from_json_obj({[
@@ -152,6 +154,7 @@ concurrent_doc_update(NumClients, DbName, InitRev) ->
     ?assertEqual(SavedValue, couch_util:get_value(<<"value">>, JsonDoc)).
 
 ensure_in_single_revision_leaf(DbName) ->
+    erlang:put(io_priority, {db_update, DbName}),
     {ok, Db} = couch_db:open_int(DbName, []),
     {ok, Leaves} = couch_db:open_doc_revs(Db, ?DOC_ID, all, []),
     ok = couch_db:close(Db),
@@ -170,6 +173,7 @@ ensure_in_single_revision_leaf(DbName) ->
     ?assertEqual(Doc, Doc2).
 
 bulk_delete_create(DbName, InitRev) ->
+    erlang:put(io_priority, {db_update, DbName}),
     {ok, Db} = couch_db:open_int(DbName, []),
 
     DeletedDoc = couch_doc:from_json_obj({[
@@ -226,6 +230,7 @@ bulk_delete_create(DbName, InitRev) ->
 
 
 bulk_create_local_doc(DbName) ->
+    erlang:put(io_priority, {db_update, DbName}),
     {ok, Db} = couch_db:open_int(DbName, []),
 
     LocalDoc = couch_doc:from_json_obj({[
@@ -246,6 +251,7 @@ bulk_create_local_doc(DbName) ->
 
 
 ignore_invalid_local_doc(DbName) ->
+    erlang:put(io_priority, {db_update, DbName}),
     {ok, Db} = couch_db:open_int(DbName, []),
 
     LocalDoc = couch_doc:from_json_obj({[
@@ -266,6 +272,7 @@ ignore_invalid_local_doc(DbName) ->
 
 spawn_client(DbName, Doc) ->
     spawn(fun() ->
+        erlang:put(io_priority, {db_update, DbName}),
         {ok, Db} = couch_db:open_int(DbName, []),
         receive
             go -> ok

--- a/src/couch/test/couchdb_vhosts_tests.erl
+++ b/src/couch/test/couchdb_vhosts_tests.erl
@@ -21,6 +21,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {db_update, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"doc1">>},

--- a/src/couch/test/couchdb_views_tests.erl
+++ b/src/couch/test/couchdb_views_tests.erl
@@ -22,6 +22,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     FooRev = create_design_doc(DbName, <<"_design/foo">>, <<"bar">>),
@@ -32,6 +33,7 @@ setup() ->
 
 setup_with_docs() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     create_docs(DbName),
@@ -165,6 +167,7 @@ upgrade_test_() ->
 
 should_not_remember_docs_in_index_after_backup_restore(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, DbName}),
         %% COUCHDB-640
 
         ok = backup_db_file(DbName),
@@ -187,6 +190,7 @@ should_not_remember_docs_in_index_after_backup_restore(DbName) ->
 
 should_upgrade_legacy_view_files({DbName, Files}) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, DbName}),
         [_NewDbFilePath, OldViewFilePath, NewViewFilePath] = Files,
         ok = config:set("query_server_config", "commit_freq", "0", false),
 
@@ -234,6 +238,7 @@ should_cleanup_all_index_files({DbName, {FooRev, BooRev}})->
 
 couchdb_1138(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, DbName}),
         {ok, IndexerPid} = couch_index_server:get_index(
             couch_mrview_index, DbName, <<"_design/foo">>),
         ?assert(is_pid(IndexerPid)),
@@ -272,6 +277,7 @@ couchdb_1138(DbName) ->
 
 couchdb_1309(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, DbName}),
         {ok, IndexerPid} = couch_index_server:get_index(
             couch_mrview_index, DbName, <<"_design/foo">>),
         ?assert(is_pid(IndexerPid)),
@@ -324,7 +330,9 @@ couchdb_1283() ->
         ok = config:set("couchdb", "max_dbs_open", "3", false),
         ok = config:set("couchdb", "delayed_commits", "false", false),
 
-        {ok, MDb1} = couch_db:create(?tempdb(), [?ADMIN_CTX]),
+        DbName = ?tempdb(),
+        erlang:put(io_priority, {view_update, DbName}),
+        {ok, MDb1} = couch_db:create(DbName, [?ADMIN_CTX]),
         DDoc = couch_doc:from_json_obj({[
             {<<"_id">>, <<"_design/foo">>},
             {<<"language">>, <<"javascript">>},

--- a/src/couch_index/src/couch_index.erl
+++ b/src/couch_index/src/couch_index.erl
@@ -81,6 +81,7 @@ get_compactor_pid(Pid) ->
 
 init({Mod, IdxState}) ->
     DbName = Mod:get(db_name, IdxState),
+    erlang:put(io_priority, {system, DbName}),
     erlang:send_after(?CHECK_INTERVAL, self(), maybe_close),
     Resp = couch_util:with_db(DbName, fun(Db) ->
         case Mod:open(Db, IdxState) of

--- a/src/couch_index/src/couch_index_compactor.erl
+++ b/src/couch_index/src/couch_index_compactor.erl
@@ -117,6 +117,8 @@ compact(Parent, Mod, IdxState) ->
 
 compact(Idx, Mod, IdxState, Opts) ->
     DbName = Mod:get(db_name, IdxState),
+    IndexName = Mod:get(idx_name, IdxState),
+    erlang:put(io_priority, {view_compact, DbName, IndexName}),
     Args = [DbName, Mod:get(idx_name, IdxState)],
     couch_log:info("Compaction started for db: ~s idx: ~s", Args),
     {ok, NewIdxState} = couch_util:with_db(DbName, fun(Db) ->

--- a/src/couch_index/src/couch_index_updater.erl
+++ b/src/couch_index/src/couch_index_updater.erl
@@ -128,6 +128,8 @@ code_change(_OldVsn, State, _Extra) ->
 
 update(Idx, Mod, IdxState) ->
     DbName = Mod:get(db_name, IdxState),
+    IndexName = Mod:get(idx_name, IdxState),
+    erlang:put(io_priority, {view_update, DbName, IndexName}),
     CurrSeq = Mod:get(update_seq, IdxState),
     UpdateOpts = Mod:get(update_options, IdxState),
     CommittedOnly = lists:member(committed_only, UpdateOpts),

--- a/src/couch_mrview/src/couch_mrview_updater.erl
+++ b/src/couch_mrview/src/couch_mrview_updater.erl
@@ -225,6 +225,7 @@ map_docs(Parent, #mrst{db_name = DbName, idx_name = IdxName} = State0) ->
 
 
 write_results(Parent, #mrst{db_name = DbName, idx_name = IdxName} = State) ->
+    erlang:put(io_priority, {view_update, DbName, IdxName}),
     case accumulate_writes(State, State#mrst.write_queue, nil) of
         stop ->
             Parent ! {new_state, State};

--- a/src/couch_mrview/test/couch_mrview_all_docs_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_all_docs_tests.erl
@@ -20,7 +20,9 @@
 
 
 setup() ->
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), map),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, map),
     Db.
 
 teardown(Db) ->

--- a/src/couch_mrview/test/couch_mrview_changes_since_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_changes_since_tests.erl
@@ -32,7 +32,9 @@ changes_since_basic_test_() ->
                 foreach,
                 fun() ->
                     Type = {changes, seq_indexed},
-                    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), Type),
+                    DbName = ?tempdb(),
+                    erlang:put(io_priority, {view_update, DbName}),
+                    {ok, Db} = couch_mrview_test_util:init_db(DbName, Type),
                     Db
                 end,
                 fun teardown/1,
@@ -57,7 +59,9 @@ changes_since_range_test_() ->
                 foreach,
                 fun() ->
                     Type = {changes, keyseq_indexed},
-                    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), Type),
+                    DbName = ?tempdb(),
+                    erlang:put(io_priority, {view_update, DbName}),
+                    {ok, Db} = couch_mrview_test_util:init_db(DbName, Type),
                     Db
                 end,
                 fun teardown/1,
@@ -79,7 +83,9 @@ changes_since_range_count_test_() ->
                 foreach,
                 fun() ->
                     Type = {changes, seq_indexed_keyseq_indexed},
-                    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), Type),
+                    DbName = ?tempdb(),
+                    erlang:put(io_priority, {view_update, DbName}),
+                    {ok, Db} = couch_mrview_test_util:init_db(DbName, Type),
                     Db
                 end,
                 fun teardown/1,

--- a/src/couch_mrview/test/couch_mrview_collation_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_collation_tests.erl
@@ -57,7 +57,9 @@
 
 
 setup() ->
-    {ok, Db1} = couch_mrview_test_util:new_db(?tempdb(), map),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db1} = couch_mrview_test_util:new_db(DbName, map),
     Docs = [couch_mrview_test_util:ddoc(red) | make_docs()],
     {ok, Db2} = couch_mrview_test_util:save_docs(Db1, Docs),
     Db2.
@@ -158,6 +160,7 @@ should_collate_without_inclusive_end_rev(Db) ->
 
 should_collate_with_endkey_docid(Db) ->
     ?_test(begin
+        erlang:put(io_priority, {interactive, couch_db:name(Db)}),
         {ok, Rows0} = run_query(Db, [
             {end_key, <<"b">>}, {end_key_docid, <<"10">>},
             {inclusive_end, false}

--- a/src/couch_mrview/test/couch_mrview_ddoc_updated_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_ddoc_updated_tests.erl
@@ -20,6 +20,7 @@
 
 setup() ->
     Name = ?tempdb(),
+    erlang:put(io_priority, {view_update, Name}),
     couch_server:delete(Name, [?ADMIN_CTX]),
     {ok, Db} = couch_db:create(Name, [?ADMIN_CTX]),
     DDoc = couch_doc:from_json_obj({[
@@ -83,6 +84,7 @@ ddoc_update_test_() ->
 
 check_indexing_stops_on_ddoc_change(Db) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, couch_db:name(Db)}),
         DDocID = <<"_design/bar">>,
 
         IndexesBefore = get_indexes_by_ddoc(DDocID, 1),
@@ -100,6 +102,7 @@ check_indexing_stops_on_ddoc_change(Db) ->
         % spawn a process for query
         Self = self(),
         QPid = spawn(fun() ->
+            erlang:put(io_priority, {view_update, couch_db:name(Db)}),
             {ok, Result} = couch_mrview:query_view(
                 Db, <<"_design/bar">>, <<"baz">>, []),
             Self ! {self(), Result}

--- a/src/couch_mrview/test/couch_mrview_ddoc_validation_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_ddoc_validation_tests.erl
@@ -18,7 +18,9 @@
 -define(LIB, {[{<<"mylib">>, {[{<<"lib1">>, <<"x=42">>}]}}]}).
 
 setup() ->
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), map),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, map),
     Db.
 
 teardown(Db) ->
@@ -87,9 +89,14 @@ should_reject_invalid_js_map(Db) ->
             ]}}
         ]}}
     ]}),
-    ?_assertThrow(
-        {bad_request, compilation_error, _},
-        couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, compilation_error, _}, Res).
 
 should_reject_invalid_js_reduce(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -101,9 +108,14 @@ should_reject_invalid_js_reduce(Db) ->
             ]}}
         ]}}
     ]}),
-    ?_assertThrow(
-        {bad_request, compilation_error, _},
-        couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, compilation_error, _}, Res).
 
 should_reject_invalid_builtin_reduce(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -115,160 +127,240 @@ should_reject_invalid_builtin_reduce(Db) ->
             ]}}
         ]}}
     ]}),
-    ?_assertThrow(
-        {bad_request, invalid_design_doc, _},
-        couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_reject_non_object_options(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_object_options">>},
         {<<"options">>, <<"invalid">>}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_reject_non_object_filters(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_object_filters">>},
         {<<"filters">>, <<"invalid">>}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_obj_in_filters(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_obj_in_filters">>},
         {<<"filters">>, ?LIB}
     ]}),
-    ?_assertMatch({ok, _}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_non_object_lists(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_object_lists">>},
         {<<"lists">>, <<"invalid">>}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_reject_non_object_shows(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_object_shows">>},
         {<<"shows">>, <<"invalid">>}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_obj_in_shows(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_obj_in_shows">>},
         {<<"shows">>, ?LIB}
     ]}),
-    ?_assertMatch({ok, _}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_non_object_updates(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_object_updates">>},
         {<<"updates">>, <<"invalid">>}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_obj_in_updates(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_obj_in_updates">>},
         {<<"updates">>, ?LIB}
     ]}),
-    ?_assertMatch({ok, _}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_non_object_views(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_object_views">>},
         {<<"views">>, <<"invalid">>}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_reject_non_string_language(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_string_language">>},
         {<<"language">>, 1}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_reject_non_string_validate_doc_update(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_string_vdu">>},
         {<<"validate_doc_update">>, 1}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_string_rewrites(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_array_rewrites">>},
         {<<"rewrites">>, <<"function(req){}">>}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_bad_rewrites(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_array_rewrites">>},
         {<<"rewrites">>, 42}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_option(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_options">>},
         {<<"options">>, {[ {<<"option1">>, <<"function(doc,req){}">>} ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_accept_any_option(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_any_option">>},
         {<<"options">>, {[ {<<"option1">>, true} ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_accept_filter(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_filters">>},
         {<<"filters">>, {[ {<<"filter1">>, <<"function(doc,req){}">>} ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_non_string_or_obj_filter_function(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_string_or_obj_filter_function">>},
         {<<"filters">>, {[ {<<"filter1">>, 1} ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_list(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_lists">>},
         {<<"lists">>, {[ {<<"list1">>, <<"function(doc,req){}">>} ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_non_string_or_obj_list_function(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_string_or_obj_list_function">>},
         {<<"lists">>, {[ {<<"list1">>, 1} ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_obj_in_lists(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_obj_in_lists">>},
         {<<"lists">>, ?LIB}
     ]}),
-    ?_assertMatch({ok, _}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 
 should_accept_show(Db) ->
@@ -276,30 +368,44 @@ should_accept_show(Db) ->
         {<<"_id">>, <<"_design/should_accept_shows">>},
         {<<"shows">>, {[ {<<"show1">>, <<"function(doc,req){}">>} ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_non_string_or_obj_show_function(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_string_or_obj_show_function">>},
         {<<"shows">>, {[ {<<"show1">>, 1} ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_update(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_accept_updates">>},
         {<<"updates">>, {[ {<<"update1">>, <<"function(doc,req){}">>} ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_non_string_or_obj_update_function(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_string_or_obj_update_function">>},
         {<<"updates">>, {[ {<<"update1">>, 1} ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_view(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -308,7 +414,8 @@ should_accept_view(Db) ->
                          {<<"view1">>, {[{<<"map">>, <<"function(d){}">>}]}}
                        ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_accept_view_with_reduce(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -320,7 +427,8 @@ should_accept_view_with_reduce(Db) ->
                                         ]}}
                        ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_accept_view_with_lib(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -334,15 +442,22 @@ should_accept_view_with_lib(Db) ->
                                       ]}}
                        ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 should_reject_view_that_is_not_an_object(Db) ->
     Doc = couch_doc:from_json_obj({[
         {<<"_id">>, <<"_design/should_reject_non_object_view">>},
         {<<"views">>, {[{<<"view1">>, <<"thisisbad">>}]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_reject_view_without_map_function(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -351,8 +466,14 @@ should_reject_view_without_map_function(Db) ->
                          {<<"view1">>, {[]}}
                        ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 
 should_reject_view_with_non_string_map_function(Db) ->
@@ -364,8 +485,14 @@ should_reject_view_with_non_string_map_function(Db) ->
                                         ]}}
                        ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_reject_view_with_non_string_reduce_function(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -377,8 +504,14 @@ should_reject_view_with_non_string_reduce_function(Db) ->
                                         ]}}
                        ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).
 
 should_accept_any_in_lib(Db) ->
     Doc = couch_doc:from_json_obj({[
@@ -390,7 +523,8 @@ should_accept_any_in_lib(Db) ->
                          {<<"lib">>, {[{<<"lib1">>, {[]}}]}}
                        ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 
 should_accept_map_object_for_queries(Db) ->
@@ -405,7 +539,8 @@ should_accept_map_object_for_queries(Db) ->
            ]}}
         ]}}
     ]}),
-    ?_assertMatch({ok,_}, couch_db:update_doc(Db, Doc, [])).
+    Res = couch_db:update_doc(Db, Doc, []),
+    ?_assertMatch({ok, _}, Res).
 
 
 should_reject_map_non_objects_for_queries(Db) ->
@@ -418,5 +553,11 @@ should_reject_map_non_objects_for_queries(Db) ->
             ]}}
         ]}}
     ]}),
-    ?_assertThrow({bad_request, invalid_design_doc, _},
-                  couch_db:update_doc(Db, Doc, [])).
+    Res =
+        try
+            couch_db:update_doc(Db, Doc, []),
+            ok
+        catch _Error:Reason ->
+            Reason
+    end,
+    ?_assertMatch({bad_request, invalid_design_doc, _}, Res).

--- a/src/couch_mrview/test/couch_mrview_design_docs_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_design_docs_tests.erl
@@ -20,7 +20,9 @@
 
 
 setup() ->
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), design),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, design),
     Db.
 
 teardown(Db) ->

--- a/src/couch_mrview/test/couch_mrview_index_info_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_index_info_tests.erl
@@ -19,7 +19,9 @@
 
 
 setup() ->
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), map),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, map),
     couch_mrview:query_view(Db, <<"_design/bar">>, <<"baz">>),
     {ok, Info} = couch_mrview:get_info(Db, <<"_design/bar">>),
     {Db, Info}.

--- a/src/couch_mrview/test/couch_mrview_local_docs_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_local_docs_tests.erl
@@ -20,7 +20,9 @@
 
 
 setup() ->
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), local),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, local),
     Db.
 
 teardown(Db) ->

--- a/src/couch_mrview/test/couch_mrview_map_views_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_map_views_tests.erl
@@ -19,7 +19,9 @@
 
 
 setup() ->
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), map),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, map),
     Db.
 
 teardown(Db) ->

--- a/src/couch_mrview/test/couch_mrview_purge_docs_fabric_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_purge_docs_fabric_tests.erl
@@ -22,6 +22,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {db_update, DbName}),
     ok = fabric:create_db(DbName, [?ADMIN_CTX, {q, 1}]),
     meck:new(couch_mrview_index, [passthrough]),
     meck:expect(couch_mrview_index, ensure_local_purge_docs, fun(A, B) ->
@@ -57,6 +58,7 @@ view_purge_fabric_test_() ->
 
 test_purge_verify_index(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, DbName}),
         Docs1 = couch_mrview_test_util:make_docs(normal, 5),
         {ok, _} = fabric:update_docs(DbName, Docs1, [?ADMIN_CTX]),
         {ok, _} = fabric:update_doc(
@@ -104,6 +106,7 @@ test_purge_verify_index(DbName) ->
 
 test_purge_hook_before_compaction(DbName) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, DbName}),
         Docs1 = couch_mrview_test_util:make_docs(normal, 5),
         {ok, _} = fabric:update_docs(DbName, Docs1, [?ADMIN_CTX]),
         {ok, _} = fabric:update_doc(

--- a/src/couch_mrview/test/couch_mrview_purge_docs_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_purge_docs_tests.erl
@@ -21,7 +21,9 @@
 
 setup() ->
     meck:new(couch_index_updater, [passthrough]),
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), map, 5),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, map, 5),
     Db.
 
 teardown(Db) ->
@@ -58,6 +60,7 @@ view_purge_test_() ->
 
 test_purge_single(Db) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, couch_db:name(Db)}),
         Result = run_query(Db, []),
         Expect = {ok, [
             {meta, [{total, 5}, {offset, 0}]},
@@ -91,6 +94,7 @@ test_purge_single(Db) ->
 
 test_purge_partial(Db) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, couch_db:name(Db)}),
         Result = run_query(Db, []),
         Expect = {ok, [
             {meta, [{total, 5}, {offset, 0}]},
@@ -130,6 +134,7 @@ test_purge_partial(Db) ->
 
 test_purge_complete(Db) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, couch_db:name(Db)}),
         Result = run_query(Db, []),
         Expect = {ok, [
             {meta, [{total, 5}, {offset, 0}]},
@@ -165,6 +170,7 @@ test_purge_complete(Db) ->
 
 test_purge_nochange(Db) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, couch_db:name(Db)}),
         Result = run_query(Db, []),
         Expect = {ok, [
             {meta, [{total, 5}, {offset, 0}]},
@@ -200,6 +206,7 @@ test_purge_nochange(Db) ->
 
 test_purge_index_reset(Db) ->
     ?_test(begin
+        erlang:put(io_priority, {view_update, couch_db:name(Db)}),
         ok = couch_db:set_purge_infos_limit(Db, 2),
         {ok, Db1} = couch_db:reopen(Db),
 
@@ -259,6 +266,7 @@ test_purge_index_reset(Db) ->
 test_purge_compact_size_check(Db) ->
     ?_test(begin
         DbName = couch_db:name(Db),
+        erlang:put(io_priority, {view_update, DbName}),
         Docs = couch_mrview_test_util:make_docs(normal, 6, 200),
         {ok, Db1} = couch_mrview_test_util:save_docs(Db, Docs),
         _Result = run_query(Db1, []),
@@ -298,6 +306,7 @@ test_purge_compact_size_check(Db) ->
 test_purge_compact_for_stale_purge_cp_without_client(Db) ->
     ?_test(begin
         DbName = couch_db:name(Db),
+        erlang:put(io_priority, {view_update, DbName}),
         % add more documents to database for purge
         Docs = couch_mrview_test_util:make_docs(normal, 6, 200),
         {ok, Db1} = couch_mrview_test_util:save_docs(Db, Docs),
@@ -351,6 +360,7 @@ test_purge_compact_for_stale_purge_cp_without_client(Db) ->
 test_purge_compact_for_stale_purge_cp_with_client(Db) ->
     ?_test(begin
         DbName = couch_db:name(Db),
+        erlang:put(io_priority, {view_update, DbName}),
         % add more documents to database for purge
         Docs = couch_mrview_test_util:make_docs(normal, 6, 200),
         {ok, Db1} = couch_mrview_test_util:save_docs(Db, Docs),

--- a/src/couch_mrview/test/couch_mrview_red_views_tests.erl
+++ b/src/couch_mrview/test/couch_mrview_red_views_tests.erl
@@ -19,7 +19,9 @@
 
 
 setup() ->
-    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), red),
+    DbName = ?tempdb(),
+    erlang:put(io_priority, {view_update, DbName}),
+    {ok, Db} = couch_mrview_test_util:init_db(DbName, red),
     Db.
 
 teardown(Db) ->

--- a/src/couch_peruser/src/couch_peruser.erl
+++ b/src/couch_peruser/src/couch_peruser.erl
@@ -73,6 +73,7 @@ init_state() ->
         couch_log:debug("peruser: enabled on node ~p", [node()]),
         DbName = ?l2b(config:get(
                          "couch_httpd_auth", "authentication_db", "_users")),
+        erlang:put(io_priority, {system, DbName}),
         DeleteDbs = config:get_boolean("couch_peruser", "delete_dbs", false),
         Q = config:get_integer("couch_peruser", "q", 1),
         Prefix = config:get("couch_peruser", "database_prefix", ?DEFAULT_USERDB_PREFIX),
@@ -137,6 +138,7 @@ start_listening(#state{db_name=DbName, delete_dbs=DeleteDbs,
 
 -spec init_changes_handler(ChangesState :: #changes_state{}) -> ok.
 init_changes_handler(#changes_state{db_name=DbName} = ChangesState) ->
+    erlang:put(io_priority, {system, DbName}),
     % couch_log:debug("peruser: init_changes_handler() on DbName ~p", [DbName]),
     try
         {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX, sys_db]),

--- a/src/couch_peruser/test/couch_peruser_test.erl
+++ b/src/couch_peruser/test/couch_peruser_test.erl
@@ -34,6 +34,7 @@ teardown_all(TestCtx) ->
 
 setup() ->
     TestAuthDb = ?tempdb(),
+    erlang:put(io_priority, {interactive, TestAuthDb}),
     do_request(put, get_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     do_request(put, get_cluster_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     set_config("couch_httpd_auth", "authentication_db", ?b2l(TestAuthDb)),

--- a/src/couch_pse_tests/src/cpse_test_attachments.erl
+++ b/src/couch_pse_tests/src/cpse_test_attachments.erl
@@ -21,14 +21,16 @@
 
 setup_each() ->
     {ok, Db} = cpse_util:create_db(),
-    Db.
+    {Db, erlang:get(io_priority)}.
 
 
-teardown_each(Db) ->
+teardown_each({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ok = couch_server:delete(couch_db:name(Db), []).
 
 
-cpse_write_attachment(Db1) ->
+cpse_write_attachment({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     AttBin = crypto:strong_rand_bytes(32768),
 
     try
@@ -80,7 +82,8 @@ cpse_write_attachment(Db1) ->
 % attachments streams when restarting (for instance if
 % we ever have something that stores attachemnts in
 % an external object store)
-cpse_inactive_stream(Db1) ->
+cpse_inactive_stream({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     AttBin = crypto:strong_rand_bytes(32768),
 
     try

--- a/src/couch_pse_tests/src/cpse_test_compaction.erl
+++ b/src/couch_pse_tests/src/cpse_test_compaction.erl
@@ -21,14 +21,16 @@
 
 setup_each() ->
     {ok, Db} = cpse_util:create_db(),
-    Db.
+    {Db, erlang:get(io_priority)}.
 
 
-teardown_each(Db) ->
+teardown_each({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ok = couch_server:delete(couch_db:name(Db), []).
 
 
-cpse_compact_empty(Db1) ->
+cpse_compact_empty({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Term1 = cpse_util:db_as_term(Db1),
 
     cpse_util:compact(Db1),
@@ -40,7 +42,8 @@ cpse_compact_empty(Db1) ->
     ?assertEqual(nodiff, Diff).
 
 
-cpse_compact_doc(Db1) ->
+cpse_compact_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [{create, {<<"foo">>, {[]}}}],
     {ok, Db2} = cpse_util:apply_actions(Db1, Actions),
     Term1 = cpse_util:db_as_term(Db2),
@@ -54,7 +57,8 @@ cpse_compact_doc(Db1) ->
     ?assertEqual(nodiff, Diff).
 
 
-cpse_compact_local_doc(Db1) ->
+cpse_compact_local_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [{create, {<<"_local/foo">>, {[]}}}],
     {ok, Db2} = cpse_util:apply_actions(Db1, Actions),
     Term1 = cpse_util:db_as_term(Db2),
@@ -68,7 +72,8 @@ cpse_compact_local_doc(Db1) ->
     ?assertEqual(nodiff, Diff).
 
 
-cpse_compact_with_everything(Db1) ->
+cpse_compact_with_everything({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     % Add a whole bunch of docs
     DocActions = lists:map(fun(Seq) ->
         {create, {docid(Seq), {[{<<"int">>, Seq}]}}}
@@ -152,7 +157,8 @@ cpse_compact_with_everything(Db1) ->
     ?assertEqual(nodiff, Diff).
 
 
-cpse_recompact_updates(Db1) ->
+cpse_recompact_updates({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions1 = lists:map(fun(Seq) ->
         {create, {docid(Seq), {[{<<"int">>, Seq}]}}}
     end, lists:seq(1, 1000)),
@@ -179,7 +185,8 @@ cpse_recompact_updates(Db1) ->
     ?assertEqual(nodiff, Diff).
 
 
-cpse_purge_during_compact(Db1) ->
+cpse_purge_during_compact({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions1 = lists:map(fun(Seq) ->
         {create, {docid(Seq), {[{<<"int">>, Seq}]}}}
     end, lists:seq(1, 1000)),
@@ -218,7 +225,8 @@ cpse_purge_during_compact(Db1) ->
     ?assertEqual(nodiff, Diff).
 
 
-cpse_multiple_purge_during_compact(Db1) ->
+cpse_multiple_purge_during_compact({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions1 = lists:map(fun(Seq) ->
         {create, {docid(Seq), {[{<<"int">>, Seq}]}}}
     end, lists:seq(1, 1000)),
@@ -263,7 +271,8 @@ cpse_multiple_purge_during_compact(Db1) ->
     ?assertEqual(nodiff, Diff).
 
 
-cpse_compact_purged_docs_limit(Db1) ->
+cpse_compact_purged_docs_limit({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     NumDocs = 1200,
     {RActions, RIds} = lists:foldl(fun(Id, {CActions, CIds}) ->
         Id1 = docid(Id),

--- a/src/couch_pse_tests/src/cpse_test_fold_changes.erl
+++ b/src/couch_pse_tests/src/cpse_test_fold_changes.erl
@@ -24,20 +24,23 @@
 
 setup_each() ->
     {ok, Db} = cpse_util:create_db(),
-    Db.
+    {Db, erlang:get(io_priority)}.
 
 
-teardown_each(Db) ->
+teardown_each({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ok = couch_server:delete(couch_db:name(Db), []).
 
 
-cpse_empty_changes(Db) ->
+cpse_empty_changes({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:count_changes_since(Db, 0)),
     ?assertEqual({ok, []},
             couch_db_engine:fold_changes(Db, 0, fun fold_fun/2, [], [])).
 
 
-cpse_single_change(Db1) ->
+cpse_single_change({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [{create, {<<"a">>, {[]}}}],
     {ok, Db2} = cpse_util:apply_actions(Db1, Actions),
 
@@ -46,7 +49,8 @@ cpse_single_change(Db1) ->
             couch_db_engine:fold_changes(Db2, 0, fun fold_fun/2, [], [])).
 
 
-cpse_two_changes(Db1) ->
+cpse_two_changes({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [
         {create, {<<"a">>, {[]}}},
         {create, {<<"b">>, {[]}}}
@@ -59,7 +63,8 @@ cpse_two_changes(Db1) ->
     ?assertEqual([{<<"a">>, 1}, {<<"b">>, 2}], lists:reverse(Changes)).
 
 
-cpse_two_changes_batch(Db1) ->
+cpse_two_changes_batch({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [
         {batch, [
             {create, {<<"a">>, {[]}}},
@@ -74,7 +79,8 @@ cpse_two_changes_batch(Db1) ->
     ?assertEqual([{<<"a">>, 1}, {<<"b">>, 2}], lists:reverse(Changes)).
 
 
-cpse_two_changes_batch_sorted(Db1) ->
+cpse_two_changes_batch_sorted({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [
         {batch, [
             {create, {<<"b">>, {[]}}},
@@ -89,7 +95,8 @@ cpse_two_changes_batch_sorted(Db1) ->
     ?assertEqual([{<<"a">>, 1}, {<<"b">>, 2}], lists:reverse(Changes)).
 
 
-cpse_update_one(Db1) ->
+cpse_update_one({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [
         {create, {<<"a">>, {[]}}},
         {update, {<<"a">>, {[]}}}
@@ -101,7 +108,8 @@ cpse_update_one(Db1) ->
             couch_db_engine:fold_changes(Db2, 0, fun fold_fun/2, [], [])).
 
 
-cpse_update_first_of_two(Db1) ->
+cpse_update_first_of_two({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [
         {create, {<<"a">>, {[]}}},
         {create, {<<"b">>, {[]}}},
@@ -115,7 +123,8 @@ cpse_update_first_of_two(Db1) ->
     ?assertEqual([{<<"b">>, 2}, {<<"a">>, 3}], lists:reverse(Changes)).
 
 
-cpse_update_second_of_two(Db1) ->
+cpse_update_second_of_two({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = [
         {create, {<<"a">>, {[]}}},
         {create, {<<"b">>, {[]}}},
@@ -129,7 +138,8 @@ cpse_update_second_of_two(Db1) ->
     ?assertEqual([{<<"a">>, 1}, {<<"b">>, 3}], lists:reverse(Changes)).
 
 
-cpse_check_mutation_ordering(Db1) ->
+cpse_check_mutation_ordering({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions = shuffle(lists:map(fun(Seq) ->
         {create, {docid(Seq), {[]}}}
     end, lists:seq(1, ?NUM_DOCS))),

--- a/src/couch_pse_tests/src/cpse_test_fold_purge_infos.erl
+++ b/src/couch_pse_tests/src/cpse_test_fold_purge_infos.erl
@@ -24,19 +24,22 @@
 
 setup_each() ->
     {ok, Db} = cpse_util:create_db(),
-    Db.
+    {Db, erlang:get(io_priority)}.
 
 
-teardown_each(Db) ->
+teardown_each({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ok = couch_server:delete(couch_db:name(Db), []).
 
 
-cpse_empty_purged_docs(Db) ->
+cpse_empty_purged_docs({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual({ok, []}, couch_db_engine:fold_purge_infos(
             Db, 0, fun fold_fun/2, [], [])).
 
 
-cpse_all_purged_docs(Db1) ->
+cpse_all_purged_docs({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     {RActions, RIds} = lists:foldl(fun(Id, {CActions, CIds}) ->
         Id1 = docid(Id),
         Action = {create, {Id1, {[{<<"int">>, Id}]}}},
@@ -62,7 +65,8 @@ cpse_all_purged_docs(Db1) ->
     ?assertEqual(IdsRevs, lists:reverse(PurgedIdRevs)).
 
 
-cpse_start_seq(Db1) ->
+cpse_start_seq({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions1 = [
         {create, {docid(1), {[{<<"int">>, 1}]}}},
         {create, {docid(2), {[{<<"int">>, 2}]}}},
@@ -90,7 +94,8 @@ cpse_start_seq(Db1) ->
     ?assertEqual(StartSeqIdRevs, lists:reverse(PurgedIdRevs)).
 
 
-cpse_id_rev_repeated(Db1) ->
+cpse_id_rev_repeated({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Actions1 = [
         {create, {<<"foo">>, {[{<<"vsn">>, 1}]}}},
         {conflict, {<<"foo">>, {[{<<"vsn">>, 2}]}}}

--- a/src/couch_pse_tests/src/cpse_test_get_set_props.erl
+++ b/src/couch_pse_tests/src/cpse_test_get_set_props.erl
@@ -28,6 +28,7 @@ teardown_each(DbName) ->
 
 cpse_default_props(DbName) ->
     {ok, {_App, Engine, _Extension}} = application:get_env(couch, test_engine),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = cpse_util:create_db(DbName),
     Node = node(),
 
@@ -59,6 +60,7 @@ cpse_default_props(DbName) ->
 
 cpse_admin_only_security(DbName) ->
     Config = [{"couchdb", "default_security", "admin_only"}],
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db1} = cpse_util:with_config(Config, fun() ->
         cpse_util:create_db(DbName)
     end),
@@ -81,6 +83,7 @@ cpse_set_revs_limit(DbName) ->
 
 
 check_prop_set(DbName, GetFun, SetFun, Default, Value) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db0} = cpse_util:create_db(DbName),
 
     ?assertEqual(Default, couch_db:GetFun(Db0)),

--- a/src/couch_pse_tests/src/cpse_test_purge_bad_checkpoints.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_bad_checkpoints.erl
@@ -40,14 +40,16 @@ setup_each() ->
     end, lists:seq(0, 9)),
     {ok, _} = cpse_util:purge(couch_db:name(Db1), PInfos),
     {ok, Db2} = couch_db:reopen(Db1),
-    Db2.
+    {Db2, erlang:get(io_priority)}.
 
 
-teardown_each(Db) ->
+teardown_each({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ok = couch_server:delete(couch_db:name(Db), []).
 
 
-cpse_bad_purge_seq(Db1) ->
+cpse_bad_purge_seq({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Db2 = save_local_doc(Db1, <<"foo">>),
     ?assertEqual(0, couch_db:get_minimum_purge_seq(Db2)),
 
@@ -56,7 +58,8 @@ cpse_bad_purge_seq(Db1) ->
     ?assertEqual(1, couch_db:get_minimum_purge_seq(Db3)).
 
 
-cpse_verify_non_boolean(Db1) ->
+cpse_verify_non_boolean({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     Db2 = save_local_doc(Db1, 2),
     ?assertEqual(0, couch_db:get_minimum_purge_seq(Db2)),
 

--- a/src/couch_pse_tests/src/cpse_test_purge_docs.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_docs.erl
@@ -32,6 +32,7 @@ teardown_each(DbName) ->
 
 
 cpse_purge_simple(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, 1.1}]}),
 
     cpse_util:assert_db_props(?MODULE, ?LINE, DbName, [
@@ -59,6 +60,7 @@ cpse_purge_simple(DbName) ->
 
 
 cpse_purge_simple_info_check(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, 1.1}]}),
     PurgeInfos = [
         {cpse_util:uuid(), <<"foo1">>, [Rev]}
@@ -74,6 +76,7 @@ cpse_purge_simple_info_check(DbName) ->
 
 
 cpse_purge_empty_db(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     PurgeInfos = [
         {cpse_util:uuid(), <<"foo">>, [{0, <<0>>}]}
     ],
@@ -92,6 +95,7 @@ cpse_purge_empty_db(DbName) ->
 
 
 cpse_purge_single_docid(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, [Rev1, _Rev2]} = cpse_util:save_docs(DbName, [
         {[{'_id', foo1}, {vsn, 1}]},
         {[{'_id', foo2}, {vsn, 2}]}
@@ -123,6 +127,7 @@ cpse_purge_single_docid(DbName) ->
 
 
 cpse_purge_multiple_docids(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, [Rev1, Rev2]} = cpse_util:save_docs(DbName, [
         {[{'_id', foo1}, {vsn, 1.1}]},
         {[{'_id', foo2}, {vsn, 1.2}]}
@@ -158,6 +163,7 @@ cpse_purge_multiple_docids(DbName) ->
 
 
 cpse_purge_no_docids(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, [_Rev1, _Rev2]} = cpse_util:save_docs(DbName, [
         {[{'_id', foo1}, {vsn, 1}]},
         {[{'_id', foo2}, {vsn, 2}]}
@@ -185,6 +191,7 @@ cpse_purge_no_docids(DbName) ->
 
 
 cpse_purge_rev_path(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo}, {vsn, 1}]}),
     Update = {[
         {<<"_id">>, <<"foo">>},
@@ -221,6 +228,7 @@ cpse_purge_rev_path(DbName) ->
 
 
 cpse_purge_deep_revision_path(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, InitRev} = cpse_util:save_doc(DbName, {[{'_id', bar}, {vsn, 0}]}),
     LastRev = lists:foldl(fun(Count, PrevRev) ->
         Update = {[
@@ -250,6 +258,7 @@ cpse_purge_deep_revision_path(DbName) ->
 
 
 cpse_purge_partial_revs(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo}, {vsn, <<"1.1">>}]}),
     Update = {[
         {'_id', foo},
@@ -276,6 +285,7 @@ cpse_purge_partial_revs(DbName) ->
 
 
 cpse_purge_missing_docid(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, [Rev1, _Rev2]} = cpse_util:save_docs(DbName, [
         {[{'_id', foo1}, {vsn, 1}]},
         {[{'_id', foo2}, {vsn, 2}]}
@@ -307,6 +317,7 @@ cpse_purge_missing_docid(DbName) ->
 
 
 cpse_purge_duplicate_docids(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, [Rev1, _Rev2]} = cpse_util:save_docs(DbName, [
         {[{'_id', foo1}, {vsn, 1}]},
         {[{'_id', foo2}, {vsn, 2}]}
@@ -340,6 +351,7 @@ cpse_purge_duplicate_docids(DbName) ->
 
 
 cpse_purge_internal_revision(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo}, {vsn, 1}]}),
     Update = {[
         {'_id', foo},
@@ -366,6 +378,7 @@ cpse_purge_internal_revision(DbName) ->
 
 
 cpse_purge_missing_revision(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, [_Rev1, Rev2]} = cpse_util:save_docs(DbName, [
         {[{'_id', foo1}, {vsn, 1}]},
         {[{'_id', foo2}, {vsn, 2}]}
@@ -389,6 +402,7 @@ cpse_purge_missing_revision(DbName) ->
 
 
 cpse_purge_repeated_revisions(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo}, {vsn, <<"1.1">>}]}),
     Update = {[
         {'_id', foo},
@@ -426,6 +440,7 @@ cpse_purge_repeated_revisions(DbName) ->
 
 
 cpse_purge_repeated_uuid(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, 1.1}]}),
 
     cpse_util:assert_db_props(?MODULE, ?LINE, DbName, [

--- a/src/couch_pse_tests/src/cpse_test_purge_replication.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_replication.erl
@@ -36,6 +36,7 @@ teardown_each({SrcDb, TgtDb}) ->
 
 
 cpse_purge_http_replication({Source, Target}) ->
+    erlang:put(io_priority, {interactive, Source}),
     {ok, Rev1} = cpse_util:save_doc(Source, {[{'_id', foo}, {vsn, 1}]}),
 
     cpse_util:assert_db_props(?MODULE, ?LINE, Source, [
@@ -120,6 +121,7 @@ cpse_purge_http_replication({Source, Target}) ->
 
 
 cpse_purge_internal_repl_disabled({Source, Target}) ->
+    erlang:put(io_priority, {interactive, Source}),
     cpse_util:with_config([{"mem3", "replicate_purges", "false"}], fun() ->
         repl(Source, Target),
 
@@ -153,6 +155,7 @@ cpse_purge_internal_repl_disabled({Source, Target}) ->
 
 
 cpse_purge_repl_simple_pull({Source, Target}) ->
+    erlang:put(io_priority, {interactive, Source}),
     repl(Source, Target),
 
     {ok, Rev} = cpse_util:save_doc(Source, {[{'_id', foo}, {vsn, 1}]}),
@@ -167,6 +170,7 @@ cpse_purge_repl_simple_pull({Source, Target}) ->
 
 
 cpse_purge_repl_simple_push({Source, Target}) ->
+    erlang:put(io_priority, {interactive, Source}),
     repl(Source, Target),
 
     {ok, Rev} = cpse_util:save_doc(Source, {[{'_id', foo}, {vsn, 1}]}),

--- a/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
@@ -28,6 +28,7 @@ teardown_each(DbName) ->
 
 
 cpse_increment_purge_seq_on_complete_purge(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, 1.1}]}),
     {ok, Rev2} = cpse_util:save_doc(DbName, {[{'_id', foo2}, {vsn, 1.2}]}),
 
@@ -69,6 +70,7 @@ cpse_increment_purge_seq_on_complete_purge(DbName) ->
 
 
 cpse_increment_purge_multiple_times(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, 1.1}]}),
     {ok, Rev2} = cpse_util:save_doc(DbName, {[{'_id', foo2}, {vsn, 1.2}]}),
 
@@ -98,6 +100,7 @@ cpse_increment_purge_multiple_times(DbName) ->
 
 
 cpse_increment_purge_seq_on_partial_purge(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, <<"1.1">>}]}),
     Update = {[
         {'_id', foo1},

--- a/src/couch_pse_tests/src/cpse_test_read_write_docs.erl
+++ b/src/couch_pse_tests/src/cpse_test_read_write_docs.erl
@@ -21,14 +21,16 @@
 
 setup_each() ->
     {ok, Db} = cpse_util:create_db(),
-    Db.
+    {Db, erlang:get(io_priority)}.
 
 
-teardown_each(Db) ->
+teardown_each({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ok = couch_server:delete(couch_db:name(Db), []).
 
 
-cpse_read_docs_from_empty_db(Db) ->
+cpse_read_docs_from_empty_db({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual([not_found], couch_db_engine:open_docs(Db, [<<"foo">>])),
     ?assertEqual(
         [not_found, not_found],
@@ -36,7 +38,8 @@ cpse_read_docs_from_empty_db(Db) ->
     ).
 
 
-cpse_read_empty_local_docs(Db) ->
+cpse_read_empty_local_docs({Db, Priority}) ->
+    erlang:put(io_priority, Priority),
     {LocalA, LocalB} = {<<"_local/a">>, <<"_local/b">>},
     ?assertEqual([not_found], couch_db_engine:open_local_docs(Db, [LocalA])),
     ?assertEqual(
@@ -45,7 +48,8 @@ cpse_read_empty_local_docs(Db) ->
     ).
 
 
-cpse_write_one_doc(Db1) ->
+cpse_write_one_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -86,7 +90,8 @@ cpse_write_one_doc(Db1) ->
     ?assertEqual({[{<<"vsn">>, 1}]}, Body1).
 
 
-cpse_write_two_docs(Db1) ->
+cpse_write_two_docs({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -109,7 +114,8 @@ cpse_write_two_docs(Db1) ->
     ?assertEqual(false, lists:member(not_found, Resps)).
 
 
-cpse_write_three_doc_batch(Db1) ->
+cpse_write_three_doc_batch({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -135,7 +141,8 @@ cpse_write_three_doc_batch(Db1) ->
     ?assertEqual(false, lists:member(not_found, Resps)).
 
 
-cpse_update_doc(Db1) ->
+cpse_update_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -177,7 +184,8 @@ cpse_update_doc(Db1) ->
     ?assertEqual({[{<<"vsn">>, 2}]}, Body1).
 
 
-cpse_delete_doc(Db1) ->
+cpse_delete_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -218,7 +226,8 @@ cpse_delete_doc(Db1) ->
     ?assertEqual({[]}, Body1).
 
 
-cpse_write_local_doc(Db1) ->
+cpse_write_local_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -241,7 +250,8 @@ cpse_write_local_doc(Db1) ->
     ?assertEqual({[{<<"yay">>, false}]}, Doc#doc.body).
 
 
-cpse_write_mixed_batch(Db1) ->
+cpse_write_mixed_batch({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -269,7 +279,8 @@ cpse_write_mixed_batch(Db1) ->
     [#doc{}] = couch_db_engine:open_local_docs(Db3, [<<"_local/foo">>]).
 
 
-cpse_update_local_doc(Db1) ->
+cpse_update_local_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
@@ -293,7 +304,8 @@ cpse_update_local_doc(Db1) ->
     ?assertEqual({[{<<"stuff">>, null}]}, Doc#doc.body).
 
 
-cpse_delete_local_doc(Db1) ->
+cpse_delete_local_doc({Db1, Priority}) ->
+    erlang:put(io_priority, Priority),
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),

--- a/src/couch_pse_tests/src/cpse_test_ref_counting.erl
+++ b/src/couch_pse_tests/src/cpse_test_ref_counting.erl
@@ -37,7 +37,8 @@ cpse_empty_monitors({Db, Pid}) ->
     Expected = [
         Pid,
         couch_db:get_pid(Db),
-        whereis(couch_stats_process_tracker)
+        whereis(couch_stats_process_tracker),
+        whereis(ioq_opener)
     ],
     ?assertEqual([], Pids -- Expected).
 
@@ -63,13 +64,13 @@ cpse_incref_decref_many({Db, _}) ->
     lists:foreach(fun(C) -> wait_client(C) end, Clients),
 
     Pids1 = couch_db_engine:monitored_by(Db),
-    % +3 for self, db pid, and process tracker
-    ?assertEqual(?NUM_CLIENTS + 3, length(Pids1)),
+    % +4 for self, db pid, process tracker, and ioq opener
+    ?assertEqual(?NUM_CLIENTS + 4, length(Pids1)),
 
     lists:foreach(fun(C) -> close_client(C) end, Clients),
 
     Pids2 = couch_db_engine:monitored_by(Db),
-    ?assertEqual(3, length(Pids2)).
+    ?assertEqual(4, length(Pids2)).
 
 
 start_client(Db0) ->

--- a/src/couch_pse_tests/src/cpse_util.erl
+++ b/src/couch_pse_tests/src/cpse_util.erl
@@ -95,11 +95,13 @@ create_db() ->
 
 
 create_db(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     Engine = get_engine(),
     couch_db:create(DbName, [{engine, Engine}, ?ADMIN_CTX]).
 
 
 open_db(DbName) ->
+    erlang:put(io_priority, {interactive, DbName}),
     Engine = get_engine(),
     couch_db:open_int(DbName, [{engine, Engine}, ?ADMIN_CTX]).
 
@@ -383,6 +385,7 @@ prep_atts(_Db, []) ->
 
 prep_atts(Db, [{FileName, Data} | Rest]) ->
     {_, Ref} = spawn_monitor(fun() ->
+        erlang:put(io_priority, {db_update, couch_db:name(Db)}),
         {ok, Stream} = couch_db:open_write_stream(Db, []),
         exit(write_att(Stream, FileName, Data, Data))
     end),

--- a/src/couch_replicator/src/couch_replicator_changes_reader.erl
+++ b/src/couch_replicator/src/couch_replicator_changes_reader.erl
@@ -37,6 +37,7 @@ start_link(StartSeq, #httpdb{} = Db, ChangesQueue, Options) ->
 start_link(StartSeq, Db, ChangesQueue, Options) ->
     Parent = self(),
     {ok, spawn_link(fun() ->
+        erlang:put(io_priority, {interactive, couch_db:name(Db)}),
         ?MODULE:read_changes(Parent, StartSeq, Db, ChangesQueue, Options)
     end)}.
 

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -123,6 +123,10 @@ update_error(#rep{db_name = DbName, doc_id = DocId, id = RepId}, Error) ->
 
 -spec ensure_rep_db_exists() -> {ok, Db::any()}.
 ensure_rep_db_exists() ->
+    case erlang:get(io_priority) of
+        undefined -> erlang:put(io_priority, {system, ?REP_DB_NAME});
+        _ -> ok
+    end,
     Db = case couch_db:open_int(?REP_DB_NAME, [?CTX, sys_db,
             nologifmissing]) of
         {ok, Db0} ->
@@ -137,6 +141,10 @@ ensure_rep_db_exists() ->
 
 -spec ensure_rep_ddoc_exists(binary()) -> ok.
 ensure_rep_ddoc_exists(RepDb) ->
+    case erlang:get(io_priority) of
+        undefined -> erlang:put(io_priority, {system, ?REP_DB_NAME});
+        _ -> ok
+    end,
     case mem3:belongs(RepDb, ?REP_DESIGN_DOC) of
         true ->
             ensure_rep_ddoc_exists(RepDb, ?REP_DESIGN_DOC);
@@ -147,6 +155,10 @@ ensure_rep_ddoc_exists(RepDb) ->
 
 -spec ensure_rep_ddoc_exists(binary(), binary()) -> ok.
 ensure_rep_ddoc_exists(RepDb, DDocId) ->
+    case erlang:get(io_priority) of
+        undefined -> erlang:put(io_priority, {system, ?REP_DB_NAME});
+        _ -> ok
+    end,
     case open_rep_doc(RepDb, DDocId) of
         {not_found, no_db_file} ->
             %% database was deleted.

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -791,6 +791,7 @@ check_strip_credentials_test() ->
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     create_vdu(DbName),
@@ -829,9 +830,8 @@ update_replicator_doc_with_bad_vdu_test_() ->
 
 
 t_vdu_does_not_crash_on_save(DbName) ->
-    ?_test(begin
-        Doc = #doc{id = <<"some_id">>, body = {[{<<"foo">>, 42}]}},
-        ?assertEqual({ok, forbidden}, save_rep_doc(DbName, Doc))
-    end).
+    Doc = #doc{id = <<"some_id">>, body = {[{<<"foo">>, 42}]}},
+    Res = save_rep_doc(DbName, Doc),
+    ?_test(?assertEqual({ok, forbidden}, Res)).
 
 -endif.

--- a/src/couch_replicator/src/couch_replicator_filters.erl
+++ b/src/couch_replicator/src/couch_replicator_filters.erl
@@ -66,7 +66,9 @@ parse(Options) ->
 -spec fetch(binary(), binary(), binary(), #user_ctx{}) ->
     {ok, {[_]}} | {error, binary()}.
 fetch(DDocName, FilterName, Source, UserCtx) ->
+    Priority = erlang:get(io_priority),
     {Pid, Ref} = spawn_monitor(fun() ->
+        erlang:put(io_priority, Priority),
         try fetch_internal(DDocName, FilterName, Source, UserCtx) of
             Resp ->
                 exit({exit_ok, Resp})

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -109,6 +109,9 @@ init(InitArgs) ->
 
 do_init(#rep{options = Options, id = {BaseId, Ext}, user_ctx=UserCtx} = Rep) ->
     process_flag(trap_exit, true),
+    %% TODO: what value to put here
+    %% what is using this?
+    erlang:put(io_priority, {db_update, <<"asdf">>}),
 
     timer:sleep(startup_jitter()),
 

--- a/src/couch_replicator/test/couch_replicator_filtered_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_filtered_tests.erl
@@ -198,6 +198,7 @@ read_doc(Db, DocIdOrInfo) ->
 
 create_db() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     DbName.

--- a/src/couch_replicator/test/couch_replicator_large_atts_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_large_atts_tests.erl
@@ -29,6 +29,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     DbName.
@@ -80,21 +81,24 @@ should_populate_replicate_compact({From, To}, {_Ctx, {Source, Target}}) ->
 should_populate_source({remote, Source}) ->
     should_populate_source(Source);
 should_populate_source(Source) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(populate_db(Source, ?DOCS_COUNT))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), populate_db(Source, ?DOCS_COUNT) end)}.
 
 should_replicate({remote, Source}, Target) ->
     should_replicate(db_url(Source), Target);
 should_replicate(Source, {remote, Target}) ->
     should_replicate(Source, db_url(Target));
 should_replicate(Source, Target) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(replicate(Source, Target))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), replicate(Source, Target) end)}.
 
 should_compare_databases({remote, Source}, Target) ->
     should_compare_databases(Source, Target);
 should_compare_databases(Source, {remote, Target}) ->
     should_compare_databases(Source, Target);
 should_compare_databases(Source, Target) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(compare_dbs(Source, Target))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), compare_dbs(Source, Target) end)}.
 
 
 populate_db(DbName, DocCount) ->

--- a/src/couch_replicator/test/couch_replicator_many_leaves_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_many_leaves_tests.erl
@@ -33,6 +33,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     DbName.
@@ -87,21 +88,25 @@ should_populate_replicate_compact({From, To}, {_Ctx, {Source, Target}}) ->
 should_populate_source({remote, Source}) ->
     should_populate_source(Source);
 should_populate_source(Source) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(populate_db(Source))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), populate_db(Source) end)}.
 
 should_replicate({remote, Source}, Target) ->
     should_replicate(db_url(Source), Target);
 should_replicate(Source, {remote, Target}) ->
     should_replicate(Source, db_url(Target));
 should_replicate(Source, Target) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(replicate(Source, Target))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), replicate(Source, Target) end)}.
 
 should_verify_target({remote, Source}, Target) ->
     should_verify_target(Source, Target);
 should_verify_target(Source, {remote, Target}) ->
     should_verify_target(Source, Target);
 should_verify_target(Source, Target) ->
+    Priority = erlang:get(io_priority),
     {timeout, ?TIMEOUT_EUNIT, ?_test(begin
+        erlang:put(io_priority, Priority),
         {ok, SourceDb} = couch_db:open_int(Source, []),
         {ok, TargetDb} = couch_db:open_int(Target, []),
         verify_target(SourceDb, TargetDb, ?DOCS_CONFLICTS),
@@ -112,7 +117,9 @@ should_verify_target(Source, Target) ->
 should_add_attachments_to_source({remote, Source}) ->
     should_add_attachments_to_source(Source);
 should_add_attachments_to_source(Source) ->
+    Priority = erlang:get(io_priority),
     {timeout, ?TIMEOUT_EUNIT, ?_test(begin
+        erlang:put(io_priority, Priority),
         {ok, SourceDb} = couch_db:open_int(Source, []),
         add_attachments(SourceDb, ?NUM_ATTS, ?DOCS_CONFLICTS),
         ok = couch_db:close(SourceDb)

--- a/src/couch_replicator/test/couch_replicator_missing_stubs_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_missing_stubs_tests.erl
@@ -26,6 +26,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     DbName.
@@ -81,19 +82,23 @@ should_replicate_docs_with_missed_att_stubs({From, To}, {_Ctx, {Source, Target}}
 should_populate_source({remote, Source}) ->
     should_populate_source(Source);
 should_populate_source(Source) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(populate_db(Source))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), populate_db(Source) end)}.
 
 should_replicate({remote, Source}, Target) ->
     should_replicate(db_url(Source), Target);
 should_replicate(Source, {remote, Target}) ->
     should_replicate(Source, db_url(Target));
 should_replicate(Source, Target) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(replicate(Source, Target))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), replicate(Source, Target) end)}.
 
 should_set_target_revs_limit({remote, Target}, RevsLimit) ->
     should_set_target_revs_limit(Target, RevsLimit);
 should_set_target_revs_limit(Target, RevsLimit) ->
+    Priority = erlang:get(io_priority),
     ?_test(begin
+        erlang:put(io_priority, Priority),
         {ok, Db} = couch_db:open_int(Target, [?ADMIN_CTX]),
         ?assertEqual(ok, couch_db:set_revs_limit(Db, RevsLimit)),
         ok = couch_db:close(Db)
@@ -104,12 +109,14 @@ should_compare_databases({remote, Source}, Target) ->
 should_compare_databases(Source, {remote, Target}) ->
     should_compare_databases(Source, Target);
 should_compare_databases(Source, Target) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(compare_dbs(Source, Target))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), compare_dbs(Source, Target) end)}.
 
 should_update_source_docs({remote, Source}, Times) ->
     should_update_source_docs(Source, Times);
 should_update_source_docs(Source, Times) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(update_db_docs(Source, Times))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), update_db_docs(Source, Times) end)}.
 
 
 populate_db(DbName) ->

--- a/src/couch_replicator/test/couch_replicator_retain_stats_between_job_runs.erl
+++ b/src/couch_replicator/test/couch_replicator_retain_stats_between_job_runs.erl
@@ -46,7 +46,9 @@ stats_retained_test_() ->
 
 
 t_stats_retained({_Ctx, {Source, Target}}) ->
+    Priority = erlang:get(io_priority),
     ?_test(begin
+        erlang:put(io_priority, Priority),
         populate_db(Source, 42),
         {ok, RepPid, RepId} = replicate(Source, Target),
         wait_target_in_sync(Source, Target),
@@ -59,6 +61,7 @@ t_stats_retained({_Ctx, {Source, Target}}) ->
 
 setup_db() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     DbName.

--- a/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
+++ b/src/couch_replicator/test/couch_replicator_small_max_request_size_target.erl
@@ -14,6 +14,7 @@
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     DbName.
@@ -102,21 +103,24 @@ should_populate_source({remote, Source}) ->
     should_populate_source(Source);
 
 should_populate_source(Source) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(add_docs(Source, 5, 3000, 0))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), add_docs(Source, 5, 3000, 0) end)}.
 
 
 should_populate_source_one_large_one_small({remote, Source}) ->
     should_populate_source_one_large_one_small(Source);
 
 should_populate_source_one_large_one_small(Source) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(one_large_one_small(Source, 12000, 3000))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), one_large_one_small(Source, 12000, 3000) end)}.
 
 
 should_populate_source_one_large_attachment({remote, Source}) ->
    should_populate_source_one_large_attachment(Source);
 
 should_populate_source_one_large_attachment(Source) ->
-  {timeout, ?TIMEOUT_EUNIT, ?_test(one_large_attachment(Source, 70000, 70000))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), one_large_attachment(Source, 70000, 70000) end)}.
 
 
 should_replicate({remote, Source}, Target) ->
@@ -126,7 +130,8 @@ should_replicate(Source, {remote, Target}) ->
     should_replicate(Source, db_url(Target));
 
 should_replicate(Source, Target) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(replicate(Source, Target))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), replicate(Source, Target) end)}.
 
 
 should_compare_databases({remote, Source}, Target, ExceptIds) ->
@@ -136,7 +141,8 @@ should_compare_databases(Source, {remote, Target}, ExceptIds) ->
     should_compare_databases(Source, Target, ExceptIds);
 
 should_compare_databases(Source, Target, ExceptIds) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(compare_dbs(Source, Target, ExceptIds))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), compare_dbs(Source, Target, ExceptIds) end)}.
 
 
 binary_chunk(Size) when is_integer(Size), Size > 0 ->

--- a/src/couch_replicator/test/couch_replicator_use_checkpoints_tests.erl
+++ b/src/couch_replicator/test/couch_replicator_use_checkpoints_tests.erl
@@ -47,6 +47,7 @@ stop(_, _) ->
 
 setup() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {interactive, DbName}),
     {ok, Db} = couch_db:create(DbName, [?ADMIN_CTX]),
     ok = couch_db:close(Db),
     DbName.
@@ -113,21 +114,24 @@ should_test_checkpoints(UseCheckpoints, {From, To}, {Source, Target}) ->
 should_populate_source({remote, Source}, DocCount) ->
     should_populate_source(Source, DocCount);
 should_populate_source(Source, DocCount) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(populate_db(Source, DocCount))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), populate_db(Source, DocCount) end)}.
 
 should_replicate({remote, Source}, Target, UseCheckpoints) ->
     should_replicate(db_url(Source), Target, UseCheckpoints);
 should_replicate(Source, {remote, Target}, UseCheckpoints) ->
     should_replicate(Source, db_url(Target), UseCheckpoints);
 should_replicate(Source, Target, UseCheckpoints) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(replicate(Source, Target, UseCheckpoints))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), replicate(Source, Target, UseCheckpoints) end)}.
 
 should_compare_databases({remote, Source}, Target) ->
     should_compare_databases(Source, Target);
 should_compare_databases(Source, {remote, Target}) ->
     should_compare_databases(Source, Target);
 should_compare_databases(Source, Target) ->
-    {timeout, ?TIMEOUT_EUNIT, ?_test(compare_dbs(Source, Target))}.
+    Priority = erlang:get(io_priority),
+    {timeout, ?TIMEOUT_EUNIT, ?_test(begin erlang:put(io_priority, Priority), compare_dbs(Source, Target) end)}.
 
 
 populate_db(DbName, DocCount) ->

--- a/src/ddoc_cache/test/ddoc_cache_remove_test.erl
+++ b/src/ddoc_cache/test/ddoc_cache_remove_test.erl
@@ -196,6 +196,7 @@ init_custom_ddoc(DbName) ->
 
 
 do_compact(ShardName) ->
+    erlang:put(io_priority, {db_compact, ShardName}),
     {ok, Db} = couch_db:open_int(ShardName, []),
     try
         {ok, Pid} = couch_db:start_compact(Db),

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -601,6 +601,10 @@ clean_stack() ->
         erlang:get_stacktrace()).
 
 set_io_priority(DbName, Options) ->
+    %% HACK: experiment with spawning IOQ2 pids prior to couch_file open
+    %%Ctx = couch_util:get_value(user_ctx, Options, undefined),
+    %%IOQPid = ioq:fetch_pid_for(DbName, Ctx),
+    %%ok = ioq:set_pid_for(DbName, IOQPid),
     case lists:keyfind(io_priority, 1, Options) of
     {io_priority, Pri} ->
         erlang:put(io_priority, Pri);

--- a/src/fabric/test/fabric_rpc_purge_tests.erl
+++ b/src/fabric/test/fabric_rpc_purge_tests.erl
@@ -214,6 +214,7 @@ wrap({Name, Fun}) ->
 
 create_db() ->
     DbName = ?tempdb(),
+    erlang:put(io_priority, {db_update, DbName}),
     couch_db:create(DbName, [?ADMIN_CTX]).
 
 
@@ -229,6 +230,12 @@ populate_db(Db) ->
 
 
 open_doc(DbName, DocId) ->
+    case erlang:get(io_priority) of
+        undefined ->
+            erlang:put(io_priority, {interactive, DbName});
+        _ ->
+            ok
+    end,
     couch_util:with_db(DbName, fun(Db) ->
         couch_db:open_doc(Db, DocId, [])
     end).

--- a/src/global_changes/src/global_changes_server.erl
+++ b/src/global_changes/src/global_changes_server.erl
@@ -60,6 +60,9 @@ init([]) ->
     UpdateDb = case UpdateDb0 of "false" -> false; _ -> true end,
     MaxWriteDelay = list_to_integer(MaxWriteDelay0),
 
+    GlobalChangesDbName = global_changes_util:get_dbname(),
+    erlang:put(io_priority, {db_update, GlobalChangesDbName}),
+
     % Start our write triggers
     erlang:send_after(MaxWriteDelay, self(), flush_updates),
 
@@ -68,7 +71,7 @@ init([]) ->
         pending_update_count=0,
         pending_updates=sets:new(),
         max_write_delay=MaxWriteDelay,
-        dbname=global_changes_util:get_dbname(),
+        dbname=GlobalChangesDbName,
         handler_ref=erlang:monitor(process, Handler)
     },
     {ok, State}.

--- a/src/mem3/src/mem3_nodes.erl
+++ b/src/mem3/src/mem3_nodes.erl
@@ -41,6 +41,8 @@ get_node_info(Node, Key) ->
     end.
 
 init([]) ->
+    DbName = list_to_binary(config:get("mem3", "nodes_db", "_nodes")),
+    erlang:put(io_priority, {system, DbName}),
     ets:new(?MODULE, [named_table, {read_concurrency, true}]),
     UpdateSeq = initialize_nodelist(),
     {Pid, _} = spawn_monitor(fun() -> listen_for_changes(UpdateSeq) end),
@@ -109,6 +111,7 @@ first_fold(#full_doc_info{id=Id}=DocInfo, Db) ->
 
 listen_for_changes(Since) ->
     DbName = config:get("mem3", "nodes_db", "_nodes"),
+    erlang:put(io_priority, {system, DbName}),
     {ok, Db} = mem3_util:ensure_exists(DbName),
     Args = #changes_args{
         feed = "continuous",

--- a/src/mem3/src/mem3_sync_event_listener.erl
+++ b/src/mem3/src/mem3_sync_event_listener.erl
@@ -258,6 +258,7 @@ subscribe_for_config_test_() ->
 should_set_sync_delay(Pid) ->
     ?_test(begin
         config:set("mem3", "sync_delay", "123", false),
+        timer:sleep(100),
         ?assertMatch(#state{delay = 123}, capture(Pid)),
         ok
     end).
@@ -265,6 +266,7 @@ should_set_sync_delay(Pid) ->
 should_set_sync_frequency(Pid) ->
     ?_test(begin
         config:set("mem3", "sync_frequency", "456", false),
+        timer:sleep(100),
         ?assertMatch(#state{frequency = 456}, capture(Pid)),
         ok
     end).

--- a/src/mem3/src/mem3_util.erl
+++ b/src/mem3/src/mem3_util.erl
@@ -85,6 +85,7 @@ write_db_doc(Doc) ->
     write_db_doc(DbName, Doc, true).
 
 write_db_doc(DbName, #doc{id=Id, body=Body} = Doc, ShouldMutate) ->
+    erlang:put(io_priority, {system, DbName}),
     {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     try couch_db:open_doc(Db, Id, [ejson_body]) of
     {ok, #doc{body = Body}} ->
@@ -111,6 +112,7 @@ delete_db_doc(DocId) ->
     delete_db_doc(DbName, DocId, true).
 
 delete_db_doc(DbName, DocId, ShouldMutate) ->
+    erlang:put(io_priority, {system, DbName}),
     {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     {ok, Revs} = couch_db:open_doc_revs(Db, DocId, all, []),
     try [Doc#doc{deleted=true} || {ok, #doc{deleted=false}=Doc} <- Revs] of


### PR DESCRIPTION
# IOQ2 Improvements


The IOQ system provides a way to prioritize a variety of request types such that
standard database operations can be run in parallel to background operations
without negative impact. IOQ also provides some levers to change
prioritization of request types on the fly, so that you can prioritize view
builds or compactions. IOQ1 was a single Erlang server pid that all requests
funneled through, which given the rise in CPU cores and SSD hard drives, quickly
becomes a fundamental bottleneck of CouchDB.

IOQ2 improves the situation by adding parallelism and faster data structures.
You can find more details about IOQ2 in [1]. With the increased parallelism, the
challenge becomes how do we dispatch requests across a pool of processes? The
simple case of round robin or random uniform distribution will do a good job of
distributing the load across the pool of processes, but it does not group
requests together in a beneficial way. This lack of grouping is problematic
because it minimizes the amount of "deduping" we can do of identical requests,
and it also greatly complicates prioritization of requests to an individual
database shard.

Deduping is very important because it results in identical in flight read
requests to only be performed once, and the result is returned to all waiting
readers.  This is especially useful for inner b-tree nodes and can have a
substantial impact on improving performance, reducing couch file overload, and
reducing IO operations.

The other big reason to group requests together that are for the same couch
file, is that it allows us to prioritize those requests in concert. When we
dispatch requests to a single couch file pid across a pool of IOQ pids, that
means we can't prioritize those requests as a whole because prioritization
happens at the IOQ2 pid level, not at a global level.

This means that ideally we want to be dispatching all requests for an individual
couch file through a single IOQ2 pid. This is exactly what the `fd_hash`
dispatch strategy does, where it takes a hash of the couch file pid modulo the
number of IOQ2 pids, so that all requests to a particular couch file go through
the same IOQ2 pid. The problem with this approach is that you can have multiple
heavily active couch file pids funneling through the same IOQ2 pid while other
IOQ2 pids are idle. This is problematic because eventually IOQ2 pids will become
bottlenecked (on metrics collection amusingly enough), and also because there is
currently no couch file concurrency control within IOQ2 pids, so heavily active
couch files can starve requests to other couch files.

This PR introduces a new approach to dispatching requests across IOQ2 pids.
Instead of having a fixed pool of IOQ2 pids to dispatch requests across, this PR
introduces an `ioq_opener` process responsible for dynamically spawning IOQ2
pids as appropriate, with configuration options for grouping requests by shard,
user, db, or even request class. The result is a dedicated IOQ2 pid per group so
all of the related requests are funneling through the same IOQ2 pid which allows
for deduping of requests and appropriate prioritization.

# Current Status

This is currently a draft PR and provides a proof of concept implementation of
the IOQ opener logic, and it also demonstrates a few approaches taken over the
course of iterating through this. The work is spread out across two repos, first
in the CouchDB repo [2] and second in the CouchDB IOQ repo [3]. Because the
commits have been structured to illustrate different ideas and approaches, I'll
link out to individual commits rather than comparing the branches as a whole.

## Initial Approach

My initial approach was to hook the IOQ opener logic into the places that open
the .couch file handles. My thought was that by fetching the appropriate IOQ pid
when the database handle was opened, that all clients of that database would be
able to utilize that pid without needing to look it back open. So the approach
was to ensure an IOQ pid was set _prior_ to storing the db reference in
`couch_server` such that all clients getting a db handle out of `couch_server`
also get a handle to the appropriate IOQ pid. This works _ok_ in the simple
cases, but starts to get complicated in a hurry.

First off, view handles don't go through `couch_server`, so similar opener logic
needs to be implemented for views and other places. Second, with the Pluggable
Storage Engines, the use of `couch_file` for the storage engine is an
implementation detail and no longer guaranteed, yet views do not support PSEs so
we have an awkward mix of an indirection layer around `couch_file`'s in primary
database operations and not in views. This is awkward because we need to key the
IOQ pid on the `couch_file` pid so that all IOQ requests to the relevant
`couch_file` go through the same IOQ pid, but the actual `couch_file` pid is
hidden behind the PSE abstraction. This wasn't too hard to work around and I
added a `get_fd_pid` to the PSE implementation to support extracting it, but
given we have to do similar types of things in `couch_server`,
`couch_bt_engine_compactor`, `couch_db_updater`, `couch_mrview_updater`, etc, it
seems like this is not an ideal approach.

You can see a rough version of this approach in the CouchDB repo at [4] and the
corresponding changes in the IOQ repo at [5].

## Lazy Opener Approach

I quickly became dissatisfied with the initial approach, especially with the
dichotomy around `couch_file` interactions with some hidden behind PSE and
others hardcoded to use `couch_file` directly. I also didn't like how spread out
the setting of IOQ pids was and the requirement that all future uses of
`couch_file` pids would need to properly set the pids as well.

I started working on a lazy opener approach where we don't open the IOQ pid
until we're in `ioq:call` and we conclude an appropriate IOQ pid has not yet
been opened. That pid is then set in the pdict of the caller pid so that further
IOQ calls to that fd will utilize the pre-determined IOQ pid. This approach
seems natural, but it has its own set of awkwardness as we're only guaranteed to
have the fd pid when we're in `ioq:call`, which means that we can't easily
determine the database name from the pid alone. I experimented with a hybrid
approach that would do an initial opener logic when the database handle was
opened and store a reference to the IOQ pid keyed off the fd in the `ioq_opener`
with the idea that we can then just lazily look up the appropriate IOQ pid based
on the fd at `ioq:call` time, which worked _ok_ but I was not a fan of sometimes
presetting the IOQ pid and other times not.

My next iteration on this approach was to switch to using the `#ioq_request{}`
record as the lookup value to `ioq_opener` rather than the fd or db name. This
request record _should_ contain the appropriate shard name and IOQ class and
other relevant information we would want to use for dispatching across IOQ pids.
You can see the combination of these two approaches in [6].

The tricky bit here being the part where we *should* have the appropriate shard
name and other information. The problem is that this information is extracted
from the `io_priority` parameter to `ioq:call`, which, if set, contains the
shard name, however there is no fixed requirement that `io_priority` is set,
which means there are a number of places that don't set an appropriate IOQ
priority and just use the default values. There's no reason to ever not want an
appropriate `io_priority` set, so this seems like an opportune time to finally
rectify the lack of `io_priority` values. To do that, I added temporary measures
to explode loudly when an IOQ request was missing an `io_priority` value. You
can see those changes for CouchDB and IOQ in [7] and [8], respectively.

So the next step was to set `io_priority` in all the places that it was not
appropriately set. I accomplished this by adding the explode loudly changes
above and then running the test suite to trigger explosions. I've updated all
of the missing `io_priority` locations with appropriate values in [9]. It's
worth noting that this is not a guaranteed exhaustive list as this is a run time
check and the run time was only exercised as efficiently as the eunit test suite
exercises it. It would surprise me if there are not a few other corner cases
where `io_priority` is not properly set.

Unfortunately, the eunit test suite almost entirely ignores setting
`io_priority` values and relies on not setting the priority being an acceptable
course of action. If we're going to ensure that `io_priority` is set, then we
need to make sure it's set in the test suite as well. The somewhat arduous
commit to set `io_priority` throughout all the test suites is in [10]. I think
we can simplify that with some logic and utilities around setting `io_priority`
in the test suites, but [10] does the initial leg work and sets it manually
everywhere it needs to be set so that the test suite passes. Figuring out what
to do on that front is one of the primary questions to be answered as part of
this work, but I think we would benefit considerably from a more rigorous
approach to `io_priority` so I took the time to make it work initially so we can
get a view of what it entails.

The changes in these two branches result in a proof of concept version of the
`ioq_opener` logic that lazily assigns the IOQ pids as needed, based on the
dimensions extracted for the `#ioq_request{}`, ensures that `io_priority` is
always set, and that the test suite passes.


# IOQ Pid Eviction

If we're going to be dynamically spawning IOQ pids as needed, we need some
mechanism to determine when to clear those processes out. The approach taken
here is basically reference counting clients to those pids. So the `ioq_opener`
process will monitor the `couch_file` pids, view pids, compaction pids, client
pids, etc, and when all the relevant pids using that IOQ pid exit, then the IOQ
pid exits as well.

# What is shared per pid?

One question is how many different client types should funnel through the same IOQ
pid? For instance, when we have a `couch_file` pid for a particular database
shard, and we have corresponding view pids for that database shard, should they
all go through the same IOQ pid? I believe they should, as otherwise we can't
actually prioritize interactive database requests versus compaction/views/etc,
so essentially the IOQ pid should be determined by database shard, not
necessarily the exact file that is currently being interacted with. Although
there are a few different dispatch strategies, one of which being fd pid based
dispatch so you _can_ run an IOQ pid per `couch_file` if so desired. You can see
the dispatch logic in [11].

# Status

This currently works and passes the test suite, although I want to add
`ioq_opener` specific tests to ensure the eviction and dispatch logic is
properly functioning. There's some inconsistencies with shard names flying around
that need to be resolved to ensure all requests goto the appropriate IOQ pid.
The IOQ config settings also need to be updated to allow per IOQ pid config
values. This is a great feature and will allow per shard concurrency levels and
priority values for classes.

Let me know what you think!


# References

[1] https://github.com/apache/couchdb-ioq/blob/master/IOQ2.md
[2] https://github.com/apache/couchdb/tree/ioq-per-shard-or-user
[3] https://github.com/apache/couchdb-ioq/tree/ioq-per-shard-or-user
[4] https://github.com/apache/couchdb/commit/1644b1dfc93106792631a7688ed5bd413dddd03b
[5] https://github.com/apache/couchdb-ioq/commit/1dee640342c4db8756606bff3962cfed6efc8bc1
[6] https://github.com/apache/couchdb-ioq/commit/acd776b23cf13235782de026a8d861b064214f6e
[7] https://github.com/apache/couchdb/commit/3b4cf711a13ac8afd41271118fca69f5c4310edf
[8] https://github.com/apache/couchdb-ioq/commit/c5e91ca9660579c634360fc63422fe2cee237d4a
[9] https://github.com/apache/couchdb/commit/b85c17d569ac6e631a02acc0eecf2bdc6090c67c
[10] https://github.com/apache/couchdb/commit/733b025be28611491de0b478534ce5984a8bd5ce
[11] https://github.com/apache/couchdb-ioq/blob/ioq-per-shard-or-user/src/ioq_opener.erl#L148-L171
