### PR TITLE
Port javascript copy doc tests into elixir test suite

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -41,7 +41,7 @@ X means done, - means partially
   - [X] Port config.js
   - [X] Port conflicts.js
   - [ ] Port cookie_auth.js
-  - [ ] Port copy_doc.js
+  - [X] Port copy_doc.js
   - [X] Port delayed_commits.js
   - [ ] Port design_docs.js
   - [ ] Port design_options.js

--- a/test/elixir/test/copy_doc_test.exs
+++ b/test/elixir/test/copy_doc_test.exs
@@ -1,0 +1,71 @@
+defmodule CopyDocTest do
+  use CouchTestCase
+
+  @moduletag :copy_doc
+
+  @moduledoc """
+  Test CouchDB Copy Doc
+  This is a port of the copy_doc.js suite
+  """
+  @tag :with_db
+  test "Copy doc tests", context do
+    db_name = context[:db_name]
+    create_doc(db_name, %{_id: "doc_to_be_copied", v: 1})
+
+    resp =
+      Couch.request(
+        :copy,
+        "/#{db_name}/doc_to_be_copied",
+        headers: [Destination: "doc_that_was_copied"]
+      )
+
+    assert resp.body["ok"]
+    assert resp.status_code == 201
+
+    assert Couch.get("/#{db_name}/doc_that_was_copied").body["v"] == 1
+
+    create_doc(db_name, %{_id: "doc_to_be_copied2", v: 1})
+    {_, resp} = create_doc(db_name, %{_id: "doc_to_be_overwritten", v: 2})
+    rev = resp.body["rev"]
+
+    resp =
+      Couch.request(
+        :copy,
+        "/#{db_name}/doc_to_be_copied2",
+        headers: [Destination: "doc_to_be_overwritten"]
+      )
+
+    assert resp.status_code == 409
+
+    resp =
+      Couch.request(
+        :copy,
+        "/#{db_name}/doc_to_be_copied2"
+      )
+
+    assert resp.status_code == 400
+    assert resp.body["reason"] == "Destination header is mandatory for COPY."
+
+    resp =
+      Couch.request(
+        :copy,
+        "/#{db_name}/doc_to_be_copied2",
+        headers: [Destination: "http://localhost:5984/#{db_name}/doc_to_be_written"]
+      )
+
+    assert resp.status_code == 400
+    assert resp.body["reason"] == "Destination URL must be relative."
+
+    resp =
+      Couch.request(
+        :copy,
+        "/#{db_name}/doc_to_be_copied2",
+        headers: [Destination: "doc_to_be_overwritten?rev=#{rev}"]
+      )
+
+    assert resp.status_code == 201
+    resp = Couch.get("/#{db_name}/doc_to_be_overwritten")
+    assert resp.body["_rev"] != rev
+    assert resp.body["v"] == 1
+  end
+end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR ports copy_doc JavaScript test suite into elixir. 

## Testing recommendations

```
make elixir tests=test/copy_doc_test.exs
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
