### PR TITLE
In the resharding API test pick the first live node

### DIFF
--- a/test/elixir/test/reshard_helpers.exs
+++ b/test/elixir/test/reshard_helpers.exs
@@ -83,9 +83,12 @@ defmodule ReshardHelpers do
   def get_first_node do
     mresp = Couch.get("/_membership")
     assert mresp.status_code == 200
-    cluster_nodes = mresp.body["cluster_nodes"]
-    [node1 | _] = cluster_nodes
-    node1
+    all_nodes = mresp.body["all_nodes"]
+
+    mresp.body["cluster_nodes"]
+    |> Enum.filter(fn n -> n in all_nodes end)
+    |> Enum.sort()
+    |> hd()
   end
 
   def wait_job_removed(id) do


### PR DESCRIPTION
Previously the first cluster node was picked. However, when running a test with
a degraded cluster and that node is down the test would fail.
