### PR TITLE
Don't reset_index if read_header fails

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -28,7 +28,7 @@ attachment_stream_buffer_size = 4096
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_only
+default_security = admin_local
 ; btree_chunk_size = 1279
 ; maintenance_mode = false
 ; stem_interactive_updates = true

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -28,7 +28,7 @@ attachment_stream_buffer_size = 4096
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_local
+default_security = admin_only
 ; btree_chunk_size = 1279
 ; maintenance_mode = false
 ; stem_interactive_updates = true

--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -122,7 +122,7 @@ open(Db, State0) ->
 
     case couch_mrview_util:open_file(IndexFName) of
         {ok, Fd} ->
-            case (catch couch_file:read_header(Fd)) of
+            case couch_file:read_header(Fd) of
                 % upgrade code for <= 1.2.x
                 {ok, {OldSig, Header}} ->
                     % Matching view signatures.
@@ -135,7 +135,7 @@ open(Db, State0) ->
                     NewSt = couch_mrview_util:init_state(Db, Fd, State, Header),
                     ensure_local_purge_doc(Db, NewSt),
                     {ok, NewSt};
-                _ ->
+                no_valid_header ->
                     NewSt = couch_mrview_util:reset_index(Db, Fd, State),
                     ensure_local_purge_doc(Db, NewSt),
                     {ok, NewSt}


### PR DESCRIPTION
This decision is an old one, I think, and took the view that an error
from read_header meant something fatally wrong with this index
file. These days, it's far more likely to be something else, a process
crash at the wrong moment, and therefore wiping the index out is an
overreaction.
