### PR TITLE
Fix upgrade clause for mem3_rpc:load_checkpoint/4,5

### DIFF
--- a/src/mem3/src/mem3_rpc.erl
+++ b/src/mem3/src/mem3_rpc.erl
@@ -68,7 +68,11 @@ get_missing_revs(Node, DbName, IdsRevs, Options) ->
 update_docs(Node, DbName, Docs, Options) ->
     rexi_call(Node, {fabric_rpc, update_docs, [DbName, Docs, Options]}).
 
-
+load_checkpoint(Node, DbName, SourceNode, SourceUUID, <<>>) ->
+    % Upgrade clause for a mixed cluster for old nodes that don't have
+    % load_checkpoint_rpc/4 yet. FilterHash is currently not
+    % used and so defaults to <<>> everywhere
+    load_checkpoint(Node, DbName, SourceNode, SourceUUID);
 load_checkpoint(Node, DbName, SourceNode, SourceUUID, FilterHash) ->
     Args = [DbName, SourceNode, SourceUUID, FilterHash],
     rexi_call(Node, {mem3_rpc, load_checkpoint_rpc, Args}).


### PR DESCRIPTION
When upgrading, the new mem3_rpc:load_checkpoint with a filter hash arg won't
be available on older nodes.

Filter hashes are not currently used anyway, so to avoid crashes on mixed
cluster call the older version without the filter hash part when the filter has
the default <<>> value.
