### PR TITLE
Expose node name via /_node/_local, closes #2005

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -269,6 +269,8 @@ handle_uuids_req(Req) ->
 
 % Node-specific request handler (_config and _stats)
 % Support _local meaning this node
+handle_node_req(#httpd{path_parts=[_, <<"_local">>]}=Req) ->
+    send_json(Req, 200, {[{name, node()}]});
 handle_node_req(#httpd{path_parts=[A, <<"_local">>|Rest]}=Req) ->
     handle_node_req(Req#httpd{path_parts=[A, node()] ++ Rest});
 % GET /_node/$node/_config


### PR DESCRIPTION
## Overview

Adds a new trivial endpoint, `GET /_node/_local`, that returns a JSON object that includes the (Erlang) name of the current node.

## Testing recommendations

1. `dev/run -n 1`
1. `curl http://localhost:15984/_node/_local`

Result should be `{"name":"node1@127.0.0.1"}`.

## Related Issues or Pull Requests

Closes #2005 

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;

Documentation PR to follow this landing.
