### PR TITLE
Improve naming of test cases

### DIFF
--- a/src/couch/src/test_util.erl
+++ b/src/couch/src/test_util.erl
@@ -37,6 +37,7 @@
 -export([start/1, start/2, start/3, stop/1]).
 
 -export([fake_db/1]).
+-export([with/1]).
 
 -record(test_context, {mocked = [], started = [], module}).
 
@@ -360,3 +361,9 @@ sort_apps(Apps) ->
 
 weight_app(couch_log) -> {0.0, couch_log};
 weight_app(Else) -> {1.0, Else}.
+
+%% eunit implementation of {with, Tests} doesn't detect test name correctly
+with(Tests) ->
+  fun(ArgsTuple) ->
+      [{Name, ?_test(Fun(ArgsTuple))} || {Name, Fun} <- Tests]
+  end.

--- a/src/fabric/test/fabric2_db_misc_tests.erl
+++ b/src/fabric/test/fabric2_db_misc_tests.erl
@@ -17,8 +17,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
--define(TDEF(A), {atom_to_list(A), fun A/1}).
-
+-define(TDEF1(A), {atom_to_list(A), fun A/1}).
 
 misc_test_() ->
     {
@@ -27,12 +26,12 @@ misc_test_() ->
             setup,
             fun setup/0,
             fun cleanup/1,
-            {with, [
-                fun empty_db_info/1,
-                fun accessors/1,
-                fun is_system_db/1,
-                fun ensure_full_commit/1
-            ]}
+            test_util:with([
+                ?TDEF1(empty_db_info),
+                ?TDEF1(accessors),
+                ?TDEF1(is_system_db),
+                ?TDEF1(ensure_full_commit)
+            ])
         }
     }.
 

--- a/src/fabric/test/fabric2_db_security_tests.erl
+++ b/src/fabric/test/fabric2_db_security_tests.erl
@@ -17,6 +17,7 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(TDEF1(A), {atom_to_list(A), fun A/1}).
 
 security_test_() ->
     {
@@ -25,21 +26,21 @@ security_test_() ->
             setup,
             fun setup/0,
             fun cleanup/1,
-            {with, [
-                fun is_admin_name/1,
-                fun is_not_admin_name/1,
-                fun is_admin_role/1,
-                fun is_not_admin_role/1,
-                fun check_is_admin/1,
-                fun check_is_not_admin/1,
-                fun check_is_member_name/1,
-                fun check_is_not_member_name/1,
-                fun check_is_member_role/1,
-                fun check_is_not_member_role/1,
-                fun check_admin_is_member/1,
-                fun check_is_member_of_public_db/1,
-                fun check_set_user_ctx/1
-            ]}
+            test_util:with([
+                ?TDEF1(is_admin_name),
+                ?TDEF1(is_not_admin_name),
+                ?TDEF1(is_admin_role),
+                ?TDEF1(is_not_admin_role),
+                ?TDEF1(check_is_admin),
+                ?TDEF1(check_is_not_admin),
+                ?TDEF1(check_is_member_name),
+                ?TDEF1(check_is_not_member_name),
+                ?TDEF1(check_is_member_role),
+                ?TDEF1(check_is_not_member_role),
+                ?TDEF1(check_admin_is_member),
+                ?TDEF1(check_is_member_of_public_db),
+                ?TDEF1(check_set_user_ctx)
+            ])
         }
     }.
 

--- a/src/fabric/test/fabric2_doc_crud_tests.erl
+++ b/src/fabric/test/fabric2_doc_crud_tests.erl
@@ -17,6 +17,7 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(TDEF1(A), {atom_to_list(A), fun A/1}).
 
 doc_crud_test_() ->
     {
@@ -25,26 +26,26 @@ doc_crud_test_() ->
             setup,
             fun setup/0,
             fun cleanup/1,
-            {with, [
-                fun open_missing_doc/1,
-                fun create_new_doc/1,
-                fun update_doc_basic/1,
-                fun update_doc_replicated/1,
-                fun update_doc_replicated_add_conflict/1,
-                fun update_doc_replicated_changes_winner/1,
-                fun update_doc_replicated_extension/1,
-                fun update_doc_replicate_existing_rev/1,
-                fun update_winning_conflict_branch/1,
-                fun update_non_winning_conflict_branch/1,
-                fun delete_doc_basic/1,
-                fun delete_changes_winner/1,
-                fun recreate_doc_basic/1,
-                fun conflict_on_create_new_with_rev/1,
-                fun conflict_on_update_with_no_rev/1,
-                fun conflict_on_create_as_deleted/1,
-                fun conflict_on_recreate_as_deleted/1,
-                fun conflict_on_extend_deleted/1
-            ]}
+            test_util:with([
+                ?TDEF1(open_missing_doc),
+                ?TDEF1(create_new_doc),
+                ?TDEF1(update_doc_basic),
+                ?TDEF1(update_doc_replicated),
+                ?TDEF1(update_doc_replicated_add_conflict),
+                ?TDEF1(update_doc_replicated_changes_winner),
+                ?TDEF1(update_doc_replicated_extension),
+                ?TDEF1(update_doc_replicate_existing_rev),
+                ?TDEF1(update_winning_conflict_branch),
+                ?TDEF1(update_non_winning_conflict_branch),
+                ?TDEF1(delete_doc_basic),
+                ?TDEF1(delete_changes_winner),
+                ?TDEF1(recreate_doc_basic),
+                ?TDEF1(conflict_on_create_new_with_rev),
+                ?TDEF1(conflict_on_update_with_no_rev),
+                ?TDEF1(conflict_on_create_as_deleted),
+                ?TDEF1(conflict_on_recreate_as_deleted),
+                ?TDEF1(conflict_on_extend_deleted)
+            ])
         }
     }.
 


### PR DESCRIPTION
## Overview

Stock implementation of `with` functionality in eunit
doesn't display test names. This commit adds test_util:with
to be used instead.

## Testing recommendations

Make sure the following command displays names of the tests it is executing
```
make eunit apps=fabric
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
