### PR TITLE
Make rexi kill all messages configurable

### DIFF
--- a/src/rexi/src/rexi.erl
+++ b/src/rexi/src/rexi.erl
@@ -80,12 +80,24 @@ kill(Node, Ref) ->
 %% No rexi_EXIT message will be sent.
 -spec kill_all([{node(), reference()}]) -> ok.
 kill_all(NodeRefs) when is_list(NodeRefs) ->
-    PerNodeMap = lists:foldl(fun({Node, Ref}, Acc) ->
-        maps:update_with(Node, fun(Refs) -> [Ref | Refs] end, [Ref], Acc)
-    end, #{}, NodeRefs),
-    maps:map(fun(Node, Refs) ->
-        rexi_utils:send(rexi_utils:server_pid(Node), cast_msg({kill_all, Refs}))
-    end, PerNodeMap),
+    %% Upgrade clause. Since kill_all is a new message, nodes in a mixed
+    %% cluster won't know how to process it. In that case, the default is to send
+    %% the individual kill messages. Once all the nodes have been upgraded, can
+    %% configure the cluster to send kill_all messages.
+    case config:get_boolean("rexi", "use_kill_all", false) of
+        true ->
+            PerNodeMap = lists:foldl(fun({Node, Ref}, Acc) ->
+                maps:update_with(Node, fun(Refs) ->
+                    [Ref | Refs]
+                end, [Ref], Acc)
+            end, #{}, NodeRefs),
+            maps:map(fun(Node, Refs) ->
+                ServerPid = rexi_utils:server_pid(Node),
+                rexi_utils:send(ServerPid, cast_msg({kill_all, Refs}))
+            end, PerNodeMap);
+        false ->
+            lists:foreach(fun({Node, Ref}) -> kill(Node, Ref) end, NodeRefs)
+    end,
     ok.
 
 %% @equiv async_server_call(Server, self(), Request)


### PR DESCRIPTION
In a future release, once all nodes know how to handle kill_all message will
re-enable it.

In low traffic clusters this might not be an issue, as the extra workers would
time out and exit eventually, but in busy clusters this could cause
couch_server and other message backups as while the upgrade is happening
workers would not be terminate quickly enough.

