### PR TITLE
Fix epoch mismatch errors

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1560,7 +1560,14 @@ calculate_start_seq(Db, _Node, {Seq, Uuid, EpochNode}) ->
 calculate_start_seq(Db, _Node, {replace, OriginalNode, Uuid, Seq}) ->
     case is_prefix(Uuid, couch_db:get_uuid(Db)) of
         true ->
-            start_seq(get_epochs(Db), OriginalNode, Seq);
+            try
+                start_seq(get_epochs(Db), OriginalNode, Seq)
+            catch throw:epoch_mismatch ->
+                couch_log:warning("~p start_seq duplicate uuid on node: ~p "
+                    "db: ~p, seq: ~p, uuid: ~p, epoch_node: ~p",
+                    [?MODULE, node(), Db#db.name, Seq, Uuid, OriginalNode]),
+                0
+            end;
         false ->
             {replace, OriginalNode, Uuid, Seq}
     end.
@@ -1607,8 +1614,8 @@ start_seq([{_, NewSeq}, {OrigNode, _} | _], OrigNode, Seq) when Seq > NewSeq ->
     NewSeq;
 start_seq([_ | Rest], OrigNode, Seq) ->
     start_seq(Rest, OrigNode, Seq);
-start_seq([], OrigNode, Seq) ->
-    erlang:error({epoch_mismatch, OrigNode, Seq}).
+start_seq([], _OrigNode, _Seq) ->
+    throw(epoch_mismatch).
 
 
 fold_docs(Db, UserFun, UserAcc) ->
@@ -1986,7 +1993,8 @@ calculate_start_seq_test_() ->
             t_calculate_start_seq_uuid_mismatch(),
             t_calculate_start_seq_is_owner(),
             t_calculate_start_seq_not_owner(),
-            t_calculate_start_seq_raw()
+            t_calculate_start_seq_raw(),
+            t_calculate_start_seq_epoch_mismatch()
         ]
     }.
 
@@ -2029,6 +2037,14 @@ t_calculate_start_seq_raw() ->
         Db = test_util:fake_db([]),
         Seq = calculate_start_seq(Db, node1, 13),
         ?assertEqual(13, Seq)
+    end).
+
+t_calculate_start_seq_epoch_mismatch() ->
+    ?_test(begin
+        Db = test_util:fake_db([]),
+        SeqIn = {replace, not_this_node, get_uuid(Db), 42},
+        Seq = calculate_start_seq(Db, node1, SeqIn),
+        ?assertEqual(0, Seq)
     end).
 
 is_owner_test() ->


### PR DESCRIPTION
## Overview

Originally we posited that duplicate UUIDs could never be created.
However due to operations interventions its possible to unintentionally
copy UUIDs in ways that violate this assumption. Instead of crashing the
process we just reset the seq to zero and log a warning as was done in
the other instances when we have mismatches in the epoch history.

## Testing recommendations

`make eunit apps=couch suites=couch_db`

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
