### PR TITLE
Blacklist all 21.x releases older than 21.2.3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -86,7 +86,7 @@ case VerList of
     [19 | _] -> NotSupported(VerString);
 
     [20 | _] = V20 when V20 < [20, 3, 8, 11] -> BadErlang(VerString);
-    [21, 2, N | _] when N < 3 -> BadErlang(VerString);
+    [21 | _] = V21 when V21 < [21, 2, 3] -> BadErlang(VerString);
     [22, 0, N | _] when N < 5 -> BadErlang(VerString);
 
     _ -> ok


### PR DESCRIPTION
This basically just extends the black list to cover the `21.{0,1}`
release range. This is due to a compiler bug [1] which is a duplicate of
[2].

[1] https://bugs.erlang.org/browse/ERL-981
[2] https://bugs.erlang.org/browse/ERL-807

---

I'm not 100% on this. Technically this range contains the bug as mentioned in the tickets, however I've got no idea if anywhere in our code base actually triggers the bug. I can't think of anyone that's reported mysterious errors on these versions but we're not running things against it in Travis either. So basically a big ol' shrug either way from me at this point. Though my risk adversity leans toward blacklisting.