### PR TITLE
Update ioq to 2.1.2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -99,7 +99,7 @@ DepDescs = [
 {ets_lru,          "ets-lru",          {tag, "1.0.0"}},
 {khash,            "khash",            {tag, "1.0.1"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.2"}},
-{ioq,              "ioq",              {tag, "2.1.1"}},
+{ioq,              "ioq",              {tag, "2.1.2"}},
 {hqueue,           "hqueue",           {tag, "1.0.1"}},
 {smoosh,           "smoosh",           {tag, "1.0.1"}},
 {ken,              "ken",              {tag, "1.0.3"}},


### PR DESCRIPTION
# Overview

Update ioq to 2.1.2 to fix flaky test when on powerful machines the latency in ioq is so small that we call log10 with 0
This update also drags additional changes. The full list of commits is:
- [5ff5921](https://github.com/apache/couchdb-ioq/commit/5ff5921) Merge pull request #15 from apache/ioq_update_hist
- [b1ce76d](https://github.com/apache/couchdb-ioq/commit/b1ce76d) Log from 0 is undefined
- [8ada5fa](https://github.com/apache/couchdb-ioq/commit/8ada5fa) Merge pull request #13 from apache/allow-for-dynamic-ioq-classes
- [c0ce268](https://github.com/apache/couchdb-ioq/commit/c0ce268) Add dynamic IOQ class documentation
- [d6e7a78](https://github.com/apache/couchdb-ioq/commit/d6e7a78) Allow dynamic classes in is_valid_class
- [08c6bbb](https://github.com/apache/couchdb-ioq/commit/08c6bbb) Rearrange IOQ config declarations into header file


## Testing recommendations

Unfortunately it doesn't seem to be possible to write a test case specifically for this problem. The change is very slow and we would have to rely on review and existent unit tests. 

## Related Issues or Pull Requests

- https://github.com/apache/couchdb-ioq/pull/15

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
