### PR TITLE
Add missing settings to default.ini file

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -375,7 +375,7 @@ verify_ssl_certificates = false
 ; Maximum peer certificate depth (must be set even if certificate validation is off).
 ssl_certificate_max_depth = 3
 ; Maximum document ID length for replication.
-;max_document_id_length = 0
+;max_document_id_length = infinity
 ; How much time to wait before retrying after a missing doc exception. This
 ; exception happens if the document was seen in the changes feed, but internal
 ; replication hasn't caught up yet, and fetching document's revisions

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -70,6 +70,17 @@ default_engine = couch
 ; is 10GiB. A value of 0 or less will disable partition size checks.
 ;max_partition_size = 10737418240
 
+[purge]
+; Allowed maximum number of documents in one purge request
+;max_document_id_number = 100
+;
+; Allowed maximum number of accumulated revisions in one purge request
+;max_revisions_number = 1000
+;
+; Allowed durations when index is not updated for local purge checkpoint
+; document. Default is 24 hours.
+;index_lag_warn_seconds = 86400
+
 [couchdb_engines]
 ; The keys in this section are the filename extension that
 ; the specified engine module will use. This is important so


### PR DESCRIPTION
The code has "infinity" as the default value and not 0

https://github.com/apache/couchdb/blob/master/src/couch_replicator/src/couch_replicator_changes_reader.erl#L124

Then also add missing purge settings. 

http://docs.couchdb.org/en/latest/cluster/purging.html#config-settings

(Except `allowed_purge_seq_lag` which is not found in the code and should probably be removed from docs)
