### PR TITLE
test(access): add some basic tests for access

### DIFF
--- a/src/couch/test/couchdb_access_tests.erl
+++ b/src/couch/test/couchdb_access_tests.erl
@@ -27,6 +27,11 @@ setup(PortType) ->
     XUrl = make_url("x", Addr, PortType),
     YUrl = make_url("y", Addr, PortType),
 
+    % cleanup and setup
+    {ok, _, _, _} = test_request:delete(AdminUrl ++ "/_users"),
+    {ok, _, _, _} = test_request:delete(AdminUrl ++ "/db?q=1"),
+    {ok, _, _, _} = test_request:put(AdminUrl ++ "/db?access=true", ""),
+
     % create users
     UserDbUrl = AdminUrl ++ "/_users",
     {ok, 201, _, _} = test_request:put(UserDbUrl, ""),
@@ -39,9 +44,6 @@ setup(PortType) ->
     UserYBody = "{ \"name\":\"y\", \"roles\": [], \"password\":\"y\", \"type\": \"user\" }",
     {ok, 201, _, _} = test_request:put(UserYUrl, UserYBody),
 
-    {ok, _, _, _} = test_request:delete(AdminUrl ++ "/db"),
-    {ok, _, _, _} = test_request:put(AdminUrl ++ "/db?access=true", ""),
-
     {AdminUrl, XUrl, YUrl}.
 
 teardown(_, _) ->
@@ -50,10 +52,22 @@ teardown(_, _) ->
 
 access_test_() ->
     Tests = [
-        fun should_let_admin_create_doc_with_access/2
+        fun should_let_admin_create_doc_with_access/2,
+        fun should_let_user_create_doc_for_themselves/2,
+        fun should_not_let_user_create_doc_for_someone_else/2,
+        fun should_let_admin_read_doc_with_access/2
+        fun user_with_access_can_read_doc/2,
+        fun user_without_access_can_not_read_doc/2,
+        fun should_let_admin_delete_doc_with_access/2,
+        fun should_let_user_delete_doc_for_themselves/2,
+        fun should_not_let_user_delete_doc_for_someone_else/2,
+        fun should_let_admin_fetch_all_docs/2,
+        fun should_let_user_fetch_their_own_all_docs/2,
+        fun should_let_admin_fetch_changes/2,
+        fun should_let_user_fetch_their_own_changes/2
     ],
     {
-        "Auth tests",
+        "Access tests",
         {
             setup,
             fun() -> test_util:start_couch([chttpd]) end, fun test_util:stop_couch/1,
@@ -69,9 +83,89 @@ make_test_cases(Mod, Funs) ->
         {foreachx, fun setup/1, fun teardown/2, [{Mod, Fun} || Fun <- Funs]}
     }.
 
+% Doc creation
 should_let_admin_create_doc_with_access(_PortType, {AdminUrl, XUrl, YUrl}) ->
     {ok, Code, _, _} = test_request:put(AdminUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
     ?_assertEqual(201, Code).
+
+should_let_user_create_doc_for_themselves(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, Code, _, _} = test_request:put(XUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    ?_assertEqual(201, Code).
+
+should_not_let_user_create_doc_for_someone_else(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, Code, _, _} = test_request:put(YUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    ?_assertEqual(401, Code).
+
+% Doc reads
+should_let_admin_read_doc_with_access(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(XUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, Code, _, _} = test_request:get(AdminUrl ++ "/db/a"),
+    ?_assertEqual(200, Code).
+
+user_with_access_can_read_doc(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, Code, _, _} = test_request:get(XUrl ++ "/db/a"),
+    ?_assertEqual(200, Code).
+
+user_without_access_can_not_read_doc(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, Code, _, _} = test_request:get(YUrl ++ "/db/a"),
+    ?_assertEqual(401, Code).
+
+% Doc deletes
+should_let_admin_delete_doc_with_access(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(XUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, Code, _, _} = test_request:delete(AdminUrl ++ "/db/a?rev=1-967a00dff5e02add41819138abb3284d"),
+    ?_assertEqual(200, Code).
+
+should_let_user_delete_doc_for_themselves(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(XUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, Code, _, _} = test_request:delete(XUrl ++ "/db/a?rev=1-967a00dff5e02add41819138abb3284d"),
+    ?_assertEqual(200, Code).
+
+should_not_let_user_delete_doc_for_someone_else(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(XUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, Code, _, _} = test_request:delete(YUrl ++ "/db/a?rev=1-967a00dff5e02add41819138abb3284d"),
+    ?_assertEqual(401, Code).
+
+% _all_docs with include_docs
+should_let_admin_fetch_all_docs(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    Admin_Fetch_Docs_Body = <<"{\"total_rows\":4,\"offset\":0,\"rows\":[\r\n{\"id\":\"a\",\"key\":\"a\",\"value\":{\"rev\":\"1-967a00dff5e02add41819138abb3284d\"},\"doc\":{\"_id\":\"a\",\"_rev\":\"1-967a00dff5e02add41819138abb3284d\",\"_access\":{}}},\r\n{\"id\":\"b\",\"key\":\"b\",\"value\":{\"rev\":\"1-967a00dff5e02add41819138abb3284d\"},\"doc\":{\"_id\":\"b\",\"_rev\":\"1-967a00dff5e02add41819138abb3284d\",\"_access\":{}}},\r\n{\"id\":\"c\",\"key\":\"c\",\"value\":{\"rev\":\"1-967a00dff5e02add41819138abb3284d\"},\"doc\":{\"_id\":\"c\",\"_rev\":\"1-967a00dff5e02add41819138abb3284d\",\"_access\":{}}},\r\n{\"id\":\"d\",\"key\":\"d\",\"value\":{\"rev\":\"1-967a00dff5e02add41819138abb3284d\"},\"doc\":{\"_id\":\"d\",\"_rev\":\"1-967a00dff5e02add41819138abb3284d\",\"_access\":{}}}\r\n]}\n">>,
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/b", "{\"b\":2,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/c", "{\"c\":3,\"_access\":[\"y\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/d", "{\"d\":4,\"_access\":[\"y\"]}"),
+    {ok, 200, _, Body} = test_request:get(AdminUrl ++ "/db/_all_docs?include_docs=true"),
+    ?_assertEqual(Admin_Fetch_Docs_Body, Body).
+
+should_let_user_fetch_their_own_all_docs(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    Admin_Fetch_Docs_Body = <<"{\"total_rows\":2,\"offset\":0,\"rows\":[\r\n{\"id\":\"a\",\"key\":\"a\",\"value\":{\"rev\":\"1-967a00dff5e02add41819138abb3284d\"},\"doc\":{\"_id\":\"a\",\"_rev\":\"1-967a00dff5e02add41819138abb3284d\",\"_access\":{}}},\r\n{\"id\":\"b\",\"key\":\"b\",\"value\":{\"rev\":\"1-967a00dff5e02add41819138abb3284d\"},\"doc\":{\"_id\":\"b\",\"_rev\":\"1-967a00dff5e02add41819138abb3284d\",\"_access\":{}}}]}\n">>,
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(XUrl ++ "/db/b", "{\"b\":2,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/c", "{\"c\":3,\"_access\":[\"y\"]}"),
+    {ok, 201, _, _} = test_request:put(YUrl ++ "/db/d", "{\"d\":4,\"_access\":[\"y\"]}"),
+    {ok, 200, _, Body} = test_request:get(XUrl ++ "/db/_all_docs?include_docs=true"),
+    ?_assertEqual(Admin_Fetch_Docs_Body, Body).
+% _changes
+should_let_admin_fetch_changes(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/b", "{\"b\":2,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/c", "{\"c\":3,\"_access\":[\"y\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/d", "{\"d\":4,\"_access\":[\"y\"]}"),
+    {ok, 200, _, Body} = test_request:get(AdminUrl ++ "/db/_changes"),
+    {Json} = jiffy:decode(Body),
+    AmountOfDocs = length(proplists:get_value(<<"results">>, Json)),
+    ?_assertEqual(4, AmountOfDocs).
+
+should_let_user_fetch_their_own_changes(_PortType, {AdminUrl, XUrl, YUrl}) ->
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/a", "{\"a\":1,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/b", "{\"b\":2,\"_access\":[\"x\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/c", "{\"c\":3,\"_access\":[\"y\"]}"),
+    {ok, 201, _, _} = test_request:put(AdminUrl ++ "/db/d", "{\"d\":4,\"_access\":[\"y\"]}"),
+    {ok, 200, _, Body} = test_request:get(XUrl ++ "/db/_changes"),
+    {Json} = jiffy:decode(Body),
+    AmountOfDocs = length(proplists:get_value(<<"results">>, Json)),
+    ?_assertEqual(2, AmountOfDocs).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions


### PR DESCRIPTION
## Overview

Adds some basic Erlang tests for @janl’s access branch, most of which currently fail because things aren’t implemented yet.

## Testing recommendations

`make eunit apps=couch tests=access_test`

## Related Issues or Pull Requests

https://github.com/apache/couchdb-documentation/pull/424
