### PR TITLE
Increase timeouts on two slow btree tests

### DIFF
--- a/src/couch/test/couch_btree_tests.erl
+++ b/src/couch/test/couch_btree_tests.erl
@@ -16,6 +16,7 @@
 -include_lib("couch/include/couch_db.hrl").
 
 -define(ROWS, 1000).
+-define(TIMEOUT, 60). % seconds
 
 
 setup() ->
@@ -276,7 +277,9 @@ should_add_every_odd_key_remove_every_even(KeyValues, {_, Btree}) ->
             false -> {Count + 1, Left, [X | Right]}
         end
                                             end, {0, [], []}, KeyValues),
-    ?_assert(test_add_remove(Btree1, Rem2Keys0, Rem2Keys1)).
+    {timeout, ?TIMEOUT,
+        ?_assert(test_add_remove(Btree1, Rem2Keys0, Rem2Keys1))
+    }.
 
 should_add_every_even_key_remove_every_old(KeyValues, {_, Btree}) ->
     {ok, Btree1} = couch_btree:add_remove(Btree, KeyValues, []),
@@ -286,7 +289,9 @@ should_add_every_even_key_remove_every_old(KeyValues, {_, Btree}) ->
             false -> {Count + 1, Left, [X | Right]}
         end
                                             end, {0, [], []}, KeyValues),
-    ?_assert(test_add_remove(Btree1, Rem2Keys1, Rem2Keys0)).
+    {timeout, ?TIMEOUT,
+        ?_assert(test_add_remove(Btree1, Rem2Keys1, Rem2Keys0))
+    }.
 
 
 should_reduce_without_specified_direction({_, Btree}) ->


### PR DESCRIPTION
## Overview

These two tests are reliably timing out on ARM hardware in Jenkins. They do a lot of individual btree operations so this is not entirely surprising. Appropriate course of action here is to raise the timeout.

## Testing recommendations

This branch should get built automatically by Jenkins so we can confirm that it fixes the build there.

I've confirmed that the timeout setting works correctly locally (e.g. by lowering it to 0.1 and watching those tests time out).

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation