### PR TITLE
Refactor Jenkins setup to enable test result capture

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,6 +144,9 @@ pipeline {
             } // withEnv
           } // steps
           post {
+            always {
+              junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+            }
             cleanup {
               sh 'rm -rf $COUCHDB_IO_LOG_DIR'
             }
@@ -172,6 +175,11 @@ pipeline {
               steps {
                 unstash 'tarball'
                 sh( script: build_and_test )
+              }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                }
               }
             }
             stage('Build CouchDB packages') {
@@ -214,6 +222,11 @@ pipeline {
               steps {
                 unstash 'tarball'
                 sh( script: build_and_test )
+              }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                }
               }
             }
             stage('Build CouchDB packages') {
@@ -258,6 +271,11 @@ pipeline {
                 unstash 'tarball'
                 sh( script: build_and_test )
               }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                }
+              }
             }
             stage('Build CouchDB packages') {
               steps {
@@ -299,6 +317,11 @@ pipeline {
               steps {
                 unstash 'tarball'
                 sh( script: build_and_test )
+              }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                }
               }
             }
             stage('Build CouchDB packages') {
@@ -342,6 +365,11 @@ pipeline {
                 unstash 'tarball'
                 sh( script: build_and_test )
               }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                }
+              }
             }
             stage('Build CouchDB packages') {
               steps {
@@ -384,6 +412,11 @@ pipeline {
                 unstash 'tarball'
                 sh( script: build_and_test )
               }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                }
+              }
             }
             stage('Build CouchDB packages') {
               steps {
@@ -425,6 +458,11 @@ pipeline {
               steps {
                 unstash 'tarball'
                 sh( script: build_and_test )
+              }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                }
               }
             }
             stage('Build CouchDB packages') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,7 +246,7 @@ pipeline {
             timeout(time: 90, unit: "MINUTES")
           }
           environment {
-            platform = 'xenial'
+            platform = 'bionic'
           }
           steps {
             sh 'rm -f apache-couchdb-*.tar.gz'
@@ -300,7 +300,7 @@ pipeline {
             timeout(time: 90, unit: "MINUTES")
           }
           environment {
-            platform = 'jessie'
+            platform = 'stretch'
           }
           steps {
             sh 'rm -f apache-couchdb-*.tar.gz'
@@ -327,7 +327,7 @@ pipeline {
             timeout(time: 90, unit: "MINUTES")
           }
           environment {
-            platform = 'jessie'
+            platform = 'aarch64-debian-stretch'
           }
           steps {
             sh 'rm -f apache-couchdb-*.tar.gz'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -457,7 +457,9 @@ pipeline {
             stage('Build from tarball & test') {
               steps {
                 unstash 'tarball'
-                sh( script: build_and_test )
+                withEnv(['MIX_HOME='+pwd(), 'HEX_HOME='+pwd()]) {
+                  sh( script: build_and_test )
+                }
               }
               post {
                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,35 +14,33 @@
 // the License.
 
 // DRYing out the Jenkinsfile...
-build_script = '''
-mkdir -p ${COUCHDB_IO_LOG_DIR}
 
-echo
-echo "Build CouchDB from tarball & test"
-builddir=$(mktemp -d)
-cd ${builddir}
+build_and_test = '''
+mkdir -p ${COUCHDB_IO_LOG_DIR}
+rm -rf build
+mkdir build
+cd build
 tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz
 cd apache-couchdb-*
 ./configure --with-curl
 make check || (build-aux/logfile-uploader.py && false)
+'''
 
-echo
-echo "Build CouchDB packages"
-cd ${builddir}
+make_packages = '''
 git clone https://github.com/apache/couchdb-pkg
+rm -rf couchdb
 mkdir couchdb
 cp ${WORKSPACE}/apache-couchdb-*.tar.gz couchdb
 tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz -C couchdb
 cd couchdb-pkg
 make ${platform} PLATFORM=${platform}
+'''
 
-echo
-echo "Cleanup & save for posterity"
+cleanup_and_save = '''
 rm -rf ${WORKSPACE}/pkgs/${platform}
 mkdir -p ${WORKSPACE}/pkgs/${platform}
-mv ../rpmbuild/RPMS/$(arch)/*rpm ${WORKSPACE}/pkgs/${platform} || true
-mv ../couchdb/*.deb ${WORKSPACE}/pkgs/${platform} || true
-rm -rf ${builddir} ${COUCHDB_IO_LOG_DIR}
+mv ${WORKSPACE}/rpmbuild/RPMS/$(arch)/*rpm ${WORKSPACE}/pkgs/${platform} || true
+mv ${WORKSPACE}/couchdb/*.deb ${WORKSPACE}/pkgs/${platform} || true
 '''
 
 pipeline {
@@ -113,11 +111,7 @@ pipeline {
     // https://issues.jenkins-ci.org/browse/JENKINS-47962
     // https://issues.jenkins-ci.org/browse/JENKINS-48050
 
-    // The builddir stuff is to prevent all the builds from live syncing
-    // their build results to each other during the build, which ACTUALLY
-    // HAPPENS. Ugh.
-
-    stage('make check') {
+    stage('Test and Package') {
 
       parallel {
 
@@ -138,18 +132,22 @@ pipeline {
                 mkdir -p $COUCHDB_IO_LOG_DIR
 
                 # Build CouchDB from tarball & test
-                builddir=$(mktemp -d)
-                cd $builddir
+                mkdir build
+                cd build
                 tar -xf $WORKSPACE/apache-couchdb-*.tar.gz
                 cd apache-couchdb-*
                 ./configure --with-curl
                 gmake check || (build-aux/logfile-uploader.py && false)
 
                 # No package build for FreeBSD at this time
-                rm -rf $builddir $COUCHDB_IO_LOG_DIR
               '''
             } // withEnv
           } // steps
+          post {
+            cleanup {
+              sh 'rm -rf $COUCHDB_IO_LOG_DIR'
+            }
+          } // post
         } // stage FreeBSD
 
         stage('CentOS 6') {
@@ -158,6 +156,8 @@ pipeline {
               image 'couchdbdev/centos-6-erlang-19.3.6:latest'
               alwaysPull true
               label 'ubuntu'
+              // this keeps builds landing on the same host from clashing with each other
+              customWorkspace pwd() + '/centos6'
             }
           }
           options {
@@ -167,14 +167,28 @@ pipeline {
           environment {
             platform = 'centos6'
           }
-          steps {
-            sh 'rm -f apache-couchdb-*.tar.gz'
-            unstash 'tarball'
-            sh( script: build_script )
-          } // steps
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
           post {
-            success {
-              archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
             }
           } // post
         } // stage
@@ -185,6 +199,7 @@ pipeline {
               image 'couchdbdev/centos-7-erlang-19.3.6:latest'
               alwaysPull true
               label 'ubuntu'
+              customWorkspace pwd() + '/centos7'
             }
           }
           options {
@@ -194,14 +209,29 @@ pipeline {
           environment {
             platform = 'centos7'
           }
-          steps {
-            sh 'rm -f apache-couchdb-*.tar.gz'
-            unstash 'tarball'
-            sh( script: build_script )
-          } // steps
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                unstash 'tarball'
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
           post {
-            success {
-              archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
             }
           } // post
         } // stage
@@ -212,6 +242,7 @@ pipeline {
               image 'couchdbdev/ubuntu-xenial-erlang-19.3.6:latest'
               alwaysPull true
               label 'ubuntu'
+              customWorkspace pwd() + '/xenial'
             }
           }
           options {
@@ -221,14 +252,28 @@ pipeline {
           environment {
             platform = 'xenial'
           }
-          steps {
-            sh 'rm -f apache-couchdb-*.tar.gz'
-            unstash 'tarball'
-            sh( script: build_script )
-          } // steps
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
           post {
-            success {
-              archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
             }
           } // post
         } // stage
@@ -239,6 +284,7 @@ pipeline {
               image 'couchdbdev/ubuntu-bionic-erlang-19.3.6:latest'
               alwaysPull true
               label 'ubuntu'
+              customWorkspace pwd() + '/bionic'
             }
           }
           options {
@@ -248,14 +294,28 @@ pipeline {
           environment {
             platform = 'bionic'
           }
-          steps {
-            sh 'rm -f apache-couchdb-*.tar.gz'
-            unstash 'tarball'
-            sh( script: build_script )
-          } // steps
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
           post {
-            success {
-              archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
             }
           } // post
         } // stage
@@ -266,6 +326,7 @@ pipeline {
               image 'couchdbdev/debian-jessie-erlang-19.3.6:latest'
               alwaysPull true
               label 'ubuntu'
+              customWorkspace pwd() + '/jessie'
             }
           }
           options {
@@ -275,14 +336,28 @@ pipeline {
           environment {
             platform = 'jessie'
           }
-          steps {
-            sh 'rm -f apache-couchdb-*.tar.gz'
-            unstash 'tarball'
-            sh( script: build_script )
-          } // steps
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
           post {
-            success {
-              archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
             }
           } // post
         } // stage
@@ -293,6 +368,7 @@ pipeline {
               image 'couchdbdev/debian-stretch-erlang-19.3.6:latest'
               alwaysPull true
               label 'ubuntu'
+              customWorkspace pwd() + '/stretch'
             }
           }
           options {
@@ -302,14 +378,28 @@ pipeline {
           environment {
             platform = 'stretch'
           }
-          steps {
-            sh 'rm -f apache-couchdb-*.tar.gz'
-            unstash 'tarball'
-            sh( script: build_script )
-          } // steps
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
           post {
-            success {
-              archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
             }
           } // post
         } // stage
@@ -320,6 +410,7 @@ pipeline {
               image 'couchdbdev/aarch64-debian-stretch-erlang-20.3.8.20:latest'
               alwaysPull true
               label 'arm'
+              customWorkspace pwd() + '/arm'
             }
           }
           options {
@@ -329,14 +420,28 @@ pipeline {
           environment {
             platform = 'aarch64-debian-stretch'
           }
-          steps {
-            sh 'rm -f apache-couchdb-*.tar.gz'
-            unstash 'tarball'
-            sh( script: build_script )
-          } // steps
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
           post {
-            success {
-              archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
             }
           } // post
         } // stage
@@ -442,7 +547,7 @@ pipeline {
         body: "Boo, we failed. ${env.RUN_DISPLAY_URL}"
     }
     cleanup {
-      sh 'rm -rf ${WORKSPACE}/*'
+      sh 'rm -rf ${COUCHDB_IO_LOG_DIR}'
     }
   }
 

--- a/Makefile
+++ b/Makefile
@@ -370,8 +370,8 @@ build-test:
 mango-test: devclean all
 	@cd src/mango && \
 		python3 -m venv .venv && \
-		.venv/bin/pip3 install -r requirements.txt
-	@cd src/mango && ../../dev/run -n 1 --admin=testuser:testpass .venv/bin/nosetests
+		.venv/bin/python3 -m pip install -r requirements.txt
+	@cd src/mango && ../../dev/run -n 1 --admin=testuser:testpass '.venv/bin/python3 -m nose'
 
 ################################################################################
 # Developing

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule CouchDBTest.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps() do
     [
+      {:junit_formatter, "~> 3.0", only: [:dev, :test, :integration]},
       {:httpotion, "~> 3.0", only: [:dev, :test, :integration], runtime: false},
       {:jiffy, path: Path.expand("src/jiffy", __DIR__)},
       {:ibrowse,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -156,7 +156,7 @@ AddConfig = [
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
     {erl_opts, [{i, "../"} | ErlOpts]},
-    {eunit_opts, [verbose]},
+    {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]},
     {plugins, [eunit_plugin]},
     {dialyzer, [
         {plt_location, local},


### PR DESCRIPTION
## Overview

This is a non-trivial refactor of the Jenkins setup:

* Builds are moved back into the workspace. Parallel builds run in unique sub-folders which seems to avoid the clashes we had observed in the past.
* The large build_script is split out into smaller parts as sequential stages. Cleanup operations are deferred to `post` actions to enable retrieval of the test results.
* Test results are captured and saved in the Jenkins UI.
* Various fixes to platform labels and configuration that should get the nightly builds running again.

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation