### PR TITLE
Remove local replication endpoints in CouchDB 3.x

### DIFF
--- a/src/couch_pse_tests/src/cpse_test_purge_replication.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_replication.erl
@@ -21,7 +21,7 @@
 
 
 setup_all() ->
-    cpse_util:setup_all([mem3, fabric, couch_replicator]).
+    cpse_util:setup_all([mem3, fabric, chttpd, couch_replicator]).
 
 
 setup_each() ->
@@ -48,8 +48,8 @@ cpse_purge_http_replication({Source, Target}) ->
     ]),
 
     RepObject = {[
-        {<<"source">>, Source},
-        {<<"target">>, Target}
+        {<<"source">>, db_url(Source)},
+        {<<"target">>, db_url(Target)}
     ]},
 
     {ok, _} = couch_replicator:replicate(RepObject, ?ADMIN_USER),
@@ -100,8 +100,8 @@ cpse_purge_http_replication({Source, Target}) ->
     % Show that replicating from the target
     % back to the source reintroduces the doc
     RepObject2 = {[
-        {<<"source">>, Target},
-        {<<"target">>, Source}
+        {<<"source">>, db_url(Target)},
+        {<<"target">>, db_url(Source)}
     ]},
 
     {ok, _} = couch_replicator:replicate(RepObject2, ?ADMIN_USER),
@@ -200,3 +200,9 @@ make_shard(DbName) ->
         dbname = DbName,
         range = [0, 16#FFFFFFFF]
     }.
+
+
+db_url(DbName) ->
+    Addr = config:get("httpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(couch_httpd, port),
+    ?l2b(io_lib:format("http://~s:~b/~s", [Addr, Port, DbName])).

--- a/src/couch_replicator/src/couch_replicator.erl
+++ b/src/couch_replicator/src/couch_replicator.erl
@@ -358,7 +358,6 @@ strip_url_creds_test_() ->
         end,
         fun (_) -> meck:unload() end,
         [
-            t_strip_local_db_creds(),
             t_strip_http_basic_creds(),
             t_strip_http_props_creds()
         ]

--- a/src/couch_replicator/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor.erl
@@ -886,8 +886,8 @@ change() ->
         {<<"id">>, ?DOC1},
         {doc, {[
             {<<"_id">>, ?DOC1},
-            {<<"source">>, <<"src">>},
-            {<<"target">>, <<"tgt">>}
+            {<<"source">>, <<"http://srchost.local/src">>},
+            {<<"target">>, <<"http://tgthost.local/tgt">>}
         ]}}
     ]}.
 
@@ -897,8 +897,8 @@ change(State) ->
         {<<"id">>, ?DOC1},
         {doc, {[
             {<<"_id">>, ?DOC1},
-            {<<"source">>, <<"src">>},
-            {<<"target">>, <<"tgt">>},
+            {<<"source">>, <<"http://srchost.local/src">>},
+            {<<"target">>, <<"http://tgthost.local/tgt">>},
             {<<"_replication_state">>, State}
         ]}}
     ]}.
@@ -910,8 +910,8 @@ deleted_change() ->
         {<<"deleted">>, true},
         {doc, {[
             {<<"_id">>, ?DOC1},
-            {<<"source">>, <<"src">>},
-            {<<"target">>, <<"tgt">>}
+            {<<"source">>, <<"http://srchost.local/src">>},
+            {<<"target">>, <<"http://tgthost.local/tgt">>}
         ]}}
     ]}.
 

--- a/src/couch_replicator/src/couch_replicator_doc_processor_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor_worker.erl
@@ -137,7 +137,7 @@ maybe_add_job_to_scheduler({DbName, DocId}, Rep, WRef) ->
 
 -define(DB, <<"db">>).
 -define(DOC1, <<"doc1">>).
--define(R1, {"0b7831e9a41f9322a8600ccfa02245f2", ""}).
+-define(R1, {"ad08e05057046eabe898a2572bbfb573", ""}).
 
 
 doc_processor_worker_test_() ->
@@ -277,8 +277,8 @@ did_not_add_job() ->
 change() ->
     {[
          {<<"_id">>, ?DOC1},
-         {<<"source">>, <<"src">>},
-         {<<"target">>, <<"tgt">>}
+         {<<"source">>, <<"http://srchost.local/src">>},
+         {<<"target">>, <<"http://tgthost.local/tgt">>}
      ]}.
 
 -endif.

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -423,8 +423,8 @@ parse_rep_db(<<"http://", _/binary>> = Url, Proxy, Options) ->
 parse_rep_db(<<"https://", _/binary>> = Url, Proxy, Options) ->
     parse_rep_db({[{<<"url">>, Url}]}, Proxy, Options);
 
-parse_rep_db(<<DbName/binary>>, _Proxy, _Options) ->
-    DbName;
+parse_rep_db(<<_/binary>>, _Proxy, _Options) ->
+    throw({error, <<"Local endpoints not supported since CouchDB 3.x">>});
 
 parse_rep_db(undefined, _Proxy, _Options) ->
     throw({error, <<"Missing replicator database">>}).
@@ -820,6 +820,31 @@ t_vdu_does_not_crash_on_save(DbName) ->
     ?_test(begin
         Doc = #doc{id = <<"some_id">>, body = {[{<<"foo">>, 42}]}},
         ?assertEqual({ok, forbidden}, save_rep_doc(DbName, Doc))
+    end).
+
+
+local_replication_endpoint_error_test_() ->
+     {
+        foreach,
+        fun () -> meck:expect(config, get,
+            fun(_, _, Default) -> Default end)
+        end,
+        fun (_) -> meck:unload() end,
+        [
+            t_error_on_local_endpoint()
+        ]
+    }.
+
+
+t_error_on_local_endpoint() ->
+    ?_test(begin
+        RepDoc = {[
+            {<<"_id">>, <<"someid">>},
+            {<<"source">>, <<"localdb">>},
+            {<<"target">>, <<"http://somehost.local/tgt">>}
+        ]},
+        Expect = <<"Local endpoints not supported since CouchDB 3.x">>,
+        ?assertThrow({bad_rep_doc, Expect}, parse_rep_doc_without_id(RepDoc))
     end).
 
 -endif.

--- a/src/couch_replicator/src/couch_replicator_filters.erl
+++ b/src/couch_replicator/src/couch_replicator_filters.erl
@@ -14,7 +14,7 @@
 
 -export([
     parse/1,
-    fetch/4,
+    fetch/3,
     view_type/2,
     ejsort/1
 ]).
@@ -63,11 +63,11 @@ parse(Options) ->
 % Fetches body of filter function from source database. Guaranteed to either
 % return {ok, Body} or an {error, Reason}. Also assume this function might
 % block due to network / socket issues for an undeterminted amount of time.
--spec fetch(binary(), binary(), binary(), #user_ctx{}) ->
+-spec fetch(binary(), binary(), binary()) ->
     {ok, {[_]}} | {error, binary()}.
-fetch(DDocName, FilterName, Source, UserCtx) ->
+fetch(DDocName, FilterName, Source) ->
     {Pid, Ref} = spawn_monitor(fun() ->
-        try fetch_internal(DDocName, FilterName, Source, UserCtx) of
+        try fetch_internal(DDocName, FilterName, Source) of
             Resp ->
                 exit({exit_ok, Resp})
         catch
@@ -108,9 +108,8 @@ view_type(Props, Options) ->
 
 % Private functions
 
-fetch_internal(DDocName, FilterName, Source, UserCtx) ->
-    Db = case (catch couch_replicator_api_wrap:db_open(Source,
-        [{user_ctx, UserCtx}])) of
+fetch_internal(DDocName, FilterName, Source) ->
+    Db = case (catch couch_replicator_api_wrap:db_open(Source)) of
     {ok, Db0} ->
         Db0;
     DbError ->

--- a/src/couch_replicator/test/eunit/couch_replicator_attachments_too_large.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_attachments_too_large.erl
@@ -33,7 +33,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
 
 
 attachment_too_large_replication_test_() ->
-    Pairs = [{local, remote}, {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Attachment size too large replication tests",
         {
@@ -96,8 +96,6 @@ delete_db(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]).
 
 
-db_url(local, DbName) ->
-    DbName;
 db_url(remote, DbName) ->
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(couch_httpd, port),

--- a/src/couch_replicator/test/eunit/couch_replicator_compact_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_compact_tests.erl
@@ -33,8 +33,6 @@ setup() ->
     ok = couch_db:close(Db),
     DbName.
 
-setup(local) ->
-    setup();
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
@@ -56,8 +54,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
     ok = test_util:stop_couch(Ctx).
 
 compact_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Compaction during replication tests",
         {

--- a/src/couch_replicator/test/eunit/couch_replicator_filtered_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_filtered_tests.erl
@@ -60,8 +60,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
     ok = test_util:stop_couch(Ctx).
 
 filtered_replication_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Filtered replication tests",
         {
@@ -72,8 +71,7 @@ filtered_replication_test_() ->
     }.
 
 query_filtered_replication_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Filtered with query replication tests",
         {
@@ -84,7 +82,7 @@ query_filtered_replication_test_() ->
     }.
 
 view_filtered_replication_test_() ->
-    Pairs = [{local, local}],
+    Pairs = [{remote, remote}],
     {
         "Filtered with a view replication tests",
         {
@@ -236,8 +234,6 @@ create_docs(DbName) ->
 delete_db(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]).
 
-db_url(local, DbName) ->
-    DbName;
 db_url(remote, DbName) ->
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(couch_httpd, port),

--- a/src/couch_replicator/test/eunit/couch_replicator_id_too_long_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_id_too_long_tests.erl
@@ -33,8 +33,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
 
 
 id_too_long_replication_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Doc id too long tests",
         {
@@ -86,8 +85,6 @@ delete_db(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]).
 
 
-db_url(local, DbName) ->
-    DbName;
 db_url(remote, DbName) ->
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(couch_httpd, port),

--- a/src/couch_replicator/test/eunit/couch_replicator_large_atts_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_large_atts_tests.erl
@@ -33,8 +33,6 @@ setup() ->
     ok = couch_db:close(Db),
     DbName.
 
-setup(local) ->
-    setup();
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
@@ -58,8 +56,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
     ok = test_util:stop_couch(Ctx).
 
 large_atts_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Replicate docs with large attachments",
         {

--- a/src/couch_replicator/test/eunit/couch_replicator_many_leaves_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_many_leaves_tests.erl
@@ -37,8 +37,7 @@ setup() ->
     ok = couch_db:close(Db),
     DbName.
 
-setup(local) ->
-    setup();
+
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
@@ -60,8 +59,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
     ok = test_util:stop_couch(Ctx).
 
 docs_with_many_leaves_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Replicate documents with many leaves",
         {

--- a/src/couch_replicator/test/eunit/couch_replicator_missing_stubs_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_missing_stubs_tests.erl
@@ -30,8 +30,6 @@ setup() ->
     ok = couch_db:close(Db),
     DbName.
 
-setup(local) ->
-    setup();
 setup(remote) ->
     {remote, setup()};
 setup({A, B}) ->
@@ -53,8 +51,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
     ok = test_util:stop_couch(Ctx).
 
 missing_stubs_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Replicate docs with missing stubs (COUCHDB-1365)",
         {

--- a/src/couch_replicator/test/eunit/couch_replicator_selector_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_selector_tests.erl
@@ -31,8 +31,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
     ok = test_util:stop_couch(Ctx).
 
 selector_replication_test_() ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Selector filtered replication tests",
         {
@@ -113,8 +112,6 @@ create_docs(DbName) ->
 delete_db(DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]).
 
-db_url(local, DbName) ->
-    DbName;
 db_url(remote, DbName) ->
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(couch_httpd, port),

--- a/src/couch_replicator/test/eunit/couch_replicator_small_max_request_size_target.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_small_max_request_size_target.erl
@@ -19,9 +19,6 @@ setup() ->
     DbName.
 
 
-setup(local) ->
-    setup();
-
 setup(remote) ->
     {remote, setup()};
 
@@ -47,7 +44,7 @@ teardown(_, {Ctx, {Source, Target}}) ->
 
 
 reduce_max_request_size_test_() ->
-    Pairs = [{local, remote}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "Replicate docs when target has a small max_http_request_size",
         {

--- a/src/couch_replicator/test/eunit/couch_replicator_use_checkpoints_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_use_checkpoints_tests.erl
@@ -51,8 +51,6 @@ setup() ->
     ok = couch_db:close(Db),
     DbName.
 
-setup(local) ->
-    setup();
 setup(remote) ->
     {remote, setup()};
 setup({_, Fun, {A, B}}) ->
@@ -88,8 +86,7 @@ use_checkpoints_test_() ->
     }.
 
 use_checkpoints_tests(UseCheckpoints, Fun) ->
-    Pairs = [{local, local}, {local, remote},
-             {remote, local}, {remote, remote}],
+    Pairs = [{remote, remote}],
     {
         "use_checkpoints: " ++ atom_to_list(UseCheckpoints),
         {


### PR DESCRIPTION
### Overview

`local` replication endpoints do something completely unexpected from a user's
point of view -- they replicate to and from node local databases on a random
node. The only way this worked correctly was if someone used the backend port
(:5986) with a single node database. However, that port is getting closed for 3.x
release as well, so it makes even less sense to keep this functionality around.

For more discussion and voting results see ML list:
https://lists.apache.org/thread.html/ddcd9db93cee363db7da571f5cbc7f2bd24b881a34e1ef734d6a0a1c@%3Cdev.couchdb.apache.org%3E

 The `_replicate` HTTP "hack" was left as is, since it does work more or less, however it is inconsistent with what `_replicator` docs do so we should probably mark it as deprecated and remove it in 4.x

### Testing recommendations

`make eunit`
 `make elixir`

Create a replication with a local db endpoint via _replicate and via _replicator

### Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made: https://github.com/apache/couchdb-documentation/pull/423
