### PR TITLE
Fix cpse_test_purge_replication eunit test

### DIFF
--- a/src/couch_pse_tests/src/cpse_test_purge_replication.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_replication.erl
@@ -21,7 +21,7 @@
 
 
 setup_all() ->
-    cpse_util:setup_all([mem3, fabric, chttpd, couch_replicator]).
+    cpse_util:setup_all([mem3, fabric, couch_replicator]).
 
 
 setup_each() ->
@@ -205,4 +205,11 @@ make_shard(DbName) ->
 db_url(DbName) ->
     Addr = config:get("httpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(couch_httpd, port),
-    ?l2b(io_lib:format("http://~s:~b/~s", [Addr, Port, DbName])).
+    Url = ?l2b(io_lib:format("http://~s:~b/~s", [Addr, Port, DbName])),
+    test_util:wait(fun() ->
+        case test_request:get(?b2l(Url)) of
+            {ok, 200, _, _} -> ok;
+            _ -> wait
+        end
+    end),
+    Url.


### PR DESCRIPTION
It doesn't work on Jenkins but worked locally.

Noticed that we started chttpd even though the clustered port was never used.

Add a wait function in `db_url/1` to make sure to wait until the db is
available via the HTTP interface before continuing.

