### PR TITLE
Do not fail 'dev/run' on connection close

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -690,27 +690,37 @@ def generate_cookie():
 
 
 def cluster_setup_with_admin_party(ctx):
+    connect_nodes(ctx)
+    host, port = "127.0.0.1", cluster_port(ctx, 1)
+    create_system_databases(host, port)
+
+
+def connect_nodes(ctx):
     host, port = "127.0.0.1", backend_port(ctx, 1)
     for node in ctx["nodes"]:
-        body = "{}"
-        conn = httpclient.HTTPConnection(host, port)
-        conn.request("PUT", "/_nodes/%s@127.0.0.1" % node, body)
-        resp = conn.getresponse()
-        if resp.status not in (200, 201, 202, 409):
-            print(("Failed to join %s into cluster: %s" % (node, resp.read())))
-            sys.exit(1)
-    create_system_databases(host, cluster_port(ctx, 1))
+        path = "/_nodes/%s@127.0.0.1" % node
+        try_request(
+            host,
+            port,
+            "PUT",
+            path,
+            (200, 201, 202, 409),
+            body="{}",
+            error="Failed to join %s into cluster:\n" % node,
+        )
 
 
-def try_request(host, port, meth, path, success_codes, retries=10, retry_dt=1):
+def try_request(
+    host, port, meth, path, success_codes, body=None, retries=10, retry_dt=1, error=""
+):
     while True:
         conn = httpclient.HTTPConnection(host, port)
-        conn.request(meth, path)
+        conn.request(meth, path, body=body)
         resp = conn.getresponse()
         if resp.status in success_codes:
             return resp.status, resp.read()
         elif retries <= 0:
-            assert resp.status in success_codes, resp.read()
+            assert resp.status in success_codes, "%s%s" % (error, resp.read())
         retries -= 1
         time.sleep(retry_dt)
 
@@ -721,7 +731,14 @@ def create_system_databases(host, port):
         conn.request("HEAD", "/" + dbname)
         resp = conn.getresponse()
         if resp.status == 404:
-            try_request(host, port, "PUT", "/" + dbname, (201, 202, 412))
+            try_request(
+                host,
+                port,
+                "PUT",
+                "/" + dbname,
+                (201, 202, 412),
+                error="Failed to create '%s' database:\n" % dbname,
+            )
 
 
 @log(


### PR DESCRIPTION
## Overview

Sometimes admin party mode causes the 'dev/run' to fail with
```
http.client.RemoteDisconnected: Remote end closed connection without response
```

This PR makes this use case more robust.

## Testing recommendations

- run `dev/run --admin=adm:pass`

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
