### PR TITLE
fixup for dreyfus_fabric_cleanup:go/1

### DIFF
--- a/src/dreyfus/src/dreyfus_fabric_cleanup.erl
+++ b/src/dreyfus/src/dreyfus_fabric_cleanup.erl
@@ -53,12 +53,12 @@ cleanup_local_purge_doc(DbName, ActiveSigs) ->
     end, [], LocalShards),
 
     DeadDirs = DirList -- ActiveDirs,
-    lists:foldl(fun(IdxDir) ->
+    lists:foreach(fun(IdxDir) ->
         Sig = dreyfus_util:get_signature_from_idxdir(IdxDir),
         case Sig of undefined -> ok; _ ->
             DocId = dreyfus_util:get_local_purge_doc_id(Sig),
             LocalShards = mem3:local_shards(DbName),
-            lists:foldl(fun(LS, _AccOuter) ->
+            lists:foreach(fun(LS) ->
                 ShardDbName = LS#shard.name,
                 {ok, ShardDb} = couch_db:open_int(ShardDbName, []),
                 case couch_db:open_doc(ShardDb, DocId, []) of
@@ -69,6 +69,6 @@ cleanup_local_purge_doc(DbName, ActiveSigs) ->
                         ok
                 end,
                 couch_db:close(ShardDb)
-            end, [], LocalShards)
+            end, LocalShards)
         end
-    end, [], DeadDirs).
+    end, DeadDirs).

--- a/src/dreyfus/src/dreyfus_util.erl
+++ b/src/dreyfus/src/dreyfus_util.erl
@@ -332,7 +332,10 @@ get_local_purge_doc_id(Sig) ->
 get_signature_from_idxdir(IdxDir) ->
     IdxDirList = filename:split(IdxDir),
     Sig = lists:last(IdxDirList),
-    case [Ch || Ch <- Sig, not (((Ch >= $0) and (Ch =< $9))
+    Sig2 = if not is_binary(Sig) -> Sig; true ->
+        binary_to_list(Sig)
+    end,
+    case [Ch || Ch <- Sig2, not (((Ch >= $0) and (Ch =< $9))
         orelse ((Ch >= $a) and (Ch =< $f))
         orelse ((Ch >= $A) and (Ch =< $F)))] == [] of
         true -> Sig;


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
```
(dbcore@db6.ibm-cluster1.cloudant.net)1> dreyfus_fabric_cleanup:go(<<"db1">>).
** exception error: no function clause matching
                    lists:foldl(#Fun<dreyfus_fabric_cleanup.2.102674665>,[],[]) (lists.erl, line 1262)
     in function  dreyfus_fabric_cleanup:go/1 (src/dreyfus_fabric_cleanup.erl, line 28)
```
## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->


```
(node1@127.0.0.1)1> dreyfus_fabric_cleanup:go(<<"db1">>).
ok
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
