### PR TITLE
Ensure EUnit inherits appropriate environment variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -529,8 +529,6 @@ pipeline {
             reprepro -b couchdb-pkg/repo includedeb jessie pkgs/jessie/*.deb
             cp js/debian-stretch/*.deb pkgs/stretch
             reprepro -b couchdb-pkg/repo includedeb stretch pkgs/stretch/*.deb
-            cp js/ubuntu-trusty/*.deb pkgs/trusty
-            reprepro -b couchdb-pkg/repo includedeb trusty pkgs/trusty/*.deb
             cp js/ubuntu-xenial/*.deb pkgs/xenial
             reprepro -b couchdb-pkg/repo includedeb xenial pkgs/xenial/*.deb
             cp js/ubuntu-bionic/*.deb pkgs/bionic

--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,11 @@ eunit: export BUILDDIR = $(shell pwd)
 eunit: export ERL_AFLAGS = -config $(shell pwd)/rel/files/eunit.config
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell pwd)/bin/couchjs $(shell pwd)/share/server/main.js
 eunit: couch
-	@$(REBAR) setup_eunit 2> /dev/null
+	@COUCHDB_VERSION=$(COUCHDB_VERSION) COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) $(REBAR) setup_eunit 2> /dev/null
 	@for dir in $(subdirs); do \
             tries=0; \
             while true; do \
-                $(REBAR) -r eunit $(EUNIT_OPTS) apps=$$dir ; \
+                COUCHDB_VERSION=$(COUCHDB_VERSION) COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) $(REBAR) -r eunit $(EUNIT_OPTS) apps=$$dir ; \
                 if [ $$? -eq 0 ]; then \
                     break; \
                 else \

--- a/Makefile.win
+++ b/Makefile.win
@@ -141,8 +141,8 @@ eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 eunit: export BUILDDIR = $(shell echo %cd%)
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 eunit: couch
-	@$(REBAR) setup_eunit 2> nul
-	@$(REBAR) -r eunit $(EUNIT_OPTS)
+	@set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) setup_eunit 2> nul
+	@set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) -r eunit $(EUNIT_OPTS)
 
 .PHONY: exunit
 # target: exunit - Run ExUnit tests

--- a/src/chttpd/test/eunit/chttpd_db_test.erl
+++ b/src/chttpd/test/eunit/chttpd_db_test.erl
@@ -23,6 +23,7 @@
 -define(DESTHEADER2, {"Destination", "foo%2Fbar%23baz%3Fpow%3Afiz"}).
 -define(FIXTURE_TXT, ?ABS_PATH(?FILE)).
 -define(i2l(I), integer_to_list(I)).
+-define(TIMEOUT, 60). % seconds
 
 setup() ->
     Hashed = couch_passwords:hash_admin_password(?PASS),
@@ -88,7 +89,7 @@ all_test_() ->
 
 
 should_return_ok_true_on_bulk_update(Url) ->
-    ?_assertEqual(true,
+    {timeout, ?TIMEOUT, ?_assertEqual(true,
         begin
             {ok, _, _, Body} = create_doc(Url, "testdoc"),
             {Json} = ?JSON_DECODE(Body),
@@ -99,27 +100,27 @@ should_return_ok_true_on_bulk_update(Url) ->
             ResultJson = ?JSON_DECODE(ResultBody),
             {InnerJson} = lists:nth(1, ResultJson),
             couch_util:get_value(<<"ok">>, InnerJson, undefined)
-        end).
+        end)}.
 
 
 should_return_ok_true_on_ensure_full_commit(Url0) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         Url = Url0 ++ "/_ensure_full_commit",
         {ok, RC, _, Body} = test_request:post(Url, [?CONTENT_JSON, ?AUTH], []),
         {Json} = ?JSON_DECODE(Body),
         ?assertEqual(201, RC),
         ?assert(couch_util:get_value(<<"ok">>, Json))
-    end).
+    end)}.
 
 
 should_return_404_for_ensure_full_commit_on_no_db(Url0) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         Url = Url0 ++ "-missing-db" ++ "/_ensure_full_commit",
         {ok, RC, _, Body} = test_request:post(Url, [?CONTENT_JSON, ?AUTH], []),
         {Json} = ?JSON_DECODE(Body),
         ?assertEqual(404, RC),
         ?assertEqual(<<"not_found">>, couch_util:get_value(<<"error">>, Json))
-    end).
+    end)}.
 
 
 should_accept_live_as_an_alias_for_continuous(Url) ->
@@ -135,7 +136,7 @@ should_accept_live_as_an_alias_for_continuous(Url) ->
         end,
         couch_util:get_value(<<"last_seq">>, Result, undefined)
     end,
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         {ok, _, _, ResultBody1} =
             test_request:get(Url ++ "/_changes?feed=live&timeout=1", [?AUTH]),
         LastSeq1 = GetLastSeq(ResultBody1),
@@ -146,11 +147,11 @@ should_accept_live_as_an_alias_for_continuous(Url) ->
         LastSeq2 = GetLastSeq(ResultBody2),
 
         ?assertNotEqual(LastSeq1, LastSeq2)
-    end).
+    end)}.
 
 
 should_return_404_for_delete_att_on_notadoc(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         {ok, RC, _, RespBody} = test_request:delete(
             Url ++ "/notadoc/att.pdf",
             [?CONTENT_JSON, ?AUTH],
@@ -168,11 +169,11 @@ should_return_404_for_delete_att_on_notadoc(Url) ->
             []
         ),
         ?assertEqual(404, RC1)
-    end).
+    end)}.
 
 
 should_return_409_for_del_att_without_rev(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         {ok, RC, _, _} = test_request:put(
             Url ++ "/testdoc3",
             [?CONTENT_JSON, ?AUTH],
@@ -186,11 +187,11 @@ should_return_409_for_del_att_without_rev(Url) ->
             []
         ),
         ?assertEqual(409, RC1)
-    end).
+    end)}.
 
 
 should_return_200_for_del_att_with_rev(Url) ->
-  ?_test(begin
+  {timeout, ?TIMEOUT, ?_test(begin
       {ok, RC, _Headers, RespBody} = test_request:put(
           Url ++ "/testdoc4",
           [?CONTENT_JSON, ?AUTH],
@@ -207,11 +208,11 @@ should_return_200_for_del_att_with_rev(Url) ->
           []
       ),
       ?assertEqual(200, RC1)
-    end).
+    end)}.
 
 
 should_return_409_for_put_att_nonexistent_rev(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         {ok, RC, _Headers, RespBody} = test_request:put(
             Url ++ "/should_return_404/file.erl?rev=1-000",
             [?CONTENT_JSON, ?AUTH],
@@ -222,11 +223,11 @@ should_return_409_for_put_att_nonexistent_rev(Url) ->
             {<<"error">>,<<"not_found">>},
             {<<"reason">>,<<"missing_rev">>}]},
             ?JSON_DECODE(RespBody))
-    end).
+    end)}.
 
 
 should_return_update_seq_when_set_on_all_docs(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 3)],
         {ok, RC, _, RespBody} = test_request:get(Url ++ "/_all_docs/"
             ++ "?update_seq=true&keys=[\"testdoc1\"]",[?CONTENT_JSON, ?AUTH]),
@@ -236,11 +237,11 @@ should_return_update_seq_when_set_on_all_docs(Url) ->
             couch_util:get_value(<<"update_seq">>, ResultJson)),
         ?assertNotEqual(undefined,
             couch_util:get_value(<<"offset">>, ResultJson))
-    end).
+    end)}.
 
 
 should_not_return_update_seq_when_unset_on_all_docs(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 3)],
         {ok, RC, _, RespBody} = test_request:get(Url ++ "/_all_docs/"
             ++ "?update_seq=false&keys=[\"testdoc1\"]",[?CONTENT_JSON, ?AUTH]),
@@ -250,11 +251,11 @@ should_not_return_update_seq_when_unset_on_all_docs(Url) ->
             couch_util:get_value(<<"update_seq">>, ResultJson)),
         ?assertNotEqual(undefined,
             couch_util:get_value(<<"offset">>, ResultJson))
-    end).
+    end)}.
 
 
 should_return_correct_id_on_doc_copy(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         {ok, _, _, _} = create_doc(Url, "testdoc"),
         {_, _, _, ResultBody1} = test_request:copy(Url ++ "/testdoc/",
             [?CONTENT_JSON, ?AUTH, ?DESTHEADER1]),
@@ -269,7 +270,7 @@ should_return_correct_id_on_doc_copy(Url) ->
             ?assertEqual(<<102,111,111,229,149,138,98,97,114>>, Id1),
             ?assertEqual(<<"foo/bar#baz?pow:fiz">>, Id2)
         ]
-    end).
+    end)}.
 
 
 attachment_doc() ->
@@ -285,7 +286,7 @@ attachment_doc() ->
 
 
 should_return_400_for_bad_engine(_) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         TmpDb = ?tempdb(),
         Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
         Port = mochiweb_socket_server:get(chttpd, port),
@@ -293,11 +294,11 @@ should_return_400_for_bad_engine(_) ->
         Url = BaseUrl ++ "?engine=cowabunga",
         {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),
         ?assertEqual(400, Status)
-    end).
+    end)}.
 
 
 should_succeed_on_all_docs_with_queries_keys(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]}]}",
         {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/queries/",
@@ -307,11 +308,11 @@ should_succeed_on_all_docs_with_queries_keys(Url) ->
         ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_all_docs_with_queries_limit_skip(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
         {ok, RC, _, RespBody} = test_request:post(Url ++ "/_all_docs/queries/",
@@ -322,11 +323,11 @@ should_succeed_on_all_docs_with_queries_limit_skip(Url) ->
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_all_docs_with_multiple_queries(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"keys\": [ \"testdoc3\", \"testdoc8\"]},
             {\"limit\": 5, \"skip\": 2}]}",
@@ -340,11 +341,11 @@ should_succeed_on_all_docs_with_multiple_queries(Url) ->
         {InnerJson2} = lists:nth(2, ResultJsonBody),
         ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
-    end).
+    end)}.
 
 
 should_succeed_on_design_docs_with_queries_keys(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"keys\": [ \"_design/ddoc3\",
             \"_design/ddoc8\"]}]}",
@@ -355,11 +356,11 @@ should_succeed_on_design_docs_with_queries_keys(Url) ->
         ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_design_docs_with_queries_limit_skip(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
         {ok, RC, _, RespBody} = test_request:post(Url ++
@@ -370,11 +371,11 @@ should_succeed_on_design_docs_with_queries_limit_skip(Url) ->
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_design_docs_with_multiple_queries(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "_design/ddoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"keys\": [ \"_design/ddoc3\",
             \"_design/ddoc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
@@ -388,11 +389,11 @@ should_succeed_on_design_docs_with_multiple_queries(Url) ->
         {InnerJson2} = lists:nth(2, ResultJsonBody),
         ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
-    end).
+    end)}.
 
 
 should_succeed_on_local_docs_with_queries_keys(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "_local/doc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"keys\":
             [ \"_local/doc3\", \"_local/doc8\"]}]}",
@@ -403,11 +404,11 @@ should_succeed_on_local_docs_with_queries_keys(Url) ->
         ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_local_docs_with_queries_limit_skip(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "_local/doc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
         {ok, RC, _, RespBody} = test_request:post(Url ++
@@ -417,11 +418,11 @@ should_succeed_on_local_docs_with_queries_limit_skip(Url) ->
         ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_local_docs_with_multiple_queries(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "_local/doc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         QueryDoc = "{\"queries\": [{\"keys\": [ \"_local/doc3\",
             \"_local/doc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
@@ -434,4 +435,4 @@ should_succeed_on_local_docs_with_multiple_queries(Url) ->
         ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
         {InnerJson2} = lists:nth(2, ResultJsonBody),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
-    end).
+    end)}.

--- a/src/chttpd/test/eunit/chttpd_view_test.erl
+++ b/src/chttpd/test/eunit/chttpd_view_test.erl
@@ -24,6 +24,7 @@
 
 -define(FIXTURE_TXT, ?ABS_PATH(?FILE)).
 -define(i2l(I), integer_to_list(I)).
+-define(TIMEOUT, 60). % seconds
 
 setup() ->
     Hashed = couch_passwords:hash_admin_password(?PASS),
@@ -71,7 +72,7 @@ all_view_test_() ->
 
 
 should_succeed_on_view_with_queries_keys(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         {ok, _, _, _} = test_request:put(Url ++ "/_design/bar",
             [?CONTENT_JSON, ?AUTH], ?DDOC),
@@ -83,11 +84,11 @@ should_succeed_on_view_with_queries_keys(Url) ->
         ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_view_with_queries_limit_skip(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         {ok, _, _, _} = test_request:put(Url ++ "/_design/bar",
             [?CONTENT_JSON, ?AUTH], ?DDOC),
@@ -100,11 +101,11 @@ should_succeed_on_view_with_queries_limit_skip(Url) ->
         {InnerJson} = lists:nth(1, ResultJsonBody),
         ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
-    end).
+    end)}.
 
 
 should_succeed_on_view_with_multiple_queries(Url) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
         {ok, _, _, _} = test_request:put(Url ++ "/_design/bar",
             [?CONTENT_JSON, ?AUTH], ?DDOC),
@@ -120,4 +121,4 @@ should_succeed_on_view_with_multiple_queries(Url) ->
         {InnerJson2} = lists:nth(2, ResultJsonBody),
         ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
         ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
-    end).
+    end)}.

--- a/src/couch/test/eunit/couch_bt_engine_upgrade_tests.erl
+++ b/src/couch/test/eunit/couch_bt_engine_upgrade_tests.erl
@@ -15,6 +15,7 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
+-define(TIMEOUT, 60). % seconds
 
 setup(_) ->
     Ctx = test_util:start_couch(),
@@ -63,7 +64,7 @@ upgrade_test_() ->
 
 
 t_upgrade_without_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         % There are three documents in the fixture
         % db with zero purge entries
         DbName = ?l2b("db_v"  ++ integer_to_list(VersionFrom)
@@ -99,11 +100,11 @@ t_upgrade_without_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
             ?assertEqual({ok, 4}, couch_db:get_doc_count(Db)),
             ?assertEqual(1, couch_db:get_purge_seq(Db))
         end)
-    end).
+    end)}.
 
 
 t_upgrade_with_1_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         % There are two documents in the fixture database
         % with a single purge entry
         DbName = ?l2b("db_v"  ++ integer_to_list(VersionFrom)
@@ -140,11 +141,11 @@ t_upgrade_with_1_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
             ?assertEqual({ok, 3}, couch_db:get_doc_count(Db)),
             ?assertEqual(2, couch_db:get_purge_seq(Db))
         end)
-    end).
+    end)}.
 
 
 t_upgrade_with_N_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         % There is one document in the fixture database
         % with two docs that have been purged
         DbName = ?l2b("db_v"  ++ integer_to_list(VersionFrom)
@@ -179,11 +180,11 @@ t_upgrade_with_N_purge_req(VersionFrom, {_Ctx, _NewPaths}) ->
             ?assertEqual({ok, 2}, couch_db:get_doc_count(Db)),
             ?assertEqual(3, couch_db:get_purge_seq(Db))
         end)
-    end).
+    end)}.
 
 
 t_upgrade_with_1_purge_req_for_2_docs(VersionFrom, {_Ctx, _NewPaths}) ->
-    ?_test(begin
+    {timeout, ?TIMEOUT, ?_test(begin
         % There are two documents (Doc4 and Doc5) in the fixture database
         % with three docs (Doc1, Doc2 and Doc3) that have been purged, and
         % with one purge req for Doc1 and another purge req for Doc 2 and Doc3
@@ -219,7 +220,7 @@ t_upgrade_with_1_purge_req_for_2_docs(VersionFrom, {_Ctx, _NewPaths}) ->
             ?assertEqual({ok, 3}, couch_db:get_doc_count(Db)),
             ?assertEqual(4, couch_db:get_purge_seq(Db))
         end)
-    end).
+    end)}.
 
 
 save_doc(DbName, Json) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Omitting COUCHDB_VERSION caused the EUnit build of the replicator to have a corrupted User-Agent header. It tried to construct a version using git, but when building from a release tarball there is no git repo so the UA had a git error message in it. This error message contained a newline, which plausibly confused some part of the HTTP stack and caused replicator HTTP requests to hang.

The second commit removes the attempt to publish packages for Ubuntu 14.04, as we're no longer building them for that (EOL) platform.

## Testing recommendations

See https://builds.apache.org/blue/organizations/jenkins/CouchDB/detail/jenkins-cpse-debugging/18/pipeline/, which is building this branch before my cleanup rebase (the final diff from master is identical).

The specific test that was quite regularly failing without this patch is `cpse_purge_http_replication`.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
