### PR TITLE
only fetch 1 query server for indexing

### DIFF
--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -215,7 +215,7 @@ write_docs(TxDb, Mrst, Docs, State) ->
     couch_views_fdb:set_update_seq(TxDb, Sig, LastSeq).
 
 
-start_query_server(#mrst{} = Mrst) ->
+start_query_server(#mrst{qserver = nil} = Mrst) ->
     #mrst{
         language = Language,
         lib = Lib,
@@ -223,7 +223,10 @@ start_query_server(#mrst{} = Mrst) ->
     } = Mrst,
     Defs = [View#mrview.def || View <- Views],
     {ok, QServer} = couch_query_servers:start_doc_map(Language, Defs, Lib),
-    Mrst#mrst{qserver = QServer}.
+    Mrst#mrst{qserver = QServer};
+
+start_query_server(#mrst{} = Mrst) ->
+    Mrst.
 
 
 report_progress(State, UpdateType) ->


### PR DESCRIPTION
# Overview

This fixes an issue where we get a new javascript query server for every 100 docs. We only need 1 server while the index is building.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
