### PR TITLE
Support map childspecs in couch_epi supervisor's children replacement

### DIFF
--- a/src/couch_epi/src/couch_epi_sup.erl
+++ b/src/couch_epi/src/couch_epi_sup.erl
@@ -136,4 +136,7 @@ modules(#couch_epi_spec{kind = data_subscriptions, behaviour = Module}) ->
 merge([], Children) ->
     Children;
 merge([{Id, _, _, _, _, _} = Spec | Rest], Children) ->
-    merge(Rest, lists:keystore(Id, 1, Children, Spec)).
+    merge(Rest, lists:keystore(Id, 1, Children, Spec));
+merge([#{id := Id} = Spec | Rest], Children) ->
+    Replace = fun(#{id := I}) when I == Id -> Spec; (E) -> E end,
+    merge(Rest, lists:map(Replace, Children)).


### PR DESCRIPTION
## Overview

Modern versions of erlang support specification of supervisor's childspecs as maps. This PR adds support for this in `couch_epi` process replacement mechanism.

## Testing recommendations

`make eunit apps=couch_epi` for isolated tests

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation