### PR TITLE
Add Mock library for testing

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -26,6 +26,7 @@
           ~r"/_build/",
           ~r"/node_modules/",
           ~r"/src/jason",
+          ~r"/src/mock",
           ~r"/src/httpotion",
           ~r"/src/credo",
           ~r"/src/junit_formatter",

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,8 @@ defmodule CouchDBTest.Mixfile do
       {:jiffy, path: Path.expand("src/jiffy", __DIR__)},
       {:ibrowse,
        path: Path.expand("src/ibrowse", __DIR__), override: true, compile: false},
-      {:credo, "~> 1.0.0", only: [:dev, :test, :integration], runtime: false}
+      {:credo, "~> 1.0.0", only: [:dev, :test, :integration], runtime: false},
+      {:mock, "~> 0.3.3", only: [:dev, :test, :integration]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,6 @@
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jiffy": {:hex, :jiffy, "0.15.2", "de266c390111fd4ea28b9302f0bc3d7472468f3b8e0aceabfbefa26d08cd73b7", [:rebar3], [], "hexpm"},
   "junit_formatter": {:hex, :junit_formatter, "3.0.0", "13950d944dbd295da7d8cc4798b8faee808a8bb9b637c88069954eac078ac9da", [:mix], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
+  "mock": {:hex, :mock, "0.3.3", "42a433794b1291a9cf1525c6d26b38e039e0d3a360732b5e467bfc77ef26c914", [:mix], [{:meck, "~> 0.8.13", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/elixir/lib/ex_unit.ex
+++ b/test/elixir/lib/ex_unit.ex
@@ -35,6 +35,10 @@ defmodule Couch.Test.ExUnit.Case do
   end
 
   setup context do
+    on_exit(fn ->
+      :meck.unload()
+    end)
+
     case context do
       %{:setup => setup_fun} ->
         {:ok, Setup.setup(context, setup_fun)}


### PR DESCRIPTION
## Overview

Add mocking library to use from ExUnit based unit tests.

## Testing recommendations

1. Create `src/couch/test/exunit/mocking_test.exs` file with the following content
  ```
  defmodule Couch.Test.Mocking do
    @moduledoc false
    use Couch.Test.ExUnit.Case

    alias Couch.Test.Setup

    import Mock

    def with_setup(context, setup) do
      setup =
        setup
        |> Setup.run()

      {context, setup}
    end

    describe "Testing mocking machinery" do
      @describetag setup: &__MODULE__.with_setup/2
      test "that we can mock CouchDB modules", _ctx do
        with_mock :fabric, all_dbs: fn -> :foo end do
          assert :fabric.all_dbs() == :foo, "Expected to get ':foo'"
        end
      end
    end
  end
  ```
2. Run test suite `make exunit tests=src/couch/test/exunit/mocking_test.exs`

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
