### PR TITLE
Call :meck.unload() automatically after every test

### DIFF
--- a/test/elixir/lib/ex_unit.ex
+++ b/test/elixir/lib/ex_unit.ex
@@ -35,6 +35,10 @@ defmodule Couch.Test.ExUnit.Case do
   end
 
   setup context do
+    on_exit(fn ->
+      :meck.unload()
+    end)
+
     case context do
       %{:setup => setup_fun} ->
         {:ok, Setup.setup(context, setup_fun)}


### PR DESCRIPTION
## Overview

We had a number  of problems with using meck and eunit. In fact these problems were one of the driving factors to switch to exunit. ExUnit has a reliable teardown behaviour. Which allows as to do a proper cleanup after meck. This PR adds an unconditional call to :meck.unload() into `on_exit` callback. This would guaranty that we wouldn't have leftover mocked modules in subsequent tests.

## Testing recommendations

Hard to test. 

## Related Issues or Pull Requests

- This PR is a replacement for https://github.com/apache/couchdb/pull/2121

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
