### PR TITLE
More timeout adjustments for Jenkins

### DIFF
--- a/src/couch/test/eunit/couch_db_split_tests.erl
+++ b/src/couch/test/eunit/couch_db_split_tests.erl
@@ -155,7 +155,7 @@ should_copy_local_docs({Desc, TotalDocs, Q}, DbName) ->
     TMap = make_targets(Ranges),
     DocsPerRange = TotalDocs div Q,
     PickFun = make_pickfun(DocsPerRange),
-    {Desc, ?_test(begin
+    {Desc, timeout, ?TIMEOUT, ?_test(begin
         {ok, UpdateSeq} = couch_db_split:split(DbName, TMap, PickFun),
         ?assertEqual(ExpectSeq, UpdateSeq),
         Response = couch_db_split:copy_local_docs(DbName, TMap, PickFun),

--- a/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
@@ -47,14 +47,17 @@ stop_couch(Ctx) ->
 
 check_not_started_test() ->
     % Starting couch, but not ddoc_cache
-    Ctx = test_util:start_couch(),
-    try
-        Key = {ddoc_cache_entry_custom, {<<"dbname">>, ?MODULE}},
-        ?assertEqual({ok, <<"dbname">>}, ddoc_cache_lru:open(Key))
-    after
-        test_util:stop_couch(Ctx)
-    end.
-
+    {
+        setup,
+        fun test_util:start_couch/0,
+        fun test_util:stop_couch/1,
+        [
+            fun(_) ->
+                Key = {ddoc_cache_entry_custom, {<<"dbname">>, ?MODULE}},
+                ?assertEqual({ok, <<"dbname">>}, ddoc_cache_lru:open(Key))
+            end
+        ]
+    }.
 
 check_lru_test_() ->
     {

--- a/test/elixir/lib/couch/db_test.ex
+++ b/test/elixir/lib/couch/db_test.ex
@@ -290,7 +290,7 @@ defmodule Couch.DBTest do
     end
   end
 
-  def retry_until(condition, sleep \\ 100, timeout \\ 5000) do
+  def retry_until(condition, sleep \\ 100, timeout \\ 30_000) do
     retry_until(condition, now(:ms), sleep, timeout)
   end
 

--- a/test/elixir/test/reshard_helpers.exs
+++ b/test/elixir/test/reshard_helpers.exs
@@ -92,7 +92,7 @@ defmodule ReshardHelpers do
   end
 
   def wait_job_removed(id) do
-    retry_until(fn -> get_job(id).status_code == 404 end, 200, 10_000)
+    retry_until(fn -> get_job(id).status_code == 404 end, 200, 60_000)
   end
 
   def wait_job_completed(id) do
@@ -100,7 +100,7 @@ defmodule ReshardHelpers do
   end
 
   def wait_job_state(id, state) do
-    retry_until(fn -> get_job_state(id) == state end, 200, 10_000)
+    retry_until(fn -> get_job_state(id) == state end, 200, 60_000)
   end
 
   def reset_reshard_state do


### PR DESCRIPTION
## Overview

This is straightforward, just adjusting more timeouts in the Jenkins whack-a-mole game. The one novelty here is that some of these timeouts are not timeouts waiting for _any_ response, but timeouts waiting for a specific observable, e.g. that documents show up in the database after an async update.

As I'm only adjusting timeouts here and previous similar changes have already been approved I'm going to go ahead and merge this one.

## Testing recommendations

https://builds.apache.org/blue/organizations/jenkins/CouchDB/detail/jenkins-elixir-retry-until-flakes/6/

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation