### PR TITLE
Update httpotion to 3.1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule CouchDBTest.Mixfile do
   defp deps() do
     [
       {:junit_formatter, "~> 3.0", only: [:dev, :test, :integration]},
-      {:httpotion, "~> 3.0", only: [:dev, :test, :integration], runtime: false},
+      {:httpotion, ">= 3.1.3", only: [:dev, :test, :integration], runtime: false},
       {:jiffy, path: Path.expand("src/jiffy", __DIR__)},
       {:ibrowse,
        path: Path.expand("src/ibrowse", __DIR__), override: true, compile: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "1.0.5", "fdea745579f8845315fe6a3b43e2f9f8866839cfbc8562bb72778e9fdaa94214", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "httpotion": {:hex, :httpotion, "3.1.2", "50e3e559c2ffe8c8908c97e4ffb01efc1c18e8547cc7ce5dd173c9cf0a573a3b", [:mix], [{:ibrowse, "== 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
+  "httpotion": {:hex, :httpotion, "3.1.3", "fdaf1e16b9318dcb722de57e75ac368c93d4c6e3c9125f93e960f953a750fb77", [:mix], [{:ibrowse, "== 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jiffy": {:hex, :jiffy, "0.15.2", "de266c390111fd4ea28b9302f0bc3d7472468f3b8e0aceabfbefa26d08cd73b7", [:rebar3], [], "hexpm"},

--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -67,7 +67,7 @@ defmodule Couch do
     base_url <> url
   end
 
-  def process_request_headers(headers, options) do
+  def process_request_headers(headers, _body, options) do
     headers = Keyword.put(headers, :"User-Agent", "couch-potion")
 
     headers =
@@ -133,105 +133,4 @@ defmodule Couch do
     %Couch.Session{cookie: token}
   end
 
-  # HACK: this is here until this commit lands in a release
-  # https://github.com/myfreeweb/httpotion/commit/f3fa2f0bc3b9b400573942b3ba4628b48bc3c614
-  def handle_response(response) do
-    case response do
-      {:ok, status_code, headers, body, _} ->
-        processed_headers = process_response_headers(headers)
-
-        %HTTPotion.Response{
-          status_code: process_status_code(status_code),
-          headers: processed_headers,
-          body: process_response_body(processed_headers, body)
-        }
-
-      {:ok, status_code, headers, body} ->
-        processed_headers = process_response_headers(headers)
-
-        %HTTPotion.Response{
-          status_code: process_status_code(status_code),
-          headers: processed_headers,
-          body: process_response_body(processed_headers, body)
-        }
-
-      {:ibrowse_req_id, id} ->
-        %HTTPotion.AsyncResponse{id: id}
-
-      {:error, {:conn_failed, {:error, reason}}} ->
-        %HTTPotion.ErrorResponse{message: error_to_string(reason)}
-
-      {:error, :conn_failed} ->
-        %HTTPotion.ErrorResponse{message: "conn_failed"}
-
-      {:error, reason} ->
-        %HTTPotion.ErrorResponse{message: error_to_string(reason)}
-    end
-  end
-
-  # Anther HACK: Until we can get process_request_headers/2 merged
-  # upstream.
-  @spec process_arguments(atom, String.t(), [{atom(), any()}]) :: %{}
-  defp process_arguments(method, url, options) do
-    options = process_options(options)
-
-    body = Keyword.get(options, :body, "")
-
-    headers =
-      Keyword.merge(
-        Application.get_env(:httpotion, :default_headers, []),
-        Keyword.get(options, :headers, [])
-      )
-
-    timeout =
-      Keyword.get(
-        options,
-        :timeout,
-        Application.get_env(:httpotion, :default_timeout, @request_timeout)
-      )
-
-    ib_options =
-      Keyword.merge(
-        Application.get_env(:httpotion, :default_ibrowse, []),
-        Keyword.get(options, :ibrowse, [{:inactivity_timeout, @inactivity_timeout}])
-      )
-
-    follow_redirects =
-      Keyword.get(
-        options,
-        :follow_redirects,
-        Application.get_env(:httpotion, :default_follow_redirects, false)
-      )
-
-    ib_options =
-      if stream_to = Keyword.get(options, :stream_to),
-        do:
-          Keyword.put(
-            ib_options,
-            :stream_to,
-            spawn(__MODULE__, :transformer, [stream_to, method, url, options])
-          ),
-        else: ib_options
-
-    ib_options =
-      if user_password = Keyword.get(options, :basic_auth) do
-        {user, password} = user_password
-        Keyword.put(ib_options, :basic_auth, {to_charlist(user), to_charlist(password)})
-      else
-        ib_options
-      end
-
-    %{
-      method: method,
-      url: url |> to_string |> process_url(options) |> to_charlist,
-      body: body |> process_request_body,
-      headers:
-        headers
-        |> process_request_headers(options)
-        |> Enum.map(fn {k, v} -> {to_charlist(k), to_charlist(v)} end),
-      timeout: timeout,
-      ib_options: ib_options,
-      follow_redirects: follow_redirects
-    }
-  end
 end


### PR DESCRIPTION

## Overview

There were couple of hacks in `test/elixir/lib/couch.ex`
We've got changes needed to remove them into `httpotion` 3.1.3.
The changes were introduced in:
- https://github.com/myfreeweb/httpotion/pull/118
- https://github.com/myfreeweb/httpotion/pull/130

This PR updates `httpotion` to 3.1.3 and removes the hacks from `couch.ex`

## Testing recommendations

1. Make sure tests pass `make elixir`
2. Make sure we set timeouts in calls to ibrowse
2.1. Start iex `iex -S mix`
2.2. Make sure calls to ibrowse have `.....{inactivity_timeout,55000}], 60000)`
```
# Start the default trace message receiver
:dbg.tracer()
# Setup call (c) tracing on current process
:dbg.p(:erlang.pid_to_list(self()), :c)
# Setup an exception return trace (x) on ibrowse:send_req
:dbg.tp(:ibrowse, :send_req, :x)
Couch.request!(:post, "http://google.com", [])
```

## Related Issues or Pull Requests

PRs in `httpotion`:

- https://github.com/myfreeweb/httpotion/pull/118
- https://github.com/myfreeweb/httpotion/pull/130

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
