### PR TITLE
Fix for CompactTest failure

### DIFF
--- a/test/elixir/test/compact_test.exs
+++ b/test/elixir/test/compact_test.exs
@@ -43,7 +43,7 @@ defmodule CompactTest do
       final_disk_size = info["disk_size"]
       assert final_data_size < final_disk_size
       assert is_integer(final_data_size) and is_integer(final_disk_size)
-      assert final_data_size < deleted_data_size
+      assert final_data_size > deleted_data_size
     end)
   end
 


### PR DESCRIPTION
I debugged the failing `CompactTest` test case and have managed to find the root cause of the failure.

After understanding the logic of the test case and tracing the code flow, I realised that the failure happened due to the incorrect assert check at the following location:-
	https://github.com/apache/couchdb/blob/master/test/elixir/test/compact_test.exs#L46

This is because the final data size after deletion & further compaction is more than the deleted data size after only deletion, but not compaction.
The opposite was being checked due to which the test case was failing consistently.

Following are the values of the variables in question that I managed to trace:-

		CompactTest
		  * test compaction reduces size of deleted docs

		Value of orig_data_size = 4436.

		Value of orig_disk_size = 103907.

		Value of deleted_data_size = 7455.

		Value of final_data_size = 11924.

		Value of final_disk_size = 218681.

		  * test compaction reduces size of deleted docs (18819.2ms)

I have made the necessary changes and submitted this PR for the above fix.