### PR TITLE
Fix _scheduler/docs response for local replication endpoints

### DIFF
--- a/src/couch_replicator/src/couch_replicator.erl
+++ b/src/couch_replicator/src/couch_replicator.erl
@@ -144,11 +144,13 @@ replication_states() ->
 
 -spec strip_url_creds(binary() | {[_]}) -> binary().
 strip_url_creds(Endpoint) ->
-    case couch_replicator_docs:parse_rep_db(Endpoint, [], []) of
-        #httpdb{url=Url} ->
-            iolist_to_binary(couch_util:url_strip_password(Url));
-        LocalDb when is_binary(LocalDb) ->
-            LocalDb
+    try
+        couch_replicator_docs:parse_rep_db(Endpoint, [], []) of
+            #httpdb{url = Url} ->
+                iolist_to_binary(couch_util:url_strip_password(Url))
+    catch
+        throw:{error, local_endpoints_not_supported} ->
+            Endpoint
     end.
 
 
@@ -359,7 +361,8 @@ strip_url_creds_test_() ->
         fun (_) -> meck:unload() end,
         [
             t_strip_http_basic_creds(),
-            t_strip_http_props_creds()
+            t_strip_http_props_creds(),
+            t_strip_local_db_creds()
         ]
     }.
 

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -424,7 +424,7 @@ parse_rep_db(<<"https://", _/binary>> = Url, Proxy, Options) ->
     parse_rep_db({[{<<"url">>, Url}]}, Proxy, Options);
 
 parse_rep_db(<<_/binary>>, _Proxy, _Options) ->
-    throw({error, <<"Local endpoints not supported since CouchDB 3.x">>});
+    throw({error, local_endpoints_not_supported});
 
 parse_rep_db(undefined, _Proxy, _Options) ->
     throw({error, <<"Missing replicator database">>}).
@@ -843,7 +843,7 @@ t_error_on_local_endpoint() ->
             {<<"source">>, <<"localdb">>},
             {<<"target">>, <<"http://somehost.local/tgt">>}
         ]},
-        Expect = <<"Local endpoints not supported since CouchDB 3.x">>,
+        Expect = local_endpoints_not_supported,
         ?assertThrow({bad_rep_doc, Expect}, parse_rep_doc_without_id(RepDoc))
     end).
 


### PR DESCRIPTION
### Overview 

When the `_scheduler/docs` response is generated, the replication docs are
parsed and credentials are stripped by `couch_replicator:strip_url_creds/1`.
When local endpoint support was removed, that function didn't properly catch
the parsing error for local endpoints and as a result was error-ing out the
whole response.

The fix is to catch the error and return the endpoint as is. The catch is
specific to that error, so turned the long binary message into a shorter, but
hopefully still obvious atom.

`_scheduler/docs` response would look like:

```
{
    "docs": [
        {
            "database": "_replicator",
            "doc_id": "r",
            "error_count": 1,
            "id": null,
            "info": "local_endpoints_not_supported",
            "last_updated": "2019-08-20T16:09:53Z",
            "source": "http://adm:*****@127.0.0.1:15984/s/",
            "start_time": "2019-08-20T16:09:53Z",
            "state": "failed",
            "target": "t"
        }
    ],
    "offset": 0,
    "total_rows": 1
}
```

Interestingly, there was already a test for this case, except it wasn't
included in the EUnit test suite list.


### Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
