### PR TITLE
Close LRU by database path for deleted database/index

### DIFF
--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -22,7 +22,7 @@
 -export([group1/7, group2/2]).
 -export([delete/2, update/3, cleanup/1, cleanup/2, rename/1]).
 -export([analyze/2, version/0, disk_size/1]).
--export([set_purge_seq/2, get_purge_seq/1, get_root_dir/0]).
+-export([set_purge_seq/2, get_purge_seq/1, get_root_dir/0, close_lru/0, close_lru/1]).
 -export([connected/0]).
 
 open_index(Peer, Path, Analyzer) ->
@@ -32,6 +32,10 @@ disk_size(Path) ->
     rpc({main, clouseau()}, {disk_size, Path}).
 get_root_dir() ->
     rpc({main, clouseau()}, {get_root_dir}).
+close_lru() ->
+    rpc({main, clouseau()}, {close_lru}).
+close_lru(DbName) ->
+    rpc({main, clouseau()}, {close_lru_by_path, DbName}).
 
 await(Ref, MinSeq) ->
     rpc(Ref, {await, MinSeq}).
@@ -81,6 +85,7 @@ cleanup(DbName) ->
     gen_server:cast({cleanup, clouseau()}, {cleanup, DbName}).
 
 rename(DbName) ->
+  close_lru(DbName),
   gen_server:cast({cleanup, clouseau()}, {rename, DbName}).
 
 cleanup(DbName, ActiveSigs) ->

--- a/src/dreyfus/src/dreyfus_index_manager.erl
+++ b/src/dreyfus/src/dreyfus_index_manager.erl
@@ -123,6 +123,7 @@ handle_db_event(DbName, deleted, _St) ->
         "enable_database_recovery", false),
     case RecoveryEnabled of
         true ->
+            clouseau_rpc:close_lru(DbName),
             gen_server:cast(?MODULE, {rename, DbName});
         false ->
             gen_server:cast(?MODULE, {cleanup, DbName})


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The problem was originally exposed when updating search index with the following error:
```
{error, "*** eval: {'EXIT',{{badmatch,{error,<<"Lock obtain timed out: NativeFSLock@/srv/search_index/shards/20000000-3fffffff/user1/db1.1509715496/ec8bc1dc690a15d795e65f7dce409e2c/write.lock">>}},\n                   [{erl_eval,expr,3,[]}]}}"}
```

Finally, it turns out that the soft-deletion path is missing a call to evict the shard from LRU (and therefore release the associated locks). This causes that lock file was left in working directory and search index failed to be updated.

To address this, the fix is to close the corresponding index in LRU before index is to be renamed/deleted.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
@theburge made excellent troubleshooting and analysis, and also wrote below script to reproduce problem.

[repro2.sh.txt](https://github.com/apache/couchdb/files/3797041/repro2.sh.txt)

The problem doesn't occur after using the fix here and cloudant-labs/clouseau#23
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
cloudant-labs/clouseau#23

## Checklist

- [x] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
