### PR TITLE
Implement fabric2_db EPI plugin

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1047,7 +1047,7 @@ db_doc_req(#httpd{method='GET', mochi_req=MochiReq}=Req, Db, DocId) ->
 
 db_doc_req(#httpd{method='POST', user_ctx=Ctx}=Req, Db, DocId) ->
     couch_httpd:validate_referer(Req),
-    couch_doc:validate_docid(DocId, fabric2_db:name(Db)),
+    fabric2_db:validate_docid(DocId),
     chttpd:validate_ctype(Req, "multipart/form-data"),
 
     Options = [{user_ctx,Ctx}],
@@ -1107,7 +1107,7 @@ db_doc_req(#httpd{method='PUT', user_ctx=Ctx}=Req, Db, DocId) ->
         update_type = UpdateType
     } = parse_doc_query(Req),
     DbName = fabric2_db:name(Db),
-    couch_doc:validate_docid(DocId, fabric2_db:name(Db)),
+    fabric2_db:validate_docid(DocId),
 
     Options = [{user_ctx, Ctx}],
 
@@ -1668,7 +1668,7 @@ db_attachment_req(#httpd{method=Method}=Req, Db, DocId, FileNameParts)
                 % check for the existence of the doc to handle the 404 case.
                 couch_doc_open(Db, DocId, nil, [])
             end,
-            couch_doc:validate_docid(DocId, fabric2_db:name(Db)),
+            fabric2_db:validate_docid(DocId),
             #doc{id=DocId};
         Rev ->
             case fabric2_db:open_doc_revs(Db, DocId, [Rev], [{user_ctx,Ctx}]) of
@@ -2031,7 +2031,7 @@ bulk_get_open_doc_revs1(Db, Props, Options, {}) ->
             {null, {error, Error}, Options};
         DocId ->
             try
-                couch_doc:validate_docid(DocId, fabric2_db:name(Db)),
+                fabric2_db:validate_docid(DocId),
                 bulk_get_open_doc_revs1(Db, Props, Options, {DocId})
             catch throw:{Error, Reason} ->
                 {DocId, {error, {null, Error, Reason}}, Options}

--- a/src/fabric/src/fabric.app.src
+++ b/src/fabric/src/fabric.app.src
@@ -21,6 +21,7 @@
         kernel,
         stdlib,
         config,
+        couch_epi,
         couch,
         rexi,
         mem3,

--- a/src/fabric/src/fabric2_db_plugin.erl
+++ b/src/fabric/src/fabric2_db_plugin.erl
@@ -1,0 +1,92 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_db_plugin).
+
+-export([
+    validate_dbname/3,
+    before_doc_update/3,
+    after_doc_read/2,
+    validate_docid/1,
+    check_is_admin/1,
+    is_valid_purge_client/2
+]).
+
+-define(SERVICE_ID, fabric2_db).
+
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+validate_dbname(DbName, Normalized, Default) ->
+    maybe_handle(validate_dbname, [DbName, Normalized], Default).
+
+
+before_doc_update(Db, Doc0, UpdateType) ->
+    Fun = fabric2_db:get_before_doc_update_fun(Db),
+    case with_pipe(before_doc_update, [Doc0, Db, UpdateType]) of
+        [Doc1, _Db, UpdateType1] when is_function(Fun) ->
+            Fun(Doc1, Db, UpdateType1);
+        [Doc1, _Db, _UpdateType] ->
+            Doc1
+    end.
+
+
+after_doc_read(Db, Doc0) ->
+    Fun = fabric2_db:get_after_doc_read_fun(Db),
+    case with_pipe(after_doc_read, [Doc0, Db]) of
+        [Doc1, _Db] when is_function(Fun) -> Fun(Doc1, Db);
+        [Doc1, _Db] -> Doc1
+    end.
+
+
+validate_docid(Id) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    %% callbacks return true only if it specifically allow the given Id
+    couch_epi:any(Handle, ?SERVICE_ID, validate_docid, [Id], []).
+
+
+check_is_admin(Db) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    %% callbacks return true only if it specifically allow the given Id
+    R = couch_epi:any(Handle, ?SERVICE_ID, check_is_admin, [Db], []),
+    %io:format(standard_error, "~n FFFFFFF ~p check_is_admin Db:~p => ~p~n", [?MODULE, fabric2_db:name(Db), R]),
+    R.
+
+
+is_valid_purge_client(DbName, Props) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    %% callbacks return true only if it specifically allow the given Id
+    couch_epi:any(Handle, ?SERVICE_ID, is_valid_purge_client, [DbName, Props], []).
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+with_pipe(Func, Args) ->
+    do_apply(Func, Args, [pipe]).
+
+do_apply(Func, Args, Opts) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    couch_epi:apply(Handle, ?SERVICE_ID, Func, Args, Opts).
+
+maybe_handle(Func, Args, Default) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    case couch_epi:decide(Handle, ?SERVICE_ID, Func, Args, []) of
+       no_decision when is_function(Default) ->
+           apply(Default, Args);
+       no_decision ->
+           Default;
+       {decided, Result} ->
+           Result
+    end.

--- a/src/fabric/src/fabric2_epi.erl
+++ b/src/fabric/src/fabric2_epi.erl
@@ -2,7 +2,7 @@
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at
 %
-%   http://www.apache.org/licenses/LICENSE-2.0
+% http://www.apache.org/licenses/LICENSE-2.0
 %
 % Unless required by applicable law or agreed to in writing, software
 % distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -10,14 +10,39 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
-{plugins, [
-    couch_db_epi,
-    fabric2_epi,
-    chttpd_epi,
-    couch_index_epi,
-    dreyfus_epi,
-    global_changes_epi,
-    mango_epi,
-    mem3_epi,
-    setup_epi
-]}.
+-module(fabric2_epi).
+
+-behaviour(couch_epi_plugin).
+
+-export([
+    app/0,
+    providers/0,
+    services/0,
+    data_subscriptions/0,
+    data_providers/0,
+    processes/0,
+    notify/3
+]).
+
+app() ->
+    fabric.
+
+providers() ->
+    [].
+
+services() ->
+    [
+        {fabric2_db, fabric2_db_plugin}
+    ].
+
+data_subscriptions() ->
+    [].
+
+data_providers() ->
+    [].
+
+processes() ->
+    [].
+
+notify(_Key, _Old, _New) ->
+    ok.

--- a/src/fabric/src/fabric2_sup.erl
+++ b/src/fabric/src/fabric2_sup.erl
@@ -29,19 +29,24 @@ start_link(Args) ->
 
 
 init([]) ->
-    Flags = #{
-        strategy => one_for_one,
-        intensity => 1,
-        period => 5
-    },
+    Flags = {one_for_one, 1, 5},
     Children = [
-        #{
-            id => fabric2_server,
-            start => {fabric2_server, start_link, []}
+        {
+            fabric2_server,
+            {fabric2_server, start_link, []},
+            permanent,
+            5000,
+            worker,
+            [fabric2_server]
         },
-        #{
-            id => fabric2_txids,
-            start => {fabric2_txids, start_link, []}
+        {
+            fabric2_txids,
+            {fabric2_txids, start_link, []},
+            permanent,
+            5000,
+            worker,
+            [fabric2_server]
         }
     ],
-    {ok, {Flags, Children}}.
+    ChildrenWithEpi = couch_epi:register_service(fabric2_epi, Children),
+    {ok, {Flags, ChildrenWithEpi}}.


### PR DESCRIPTION
This mostly equivalent to the `couch_db` EPI plugin, but using fabric2 calls
and without some of the functions that are not relevant to FDB such as
on_compact/1 and others..

Unfortunately had to revert fabric2_sup to tuples temporarily until we rebase
from master and pick up commit 1db0294eb1093066773760b75a200d99aa453be8

