### PR TITLE
Send a 500, not a 400, for unknown search errors

### DIFF
--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -69,7 +69,7 @@ info(mango_cursor_text, {text_search_error, {error, {bad_request, Msg}}})
     };
 info(mango_cursor_text, {text_search_error, {error, Error}}) ->
     {
-        400,
+        500,
         <<"text_search_error">>,
         fmt("~p", [Error])
     };


### PR DESCRIPTION
## Overview

We should only send a 400 Bad Request if there is genuinely something
wrong with the request, otherwise we mislead users and sysadmins.

## Testing recommendations

Induce a search failure that is unrelated to the request itself, confirm you get a 500 status code.

This does change existing behaviour, but in a good way. Only genuinely bad requests will get a 400 code.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation

(no existing test to update. No new config params. The `_find` endpoint already documented to throw a 500).