### PR TITLE
Handle badmatch timeout in all_docs query

### DIFF
--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -109,7 +109,9 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
             ),
             Callback(complete, Acc2);
         {'DOWN', Ref, _, _, Error} ->
-            Callback({error, Error}, Acc0)
+            Callback({error, Error}, Acc0);
+        timeout ->
+            Callback(timeout, Acc0)
     after Timeout ->
         Callback(timeout, Acc0)
     end.


### PR DESCRIPTION
## Overview

Seeing this in logs:

```
req_err(2563825449) badmatch : timeout
 [<<"fabric_view_all_docs:go/5 L105">>,<<"chttpd_db:all_docs_view/4 L769">>,<<"chttpd:handle_req_after_auth/2 L320">>,<<"chttpd:process_request/1 L303">>,<<"chttpd:handle_request_int/1 L243">>,<<"mochiweb_http:headers/6 L128">>,<<"proc_lib:init_p_do_apply/3 L247">>]
```

on 2.3.0.

Believe this was introduced by:

https://github.com/apache/couchdb/commit/99825820d12d992c30caad007de3942761bf457e#diff-9d6b535641fc74e993a6c0a246313619L111-R112

where the `timeout` clause was removed by @eiri .

This PR restores the missing clause.

## Testing recommendations

`¯\_(ツ)_/¯`

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
