### PR TITLE
Fix badmatch in fabric_view_all_docs

### DIFF
--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -104,10 +104,15 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
                     [{total, TotalRows}, {offset, null}, {update_seq, null}]
             end,
             {ok, Acc1} = Callback({meta, Meta}, Acc0),
-            {ok, Acc2} = doc_receive_loop(
+            Resp = doc_receive_loop(
                 Keys3, queue:new(), SpawnFun, MaxJobs, Callback, Acc1
             ),
-            Callback(complete, Acc2);
+            case Resp of
+                {ok, Acc2} ->
+                    Callback(complete, Acc2);
+                timeout ->
+                    Callback(timeout, Acc0)
+            end;
         {'DOWN', Ref, _, _, Error} ->
             Callback({error, Error}, Acc0)
     after Timeout ->


### PR DESCRIPTION
## Overview

In query for `all_docs` with passed `keys` array it is possible for `doc_receive_loop/6` to timeout and trigger `badmatch` exception.

The fix changes code to accept `timeout` as a possible response and passes it to Callback to process.

## Testing recommendations

It's kind of hard to induce timeout on that all_docs read without actual code tweaking, so base tests just need to pass.

## Related Issues or Pull Requests

Described in #2149 

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation