### PR TITLE
Remove deprecated dbinfo fields

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -594,9 +594,6 @@ get_db_info(Db) ->
     {ok, DocCount} = get_doc_count(Db),
     {ok, DelDocCount} = get_del_doc_count(Db),
     SizeInfo = couch_db_engine:get_size_info(Db),
-    FileSize = couch_util:get_value(file, SizeInfo, null),
-    ActiveSize = couch_util:get_value(active, SizeInfo, null),
-    ExternalSize = couch_util:get_value(external, SizeInfo, null),
     DiskVersion = couch_db_engine:get_disk_version(Db),
     Uuid = case get_uuid(Db) of
         undefined -> null;

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -619,14 +619,6 @@ get_db_info(Db) ->
         {purge_seq, couch_db_engine:get_purge_seq(Db)},
         {compact_running, Compactor /= nil},
         {sizes, {SizeInfo}},
-        % TODO: Remove this in 3.0
-        % These are legacy and have been duplicated under
-        % the sizes key since 2.0. We should make a note
-        % in our release notes that we'll remove these
-        % old versions in 3.0
-        {disk_size, FileSize}, % legacy
-        {data_size, ActiveSize},
-        {other, {[{data_size, ExternalSize}]}},
         {instance_start_time, StartTime},
         {disk_format_version, DiskVersion},
         {committed_update_seq, CommittedUpdateSeq},

--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -80,8 +80,6 @@ get(info, State) ->
     {ok, [
         {signature, list_to_binary(couch_index_util:hexsig(Sig))},
         {language, Lang},
-        {disk_size, FileSize}, % legacy
-        {data_size, ExternalSize}, % legacy
         {sizes, {[
             {file, FileSize},
             {active, ActiveSize},

--- a/src/couch_mrview/test/eunit/couch_mrview_index_info_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_index_info_tests.erl
@@ -48,8 +48,6 @@ view_info_test_() ->
                     fun file_size_is_non_neg_int/1,
                     fun active_size_is_non_neg_int/1,
                     fun external_size_is_non_neg_int/1,
-                    fun disk_size_is_file_size/1,
-                    fun data_size_is_external_size/1,
                     fun active_size_less_than_file_size/1,
                     fun update_seq_is_non_neg_int/1,
                     fun purge_seq_is_non_neg_int/1,
@@ -78,14 +76,6 @@ active_size_is_non_neg_int({_, Info}) ->
 
 external_size_is_non_neg_int({_, Info}) ->
     ?_assert(check_non_neg_int([sizes, external], Info)).
-
-
-disk_size_is_file_size({_, Info}) ->
-    ?_assertEqual(prop([sizes, file], Info), prop(disk_size, Info)).
-
-
-data_size_is_external_size({_, Info}) ->
-    ?_assertEqual(prop([sizes, external], Info), prop(data_size, Info)).
 
 
 active_size_less_than_file_size({_, Info}) ->

--- a/src/fabric/src/fabric_db_info.erl
+++ b/src/fabric/src/fabric_db_info.erl
@@ -99,14 +99,8 @@ merge_results(Info) ->
             [{doc_del_count, lists:sum(X)} | Acc];
         (compact_running, X, Acc) ->
             [{compact_running, lists:member(true, X)} | Acc];
-        (disk_size, X, Acc) -> % legacy
-            [{disk_size, lists:sum(X)} | Acc];
-        (data_size, X, Acc) -> % legacy
-            [{data_size, lists:sum(X)} | Acc];
         (sizes, X, Acc) ->
             [{sizes, {merge_object(X)}} | Acc];
-        (other, X, Acc) -> % legacy
-            [{other, {merge_other_results(X)}} | Acc];
         (disk_format_version, X, Acc) ->
             [{disk_format_version, lists:max(X)} | Acc];
         (cluster, [X], Acc) ->
@@ -116,17 +110,6 @@ merge_results(Info) ->
         (_K, _V, Acc) ->
             Acc
     end, [{instance_start_time, <<"0">>}], Dict).
-
-merge_other_results(Results) ->
-    Dict = lists:foldl(fun({Props}, D) ->
-        lists:foldl(fun({K,V},D0) -> orddict:append(K,V,D0) end, D, Props)
-    end, orddict:new(), Results),
-    orddict:fold(fun
-        (data_size, X, Acc) ->
-            [{data_size, lists:sum(X)} | Acc];
-        (_, _, Acc) ->
-            Acc
-    end, [], Dict).
 
 merge_object(Objects) ->
     Dict = lists:foldl(fun({Props}, D) ->

--- a/src/fabric/src/fabric_group_info.erl
+++ b/src/fabric/src/fabric_group_info.erl
@@ -111,10 +111,6 @@ merge_results(Info) ->
             [{signature, X} | Acc];
         (language, [X | _], Acc) ->
             [{language, X} | Acc];
-        (disk_size, X, Acc) -> % legacy
-            [{disk_size, lists:sum(X)} | Acc];
-        (data_size, X, Acc) -> % legacy
-            [{data_size, lists:sum(X)} | Acc];
         (sizes, X, Acc) ->
             [{sizes, {merge_object(X)}} | Acc];
         (compact_running, X, Acc) ->

--- a/test/elixir/test/compact_test.exs
+++ b/test/elixir/test/compact_test.exs
@@ -21,8 +21,8 @@ defmodule CompactTest do
     db = context[:db_name]
     docs = populate(db)
     info = get_info(db)
-    orig_data_size = info["data_size"]
-    orig_disk_size = info["disk_size"]
+    orig_data_size = info["sizes"]["active"]
+    orig_disk_size = info["sizes"]["file"]
     start_time = info["instance_start_time"]
     assert is_integer(orig_data_size) and is_integer(orig_disk_size)
     assert orig_data_size < orig_disk_size
@@ -42,8 +42,8 @@ defmodule CompactTest do
       assert get_info(db)["instance_start_time"] == start_time
       assert_attachment_available(db)
       info = get_info(db)
-      final_data_size = info["data_size"]
-      final_disk_size = info["disk_size"]
+      final_data_size = info["sizes"]["active"]
+      final_disk_size = info["sizes"]["file"]
       assert final_data_size < final_disk_size
       assert is_integer(final_data_size) and is_integer(final_disk_size)
       assert final_data_size < deleted_data_size

--- a/test/javascript/tests/attachments.js
+++ b/test/javascript/tests/attachments.js
@@ -218,7 +218,7 @@ couchTests.attachments= function(debug) {
   // re-create them
   var saved3 = db.bulkSave(docs);
 
-  var before = db.info().disk_size;
+  var before = db.info().sizes.file;
 
   // Compact it.
   /*T(db.compact().ok);
@@ -226,7 +226,7 @@ couchTests.attachments= function(debug) {
   // compaction isn't instantaneous, loop until done
   while (db.info().compact_running) {};
 
-  var after = db.info().disk_size;
+  var after = db.info().sizes.file;
 
   // Compaction should reduce the database slightly, but not
   // orders of magnitude (unless attachments introduce sparseness)

--- a/test/javascript/tests/compact.js
+++ b/test/javascript/tests/compact.js
@@ -30,19 +30,19 @@ couchTests.compact = function(debug) {
 
   T(db.save(binAttDoc).ok);
 
-  var originalsize = db.info().disk_size;
-  var originaldatasize = db.info().data_size;
+  var originalsize = db.info().sizes.disk;
+  var originaldatasize = db.info().sizes.active;
   var start_time = db.info().instance_start_time;
 
-  TEquals("number", typeof originaldatasize, "data_size is a number");
+  TEquals("number", typeof originaldatasize, "data size is a number");
   T(originaldatasize < originalsize, "data size is < then db file size");
 
   for(var i in docs) {
       db.deleteDoc(docs[i]);
   }
   T(db.ensureFullCommit().ok);
-  var deletesize = db.info().disk_size;
-  var deletedatasize = db.info().data_size;
+  var deletesize = db.info().sizes.disk;
+  var deletedatasize = db.info().sizes.active;
   T(deletesize > originalsize);
   T(db.setDbProperty("_revs_limit", 666).ok);
 
@@ -59,9 +59,9 @@ couchTests.compact = function(debug) {
   T(xhr.responseText == "This is a base64 encoded text");
   T(xhr.getResponseHeader("Content-Type") == "text/plain");
   T(db.info().doc_count == 1);
-  // XXX BUGGED! T(db.info().data_size < deletedatasize);
-  TEquals("number", typeof db.info().data_size, "data_size is a number");
-  T(db.info().data_size < db.info().disk_size, "data size is < then db file size");
+  // XXX BUGGED! T(db.info().sizes.active < deletedatasize);
+  TEquals("number", typeof db.info().sizes.active, "data size is a number");
+  T(db.info().sizes.active < db.info().sizes.disk, "data size is < then db file size");
 
   // cleanup
   db.deleteDb();

--- a/test/javascript/tests/compact.js
+++ b/test/javascript/tests/compact.js
@@ -30,7 +30,7 @@ couchTests.compact = function(debug) {
 
   T(db.save(binAttDoc).ok);
 
-  var originalsize = db.info().sizes.disk;
+  var originalsize = db.info().sizes.file;
   var originaldatasize = db.info().sizes.active;
   var start_time = db.info().instance_start_time;
 
@@ -41,7 +41,7 @@ couchTests.compact = function(debug) {
       db.deleteDoc(docs[i]);
   }
   T(db.ensureFullCommit().ok);
-  var deletesize = db.info().sizes.disk;
+  var deletesize = db.info().sizes.file;
   var deletedatasize = db.info().sizes.active;
   T(deletesize > originalsize);
   T(db.setDbProperty("_revs_limit", 666).ok);
@@ -61,7 +61,7 @@ couchTests.compact = function(debug) {
   T(db.info().doc_count == 1);
   // XXX BUGGED! T(db.info().sizes.active < deletedatasize);
   TEquals("number", typeof db.info().sizes.active, "data size is a number");
-  T(db.info().sizes.active < db.info().sizes.disk, "data size is < then db file size");
+  T(db.info().sizes.active < db.info().sizes.file, "data size is < then db file size");
 
   // cleanup
   db.deleteDb();

--- a/test/javascript/tests/design_docs.js
+++ b/test/javascript/tests/design_docs.js
@@ -247,7 +247,7 @@ couchTests.design_docs = function(debug) {
 
 
     var prev_view_sig = db.designInfo("_design/test").view_index.signature;
-    var prev_view_size = db.designInfo("_design/test").view_index.disk_size;
+    var prev_view_size = db.designInfo("_design/test").view_index.sizes.file;
 
     db.bulkSave(makeDocs(1, numDocs + 1));
     T(db.ensureFullCommit().ok);
@@ -260,7 +260,7 @@ couchTests.design_docs = function(debug) {
       var dinfo = db.designInfo("_design/test");
       TEquals("test", dinfo.name);
       var vinfo = dinfo.view_index;
-      TEquals(prev_view_size, vinfo.disk_size, "view group disk size didn't change");
+      TEquals(prev_view_size, vinfo.sizes.file, "view group disk size didn't change");
       TEquals(false, vinfo.compact_running);
       TEquals(prev_view_sig, vinfo.signature, 'ddoc sig');
       // wait some time (there were issues where an update

--- a/test/javascript/tests/view_compaction.js
+++ b/test/javascript/tests/view_compaction.js
@@ -102,7 +102,7 @@ couchTests.view_compaction = function(debug) {
 
   resp = db.designInfo("_design/foo");
   TEquals(30001, resp.view_index.update_seq);
-  T(resp.view_index.disk_size < disk_size_before_compact);
+  T(resp.view_index.sizes.file < disk_size_before_compact);
   TEquals("number", typeof resp.view_index.sizes.active, "data size is a number");
   T(resp.view_index.sizes.active < resp.view_index.sizes.file, "data size < file size");
 

--- a/test/javascript/tests/view_compaction.js
+++ b/test/javascript/tests/view_compaction.js
@@ -78,7 +78,7 @@ couchTests.view_compaction = function(debug) {
   resp = db.designInfo("_design/foo");
   TEquals(30001, resp.view_index.update_seq);
 
-  var disk_size_before_compact = resp.view_index.sizes.disk;
+  var disk_size_before_compact = resp.view_index.sizes.file;
   var data_size_before_compact = resp.view_index.sizes.active;
 
   TEquals("number", typeof data_size_before_compact, "data size is a number");
@@ -104,7 +104,7 @@ couchTests.view_compaction = function(debug) {
   TEquals(30001, resp.view_index.update_seq);
   T(resp.view_index.disk_size < disk_size_before_compact);
   TEquals("number", typeof resp.view_index.sizes.active, "data size is a number");
-  T(resp.view_index.sizes.active < resp.view_index.sizes.disk, "data size < file size");
+  T(resp.view_index.sizes.active < resp.view_index.sizes.file, "data size < file size");
 
   // cleanup
   db.deleteDb();

--- a/test/javascript/tests/view_compaction.js
+++ b/test/javascript/tests/view_compaction.js
@@ -78,8 +78,8 @@ couchTests.view_compaction = function(debug) {
   resp = db.designInfo("_design/foo");
   TEquals(30001, resp.view_index.update_seq);
 
-  var disk_size_before_compact = resp.view_index.disk_size;
-  var data_size_before_compact = resp.view_index.data_size;
+  var disk_size_before_compact = resp.view_index.sizes.disk;
+  var data_size_before_compact = resp.view_index.sizes.active;
 
   TEquals("number", typeof data_size_before_compact, "data size is a number");
   T(data_size_before_compact < disk_size_before_compact, "data size < file size");
@@ -103,8 +103,8 @@ couchTests.view_compaction = function(debug) {
   resp = db.designInfo("_design/foo");
   TEquals(30001, resp.view_index.update_seq);
   T(resp.view_index.disk_size < disk_size_before_compact);
-  TEquals("number", typeof resp.view_index.data_size, "data size is a number");
-  T(resp.view_index.data_size < resp.view_index.disk_size, "data size < file size");
+  TEquals("number", typeof resp.view_index.sizes.active, "data size is a number");
+  T(resp.view_index.sizes.active < resp.view_index.sizes.disk, "data size < file size");
 
   // cleanup
   db.deleteDb();


### PR DESCRIPTION
## Overview

These fields are all marked as deprecated in the current documentation
and they have more specific replacements in the `sizes` object.

Fauxton needs an update as well.

## Testing recommendations

## Related Issues or Pull Requests

Closes #2162 
Documentation PR at apache/couchdb-documentation#435

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
