### PR TITLE
Add a max db name length config option

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -37,6 +37,13 @@ default_security = admin_local
 ; influenced directly with this setting - increase for faster processing at the
 ; expense of more memory usage.
 changes_doc_ids_optimization_threshold = 100
+;
+; Maximum database name length. The default setting is chosen for CouchDB < 4.x
+; compatibility, where it was determined by the maximum file name size. On most
+; current file systems that is 255, and with timestamp and ".couch" extension
+; subtracted it ends up as 238.
+;max_database_name_length = 238
+;
 ; Maximum document ID length. Can be set to an integer or 'infinity'.
 ;max_document_id_length = infinity
 ;

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -45,6 +45,13 @@ defmodule BasicsTest do
     {:ok, _} = delete_db(db_name)
   end
 
+  test "Exceeding configured DB name size limit returns an error" do
+    db_name = String.duplicate("x", 239)
+    resp = Couch.put("/#{db_name}")
+    assert resp.status_code == 400
+    assert resp.body["error"] == "database_name_too_long"
+  end
+
   @tag :with_db
   test "Created database has appropriate db info name", context do
     db_name = context[:db_name]


### PR DESCRIPTION
This is done for compatibility with CouchDB < 4.x where this limit was
implicitly enforced by the file system's max filename size. The default value
enforces the same limit for FDB in case users decide to replicate back and
forth between old and new instances with 'create_target = true' option.

