### PR TITLE
Handle update_seq for _local_docs

### DIFF
--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -738,15 +738,7 @@ fold_docs(Db, UserFun, UserAcc0, Options) ->
             } = TxDb,
 
             Prefix = erlfdb_tuple:pack({?DB_ALL_DOCS}, DbPrefix),
-            NS = couch_util:get_value(namespace, Options),
-            DocCount = get_doc_count(TxDb, NS),
-            Meta = case lists:keyfind(update_seq, 1, Options) of
-                {_, true} ->
-                    UpdateSeq = fabric2_db:get_update_seq(TxDb),
-                    [{update_seq, UpdateSeq}];
-                _ ->
-                    []
-            end ++ [{total, DocCount}, {offset, null}],
+            Meta = get_all_docs_meta(TxDb, Options),
 
             UserAcc1 = maybe_stop(UserFun({meta, Meta}, UserAcc0)),
 
@@ -780,8 +772,7 @@ fold_local_docs(Db, UserFun, UserAcc0, Options) ->
             } = TxDb,
 
             Prefix = erlfdb_tuple:pack({?DB_LOCAL_DOCS}, DbPrefix),
-            DocCount = get_doc_count(TxDb, <<"doc_local_count">>),
-            Meta = [{total, DocCount}, {offset, null}],
+            Meta = get_all_docs_meta(TxDb, Options),
 
             UserAcc1 = maybe_stop(UserFun({meta, Meta}, UserAcc0)),
 
@@ -957,6 +948,18 @@ new_revid(Db, Doc) ->
         revs = {OldStart + 1, [Rev | OldRevs]},
         atts = NewAtts
     }.
+
+
+get_all_docs_meta(TxDb, Options) ->
+    NS = couch_util:get_value(namespace, Options),
+    DocCount = get_doc_count(TxDb, NS),
+    case lists:keyfind(update_seq, 1, Options) of
+        {_, true} ->
+            UpdateSeq = fabric2_db:get_update_seq(TxDb),
+            [{update_seq, UpdateSeq}];
+        _ ->
+            []
+    end ++ [{total, DocCount}, {offset, null}].
 
 
 maybe_set_user_ctx(Db, Options) ->

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -424,6 +424,11 @@ defmodule BasicsTest do
     resp = Couch.get("/#{db_name}/_design_docs?" <> qstr)
     assert resp.status_code == 200
     assert resp.body == %{"offset" => :null, "rows" => [], "total_rows" => 2}
+
+    # update_seq=true
+    resp = Couch.get("/#{db_name}/_design_docs?update_seq=true")
+    assert resp.status_code == 200
+    assert Map.has_key?(resp.body, "update_seq")
   end
 
   @tag :with_db
@@ -480,6 +485,11 @@ defmodule BasicsTest do
     resp = Couch.get("/#{db_name}/_local_docs?" <> qstr)
     assert resp.status_code == 200
     assert resp.body == %{"offset" => :null, "rows" => [], "total_rows" => 2}
+
+    # update_seq=true
+    resp = Couch.get("/#{db_name}/_local_docs?update_seq=true")
+    assert resp.status_code == 200
+    assert Map.has_key?(resp.body, "update_seq")
   end
 
 end


### PR DESCRIPTION
On master `_local_docs&update_seq=true` returns the update sequence of the
database. Even though it might not make much sense since updating local docs
doesn't bump the sequence, it's probably a good idea to stay consistent.

It's also worth mentioning another inconsistency is when FDB returns a
`total_rows` count for `_local_docs` while master returns `null`. I think
that's probably acceptable. Master would return the count if had it available
easily and having it seems like a useful thing and an improvement.

To test:
```
make elixir tests=test/elixir/test/basics_test.exs
```