### PR TITLE
do not cleanup ongoing compact files using fabric:cleanup_index_files/1

### DIFF
--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -524,8 +524,11 @@ inactive_index_files(DbName) ->
     end, mem3:local_shards(dbname(DbName))),
 
     if ActiveSigs =:= [] -> FileList; true ->
+        %% <sig>.view and <sig>.compact.view where <sig> is in ActiveSigs
+        %% will be excluded from FileList because they are active view
+        %% files and should not be deleted.
         lists:filter(fun(FilePath) ->
-            not maps:is_key(filename:basename(FilePath, ".view"), ActiveSigs)
+            not maps:is_key(get_view_sig_from_filename(FilePath), ActiveSigs)
         end, FileList)
     end.
 
@@ -662,6 +665,8 @@ kl_to_record(KeyList,RecName) ->
 set_namespace(NS, #mrargs{extra = Extra} = Args) ->
     Args#mrargs{extra = [{namespace, NS} | Extra]}.
 
+get_view_sig_from_filename(FilePath) ->
+    filename:basename(filename:basename(FilePath, ".view"), ".compact").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
This PR is not to cleanup ongoing compact files using fabric:cleanup_index_files/1

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make exunit tests=src/couch/test/exunit/fabric_test.exs

```
17:55:56.045 [debug] Calling 'teardown/3' for 'Elixir.Couch.Test.Setup.Step.Config'
  * test Fabric miscellaneous API Get inactive_index_files (1146.4ms)


Finished in 1.2 seconds
1 test, 0 failures
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/2101
## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
