### PR TITLE
feat: less scary error message

### DIFF
--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -113,6 +113,9 @@ handle_info({'DOWN', _, _, Pid, Reason}, #state{changes_pid=Pid} = State) ->
     Seq = case Reason of
         {seq, EndSeq} ->
             EndSeq;
+    {database_does_not_exist, _} ->
+            couch_log:notice("~p changes listener died because the _users database does not exist. Create the database to silence this notice.", [?MODULE]),
+            0;
         _ ->
             couch_log:notice("~p changes listener died ~r", [?MODULE, Reason]),
             0


### PR DESCRIPTION
## Overview

This stack trace comes up in user support a lot, mostly in unrelated discussions. This should remove a red herring stack trace and simplify support.

## Testing recommendations

Start a node without going through the setup procedure. Or delete the `_users` db and restart a node.

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests // we have no tests for log messages
