### PR TITLE
Handle _changes since=now param

### DIFF
--- a/src/chttpd/src/chttpd_changes.erl
+++ b/src/chttpd/src/chttpd_changes.erl
@@ -106,11 +106,9 @@ handle_changes(Args1, Req, Db, Type) ->
         {SNFun, undefined}
     end,
     Start = fun() ->
-        StartSeq = case Dir of
-        rev ->
-            fabric2_fdb:get_update_seq(Db);
-        fwd ->
-            Since
+        StartSeq = case Dir =:= rev orelse Since =:= now of
+            true -> fabric2_db:get_update_seq(Db);
+            false -> Since
         end,
         View2 = if UseViewChanges ->
             {ok, {_, View1, _}, _, _} = couch_mrview_util:get_view(

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1945,6 +1945,9 @@ parse_changes_query(Req) ->
     end.
 
 
+parse_since_seq(<<"now">>) ->
+    now;
+
 parse_since_seq(Seq) when is_binary(Seq), size(Seq) > 30 ->
     throw({bad_request, url_encoded_since_seq});
 


### PR DESCRIPTION
On master this is happening in `fabric_view_changes` but on FDB we don't go
through that module anymore, so we do in `chttpd_changes` module instead.
