### PR TITLE
Fix _changes heartbeat option

### DIFF
--- a/src/chttpd/src/chttpd_changes.erl
+++ b/src/chttpd/src/chttpd_changes.erl
@@ -483,10 +483,10 @@ get_changes_timeout(Args, Callback) ->
         end;
     true ->
         {DefaultTimeout,
-            fun(UserAcc) -> {ok, Callback({timeout, ResponseType}, UserAcc)} end};
+            fun(UserAcc) -> Callback({timeout, ResponseType}, UserAcc) end};
     _ ->
         {lists:min([DefaultTimeout, Heartbeat]),
-            fun(UserAcc) -> {ok, Callback({timeout, ResponseType}, UserAcc)} end}
+            fun(UserAcc) -> Callback({timeout, ResponseType}, UserAcc) end}
     end.
 
 start_sending_changes(Callback, UserAcc) ->
@@ -961,9 +961,9 @@ maybe_heartbeat(Timeout, TimeoutFun, Acc) ->
         Now = os:timestamp(),
         case timer:now_diff(Now, Before) div 1000 >= Timeout of
         true ->
-            Acc2 = TimeoutFun(Acc),
+            {StopOrGo, Acc2} = TimeoutFun(Acc),
             put(last_changes_heartbeat, Now),
-            Acc2;
+            {StopOrGo, Acc2};
         false ->
             {ok, Acc}
         end

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -210,7 +210,7 @@ changes_callback(waiting_for_updates, Acc) ->
     #cacc{buffer = Buf, mochi = Resp} = Acc,
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp, Buf),
     {ok, Acc#cacc{buffer = [], bufsize = 0, mochi = Resp1}};
-changes_callback(timeout, Acc) ->
+changes_callback({timeout, _ResponseType}, Acc) ->
     {ok, Resp1} = chttpd:send_delayed_chunk(Acc#cacc.mochi, "\n"),
     {ok, Acc#cacc{mochi = Resp1}};
 changes_callback({error, Reason}, #cacc{mochi = #httpd{}} = Acc) ->


### PR DESCRIPTION
`TimeoutFun` was already returning `{ok|stop, UserAcc}` so there was no need to
wrap it another `{ok, ...} tuple.

Also TimeoutFun was calling user with`{timeout, _ResponseType}` not just timeout, so added a clause to handle that as well.
