### PR TITLE
Support `--extra_args` parameter in `dev/run`

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -110,6 +110,11 @@ def setup_logging(ctx):
 
 
 def setup_argparse():
+    parser = get_args_parser()
+    return parser.parse_args()
+
+
+def get_args_parser():
     parser = optparse.OptionParser(description="Runs CouchDB 2.0 dev cluster")
     parser.add_option(
         "-a",
@@ -206,7 +211,13 @@ def setup_argparse():
         action="store_true",
         help="Select available ports for nodes automatically",
     )
-    return parser.parse_args()
+    parser.add_option(
+        "--extra_args",
+        dest="extra_args",
+        default=None,
+        help="Extra arguments to pass to beam process",
+    )
+    return parser
 
 
 def setup_context(opts, args):
@@ -230,6 +241,7 @@ def setup_context(opts, args):
         "config_overrides": opts.config_overrides,
         "erlang_config": opts.erlang_config,
         "no_eval": opts.no_eval,
+        "extra_args": opts.extra_args,
         "reset_logs": True,
         "procs": [],
         "auto_ports": opts.auto_ports,
@@ -585,6 +597,8 @@ def boot_node(ctx, node):
         mode = "r+b"
     logfname = os.path.join(ctx["devdir"], "logs", "%s.log" % node)
     log = open(logfname, mode)
+    if "extra_args" in ctx and ctx["extra_args"]:
+        cmd += ctx["extra_args"].split(" ")
     cmd = [toposixpath(x) for x in cmd]
     return sp.Popen(cmd, stdin=sp.PIPE, stdout=log, stderr=sp.STDOUT, env=env)
 


### PR DESCRIPTION
## Overview

Sometimes there is a need to specify additional arguments for the beam process we start from dev/run.
In particular the feature is handy for:
- changing emulator flags
- simulate OOM via available RAM restrictions
- enable module loading tracing
- configure number of schedulers
- modify applications configuration
- run customization script to add extra development deps (such as automatic code reload)

Historically developers had to edit dev/run to do it.
This PR adds an ability to specify additional arguments via `--extra_args` argument.

In order to run customization script create `customization.erl` which exports `start/0` and run it using:
```
dev/run --extra_args='-run customization'
```

This is cherry-pick from master
```
git cherry-pick dd5ac138ecbdee76ff3ba68664f25c2a5cdda7cc
```


## Testing recommendations

- this is a cherry-pick of a commit from master

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/pull/2183

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
