### PR TITLE
Fix typo in couch_mrview comment

### DIFF
--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -224,7 +224,7 @@ validate(Db,  DDoc) ->
                 couch_query_servers:ret_os_process(Proc)
             end
     catch {unknown_query_language, _Lang} ->
-        %% Allow users to save ddocs written in uknown languages
+    %% Allow users to save ddocs written in unknown languages
         ok
     end.
 


### PR DESCRIPTION
## Overview

Fixes a very small typo in a comment in couch_mrview,erl
"uknown languages" to "unknown languages"

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
