### PR TITLE
Make get_security and revs_limit calls consistent

### DIFF
--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -346,12 +346,18 @@ get_pid(#{}) ->
     nil.
 
 
-get_revs_limit(#{revs_limit := RevsLimit}) ->
-    RevsLimit.
+get_revs_limit(#{} = Db) ->
+    RevsLimitBin = fabric2_fdb:transactional(Db, fun(TxDb) ->
+        fabric2_fdb:get_config(TxDb, <<"revs_limit">>)
+    end),
+    ?bin2uint(RevsLimitBin).
 
 
-get_security(#{security_doc := SecurityDoc}) ->
-    SecurityDoc.
+get_security(#{} = Db) ->
+    SecBin = fabric2_fdb:transactional(Db, fun(TxDb) ->
+        fabric2_fdb:get_config(TxDb, <<"security_doc">>)
+    end),
+    ?JSON_DECODE(SecBin).
 
 
 get_update_seq(#{} = Db) ->


### PR DESCRIPTION
Make get_security and get_revs_limit calls consistent

There are two fixes:

1) In `fabric2_fdb:get_config/1`, Db was matched before and after
`ensure_current/1`. Only the db prefix path was used, which doesn't normally
change, but it's worth fixing it anyway.

2) We used a cached version of the security document outside the transaction.
Now we force it go through a transaction to call `fabric2_fdb:get_config/1`
which call `ensure_current/1`. When done, we also update the cached Db handle.
Do the same thing for revs_limit even thought it is not as critical as
security.