### PR TITLE
Include search in the list of advertised features

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -51,7 +51,7 @@ handle_welcome_req(#httpd{method='GET'}=Req, WelcomeMessage) ->
         {version, list_to_binary(couch_server:get_version())},
         {git_sha, list_to_binary(couch_server:get_git_sha())},
         {uuid, couch_server:get_uuid()},
-        {features, config:features()}
+        {features, get_features()}
         ] ++ case config:get("vendor") of
         [] ->
             [];
@@ -61,6 +61,14 @@ handle_welcome_req(#httpd{method='GET'}=Req, WelcomeMessage) ->
     });
 handle_welcome_req(Req, _) ->
     send_method_not_allowed(Req, "GET,HEAD").
+
+get_features() ->
+    case clouseau_rpc:connected() of
+        true ->
+            [search | config:features()];
+        false ->
+            config:features()
+    end.
 
 handle_favicon_req(Req) ->
     handle_favicon_req(Req, get_docroot()).


### PR DESCRIPTION
## Overview

The reason we don't do this in `config:features()` directly is because this one is a dynamic check for the presence of a connected clouseau node. Calling `enable_feature` every time we conduct that check seemed too heavyweight, but I didn't see a good opportunity to just call it once and be confident that it would reliably advertise the feature.

The downside here is that CouchDB will not advertise the "search" feature if Clouseau is disconnected for maintenance or whatever, although technically it's accurate since search requests submitted during that interval would fail.

## Testing recommendations

Wire up CouchDB with Clouseau and see if "search" shows up in the list of features.

## Related Issues or Pull Requests

#2205 

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
