### PR TITLE
Fix clouseau detection

### DIFF
--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -345,12 +345,7 @@ make_text_field_name([P | Rest], Type) ->
 
 
 validate_index_info(IndexInfo) ->
-    IdxTypes = case clouseau_rpc:connected() of
-        true ->
-            [mango_idx_view, mango_idx_text];
-        false ->
-            [mango_idx_view]
-    end,
+    IdxTypes = [mango_idx_view, mango_idx_text],
     Results = lists:foldl(fun(IdxType, Results0) ->
         try
             IdxType:validate_index_def(IndexInfo),


### PR DESCRIPTION
This check breaks if clouseau is excluded entirely from the release.

## Overview

Our check for clouseau did not anticipate clouseau not existing.

## Testing recommendations

Delete clouseau_rpc.beam and `make check`

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
