### PR TITLE
Ping clouseau directly

### DIFF
--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -98,13 +98,8 @@ connected() ->
         true ->
             true;
         false ->
-            % We might have just booted up, so let's send a test RPC
-            case (catch version()) of
-                {ok, _} ->
-                    true;
-                _Err ->
-                    false
-            end
+            % We might have just booted up, so let's ping
+            pong == net_adm:ping(clouseau())
     end.
 
 rpc(Ref, Msg) ->


### PR DESCRIPTION
## Overview

Ping clouseau directly

## Testing recommendations

clouseau_rpc:connected() should return false if clouseau is down.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
