### PR TITLE
Fix timeout in couch_views

### DIFF
--- a/src/couch_views/src/couch_views_jobs.erl
+++ b/src/couch_views/src/couch_views_jobs.erl
@@ -29,7 +29,7 @@
 
 
 set_timeout() ->
-    couch_jobs:set_type_timeout(?INDEX_JOB_TYPE, 6 * 1000).
+    couch_jobs:set_type_timeout(?INDEX_JOB_TYPE, 6).
 
 
 build_view(TxDb, Mrst, UpdateSeq) ->


### PR DESCRIPTION
set_type_timeout takes seconds as the argument but we gave it milliseconds
