### PR TITLE
Return headers from _changes feed when there are no changes

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -46,6 +46,7 @@
     mochi,
     prepend = "",
     responding = false,
+    chunks_sent = 0,
     buffer = [],
     bufsize = 0,
     threshold
@@ -170,10 +171,10 @@ changes_callback({change, {ChangeProp}=Change}, #cacc{feed = eventsource} = Acc)
     Len = iolist_size(Chunk),
     maybe_flush_changes_feed(Acc, Chunk, Len);
 changes_callback(timeout, #cacc{feed = eventsource} = Acc) ->
-    #cacc{mochi = Resp} = Acc,
+    #cacc{mochi = Resp, chunks_sent = ChunksSet} = Acc,
     Chunk = "event: heartbeat\ndata: \n\n",
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp, Chunk),
-    {ok, Acc#cacc{mochi = Resp1}};
+    {ok, Acc#cacc{mochi = Resp1, chunks_sent = ChunksSet + 1}};
 changes_callback({stop, _EndSeq}, #cacc{feed = eventsource} = Acc) ->
     #cacc{mochi = Resp, buffer = Buf} = Acc,
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp, Buf),
@@ -209,14 +210,27 @@ changes_callback({stop, EndSeq, Pending}, Acc) ->
     chttpd:end_delayed_json_response(Resp1);
 
 changes_callback(waiting_for_updates, #cacc{buffer = []} = Acc) ->
-    {ok, Acc};
+    #cacc{mochi = Resp, chunks_sent = ChunksSent} = Acc,
+    case ChunksSent > 0 of
+        true ->
+            {ok, Acc};
+        false ->
+            {ok, Resp1} = chttpd:send_delayed_chunk(Resp, <<"\n">>),
+            {ok, Acc#cacc{mochi = Resp1, chunks_sent = 1}}
+    end;
 changes_callback(waiting_for_updates, Acc) ->
-    #cacc{buffer = Buf, mochi = Resp} = Acc,
+    #cacc{buffer = Buf, mochi = Resp, chunks_sent = ChunksSent} = Acc,
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp, Buf),
-    {ok, Acc#cacc{buffer = [], bufsize = 0, mochi = Resp1}};
+    {ok, Acc#cacc{
+        buffer = [],
+        bufsize = 0,
+        mochi = Resp1,
+        chunks_sent = ChunksSent + 1
+    }};
 changes_callback(timeout, Acc) ->
-    {ok, Resp1} = chttpd:send_delayed_chunk(Acc#cacc.mochi, "\n"),
-    {ok, Acc#cacc{mochi = Resp1}};
+    #cacc{mochi = Resp, chunks_sent = ChunksSent} = Acc,
+    {ok, Resp1} = chttpd:send_delayed_chunk(Resp, "\n"),
+    {ok, Acc#cacc{mochi = Resp1, chunks_sent = ChunksSent + 1}};
 changes_callback({error, Reason}, #cacc{mochi = #httpd{}} = Acc) ->
     #cacc{mochi = Req} = Acc,
     chttpd:send_error(Req, Reason);
@@ -232,11 +246,12 @@ maybe_flush_changes_feed(#cacc{bufsize=Size, threshold=Max} = Acc, Data, Len)
     {ok, R1} = chttpd:send_delayed_chunk(Resp, Buffer),
     {ok, Acc#cacc{prepend = ",\r\n", buffer = Data, bufsize=Len, mochi = R1}};
 maybe_flush_changes_feed(Acc0, Data, Len) ->
-    #cacc{buffer = Buf, bufsize = Size} = Acc0,
+    #cacc{buffer = Buf, bufsize = Size, chunks_sent = ChunksSent} = Acc0,
     Acc = Acc0#cacc{
         prepend = ",\r\n",
         buffer = [Buf | Data],
-        bufsize = Size + Len
+        bufsize = Size + Len,
+        chunks_sent = ChunksSent + 1
     },
     {ok, Acc}.
 


### PR DESCRIPTION
# Overview

Problem
-------

The request of continious _changes feed doesn't return until either:
- new change is made to the database
- the heartbeat interval is reached

This causes clients to block on subscription call.

Solution
--------

Introduce a counter to account for number of chunks sent.
Send '\n' exactly once on `waiting_for_updates` when `chunks_sent`
is still 0.

The implementation is suggested by @davisp [here](https://github.com/apache/couchdb/issues/985#issuecomment-537150907). There is only one difference from his proposal which is:
```
diff --git a/src/chttpd/src/chttpd_db.erl b/src/chttpd/src/chttpd_db.erl
index aba1bd22f..9cd6944d2 100644
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -215,7 +215,7 @@ changes_callback(waiting_for_updates, #cacc{buffer = []} = Acc) ->
         true ->
             {ok, Acc};
         false ->
-            {ok, Resp1} = chttpd:send_delayed_chunk(Resp, []),
+            {ok, Resp1} = chttpd:send_delayed_chunk(Resp, <<"\n">>),
             {ok, Acc#cacc{mochi = Resp1, chunks_sent = 1}}
     end;
 changes_callback(waiting_for_updates, Acc) ->
```

## Testing recommendations

```
make eunit apps=couch tests=changes_test_
make eunit apps=chttpd tests=all_test_
```

## Related Issues or Pull Requests

- fixes #985 

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
