### PR TITLE
Stop creating node local _replicator db

### DIFF
--- a/src/couch_replicator/README.md
+++ b/src/couch_replicator/README.md
@@ -278,14 +278,6 @@ A description of each child:
         of replications running, having each one checking their filter often is
         not a good idea.
 
- * `couch_replicator`: This is an unusual but useful pattern. This child is not
-   an actual process but a one-time call to the
-   `couch_replicator:ensure_rep_db_exists/0` function, executed by the
-   supervisor in the correct order (and monitored for crashes). This ensures
-   the local replicator db exists, then returns `ignore`. This pattern is
-   useful for doing setup-like things at the top level and in the correct order
-   regarding the rest of the children in the supervisor.
-
  * `couch_replicator_db_changes`: This process specializes and configures
    `couch_multidb_changes` so that it looks for `_replicator` suffixed shards
    and makes sure to restart it when node membership changes.

--- a/src/couch_replicator/src/couch_replicator.erl
+++ b/src/couch_replicator/src/couch_replicator.erl
@@ -14,7 +14,6 @@
 
 -export([
     replicate/2,
-    ensure_rep_db_exists/0,
     replication_states/0,
     job/1,
     doc/3,
@@ -77,14 +76,6 @@ replicate(PostBody, Ctx) ->
         couch_replicator_notifier:stop(Listener),
         Result
     end.
-
-
-% This is called from supervisor. Must respect supervisor protocol so
-% it returns `ignore`.
--spec ensure_rep_db_exists() -> ignore.
-ensure_rep_db_exists() ->
-    {ok, _Db} = couch_replicator_docs:ensure_rep_db_exists(),
-    ignore.
 
 
 -spec do_replication_loop(#rep{}) ->

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -20,7 +20,6 @@
     parse_rep_doc_without_id/2,
     before_doc_update/3,
     after_doc_read/2,
-    ensure_rep_db_exists/0,
     ensure_rep_ddoc_exists/1,
     ensure_cluster_rep_ddoc_exists/1,
     remove_state_fields/2,
@@ -119,20 +118,6 @@ update_error(#rep{db_name = DbName, doc_id = DocId, id = RepId}, Error) ->
         {<<"_replication_stats">>, undefined},
         {<<"_replication_id">>, BinRepId}]),
     ok.
-
-
--spec ensure_rep_db_exists() -> {ok, Db::any()}.
-ensure_rep_db_exists() ->
-    Db = case couch_db:open_int(?REP_DB_NAME, [?CTX, sys_db,
-            nologifmissing]) of
-        {ok, Db0} ->
-            Db0;
-        _Error ->
-            {ok, Db0} = couch_db:create(?REP_DB_NAME, [?CTX, sys_db]),
-            Db0
-    end,
-    ok = ensure_rep_ddoc_exists(?REP_DB_NAME),
-    {ok, Db}.
 
 
 -spec ensure_rep_ddoc_exists(binary()) -> ok.

--- a/src/couch_replicator/src/couch_replicator_sup.erl
+++ b/src/couch_replicator/src/couch_replicator_sup.erl
@@ -62,15 +62,6 @@ init(_Args) ->
             brutal_kill,
             worker,
             [couch_replicator_doc_processor]},
-        {couch_replicator,
-            % This is a simple function call which does not create a process
-            % but returns `ignore`. It is used to make sure each node
-            % has a local `_replicator` database.
-            {couch_replicator, ensure_rep_db_exists, []},
-            transient,
-            brutal_kill,
-            worker,
-            [couch_replicator]},
         {couch_replicator_db_changes,
             {couch_replicator_db_changes, start_link, []},
             permanent,


### PR DESCRIPTION
We don't support "local" replications in 3.x so there is not need to waste resources creating this db on every node, and then continuously listening for replication doc updates from it.

