### PR TITLE
Update Fauxton to 1.2.2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -110,7 +110,7 @@ DepDescs = [
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
                    {tag, "2.3.0"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
-                   {tag, "v1.2.1"}, [raw]},
+                   {tag, "v1.2.2"}, [raw]},
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-4"}},


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Update Fauxton to 1.2.2. This release explicitly installs peer dependencies, the lack of which were causing the webpack bundling to fail (i.e. fixes build from source).

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb-fauxton/issues/1229

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
