### PR TITLE
Use a shorter name for create_or_open_couchdb_dir

### DIFF
--- a/src/couch_jobs/src/couch_jobs_fdb.erl
+++ b/src/couch_jobs/src/couch_jobs_fdb.erl
@@ -615,7 +615,7 @@ init_jtx(undefined) ->
     fabric2_fdb:transactional(fun(Tx) -> init_jtx(Tx) end);
 
 init_jtx({erlfdb_transaction, _} = Tx) ->
-    LayerPrefix = fabric2_fdb:create_or_open_couchdb_dir(Tx),
+    LayerPrefix = fabric2_fdb:get_dir(Tx),
     Jobs = erlfdb_tuple:pack({?JOBS}, LayerPrefix),
     Version = erlfdb:wait(erlfdb:get(Tx, ?METADATA_VERSION_KEY)),
     % layer_prefix, md_version and tx here match db map fields in fabric2_fdb

--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -24,7 +24,7 @@
     delete/1,
     exists/1,
 
-    create_or_open_couchdb_dir/1,
+    get_dir/1,
 
     list_dbs/4,
 
@@ -276,7 +276,7 @@ exists(#{name := DbName} = Db) when is_binary(DbName) ->
     end.
 
 
-create_or_open_couchdb_dir(Tx) ->
+get_dir(Tx) ->
     Root = erlfdb_directory:root(),
     Dir = fabric2_server:fdb_directory(),
     CouchDB = erlfdb_directory:create_or_open(Tx, Root, Dir),
@@ -284,7 +284,7 @@ create_or_open_couchdb_dir(Tx) ->
 
 
 list_dbs(Tx, Callback, AccIn, Options) ->
-    LayerPrefix = create_or_open_couchdb_dir(Tx),
+    LayerPrefix = get_dir(Tx),
     Prefix = erlfdb_tuple:pack({?ALL_DBS}, LayerPrefix),
     fold_range({tx, Tx}, Prefix, fun({K, _V}, Acc) ->
         {DbName} = erlfdb_tuple:unpack(K, Prefix),
@@ -787,7 +787,7 @@ debug_cluster(Start, End) ->
 
 
 init_db(Tx, DbName, Options) ->
-    Prefix = create_or_open_couchdb_dir(Tx),
+    Prefix = get_dir(Tx),
     Version = erlfdb:wait(erlfdb:get(Tx, ?METADATA_VERSION_KEY)),
     #{
         name => DbName,

--- a/src/fabric/src/fabric2_txids.erl
+++ b/src/fabric/src/fabric2_txids.erl
@@ -44,7 +44,7 @@ start_link() ->
 
 
 create(Tx, undefined) ->
-    Prefix = fabric2_fdb:create_or_open_couchdb_dir(Tx),
+    Prefix = fabric2_fdb:get_dir(Tx),
     create(Tx, Prefix);
 
 create(_Tx, LayerPrefix) ->
@@ -133,7 +133,7 @@ clean(St, NeedsSweep) ->
 
 
 sweep(Tx, {Mega, Secs, Micro}) ->
-    Prefix = fabric2_fdb:create_or_open_couchdb_dir(Tx),
+    Prefix = fabric2_fdb:get_dir(Tx),
     StartKey = erlfdb_tuple:pack({?TX_IDS}, Prefix),
     EndKey = erlfdb_tuple:pack({?TX_IDS, Mega, Secs, Micro}, Prefix),
     erlfdb:set_option(Tx, next_write_no_write_conflict_range),


### PR DESCRIPTION
Use `get_dir` instead
