### PR TITLE
Take better advantage of metadata version key feature

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -59,8 +59,10 @@
 -define(PDICT_DB_KEY, '$fabric_db_handle').
 -define(PDICT_LAYER_CACHE, '$fabric_layer_id').
 -define(PDICT_CHECKED_DB_IS_CURRENT, '$fabric_checked_db_is_current').
+-define(PDICT_CHECKED_MD_IS_CURRENT, '$fabric_checked_md_is_current').
 -define(PDICT_TX_ID_KEY, '$fabric_tx_id').
 -define(PDICT_TX_RES_KEY, '$fabric_tx_result').
+-define(PDICT_ON_COMMIT_FUN, '$fabric_on_commit_fun').
 -define(COMMIT_UNKNOWN_RESULT, 1021).
 
 


### PR DESCRIPTION
Take better advantage of metadata version key feature

Issue https://github.com/apache/couchdb/issues/2224

FDB's metadata version key allows more efficient metadata invalidation
(see apple/foundationdb#1213). To take advantage of
that feature update the caching logic to check the metadata version first, and
if it is current, skip checking the db version altogether.

When db version is bumped we now update the metadata version as well.

There is a bit of a subtlety when the metadata version is stale. In that case
we check the db version, and if that is current, we still don't reopen the
database, instead we continue with the transaction. Then, after the transaction
succeeds, we update the cached metadata version for that db handle. Next client
would get the updated db metadata, it will be current, and they won't need to
check the db version. If the db version is stale as well, then we throw a
`reopen` exception and the handle gets removed from the cache and reopened.

Note: this commit doesn't actually use the new metadata version key, it still
uses the old plain key. That update will be a separate commit where we also start
setting a new API version (610) and will only work on FDB version 6.1.x
