### PR TITLE
Update ken to 1.0.5

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -104,7 +104,7 @@ DepDescs = [
 {ioq,              "ioq",              {tag, "2.1.2"}},
 {hqueue,           "hqueue",           {tag, "1.0.1"}},
 {smoosh,           "smoosh",           {tag, "1.0.1"}},
-{ken,              "ken",              {tag, "1.0.4"}},
+{ken,              "ken",              {tag, "1.0.5"}},
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},


### PR DESCRIPTION
* Always include 'query' as an allowed language
