### PR TITLE
Make changes feed return bad request for invalid heartbeat values

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1816,7 +1816,14 @@ parse_changes_query(Req) ->
         {"heartbeat", "true"} ->
             Args#changes_args{heartbeat=true};
         {"heartbeat", _} ->
-            Args#changes_args{heartbeat=list_to_integer(Value)};
+            try list_to_integer(Value) of
+                HeartbeatInteger when HeartbeatInteger > 0 ->
+                    Args#changes_args{heartbeat=HeartbeatInteger};
+                _ ->
+                    throw({bad_request, <<"The heartbeat value should be a positive integer (in milliseconds).">>})
+            catch error:badarg ->
+                throw({bad_request, <<"Invalid heartbeat value. Expecting a positive integer value (in milliseconds).">>})
+            end;
         {"timeout", _} ->
             Args#changes_args{timeout=list_to_integer(Value)};
         {"include_docs", "true"} ->

--- a/test/elixir/test/changes_test.exs
+++ b/test/elixir/test/changes_test.exs
@@ -1,0 +1,43 @@
+defmodule ChangesTest do
+  use CouchTestCase
+
+  @moduletag :changes
+
+  @moduledoc """
+  Test CouchDB /{db}/_changes
+  """
+
+  @tag :with_db
+  test "Changes feed negative heartbeat", context do
+    db_name = context[:db_name]
+
+    resp = Couch.get(
+      "/#{db_name}/_changes",
+      query: %{
+        :feed => "continuous",
+        :heartbeat => -1000
+      }
+    )
+
+    assert resp.status_code == 400
+    assert resp.body["error"] == "bad_request"
+    assert resp.body["reason"] == "The heartbeat value should be a positive integer (in milliseconds)."
+  end
+
+  @tag :with_db
+  test "Changes feed non-integer heartbeat", context do
+    db_name = context[:db_name]
+
+    resp = Couch.get(
+      "/#{db_name}/_changes",
+      query: %{
+        :feed => "continuous",
+        :heartbeat => "a1000"
+      }
+    )
+
+    assert resp.status_code == 400
+    assert resp.body["error"] == "bad_request"
+    assert resp.body["reason"] == "Invalid heartbeat value. Expecting a positive integer value (in milliseconds)."
+  end
+end


### PR DESCRIPTION
## Overview

Using a negative heartbeat value does not return a 400 bad request, instead getting just an empty response with no status code at all.

This commit adds extra checks so that negative and non-integer heartbeat values return 400 bad request responses.



## Testing recommendations

The changes has been tested manually:
```
[donat:~/couchdb] changes-feed-input-validation 1 ± curl -XPUT http://127.0.0.1:15984/asd
{"ok":true}
[donat:~/couchdb] changes-feed-input-validation ± curl -v http://127.0.0.1:15984/asd/_changes?feed=continuous\&heartbeat=-1000
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 15984 (#0)
> GET /asd/_changes?feed=continuous&heartbeat=-1000 HTTP/1.1
> Host: 127.0.0.1:15984
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Cache-Control: must-revalidate
< Content-Length: 60
< Content-Type: application/json
< Date: Wed, 23 Oct 2019 15:10:52 GMT
< Server: CouchDB/3.0.0-1dd00d6ac (Erlang OTP/22)
< X-Couch-Request-ID: 61d1b854bd
< X-CouchDB-Body-Time: 0
<
{"error":"bad_request","reason":"Negative heartbeat value"}
* Connection #0 to host 127.0.0.1 left intact
* Closing connection 0
[donat:~/couchdb] changes-feed-input-validation ± curl -v http://127.0.0.1:15984/asd/_changes?feed=continuous\&heartbeat=a1000
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 15984 (#0)
> GET /asd/_changes?feed=continuous&heartbeat=a1000 HTTP/1.1
> Host: 127.0.0.1:15984
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 400 Bad Request
< Cache-Control: must-revalidate
< Content-Length: 59
< Content-Type: application/json
< Date: Wed, 23 Oct 2019 15:11:01 GMT
< Server: CouchDB/3.0.0-1dd00d6ac (Erlang OTP/22)
< X-Couch-Request-ID: 4e9ae14ede
< X-CouchDB-Body-Time: 0
<
{"error":"bad_request","reason":"Invalid heartbeat value"}
* Connection #0 to host 127.0.0.1 left intact
* Closing connection 0
```
Also, there are new test cases added for the new behavior.

## Related Issues or Pull Requests

This fixes #2234

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation

