### PR TITLE
Remove old clause which is no longer used

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1038,9 +1038,6 @@ error_headers(#httpd{mochi_req=MochiReq}=Req, 401=Code, ErrorStr, ReasonStr) ->
 error_headers(_, Code, _, _) ->
     {Code, []}.
 
-send_error(_Req, {already_sent, Resp, _Error}) ->
-    {ok, Resp};
-
 send_error(#httpd{} = Req, Error) ->
     update_timeout_stats(Error, Req),
 

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -977,9 +977,6 @@ error_headers(#httpd{mochi_req=MochiReq}=Req, Code, ErrorStr, ReasonStr) ->
         {Code, []}
     end.
 
-send_error(_Req, {already_sent, Resp, _Error}) ->
-    {ok, Resp};
-
 send_error(Req, Error) ->
     {Code, ErrorStr, ReasonStr} = error_info(Error),
     {Code1, Headers} = error_headers(Req, Code, ErrorStr, ReasonStr),


### PR DESCRIPTION
# Overview

The history of `send_error(_Req, {already_sent, Resp, _Error})`
clause is bellow:

- it was added on [2009/04/18](https://svn.apache.org/viewvc/couchdb/trunk/src/couchdb/couch_httpd.erl?r1=762574&r2=765819&diff_format=h)
- we triggered that clause [in couch_httpd:do](https://svn.apache.org/viewvc/couchdb/trunk/src/couchdb/couch_httpd.erl?revision=642432&view=markup#l88)
- at that time we were using inets webserver [see use of `httpd_response/3`](https://svn.apache.org/viewvc/couchdb/trunk/src/couchdb/couch_httpd.erl?revision=642432&view=markup#l170)
- The inets OTP codebase uses `already_sent` messages [here](https://github.com/erlang/otp/blob/50214f02501926fee6ec286efa68a57a47c2e531/lib/inets/src/http_server/httpd_response.erl#L220)

It should be safe to remove this clause because we are not using inets anymore
and search of `already_sent` term across all dependencies doesn't return any results.

## Testing recommendations

Standard test suite run should be sufficient

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
