### PR TITLE
Pass timeout as an error to callback in `fabric_view_all_docs`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     - libmozjs185-dev
     - pkg-config
     - python3.6
+    - python3.6-dev
     - python3.6-venv
     - python3-requests
     - python3-sphinx

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -111,12 +111,12 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
                 {ok, Acc2} ->
                     Callback(complete, Acc2);
                 timeout ->
-                    Callback(timeout, Acc0)
+                    Callback({error, timeout}, Acc0)
             end;
         {'DOWN', Ref, _, _, Error} ->
             Callback({error, Error}, Acc0)
     after Timeout ->
-        Callback(timeout, Acc0)
+        Callback({error, timeout}, Acc0)
     end.
 
 go(DbName, _Options, Workers, QueryArgs, Callback, Acc0) ->


### PR DESCRIPTION
## Overview

This PR fixes a bug introduced in #2153 where `timeout` was passed to `Callback` as a plain atom instead of tagged tuple `{error, timeout}`, inducing a function clause crash in `couch_mrview_http`.

## Related Issues or Pull Requests

Ref: #2153 

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
