### PR TITLE
Use "\xFF/metadataVersion" key for checking metadata

### DIFF
--- a/src/couch_jobs/src/couch_jobs.hrl
+++ b/src/couch_jobs/src/couch_jobs.hrl
@@ -10,6 +10,8 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
+-include_lib("fabric/include/fabric2.hrl").
+
 
 % Job map/json field definitions
 %
@@ -20,10 +22,7 @@
 
 % These might be in a fabric public hrl eventually
 %
--define(uint2bin(I), binary:encode_unsigned(I, little)).
--define(bin2uint(I), binary:decode_unsigned(I, little)).
 -define(UNSET_VS, {versionstamp, 16#FFFFFFFFFFFFFFFF, 16#FFFF}).
--define(METADATA_VERSION_KEY, <<"$metadata_version_key$">>).
 
 % Data model definitions
 %

--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -13,18 +13,7 @@
 
 -define(uint2bin(I), binary:encode_unsigned(I, little)).
 -define(bin2uint(I), binary:decode_unsigned(I, little)).
-
-% This will eventually be the `\xFFmetadataVersion` key that is
-% currently only available in FoundationDB master.
-%
-%  https://forums.foundationdb.org/t/a-new-tool-for-managing-layer-metadata/1191
-%
-% Until then we'll fake the same behavior using a randomish
-% key for tracking metadata changse. Once we get to the
-% new feature this will be more performant by updating
-% this define.
--define(METADATA_VERSION_KEY, <<"$metadata_version_key$">>).
-
+-define(METADATA_VERSION_KEY, <<16#FF, "/metadataVersion">>).
 
 % Prefix Definitions
 


### PR DESCRIPTION
Need to use FDB version 6.1+ and erlfdb version that has this commit: https://github.com/cloudant-labs/couchdb-erlfdb/commit/7718a3d7e1994e1384c56d39fae5cad3d8c6c4b3

Since fabric2.hrl is a public include now, use that in couch_jobs to avoid redefining a bunch of things.
