### PR TITLE
Show source and target proxies in _scheduler/docs output

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -529,8 +529,8 @@ reorder_results(Keys, SortedResults) ->
 
 url_strip_password(Url) ->
     re:replace(Url,
-        "http(s)?://([^:]+):[^@]+@(.*)$",
-        "http\\1://\\2:*****@\\3",
+        "(http|https|socks5)://([^:]+):[^@]+@(.*)$",
+        "\\1://\\2:*****@\\3",
         [{return, list}]).
 
 encode_doc_id(#doc{id = Id}) ->


### PR DESCRIPTION
### Overview

Since we now have separate proxies for source and target, show them in `_scheduler/docs` endpoint as separate as well. Previously we just read the proxy value from the source.

When formatting the proxy url for output, make sure `socks5` schema is handled
by the url credentials stripping code to avoid exposing user credentials.

### Testing recommendations

   `make eunit apps=couch_replicator suites=couch_replicator_scheduler`

Start a replication with source and/or target proxies defined, then call _scheduler/docs and inspect the output.

### Related Issues or Pull Requests

https://github.com/apache/couchdb/commit/053d494e698181ae3b0b0698055f5a24e7995172

### Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation/pull/454