### PR TITLE
Allow override of `-couch_ini` parameter

### DIFF
--- a/rel/files/couchdb.in
+++ b/rel/files/couchdb.in
@@ -31,8 +31,10 @@ export COUCHDB_QUERY_SERVER_COFFEESCRIPT="{{prefix}}/bin/couchjs {{prefix}}/shar
 export COUCHDB_FAUXTON_DOCROOT={{fauxton_root}}
 
 ARGS_FILE="${COUCHDB_ARGS_FILE:-$ROOTDIR/etc/vm.args}"
+[ -n "${COUCHDB_INI_FILES:-}" ] && INI_ARGS="-couch_ini $COUCHDB_INI_FILES"
 SYSCONFIG_FILE="${COUCHDB_SYSCONFIG_FILE:-$ROOTDIR/releases/$APP_VSN/sys.config}"
 
 exec "$BINDIR/erlexec" -boot "$ROOTDIR/releases/$APP_VSN/couchdb" \
      -args_file "${ARGS_FILE}" \
+     ${INI_ARGS:-} \
      -config "${SYSCONFIG_FILE}" "$@"


### PR DESCRIPTION
This is the continuation of commit 649b808 "Allow override of
`-args_file` and `-config` parameters (#1095)".

This allows setting the `-couch_ini` files location if needed, using
`COUCHDB_INI_FILES` env var:
- If unset (the default), `-couch_ini` argument won't be passed.
- If set (to a file, or list of files like
  `COUCHDB_INI_FILES=/chroot/etc/couchdb/default.ini`
  `/chroot/etc/couchdb/default.d ...`) it will allow running CouchDB with
  different settings. A useful case is being able to run multiple
  CouchDB servers on the same machine.