### PR TITLE
Ensure we can create partitioned design docs with FDB

### DIFF
--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -184,7 +184,7 @@ validate(Db, DDoc) ->
     validate(DbName, IsPartitioned, DDoc).
 
 
-validate(DbName, IsDbPartitioned,  DDoc) ->
+validate(DbName, _IsDbPartitioned,  DDoc) ->
     ok = validate_ddoc_fields(DDoc#doc.body),
     GetName = fun
         (#mrview{map_names = [Name | _]}) -> Name;
@@ -211,18 +211,8 @@ validate(DbName, IsDbPartitioned,  DDoc) ->
     end,
     {ok, #mrst{
         language = Lang,
-        views = Views,
-        partitioned = Partitioned
+        views = Views
     }} = couch_mrview_util:ddoc_to_mrst(DbName, DDoc),
-
-    case {IsDbPartitioned, Partitioned} of
-        {false, true} ->
-            throw({invalid_design_doc,
-                <<"partitioned option cannot be true in a "
-                  "non-partitioned database.">>});
-        {_, _} ->
-            ok
-    end,
 
     try Views =/= [] andalso couch_query_servers:get_os_process(Lang) of
         false ->

--- a/src/fabric/test/fabric2_doc_crud_tests.erl
+++ b/src/fabric/test/fabric2_doc_crud_tests.erl
@@ -33,6 +33,7 @@ doc_crud_test_() ->
                 fun create_ddoc_requires_admin/1,
                 fun create_ddoc_requires_validation/1,
                 fun create_ddoc_requires_compilation/1,
+                fun can_create_a_partitioned_ddoc/1,
                 fun update_doc_basic/1,
                 fun update_ddoc_basic/1,
                 fun update_doc_replicated/1,
@@ -106,6 +107,23 @@ create_ddoc_basic({Db, _}) ->
     {ok, {RevPos, Rev}} = fabric2_db:update_doc(Db, Doc),
     NewDoc = Doc#doc{revs = {RevPos, [Rev]}},
     ?assertEqual({ok, NewDoc}, fabric2_db:open_doc(Db, Doc#doc.id)).
+
+
+can_create_a_partitioned_ddoc({Db, _}) ->
+    UUID = fabric2_util:uuid(),
+    DDocId = <<"_design/", UUID/binary>>,
+    Doc = #doc{
+        id = DDocId,
+        body = {[
+            {<<"options">>, {[{<<"partitioned">>, true}]}},
+            {<<"views">>, {[
+                {<<"foo">>, {[
+                    {<<"map">>, <<"function(doc) {}">>}
+                ]}}
+            ]}}
+        ]}
+    },
+    ?assertMatch({ok, {_, _}}, fabric2_db:update_doc(Db, Doc)).
 
 
 create_ddoc_requires_admin({Db, _}) ->


### PR DESCRIPTION
Users should be able to replicate their partitioned dbs to the new environment.

