### PR TITLE
Check security properties in the main transaction

### DIFF
--- a/src/chttpd/src/chttpd_auth_request.erl
+++ b/src/chttpd/src/chttpd_auth_request.erl
@@ -102,9 +102,8 @@ server_authorization_check(#httpd{method=Method, path_parts=[<<"_utils">>|_]}=Re
 server_authorization_check(#httpd{path_parts=[<<"_", _/binary>>|_]}=Req) ->
     require_admin(Req).
 
-db_authorization_check(#httpd{path_parts=[DbName|_],user_ctx=Ctx}=Req) ->
-    {ok, Db} = fabric2_db:open(DbName, [{user_ctx, Ctx}]),
-    fabric2_db:check_is_member(Db),
+db_authorization_check(#httpd{path_parts=[_DbName|_]}=Req) ->
+    % Db authorization checks are performed in fabric before every FDB operation
     Req.
 
 require_admin(Req) ->

--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -458,11 +458,14 @@ is_users_db(DbName) when is_binary(DbName) ->
 set_revs_limit(#{} = Db0, RevsLimit) ->
     Db1 = require_admin_check(Db0),
     RevsLimBin = ?uint2bin(max(1, RevsLimit)),
-    {Resp, Db2} = fabric2_fdb:transactional(Db1, fun(TxDb) ->
-        {fabric2_fdb:set_config(TxDb, <<"revs_limit">>, RevsLimBin), TxDb}
+    Resp = fabric2_fdb:transactional(Db1, fun(TxDb) ->
+        fabric2_fdb:set_config(TxDb, <<"revs_limit">>, RevsLimBin)
     end),
-    if Resp /= ok -> Resp; true ->
-        fabric2_server:store(Db2#{revs_limit := RevsLimit})
+    case Resp of
+        {ok, #{} = Db2} ->
+             fabric2_server:store(Db2#{revs_limit := RevsLimit});
+        Err ->
+            Err
     end.
 
 
@@ -470,11 +473,14 @@ set_security(#{} = Db0, Security) ->
     Db1 = require_admin_check(Db0),
     ok = fabric2_util:validate_security_object(Security),
     SecBin = ?JSON_ENCODE(Security),
-    {Resp, Db2} = fabric2_fdb:transactional(Db1, fun(TxDb) ->
-        {fabric2_fdb:set_config(TxDb, <<"security_doc">>, SecBin), TxDb}
+    Resp = fabric2_fdb:transactional(Db1, fun(TxDb) ->
+        fabric2_fdb:set_config(TxDb, <<"security_doc">>, SecBin)
     end),
-    if Resp /= ok -> Resp; true ->
-        fabric2_server:store(Db2#{security_doc := Security})
+    case Resp of
+        {ok, #{} = Db2} ->
+            fabric2_server:store(Db2#{security_doc := Security});
+        Err ->
+            Err
     end.
 
 

--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -455,32 +455,26 @@ is_users_db(DbName) when is_binary(DbName) ->
     IsAuthCache orelse IsCfgUsersDb orelse IsGlobalUsersDb.
 
 
-set_revs_limit(#{} = Db0, RevsLimit) ->
+set_revs_limit(#{} = Db0, RevsLimit) when is_integer(RevsLimit) ->
     Db1 = require_admin_check(Db0),
-    RevsLimBin = ?uint2bin(max(1, RevsLimit)),
     Resp = fabric2_fdb:transactional(Db1, fun(TxDb) ->
-        fabric2_fdb:set_config(TxDb, <<"revs_limit">>, RevsLimBin)
+        fabric2_fdb:set_config(TxDb, revs_limit, RevsLimit)
     end),
     case Resp of
-        {ok, #{} = Db2} ->
-             fabric2_server:store(Db2#{revs_limit := RevsLimit});
-        Err ->
-            Err
+        {ok, #{} = Db2} -> fabric2_server:store(Db2);
+        Err -> Err
     end.
 
 
 set_security(#{} = Db0, Security) ->
     Db1 = require_admin_check(Db0),
     ok = fabric2_util:validate_security_object(Security),
-    SecBin = ?JSON_ENCODE(Security),
     Resp = fabric2_fdb:transactional(Db1, fun(TxDb) ->
-        fabric2_fdb:set_config(TxDb, <<"security_doc">>, SecBin)
+        fabric2_fdb:set_config(TxDb, security_doc, Security)
     end),
     case Resp of
-        {ok, #{} = Db2} ->
-            fabric2_server:store(Db2#{security_doc := Security});
-        Err ->
-            Err
+        {ok, #{} = Db2} -> fabric2_server:store(Db2);
+        Err -> Err
     end.
 
 

--- a/src/fabric/src/fabric2_server.erl
+++ b/src/fabric/src/fabric2_server.erl
@@ -56,7 +56,8 @@ fetch(DbName) when is_binary(DbName) ->
 store(#{name := DbName} = Db0) when is_binary(DbName) ->
     Db1 = Db0#{
         tx := undefined,
-        user_ctx := #user_ctx{}
+        user_ctx := #user_ctx{},
+        security_fun := undefined
     },
     true = ets:insert(?MODULE, {DbName, Db1}),
     ok.

--- a/src/fabric/test/fabric2_db_security_tests.erl
+++ b/src/fabric/test/fabric2_db_security_tests.erl
@@ -39,9 +39,9 @@ security_test_() ->
                 fun check_admin_is_member/1,
                 fun check_is_member_of_public_db/1,
                 fun check_set_user_ctx/1,
-                fun check_open_forbidden/1,
-                fun check_fail_open_no_opts/1,
-                fun check_fail_open_name_null/1
+                fun check_forbidden/1,
+                fun check_fail_no_opts/1,
+                fun check_fail_name_null/1
             ]}
         }
     }.
@@ -165,18 +165,21 @@ check_set_user_ctx({Db0, _, _}) ->
     ?assertEqual(UserCtx, fabric2_db:get_user_ctx(Db1)).
 
 
-check_open_forbidden({Db0, _, _}) ->
+check_forbidden({Db0, _, _}) ->
     DbName = fabric2_db:name(Db0),
     UserCtx = #user_ctx{name = <<"foo">>, roles = [<<"bar">>]},
-    ?assertThrow({forbidden, _}, fabric2_db:open(DbName, [{user_ctx, UserCtx}])).
+    {ok, Db} = fabric2_db:open(DbName, [{user_ctx, UserCtx}]),
+    ?assertThrow({forbidden, _}, fabric2_db:get_db_info(Db)).
 
 
-check_fail_open_no_opts({Db0, _, _}) ->
+check_fail_no_opts({Db0, _, _}) ->
     DbName = fabric2_db:name(Db0),
-    ?assertThrow({unauthorized, _}, fabric2_db:open(DbName, [])).
+    {ok, Db} = fabric2_db:open(DbName, []),
+    ?assertThrow({unauthorized, _}, fabric2_db:get_db_info(Db)).
 
 
-check_fail_open_name_null({Db0, _, _}) ->
+check_fail_name_null({Db0, _, _}) ->
     DbName = fabric2_db:name(Db0),
     UserCtx = #user_ctx{name = null},
-    ?assertThrow({unauthorized, _}, fabric2_db:open(DbName, [{user_ctx, UserCtx}])).
+    {ok, Db} = fabric2_db:open(DbName, [{user_ctx, UserCtx}]),
+    ?assertThrow({unauthorized, _}, fabric2_db:get_db_info(Db)).


### PR DESCRIPTION
Previously we checked security properties in a separate transaction, after
opening the db or fetching it from the cache. To avoid running an extra
transaction move the check inside the main transaction right after the metadata
check runs. That ensure it will be consistent and it won't be accidentally
missed as all operations run the `ensure_current` metadata check.

Also remove the special `get_config/2` function in `fabric2_fdb` for getting
revs limit and security properties and just read them directly from the db map.

Test with:

`make && make eunit apps=fabric,couch_views,couch_jobs`

`make && make elixir tests=test/elixir/test/basics_test.exs,test/elixir/test/replication_test.exs,test/elixir/test/map_test.exs,test/elixir/test/all_docs_test.exs,test/elixir/test/bulk_docs_test.exs`