### PR TITLE
enable couchjs to accept HTTP 0.9 responses

### DIFF
--- a/src/couch/priv/couch_js/http.c
+++ b/src/couch/priv/couch_js/http.c
@@ -450,6 +450,9 @@ go(JSContext* cx, JSObject* obj, HTTPData* http, char* body, size_t bodylen)
         curl_easy_setopt(HTTP_HANDLE, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
         curl_easy_setopt(HTTP_HANDLE, CURLOPT_ERRORBUFFER, ERRBUF);
         curl_easy_setopt(HTTP_HANDLE, CURLOPT_COOKIEFILE, "");
+#if LIBCURL_VERSION_NUM >= 0x074000
+        curl_easy_setopt(HTTP_HANDLE, CURLOPT_HTTP09_ALLOWED, 1L);
+#endif
         curl_easy_setopt(HTTP_HANDLE, CURLOPT_USERAGENT,
                                             "CouchHTTP Client - Relax");
     }


### PR DESCRIPTION
Since curl 7.66.0, HTTP/0.9 is disabled by default [1]. This is present in
FreeBSD's latest ports tree as of 12.1-RELEASE, and breaks a number of
our couchjs-related tests [2], on several platforms, as reported on IRC.

As this libcurl update will propagate through the open source space-time
continuum, pro-actively un-break future couchjs libcurl.

[1]: https://github.com/curl/curl/pull/4191
[2]: https://builds.apache.org/blue/organizations/jenkins/CouchDB/detail/master/608/pipeline/#step-163-log-2062

## testing recommendations

- @janl does this resolve the build on OSX for you?
- @kocolosk to re-enable the FreeBSD ci test to see if this helps
