### PR TITLE
Send only as many bytes as requested by Range header

### DIFF
--- a/src/couch/src/couch_stream.erl
+++ b/src/couch/src/couch_stream.erl
@@ -145,7 +145,7 @@ foldl_length(Bin, {Length, UserFun, UserAcc}) ->
         true ->
             {Length - BinSize, UserFun, UserFun(Bin, UserAcc)};
         false ->
-            <<Trunc:BinSize/binary, _/binary>> = Bin,
+            <<Trunc:Length/binary, _/binary>> = Bin,
             throw({finished, UserFun(Trunc, UserAcc)})
     end.
 


### PR DESCRIPTION
## Overview

We have been failing to honor Range requests that specify an ending byte less than the final byte of an attachment. The code that was supposed to truncate the binary to the desired length was actually executing a noop statement that preserved the entire binary.

Many HTTP clients will ignore the extra bytes on the wire and so this bug has gone undetected for a long time. Newer releases of libcurl that disable HTTP/0.9 support do detect it, and so we implicitly have a test for this in attachment_ranges.js, but ideally we'd have a more explicit one at some point in the future.

## Testing recommendations

Without this patch the attachment_ranges test fails when using libcurl version 7.66 or higher.

## Related Issues or Pull Requests

Fixes #2244

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
