### PR TITLE
Set autoupdate:false during update=false mango test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
           } // steps
           post {
             always {
-              junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+              junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
             }
             cleanup {
               sh 'rm -rf $COUCHDB_IO_LOG_DIR'
@@ -178,7 +178,7 @@ pipeline {
               }
               post {
                 always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
                 }
               }
             }
@@ -225,7 +225,7 @@ pipeline {
               }
               post {
                 always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
                 }
               }
             }
@@ -273,7 +273,7 @@ pipeline {
               }
               post {
                 always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
                 }
               }
             }
@@ -320,7 +320,7 @@ pipeline {
               }
               post {
                 always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
                 }
               }
             }
@@ -367,7 +367,7 @@ pipeline {
               }
               post {
                 always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
                 }
               }
             }
@@ -414,7 +414,7 @@ pipeline {
               }
               post {
                 always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
                 }
               }
             }
@@ -463,7 +463,7 @@ pipeline {
               }
               post {
                 always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml'
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml'
                 }
               }
             }

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ mango-test: devclean all
 	@cd src/mango && \
 		python3 -m venv .venv && \
 		.venv/bin/python3 -m pip install -r requirements.txt
-	@cd src/mango && ../../dev/run -n 1 --admin=testuser:testpass '.venv/bin/python3 -m nose'
+	@cd src/mango && ../../dev/run -n 1 --admin=testuser:testpass '.venv/bin/python3 -m nose --with-xunit'
 
 ################################################################################
 # Developing

--- a/src/mango/test/13-stable-update-test.py
+++ b/src/mango/test/13-stable-update-test.py
@@ -36,7 +36,14 @@ DOCS1 = [
 class SupportStableAndUpdate(mango.DbPerClass):
     def setUp(self):
         self.db.recreate()
-        self.db.create_index(["name"])
+        # Hack to prevent auto-indexer from foiling update=False test
+        # https://github.com/apache/couchdb/issues/2313
+        self.db.save_doc({
+            "_id": "_design/foo",
+            "language": "query",
+            "autoupdate": False
+        })
+        self.db.create_index(["name"], ddoc="foo")
         self.db.save_docs(copy.deepcopy(DOCS1))
 
     def test_update_updates_view_when_specified(self):

--- a/src/mango/test/13-stable-update-test.py
+++ b/src/mango/test/13-stable-update-test.py
@@ -38,11 +38,9 @@ class SupportStableAndUpdate(mango.DbPerClass):
         self.db.recreate()
         # Hack to prevent auto-indexer from foiling update=False test
         # https://github.com/apache/couchdb/issues/2313
-        self.db.save_doc({
-            "_id": "_design/foo",
-            "language": "query",
-            "autoupdate": False
-        })
+        self.db.save_doc(
+            {"_id": "_design/foo", "language": "query", "autoupdate": False}
+        )
         self.db.create_index(["name"], ddoc="foo")
         self.db.save_docs(copy.deepcopy(DOCS1))
 


### PR DESCRIPTION
## Overview

Tell the auto-indexer to stand down during the unit test to prevent an occasional flake.

Also, include Mango test results in Jenkins reporting.

## Testing recommendations

Jenkins is building automatically here:

https://builds.apache.org/blue/organizations/jenkins/CouchDB/activity?branch=jenkins-add-mango-test-reporting

Last build was largely successful, and every platform passed the test that is being fixed here.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
