### PR TITLE
Implement node types

### DIFF
--- a/src/chttpd/src/chttpd_app.erl
+++ b/src/chttpd/src/chttpd_app.erl
@@ -14,8 +14,8 @@
 -behaviour(application).
 -export([start/2, stop/1]).
 
-start(_Type, StartArgs) ->
-    chttpd_sup:start_link(StartArgs).
+start(_Type, _StartArgs) ->
+    chttpd_sup:start_link().
 
 stop(_State) ->
     ok.

--- a/src/couch_views/src/couch_views_app.erl
+++ b/src/couch_views/src/couch_views_app.erl
@@ -23,8 +23,8 @@
 ]).
 
 
-start(_StartType, StartArgs) ->
-    couch_views_sup:start_link(StartArgs).
+start(_StartType, _StartArgs) ->
+    couch_views_sup:start_link().
 
 
 stop(_State) ->

--- a/src/fabric/src/fabric2_node_types.erl
+++ b/src/fabric/src/fabric2_node_types.erl
@@ -1,0 +1,52 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_node_types).
+
+
+-export([
+    is_type/1
+]).
+
+
+is_type(Type) when is_atom(Type) ->
+    case {from_os_env(Type), from_app_env(Type)} of
+        {V, _} when is_boolean(V) ->
+            V;
+        {undefined, V} when is_boolean(V) ->
+            V;
+        {undefined, undefined} ->
+            % When not defined anywhere assume `true`, that is by default a
+            % node will perform all the background tasks
+            true
+    end.
+
+
+from_os_env(Type) when is_atom(Type) ->
+    StrType = erlang:atom_to_list(Type),
+    StrTypeUpper = string:to_upper(StrType),
+    case os:getenv("COUCHDB_NODE_TYPE_" ++ StrTypeUpper) of
+        false ->
+            undefined;
+        Str when is_list(Str) ->
+            case string:to_lower(Str) of
+                "false" -> false;
+                _ -> true
+            end
+    end.
+
+
+from_app_env(Type) when is_atom(Type) ->
+    case application:get_env(fabric, node_types) of
+        undefined ->  undefined;
+        {ok, Props} when is_list(Props) -> proplists:get_value(Type, Props)
+    end.

--- a/src/fabric/test/fabric2_node_types_tests.erl
+++ b/src/fabric/test/fabric2_node_types_tests.erl
@@ -1,0 +1,73 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_node_types_tests).
+
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+-define(TDEF(A), {atom_to_list(A), fun A/0}).
+
+
+node_types_test_() ->
+    {
+        "Test node types",
+        foreach,
+        fun() ->
+            os:putenv("COUCHDB_NODE_TYPE_FOO", "false"),
+            os:putenv("COUCHDB_NODE_TYPE_BAZ", "true"),
+            os:putenv("COUCHDB_NODE_TYPE_ZIG", ""),
+            % erlfdb, rexi and mem3 are all dependent apps for fabric. We make
+            % sure to start them so when fabric is started during the test it
+            % already has its dependencies
+            test_util:start_couch([erlfdb, rexi, mem3, ctrace])
+        end,
+        fun(Ctx) ->
+            ok = application:stop(fabric),
+            test_util:stop_couch(Ctx),
+            application:unset_env(fabric, node_types),
+            os:unsetenv("COUCHDB_NODE_TYPE_FOO"),
+            os:unsetenv("COUCHDB_NODE_TYPE_BAZ"),
+            os:unsetenv("COUCHDB_NODE_TYPE_ZIG")
+        end,
+        [
+            ?TDEF(basics),
+            ?TDEF(os_env_priority)
+        ]
+    }.
+
+
+basics() ->
+    ok = application:start(fabric),
+
+    % default is true for new types
+    ?assert(fabric2_node_types:is_type(some_new_node_type)),
+
+    % defined in os env
+    ?assert(fabric2_node_types:is_type(baz)),
+    ?assert(not fabric2_node_types:is_type(foo)),
+    ?assert(fabric2_node_types:is_type(zig)),
+
+    % defined in app env
+    application:set_env(fabric, node_types, [{zag, true}, {bam, false}]),
+    ?assert(fabric2_node_types:is_type(zag)),
+    ?assert(not fabric2_node_types:is_type(bam)).
+
+
+os_env_priority() ->
+    ok = application:start(fabric),
+
+    % os env takes precedence
+    application:set_env(fabric, node_types, [{foo, true}, {baz, false}]),
+    ?assert(not fabric2_node_types:is_type(foo)),
+    ?assert(fabric2_node_types:is_type(baz)).


### PR DESCRIPTION
Implementation follows the  [RFC][1]

[1]: https://github.com/apache/couchdb-documentation/blob/master/rfcs/013-node-types.md

Run tests with:

```
make eunit apps=fabric suites=fabric2_node_types_tests
======================== EUnit ========================
module 'fabric2_node_types_tests'
  Test node types
Application crypto was left running!
    fabric2_node_types_tests: node_types_test_ (basics)...[1.224 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    fabric2_node_types_tests: node_types_test_ (os_env_priority)...[0.009 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 2.135 s]
  [done in 2.135 s]
=======================================================
  2 tests passed.
```