### PR TITLE
Don't require auth on login attempts

### DIFF
--- a/src/chttpd/src/chttpd_auth.erl
+++ b/src/chttpd/src/chttpd_auth.erl
@@ -51,6 +51,9 @@ cookie_authentication_handler(Req) ->
 proxy_authentication_handler(Req) ->
     couch_httpd_auth:proxy_authentication_handler(Req).
 
+party_mode_handler(#httpd{method='POST', path_parts=[<<"_session">>]} = Req) ->
+    % See #1947 - users should always be able to attempt a login
+    Req#httpd{user_ctx=#user_ctx{}};
 party_mode_handler(Req) ->
     case config:get("chttpd", "require_valid_user", "false") of
     "true" ->

--- a/src/couch/test/eunit/couchdb_auth_tests.erl
+++ b/src/couch/test/eunit/couchdb_auth_tests.erl
@@ -22,14 +22,14 @@ setup(PortType) ->
     lists:concat(["http://", Addr, ":", port(PortType), "/_session"]).
 
 setup_require_valid_user(PortType) ->
-    ok = config:set("couchdb", "require_valid_user", "true", _Persist=false),
+    ok = config:set("chttpd", "require_valid_user", "true", _Persist=false),
     setup(PortType).
 
 teardown(_, _) ->
     ok.
 
 teardown_require_valid_user(_, _) ->
-    config:set("couchdb", "require_valid_user", "false", _Persist=false).
+    config:set("chttpd", "require_valid_user", "false", _Persist=false).
 
 
 auth_test_() ->
@@ -63,7 +63,7 @@ make_test_cases(Mod, Funs) ->
 
 make_require_valid_user_test_cases(Mod, Funs) ->
     {
-        lists:flatten(io_lib:format("~s", [Mod])),
+        lists:flatten(io_lib:format("~s require_valid_user=true", [Mod])),
         {foreachx, fun setup_require_valid_user/1, fun teardown_require_valid_user/2,
             [{Mod, Fun} || Fun <- Funs]}
     }.


### PR DESCRIPTION
## Overview

Previously with require_valid_user=true configured a user would need to supply Basic auth credentials in order to login via the _session endpoint (or have some otgher Catch-22 way of using an existing session). This patch makes it so that any attempt to POST to _session is allowed to proceed.

## Testing recommendations

Try to POST to `_session` with `require_valid_user = true` and don't supply any additional basic auth header. Without this patch you would get rejected.

## Related Issues or Pull Requests

Closes #1947.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
