### PR TITLE
close writer before soft deletion of search index

### DIFF
--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -20,7 +20,7 @@
 -export([open_index/3]).
 -export([await/2, commit/2, get_update_seq/1, info/1, search/2]).
 -export([group1/7, group2/2]).
--export([delete/2, update/3, cleanup/1, cleanup/2, rename/1]).
+-export([delete/2, soft_delete/1, update/3, cleanup/1, cleanup/2]).
 -export([analyze/2, version/0, disk_size/1]).
 -export([set_purge_seq/2, get_purge_seq/1, get_root_dir/0, close_lru/0, close_lru/1]).
 -export([connected/0]).
@@ -78,15 +78,14 @@ group2(Ref, Args) ->
 delete(Ref, Id) ->
     rpc(Ref, {delete, couch_util:to_binary(Id)}).
 
+soft_delete(DbName) ->
+    gen_server:cast({cleanup, clouseau()}, {soft_delete, DbName}).
+
 update(Ref, Id, Fields) ->
     rpc(Ref, {update, Id, Fields}).
 
 cleanup(DbName) ->
     gen_server:cast({cleanup, clouseau()}, {cleanup, DbName}).
-
-rename(DbName) ->
-  close_lru(DbName),
-  gen_server:cast({cleanup, clouseau()}, {rename, DbName}).
 
 cleanup(DbName, ActiveSigs) ->
     gen_server:cast({cleanup, clouseau()}, {cleanup, DbName, ActiveSigs}).

--- a/src/dreyfus/src/dreyfus_index_manager.erl
+++ b/src/dreyfus/src/dreyfus_index_manager.erl
@@ -84,8 +84,8 @@ handle_cast({cleanup, DbName}, State) ->
     clouseau_rpc:cleanup(DbName),
     {noreply, State};
 
-handle_cast({rename, DbName}, State) ->
-    clouseau_rpc:rename(DbName),
+handle_cast({soft_delete, DbName}, State) ->
+    clouseau_rpc:soft_delete(DbName),
     {noreply, State}.
 
 handle_info({'EXIT', FromPid, Reason}, State) ->
@@ -123,8 +123,7 @@ handle_db_event(DbName, deleted, _St) ->
         "enable_database_recovery", false),
     case RecoveryEnabled of
         true ->
-            clouseau_rpc:close_lru(DbName),
-            gen_server:cast(?MODULE, {rename, DbName});
+            gen_server:cast(?MODULE, {soft_delete, DbName});
         false ->
             gen_server:cast(?MODULE, {cleanup, DbName})
     end,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
This fix is to refactor the logic for soft-deletion of search index. In the past, there is case where write.lock was stayed in search index directory and can't be moved. It is due to the fact that the index was not closed gracefully before moving/renaming search index. With this fix, the search index writer can be closed, and then search index can be moved to .deleted directory smoothly.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.cloudant.clouseau.AnalyzerServiceSpec
Running com.cloudant.clouseau.AnalyzerServiceSpec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 sec
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.238 sec
Running com.cloudant.clouseau.ClouseauTypeFactorySpec
Running com.cloudant.clouseau.ClouseauTypeFactorySpec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 sec
Running com.cloudant.clouseau.IndexManagerServiceSpec
Running com.cloudant.clouseau.IndexManagerServiceSpec
2019-11-21 15:26:30 clouseau [INFO] foo.5432109876 Renaming '/Users/jiangph/couchdb/clouseau.dreyfus/clouseau/target/indexes/foo.5432109876' to '/Users/jiangph/couchdb/clouseau.dreyfus/clouseau/target/indexes/foo.20191121.072630.deleted.5432109876'
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.445 sec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.465 sec
Running com.cloudant.clouseau.ClouseauQueryParserSpec
Running com.cloudant.clouseau.ClouseauQueryParserSpec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec
Running com.cloudant.clouseau.IndexServiceSpec
Running com.cloudant.clouseau.IndexServiceSpec
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.937 sec
Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 23.954 sec
Running com.cloudant.clouseau.SupportedAnalyzersSpec
Running com.cloudant.clouseau.SupportedAnalyzersSpec
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec
Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.109 sec

Results :

Tests run: 95, Failures: 0, Errors: 0, Skipped: 0
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/2130
https://github.com/cloudant-labs/clouseau/pull/25
## Checklist

- [x] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
