### PR TITLE
Change end-point `/_up` to check fdb connectivity

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -498,12 +498,11 @@ handle_up_req(#httpd{method='GET'} = Req) ->
     "nolb" ->
         send_json(Req, 404, {[{status, nolb}]});
     _ ->
-        {ok, {Status}} = mem3_seeds:get_status(),
-        case couch_util:get_value(status, Status) of
-            ok ->
-                send_json(Req, 200, {Status});
-            seeding ->
-                send_json(Req, 404, {Status})
+        try
+            fabric2_db:list_dbs([{limit, 0}]),
+            send_json(Req, 200, {[{status, ok}]})
+        catch error:{timeout, _} ->
+            send_json(Req, 404, {[{status, backend_unavailable}]})
         end
     end;
 

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -18,6 +18,12 @@ defmodule BasicsTest do
     assert Couch.get("/").body["couchdb"] == "Welcome", "Should say welcome"
   end
 
+  test "Ready endpoint" do
+    resp = Couch.get("/_up")
+    assert resp.status_code == 200
+    assert resp.body["status"] == "ok"
+  end
+
   @tag :with_db
   test "PUT on existing DB should return 412 instead of 500", context do
     db_name = context[:db_name]


### PR DESCRIPTION
## Overview

This changes an end-point `/_up` to verify that fdb cluster is accessible, i.e. confirms that fdb-layer node is ready to serve.

## Testing recommendations

`make elixir tests=test/elixir/test/basics_test.exs:21`

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
