### PR TITLE
Return 400 error for missing partition key

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -279,6 +279,9 @@ handle_view_cleanup_req(Req, Db) ->
     send_json(Req, 202, {[{ok, true}]}).
 
 
+handle_partition_req(#httpd{path_parts=[_,_]}=_Req, _Db) ->
+    throw({bad_request, invalid_partition_req});
+
 handle_partition_req(#httpd{method='GET', path_parts=[_,_,PartId]}=Req, Db) ->
     couch_partition:validate_partition(PartId),
     case couch_db:is_partitioned(Db) of

--- a/test/elixir/test/partition_crud_test.exs
+++ b/test/elixir/test/partition_crud_test.exs
@@ -95,6 +95,15 @@ defmodule PartitionCrudTest do
   end
 
   @tag :with_partitioned_db
+  test "GET to partition returns 400", context do
+    db_name = context[:db_name]
+    url = "/#{db_name}/_partition"
+
+    resp = Couch.get("#{url}")
+    assert resp.status_code == 400
+  end
+
+  @tag :with_partitioned_db
   test "POST and _bulk_get document", context do
     db_name = context[:db_name]
     id = "my-partition-post:doc"


### PR DESCRIPTION
Return a 400 for urls /partitiondb/_partition with no partition key

Fixes #2332

