### PR TITLE
Update usage of couch_hash:md5_hash shim

### DIFF
--- a/src/couch_mrview/test/eunit/couch_mrview_purge_docs_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_purge_docs_tests.erl
@@ -139,7 +139,7 @@ test_purge_partial(Db) ->
         FDI1 = couch_db:get_full_doc_info(Db, <<"1">>), Rev1 = get_rev(FDI1),
         Update = {[
             {'_id', <<"1">>},
-            {'_rev', couch_doc:rev_to_str({1, [crypto:hash(md5, <<"1.2">>)]})},
+            {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
             {'val', 1.2}
         ]},
         {ok, [_Rev2]} = save_docs(Db, [Update], [replicated_changes]),

--- a/src/couch_pse_tests/src/cpse_test_purge_docs.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_docs.erl
@@ -253,7 +253,7 @@ cpse_purge_partial_revs(DbName) ->
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo}, {vsn, <<"1.1">>}]}),
     Update = {[
         {'_id', foo},
-        {'_rev', couch_doc:rev_to_str({1, [crypto:hash(md5, <<"1.2">>)]})},
+        {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
         {vsn, <<"1.2">>}
     ]},
     {ok, [_Rev2]} = cpse_util:save_docs(DbName, [Update], [replicated_changes]),
@@ -392,7 +392,7 @@ cpse_purge_repeated_revisions(DbName) ->
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo}, {vsn, <<"1.1">>}]}),
     Update = {[
         {'_id', foo},
-        {'_rev', couch_doc:rev_to_str({1, [crypto:hash(md5, <<"1.2">>)]})},
+        {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
         {vsn, <<"1.2">>}
     ]},
     {ok, [Rev2]} = cpse_util:save_docs(DbName, [Update], [replicated_changes]),

--- a/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
@@ -101,7 +101,7 @@ cpse_increment_purge_seq_on_partial_purge(DbName) ->
     {ok, Rev1} = cpse_util:save_doc(DbName, {[{'_id', foo1}, {vsn, <<"1.1">>}]}),
     Update = {[
         {'_id', foo1},
-        {'_rev', couch_doc:rev_to_str({1, [crypto:hash(md5, <<"1.2">>)]})},
+        {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
         {vsn, <<"1.2">>}
     ]},
     {ok, [_Rev2]} = cpse_util:save_docs(DbName, [Update], [replicated_changes]),

--- a/src/couch_pse_tests/src/cpse_util.erl
+++ b/src/couch_pse_tests/src/cpse_util.erl
@@ -371,11 +371,11 @@ gen_write(Db, {Action, {DocId, Body, Atts}}) ->
 
 
 gen_rev(A, DocId, {Pos, Rev}, Body, Atts) when A == update; A == delete ->
-    NewRev = crypto:hash(md5, term_to_binary({DocId, Rev, Body, Atts})),
+    NewRev = couch_hash:md5_hash(term_to_binary({DocId, Rev, Body, Atts})),
     {Pos + 1, [NewRev, Rev]};
 gen_rev(conflict, DocId, _, Body, Atts) ->
     UUID = couch_uuids:random(),
-    NewRev = crypto:hash(md5, term_to_binary({DocId, UUID, Body, Atts})),
+    NewRev = couch_hash:md5_hash(term_to_binary({DocId, UUID, Body, Atts})),
     {1, [NewRev]}.
 
 

--- a/src/dreyfus/src/dreyfus_index.erl
+++ b/src/dreyfus/src/dreyfus_index.erl
@@ -197,7 +197,7 @@ handle_info({'EXIT', FromPid, {updated, NewSeq}},
                 nil;
             false ->
                 spawn_link(fun() ->
-                    dreyfus_index_updater:update(IndexPid, Index) 
+                    dreyfus_index_updater:update(IndexPid, Index)
                 end)
         end,
         {noreply, State#state{index=Index,
@@ -274,7 +274,7 @@ design_doc_to_index(#doc{id=Id,body={Fields}}, IndexName) ->
                 undefined ->
                     {error, InvalidDDocError};
                 Def ->
-                    Sig = ?l2b(couch_util:to_hex(crypto:hash(md5,
+                    Sig = ?l2b(couch_util:to_hex(couch_hash:md5_hash(
                         term_to_binary({Analyzer, Def})))),
                     {ok, #index{
                         analyzer=Analyzer,

--- a/src/fabric/test/eunit/fabric_rpc_purge_tests.erl
+++ b/src/fabric/test/eunit/fabric_rpc_purge_tests.erl
@@ -241,7 +241,7 @@ create_update(Doc, NewVsn) ->
         body = {Props}
     } = Doc,
     NewProps = lists:keyreplace(<<"vsn">>, 1, Props, {<<"vsn">>, NewVsn}),
-    NewRev = crypto:hash(md5, term_to_binary({DocId, Rev, {NewProps}})),
+    NewRev = couch_hash:md5_hash(term_to_binary({DocId, Rev, {NewProps}})),
     Doc#doc{
         revs = {Pos + 1, [NewRev | Revs]},
         body = {NewProps}


### PR DESCRIPTION
https://github.com/apache/couchdb/pull/1445 introduced a shim to
enable CouchDB to be compiled to use the Erlang MD5 function.
This allows CouchDB to run in FIPS environments where the crypto
module is restricted such that `crypto:hash(md5,..)` is blocked
(fails with `notsup` error).

This commit replaces usage of `crypto:hash(md5, ..)` introduced since
the original PR with the shim function.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
