### PR TITLE
Allow all params to be passed via body for POST view

### DIFF
--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -1152,7 +1152,6 @@ extract_view_reduce({red, {N, _Lang, #mrview{reduce_funs=Reds}}, _Ref}) ->
 get_view_keys({Props}) ->
     case couch_util:get_value(<<"keys">>, Props) of
         undefined ->
-            couch_log:debug("POST with no keys member.", []),
             undefined;
         Keys when is_list(Keys) ->
             Keys;

--- a/test/elixir/test/view_test.exs
+++ b/test/elixir/test/view_test.exs
@@ -1,0 +1,143 @@
+defmodule ViewTest do
+  use CouchTestCase
+
+  @moduletag :view
+
+  @moduledoc """
+  Test CouchDB /{db}/_design/{ddoc}/_view/{view}
+  """
+
+  setup_all do
+    db_name = random_db_name()
+    {:ok, _} = create_db(db_name)
+    on_exit(fn -> delete_db(db_name) end)
+
+    {:ok, _} = create_doc(
+      db_name,
+      %{
+        _id: "foo",
+        bar: "baz"
+      }
+    )
+
+    {:ok, _} = create_doc(
+      db_name,
+      %{
+        _id: "foo2",
+        bar: "baz2"
+      }
+    )
+
+    map_fun = """
+      function(doc) {
+        emit(doc._id, doc.bar);
+      }
+    """
+
+
+    body = %{
+      :docs => [
+        %{
+          _id: "_design/map",
+          views: %{
+            some: %{
+              map: map_fun
+            }
+          }
+        }
+      ]
+    }
+
+    resp = Couch.post("/#{db_name}/_bulk_docs", body: body)
+    Enum.each(resp.body, &assert(&1["ok"]))
+
+    {:ok, [db_name: db_name]}
+  end
+
+  test "GET with no parameters", context do
+    resp = Couch.get(
+      "/#{context[:db_name]}/_design/map/_view/some"
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "GET with one key", context do
+    resp = Couch.get(
+      "/#{context[:db_name]}/_design/map/_view/some",
+      query: %{
+        :key => "\"foo\"",
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  test "GET with multiple keys", context do
+    resp = Couch.get(
+      "/#{context[:db_name]}/_design/map/_view/some",
+      query: %{
+        :keys => "[\"foo\", \"foo2\"]",
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "POST with empty body", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design/map/_view/some",
+      body: %{}
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "POST with keys and limit", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design/map/_view/some",
+      body: %{
+        :keys => ["foo", "foo2"],
+        :limit => 1
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  test "POST with query parameter and JSON body", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design/map/_view/some",
+      query: %{
+        :limit => 1
+      },
+      body: %{
+        :keys => ["foo", "foo2"]
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  test "POST edge case with colliding parameters - query takes precedence", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design/map/_view/some",
+      query: %{
+        :limit => 1
+      },
+      body: %{
+        :keys => ["foo", "foo2"],
+        :limit => 2
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This change should allow users to supply all params in [POST](http://docs.couchdb.org/en/stable/api/ddoc/views.html#post--db-_design-ddoc-_view-view) that can be supplied for [GET](http://docs.couchdb.org/en/stable/api/ddoc/views.html#get--db-_design-ddoc-_view-view) now. This way we could avoid the `?key="foo"` things that would probably cause a lot of pain for users.


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
So far this has been tested manually and it seems to be working.
```
curl -H 'Content-Type: application/json'  -XPOST -d '{"key": "yo"}' http://127.0.0.1:15984/asd/_design/newDD/_view/newview |jq
{
  "total_rows": 2,
  "offset": 0,
  "rows": [
    {
      "id": "yo",
      "key": "yo",
      "value": {
        "fromView": "yes",
        "_id": "yo",
        "_rev": "1-ffdc431dc4d2660c2af2e85e3abf723e",
        "asd": "dsa"
      }
    }
  ]
}
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation: https://github.com/apache/couchdb-documentation/pull/459
