### PR TITLE
All databases now admin-only by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ EXUNIT_OPTS=$(subst $(comma),$(space),$(tests))
 #ignore javascript tests
 ignore_js_suites=
 
+TEST_OPTS="-c 'startup_jitter=0' -c 'default_security=admin_local'"
+
 ################################################################################
 # Main commands
 ################################################################################
@@ -221,7 +223,7 @@ python-black: .venv/bin/black
 	@python3 -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		LC_ALL=C.UTF-8 LANG=C.UTF-8 .venv/bin/black --check \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
-		. dev/run rel/overlay/bin/couchup test/javascript/run
+		. dev/run "$(TEST_OPTS)" rel/overlay/bin/couchup test/javascript/run
 
 python-black-update: .venv/bin/black
 	@python3 -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
@@ -234,7 +236,7 @@ python-black-update: .venv/bin/black
 .PHONY: elixir
 elixir: export MIX_ENV=integration
 elixir: elixir-init elixir-check-formatted elixir-credo devclean
-	@dev/run -a adm:pass -n 1 --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+	@dev/run "$(TEST_OPTS)" -a adm:pass -n 1 --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-init
 elixir-init: MIX_ENV=test
@@ -277,7 +279,7 @@ else
 endif
 	@dev/run -n 1 -q --with-admin-party-please \
             --enable-erlang-views \
-            -c 'startup_jitter=0' \
+            "$(TEST_OPTS)" \
             'test/javascript/run --suites "$(suites)" \
             --ignore "$(ignore_js_suites)"'
 
@@ -292,7 +294,7 @@ else
 endif
 	@dev/run -n 3 -q --with-admin-party-please \
             --enable-erlang-views --degrade-cluster 1 \
-            -c 'startup_jitter=0' \
+            "$(TEST_OPTS)" \
             'test/javascript/run --suites "$(suites)" \
             --ignore "$(ignore_js_suites)" \
 	    --path test/javascript/tests-cluster/with-quorum'
@@ -308,7 +310,7 @@ else
 endif
 	@dev/run -n 3 -q --with-admin-party-please \
             --enable-erlang-views --degrade-cluster 2 \
-            -c 'startup_jitter=0' \
+            "$(TEST_OPTS)" \
             'test/javascript/run --suites "$(suites)" \
             --ignore "$(ignore_js_suites)" \
             --path test/javascript/tests-cluster/without-quorum'
@@ -325,7 +327,7 @@ endif
 	@rm -rf dev/lib
 	while [ $$? -eq 0 ]; do \
 		dev/run -n 1 -q --with-admin-party-please \
-				-c 'startup_jitter=0' \
+				"$(TEST_OPTS)" \
 				'test/javascript/run --suites "$(suites)" \
 				--ignore "$(ignore_js_suites)"'  \
 	done
@@ -372,7 +374,7 @@ mango-test: devclean all
 	@cd src/mango && \
 		python3 -m venv .venv && \
 		.venv/bin/python3 -m pip install -r requirements.txt
-	@cd src/mango && ../../dev/run -n 1 --admin=testuser:testpass '.venv/bin/python3 -m nose --with-xunit'
+	@cd src/mango && ../../dev/run "$(TEST_OPTS)" -n 1 --admin=testuser:testpass '.venv/bin/python3 -m nose --with-xunit'
 
 ################################################################################
 # Developing

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -27,7 +27,7 @@ attachment_stream_buffer_size = 4096
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_local
+default_security = admin_only
 ; btree_chunk_size = 1279
 ; maintenance_mode = false
 ; stem_interactive_updates = true

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -851,7 +851,7 @@ get_meta_body_size(Meta) ->
 
 
 default_security_object(<<"shards/", _/binary>>) ->
-    case config:get("couchdb", "default_security", "everyone") of
+    case config:get("couchdb", "default_security", "admin_only") of
         "admin_only" ->
             [{<<"members">>,{[{<<"roles">>,[<<"_admin">>]}]}},
              {<<"admins">>,{[{<<"roles">>,[<<"_admin">>]}]}}];
@@ -859,7 +859,7 @@ default_security_object(<<"shards/", _/binary>>) ->
             []
     end;
 default_security_object(_DbName) ->
-    case config:get("couchdb", "default_security", "everyone") of
+    case config:get("couchdb", "default_security", "admin_only") of
         Admin when Admin == "admin_only"; Admin == "admin_local" ->
             [{<<"members">>,{[{<<"roles">>,[<<"_admin">>]}]}},
              {<<"admins">>,{[{<<"roles">>,[<<"_admin">>]}]}}];


### PR DESCRIPTION
## Overview

Change the default security object for all databases, both clustered and local to admin only.

## Testing recommendations

No additional testing is needed but the existing tests might need to authenticate where they didn't previously.

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/2191

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
