### PR TITLE
Allow all params to be passed via body for POST _all_docs

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -882,7 +882,7 @@ multi_all_docs_view(Req, Db, OP, Queries) ->
     chttpd:end_delayed_json_response(Resp1).
 
 all_docs_view(Req, Db, Keys, OP) ->
-    Args0 = couch_mrview_http:parse_params(Req, Keys),
+    Args0 = couch_mrview_http:parse_body_and_query(Req, Keys),
     Args1 = Args0#mrargs{view_type=map},
     Args2 = fabric_util:validate_all_docs_args(Db, Args1),
     Args3 = set_namespace(OP, Args2),

--- a/src/chttpd/src/chttpd_show.erl
+++ b/src/chttpd/src/chttpd_show.erl
@@ -204,7 +204,7 @@ handle_view_list(Req, Db, DDoc, LName, {ViewDesignName, ViewName}, Keys) ->
     DbName = couch_db:name(Db),
     {ok, VDoc} = ddoc_cache:open(DbName, <<"_design/", ViewDesignName/binary>>),
     CB = fun list_cb/2,
-    QueryArgs = couch_mrview_http:parse_params(Req, Keys),
+    QueryArgs = couch_mrview_http:parse_body_and_query(Req, Keys),
     Options = [{user_ctx, Req#httpd.user_ctx}],
     couch_query_servers:with_ddoc_proc(DDoc, fun(QServer) ->
         Acc = #lacc{

--- a/src/couch_mrview/src/couch_mrview_show.erl
+++ b/src/couch_mrview/src/couch_mrview_show.erl
@@ -181,7 +181,7 @@ handle_view_list_req(Req, _Db, _DDoc) ->
 
 
 handle_view_list(Req, Db, DDoc, LName, VDDoc, VName, Keys) ->
-    Args0 = couch_mrview_http:parse_params(Req, Keys),
+    Args0 = couch_mrview_http:parse_body_and_query(Req, Keys),
     ETagFun = fun(BaseSig, Acc0) ->
         UserCtx = Req#httpd.user_ctx,
         Name = UserCtx#user_ctx.name,

--- a/test/elixir/test/all_docs_test.exs
+++ b/test/elixir/test/all_docs_test.exs
@@ -186,4 +186,114 @@ defmodule AllDocsTest do
 
     assert length(rows) == 1
   end
+
+  @tag :with_db
+  test "GET with one key", context do
+    db_name = context[:db_name]
+
+    {:ok, _} = create_doc(
+      db_name,
+      %{
+        _id: "foo",
+        bar: "baz"
+      }
+    )
+
+    {:ok, _} = create_doc(
+      db_name,
+      %{
+        _id: "foo2",
+        bar: "baz2"
+      }
+    )
+
+    resp = Couch.get(
+      "/#{db_name}/_all_docs",
+      query: %{
+        :key => "\"foo\"",
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+
+  @tag :with_db
+  test "POST with empty body", context do
+    db_name = context[:db_name]
+
+    resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..2)})
+    assert resp.status_code == 201
+
+    resp = Couch.post(
+      "/#{db_name}/_all_docs",
+      body: %{}
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 3
+  end
+
+  @tag :with_db
+  test "POST with keys and limit", context do
+    db_name = context[:db_name]
+
+    resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
+    assert resp.status_code == 201
+
+    resp = Couch.post(
+      "/#{db_name}/_all_docs",
+      body: %{
+        :keys => [1, 2],
+        :limit => 1
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  @tag :with_db
+  test "POST with query parameter and JSON body", context do
+    db_name = context[:db_name]
+
+    resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
+    assert resp.status_code == 201
+
+    resp = Couch.post(
+      "/#{db_name}/_all_docs",
+      query: %{
+        :limit => 1
+      },
+      body: %{
+        :keys => [1, 2]
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  @tag :with_db
+  test "POST edge case with colliding parameters - query takes precedence", context do
+    db_name = context[:db_name]
+
+    resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
+    assert resp.status_code == 201
+
+    resp = Couch.post(
+      "/#{db_name}/_all_docs",
+      query: %{
+        :limit => 1
+      },
+      body: %{
+        :keys => [1, 2],
+        :limit => 2
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
 end

--- a/test/elixir/test/design_docs_test.exs
+++ b/test/elixir/test/design_docs_test.exs
@@ -1,0 +1,108 @@
+defmodule DesignDocsTest do
+  use CouchTestCase
+
+  @moduletag :design_docs
+
+  @moduledoc """
+  Test CouchDB /{db}/_design_docs
+  """
+
+  setup_all do
+    db_name = random_db_name()
+    {:ok, _} = create_db(db_name)
+    on_exit(fn -> delete_db(db_name) end)
+
+    {:ok, _} = create_doc(
+      db_name,
+      %{
+        _id: "_design/foo",
+        bar: "baz"
+      }
+    )
+
+    {:ok, _} = create_doc(
+      db_name,
+      %{
+        _id: "_design/foo2",
+        bar: "baz2"
+      }
+    )
+
+    {:ok, [db_name: db_name]}
+  end
+
+  test "GET with no parameters", context do
+    resp = Couch.get(
+      "/#{context[:db_name]}/_design_docs"
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "GET with multiple keys", context do
+    resp = Couch.get(
+      "/#{context[:db_name]}/_design_docs",
+      query: %{
+        :keys => "[\"_design/foo\", \"_design/foo2\"]",
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "POST with empty body", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design_docs",
+      body: %{}
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "POST with keys and limit", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design_docs",
+      body: %{
+        :keys => ["_design/foo", "_design/foo2"],
+        :limit => 1
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  test "POST with query parameter and JSON body", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design_docs",
+      query: %{
+        :limit => 1
+      },
+      body: %{
+        :keys => ["_design/foo", "_design/foo2"]
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  test "POST edge case with colliding parameters - query takes precedence", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design_docs",
+      query: %{
+        :limit => 0
+      },
+      body: %{
+        :keys => ["_design/foo", "_design/foo2"],
+        :limit => 2
+      }
+    )
+
+    assert resp.status_code == 200
+    assert Enum.empty?(Map.get(resp, :body)["rows"])
+  end
+end

--- a/test/elixir/test/local_docs_test.exs
+++ b/test/elixir/test/local_docs_test.exs
@@ -1,0 +1,110 @@
+defmodule LocalDocsTest do
+  use CouchTestCase
+
+  @moduletag :local_docs
+
+  @moduledoc """
+  Test CouchDB _local_docs
+  """
+
+  setup_all do
+    db_name = random_db_name()
+    {:ok, _} = create_db(db_name)
+    on_exit(fn -> delete_db(db_name) end)
+
+    resp1 = Couch.put(
+      "/#{db_name}/_local/foo",
+      body: %{
+        _id: "foo",
+        bar: "baz"
+      }
+    )
+    assert resp1.status_code == 201
+
+    resp2 = Couch.put(
+      "/#{db_name}/_local/foo2",
+      body: %{
+        _id: "foo",
+        bar: "baz2"
+      }
+    )
+    assert resp2.status_code == 201
+
+    {:ok, [db_name: db_name]}
+  end
+
+  test "GET with no parameters", context do
+    resp = Couch.get(
+      "/#{context[:db_name]}/_local_docs"
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "GET with multiple keys", context do
+    resp = Couch.get(
+      "/#{context[:db_name]}/_local_docs",
+      query: %{
+        :keys => "[\"_local/foo\", \"_local/foo2\"]",
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "POST with empty body", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_local_docs",
+      body: %{}
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 2
+  end
+
+  test "POST with keys and limit", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_local_docs",
+      body: %{
+        :keys => ["_local/foo", "_local/foo2"],
+        :limit => 1
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  test "POST with query parameter and JSON body", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_local_docs",
+      query: %{
+        :limit => 1
+      },
+      body: %{
+        :keys => ["_local/foo", "_local/foo2"]
+      }
+    )
+
+    assert resp.status_code == 200
+    assert length(Map.get(resp, :body)["rows"]) == 1
+  end
+
+  test "POST edge case with colliding parameters - query takes precedence", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_local_docs",
+      query: %{
+        :limit => 0
+      },
+      body: %{
+        :keys => ["_local/foo", "_local/foo2"],
+        :limit => 2
+      }
+    )
+
+    assert resp.status_code == 200
+    assert Enum.empty?(Map.get(resp, :body)["rows"])
+  end
+end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This change should allow users to supply all params in POST that can be supplied for GET now. This way we could avoid the ?key="foo" things that would probably cause a lot of pain for users.

As `/{db}/_design_docs` and `/{db}/_local_docs` are analogous to `_all_docs`, this change applies to all three of them.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Just run the tests included with this PR.
Let me know if you need instructions for manual testing.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

https://github.com/apache/couchdb-documentation/pull/462

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation: https://github.com/apache/couchdb-documentation/pull/462
