### PR TITLE
2 small release file fixes

### DIFF
--- a/rel/files/couchdb.cmd.in
+++ b/rel/files/couchdb.cmd.in
@@ -27,6 +27,7 @@ set PATH=%PATH%;%COUCHDB_BIN_DIR%
 
 set COUCHDB_QUERY_SERVER_JAVASCRIPT="{{prefix}}/bin/couchjs {{prefix}}/share/server/main.js"
 set COUCHDB_QUERY_SERVER_COFFEESCRIPT="{{prefix}}/bin/couchjs {{prefix}}/share/server/main-coffee.js"
+REM set COUCHDB_FAUXTON_DOCROOT="{{fauxton_root}}"
 
 "%BINDIR%\erl" -boot "%ROOTDIR%\releases\%APP_VSN%\couchdb" ^
 -args_file "%ROOTDIR%\etc\vm.args" ^

--- a/rel/overlay/etc/local.ini
+++ b/rel/overlay/etc/local.ini
@@ -44,9 +44,6 @@ enable = true ; for the test suites
 ; the whitelist.
 ;config_whitelist = [{httpd,config_whitelist}, {log,level}, {etc,etc}]
 
-[query_servers]
-;nodejs = /usr/local/bin/couchjs-node /path/to/couchdb/share/server/main.js
-
 [couch_httpd_auth]
 ; If you set this to true, you should also uncomment the WWW-Authenticate line
 ; above. If you don't configure a WWW-Authenticate header, CouchDB will send


### PR DESCRIPTION
## Overview

* Missing `COUCHDB_FAUXTON_DOCROOT` in `couchdb.cmd`
    * Since it's still working, line is `REM`med out for now
* Invalid `[query_servers]` section still present in `local.ini`