### PR TITLE
Fix timeout case clause in fabric_db_info

### DIFF
--- a/src/fabric/src/fabric_db_info.erl
+++ b/src/fabric/src/fabric_db_info.erl
@@ -30,7 +30,7 @@ go(DbName) ->
 
             {ok, Acc} ->
                 {ok, Acc};
-            {timeout, {WorkersDict, _}} ->
+            {timeout, {WorkersDict, _, _}} ->
                 DefunctWorkers = fabric_util:remove_done_workers(
                     WorkersDict,
                     nil


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Unlike most other fabric_db_* message handlers, the accumulator
for fabric_db_info has 3 terms. When a rexi timeout occurs, it
returns `{timeout, Accumulator}`; the case clause handling this
needs to expect 3 terms in the Accumulator instead of 2.

## Testing recommendations

I can't see a good precedent for testing this but I'm happy to add a test if somebody can point me to an example.

## Related Issues or Pull Requests

Fixes #2350

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
