### PR TITLE
Remsh improvements

### DIFF
--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -23,8 +23,18 @@ BINDIR=$ROOTDIR/erts-$ERTS_VSN/bin
 PROGNAME=${0##*/}
 VERBOSE=""
 NODE="couchdb@127.0.0.1"
-COOKIE=monster
 LHOST=127.0.0.1
+VM_ARGS=$COUCHDB_BIN_DIR/../etc/vm.args
+
+# If present, extract cookie from ERL_FLAGS
+# This is used by the CouchDB Dockerfile and Helm chart
+COOKIE=$(echo "$ERL_FLAGS" | sed 's/^.*setcookie \([^ ][^ ]*\).*$/\1/g')
+if test -f "$VM_ARGS"; then
+# else attempt to extract from vm.args
+  VM_ARGS_COOKIE=$(awk '$1=="-setcookie"{print $2}' "$VM_ARGS")
+  COOKIE="${COOKIE:-$VM_ARGS_COOKIE}"
+fi
+COOKIE="${COOKIE:-monster}"
 
 printHelpAndExit() {
   echo "Usage: ${PROGNAME} [OPTION]... [-- <additional Erlang cli options>]"

--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -71,6 +71,10 @@ if [ ! -z "$VERBOSE" ]; then
   set -x
 fi
 
-exec "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
+# If present, strip -name or -setcookie from ERL_FLAGS
+# to avoid conflicts with the cli parameters
+ERL_FLAGS_CLEAN=$(echo "$ERL_FLAGS" | sed 's/-setcookie \([^ ][^ ]*\)//g' | sed 's/-name \([^ ][^ ]*\)//g')
+
+exec env ERL_FLAGS="$ERL_FLAGS_CLEAN" "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
     -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie $COOKIE \
     "$@"


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This adds a couple of improvements to remsh following an incident where I needed to use it in a CouchDB deployed via Helm. The CouchDB docker container and Helm chart both utilize `ERL_FLAGS` to set the Erlang cookie. Unfortunately, this interferes with `./remsh`, which adds it's own `-setcookie` parameter when calling `erl` - you end up with multiple `-setcookie` and, in the case of the Helm chart, multiple `-name` parameters, resulting in Erlang failing to connect to the remote node.

The PR firstly sets `ERL_FLAGS` to empty when invoking `erl`, to avoid conflicts with explicitly set parameters. Secondly, it attempts to automatically locate the cookie from `ERL_FLAGS` or `vm.args` which should yield a better default than `monster` in most cases.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Testing is a little tricky as it requires a CouchDB deployed using ERL_FLAGS and/or vm.args. I tested it by building a CouchDB release / Docker container locally and passing `-e ERL_FLAGS="-setcookie somecookie"` to `docker run`.    

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
