### PR TITLE
Fix exunit compiler warnings

### DIFF
--- a/test/elixir/lib/step/config.ex
+++ b/test/elixir/lib/step/config.ex
@@ -12,7 +12,7 @@ defmodule Couch.Test.Setup.Step.Config do
     setup |> Setup.step(id, %__MODULE__{config_file: config_file})
   end
 
-  def setup(_setup, %__MODULE__{config_file: config_file} = step) do
+  def setup(_setup, %__MODULE__{config_file: _config_file} = step) do
     # TODO we would need to access config file here
     %{step | config: %{
        backdoor: %{

--- a/test/elixir/lib/step/create_db.ex
+++ b/test/elixir/lib/step/create_db.ex
@@ -19,7 +19,7 @@ defmodule Couch.Test.Setup.Step.Create.DB do
 
   defstruct [:name]
 
-  import ExUnit.Assertions, only: [assert: 1, assert: 2]
+  import ExUnit.Assertions, only: [assert: 2]
 
   import Utils
 
@@ -41,7 +41,7 @@ defmodule Couch.Test.Setup.Step.Create.DB do
     step
   end
 
-  def teardown(setup, %__MODULE__{name: name} = step) do
+  def teardown(_setup, %__MODULE__{name: name} = _step) do
     :fabric.delete_db(name, [@admin])
     :ok
   end

--- a/test/elixir/lib/step/user.ex
+++ b/test/elixir/lib/step/user.ex
@@ -15,7 +15,6 @@ defmodule Couch.Test.Setup.Step.User do
   """
 
   alias Couch.Test.Setup
-  alias Couch.Test.Setup.Step
   alias Couch.Test.Utils
 
   import ExUnit.Callbacks, only: [on_exit: 1]
@@ -32,7 +31,7 @@ defmodule Couch.Test.Setup.Step.User do
     setup |> Setup.step(id, %__MODULE__{roles: roles || []})
   end
 
-  def setup(setup, %__MODULE__{roles: roles} = step) do
+  def setup(_setup, %__MODULE__{roles: roles} = step) do
     users_db = IO.chardata_to_string(
       :config.get('chttpd_auth', 'authentication_db', '_users'))
     if not Utils.db_exists?(users_db) do
@@ -75,7 +74,7 @@ defmodule Couch.Test.Setup.Step.User do
     end
   end
 
-  def teardown(setup, %__MODULE__{name: name, users_db: users_db, roles: roles} = step) do
+  def teardown(_setup, %__MODULE__{name: name, users_db: users_db, roles: roles} = _step) do
     if :server_admin in roles do
       :config.delete("admins", String.to_charlist(name), false)
     else


### PR DESCRIPTION
## Overview

This suppresses the following warnings emitted during `make exunit`:

```
==> couchdbtest
Compiling 12 files (.ex)
warning: variable "config_file" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/elixir/lib/step/config.ex:15

warning: variable "setup" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/elixir/lib/step/create_db.ex:44

warning: variable "step" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/elixir/lib/step/create_db.ex:44

warning: variable "setup" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/elixir/lib/step/user.ex:35

warning: variable "setup" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/elixir/lib/step/user.ex:78

warning: variable "step" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/elixir/lib/step/user.ex:78

warning: unused import ExUnit.Assertions.assert/1
  test/elixir/lib/step/create_db.ex:22

warning: unused alias Step
  test/elixir/lib/step/user.ex:18
```
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Run `make exunit` first on master and notice the above warnings. With this change, those warnings should no longer be emitted.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
