### PR TITLE
Address flakey Mango Elixir tests

### DIFF
--- a/test/elixir/test/partition_mango_test.exs
+++ b/test/elixir/test/partition_mango_test.exs
@@ -17,6 +17,26 @@ defmodule PartitionMangoTest do
 
     assert resp.status_code == 200
     assert resp.body["result"] == "created"
+    assert resp.body["id"] != nil
+    assert resp.body["name"] != nil
+
+    # wait until the database reports the index as available
+    retry_until(fn ->
+      get_index(db_name, resp.body["id"], resp.body["name"]) != nil
+    end)
+  end
+
+  def list_indexes(db_name) do
+    resp = Couch.get("/#{db_name}/_index")
+    assert resp.status_code == 200
+    resp.body["indexes"]
+  end
+
+  def get_index(db_name, ddocid, name) do
+    indexes = list_indexes(db_name)
+    Enum.find(indexes, fn(index) ->
+      match?(%{"ddoc" => ^ddocid, "name" => ^name}, index)
+    end)
   end
 
   def get_partitions(resp) do


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

When creating a Mango index in the Elixir tests, we need to block until the database reports the index as available. This workaround was present in the python Mango tests but did not
get ported to Elixir when the partitioned Mango tests were added.

Presumably this is needed to workaround an underlying race condition between the index write and the ddoc cache.

## Testing recommendations

let's see if it reliably passes in CI...

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
