### PR TITLE
Warn about orphan .git directories

### DIFF
--- a/configure
+++ b/configure
@@ -237,4 +237,12 @@ if [ -d .git  -a $SKIP_DEPS -ne 1 ]; then
     ${REBAR} get-deps update-deps
 fi
 
+# External repos frequently become integrated with the primary repo,
+# resulting in obsolete .git directories, and possible confusion.
+# It is usually a good idea to delete these .git directories.
+for path in $(find src -name .git -type d); do
+    git ls-files --error-unmatch $(dirname $path) > /dev/null 2>&1 && \
+        echo "WARNING unexpected .git directory $path"
+done
+
 echo "You have configured Apache CouchDB, time to relax. Relax."


### PR DESCRIPTION
## Overview

A .git directory found in src/ usually indicates that the code in the
enclosing directory is managed from said .git directory. This can lead
to confusion, and developers opening PRs against obsolete repos when, as
happens frequently, a formerly separate repository becomes integrated
into the primary repo.

This patch changes the configure script to warn when it finds such .git
directories.


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Example output:
```
$ ./configure --dev --skip-deps
==> configuring couchdb in rel/couchdb.config
WARNING unexpected .git directory src/couch_tests/.git
WARNING unexpected .git directory src/rexi/.git
WARNING unexpected .git directory src/mem3/.git
WARNING unexpected .git directory src/smoosh/.git
WARNING unexpected .git directory src/couch_mrview/.git
WARNING unexpected .git directory src/couch/.git
WARNING unexpected .git directory src/couch_replicator/.git
WARNING unexpected .git directory src/ddoc_cache/.git
WARNING unexpected .git directory src/couch_peruser/.git
WARNING unexpected .git directory src/setup/.git
WARNING unexpected .git directory src/couch_log/.git
WARNING unexpected .git directory src/couch_epi/.git
WARNING unexpected .git directory src/mango/.git
WARNING unexpected .git directory src/chttpd/.git
WARNING unexpected .git directory src/couch_stats/.git
WARNING unexpected .git directory src/global_changes/.git
WARNING unexpected .git directory src/couch_event/.git
WARNING unexpected .git directory src/fabric/.git
WARNING unexpected .git directory src/couch_plugins/.git
WARNING unexpected .git directory src/ken/.git
WARNING unexpected .git directory src/couch_index/.git
You have configured Apache CouchDB, time to relax. Relax.
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
