### PR TITLE
Make smoosh use UTC for scheduling window

### DIFF
--- a/src/smoosh/src/smoosh_utils.erl
+++ b/src/smoosh/src/smoosh_utils.erl
@@ -66,7 +66,7 @@ in_allowed_window(Channel) ->
     in_allowed_window(From, To).
 
 in_allowed_window(From, To) ->
-    {HH, MM, _} = erlang:time(),
+    {_, {HH, MM, _}} = calendar:universal_time(),
     case From < To of
     true ->
         ({HH, MM} >= From) andalso ({HH, MM} < To);

--- a/src/smoosh/test/exunit/scheduling_window_test.exs
+++ b/src/smoosh/test/exunit/scheduling_window_test.exs
@@ -1,8 +1,6 @@
 defmodule SmooshSchedulingWindowTest do
   use Couch.Test.ExUnit.Case
 
-  alias Couch.Test.Setup
-
   setup_all(context) do
     test_ctx = :test_util.start_couch([])
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Smoosh's exunit tests use UTC, so they sometimes fail when run in non-GMT time zones:

```
  1) test in_allowed_window returns true when to < from < now (SmooshSchedulingWindowTest)
     src/smoosh/test/exunit/scheduling_window_test.exs:53
     Assertion with == failed
     code:  assert :smoosh_utils.in_allowed_window('test_channel') == true
     left:  false
     right: true
     stacktrace:
       src/smoosh/test/exunit/scheduling_window_test.exs:59: (test)

  * test in_allowed_window returns false when from < to < now (0.5ms)
 
 2) test in_allowed_window returns false when from < to < now (SmooshSchedulingWindowTest)
     src/smoosh/test/exunit/scheduling_window_test.exs:44
     Assertion with == failed
     code:  assert :smoosh_utils.in_allowed_window('test_channel') == false
     left:  true
     right: false
     stacktrace:
       src/smoosh/test/exunit/scheduling_window_test.exs:50: (test)

  * test in_allowed_window returns true by default (0.03ms)
  * test in_allowed_window returns false when to < now < from (0.4ms)

  3) test in_allowed_window returns false when to < now < from (SmooshSchedulingWindowTest)
     src/smoosh/test/exunit/scheduling_window_test.exs:62
     Assertion with == failed
     code:  assert :smoosh_utils.in_allowed_window('test_channel') == false
     left:  true
     right: false
     stacktrace:
       src/smoosh/test/exunit/scheduling_window_test.exs:68: (test)

  * test in_allowed_window returns true when now < to < from (0.4ms)
  * test in_allowed_window returns false when now < from < to (0.5ms)
  * test in_allowed_window returns true when from < now < to (0.4ms)

  4) test in_allowed_window returns true when from < now < to (SmooshSchedulingWindowTest)
     src/smoosh/test/exunit/scheduling_window_test.exs:35
     Assertion with == failed
     code:  assert :smoosh_utils.in_allowed_window('test_channel') == true
     left:  false
     right: true
     stacktrace:
       src/smoosh/test/exunit/scheduling_window_test.exs:41: (test)
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make exunit
```
should pass regardless of when or in which time zone the tests are run.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
