### PR TITLE
Remove elixir tests from Makefile "check" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ check: all
 	@$(MAKE) eunit
 	@$(MAKE) javascript
 	@$(MAKE) mango-test
-	@$(MAKE) elixir
+#	@$(MAKE) elixir
 #	@$(MAKE) build-test
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The elixir tests are by far the flakiest tests in the entire suite. In
the interest of being able to merge changes to master without having to
retry over several days, temporarily disable elixir tests from running
via `make check`.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make check
```
should not run the elixir test suite

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
