### PR TITLE
Switch make elixir to use n = 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ python-black-update: .venv/bin/black
 .PHONY: elixir
 elixir: export MIX_ENV=integration
 elixir: elixir-init elixir-check-formatted elixir-credo devclean
-	@dev/run -a adm:pass --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+	@dev/run -a adm:pass -n 1 --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-init
 elixir-init: MIX_ENV=test

--- a/src/dreyfus/test/elixir/test/partition_search_test.exs
+++ b/src/dreyfus/test/elixir/test/partition_search_test.exs
@@ -22,7 +22,7 @@ defmodule PartitionSearchTest do
     end
 
     resp = Couch.post("/#{db_name}/_bulk_docs", body: %{:docs => docs}, query: %{w: 3})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   def create_ddoc(db_name, opts \\ %{}) do
@@ -39,7 +39,7 @@ defmodule PartitionSearchTest do
     ddoc = Enum.into(opts, default_ddoc)
 
     resp = Couch.put("/#{db_name}/_design/library", body: ddoc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert Map.has_key?(resp.body, "ok") == true
   end
 

--- a/test/elixir/lib/couch/db_test.ex
+++ b/test/elixir/lib/couch/db_test.ex
@@ -191,7 +191,7 @@ defmodule Couch.DBTest do
         }
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   def query(
@@ -251,7 +251,7 @@ defmodule Couch.DBTest do
         body: ddoc
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/#{ddoc_name}/_view/view", query: request_options)
     assert resp.status_code == 200

--- a/test/elixir/test/all_docs_test.exs
+++ b/test/elixir/test/all_docs_test.exs
@@ -224,7 +224,7 @@ defmodule AllDocsTest do
     db_name = context[:db_name]
 
     resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..2)})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.post(
       "/#{db_name}/_all_docs",
@@ -240,7 +240,7 @@ defmodule AllDocsTest do
     db_name = context[:db_name]
 
     resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.post(
       "/#{db_name}/_all_docs",
@@ -259,7 +259,7 @@ defmodule AllDocsTest do
     db_name = context[:db_name]
 
     resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.post(
       "/#{db_name}/_all_docs",
@@ -280,7 +280,7 @@ defmodule AllDocsTest do
     db_name = context[:db_name]
 
     resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.post(
       "/#{db_name}/_all_docs",

--- a/test/elixir/test/attachment_names_test.exs
+++ b/test/elixir/test/attachment_names_test.exs
@@ -50,7 +50,7 @@ defmodule AttachmentNamesTest do
     filename = URI.encode("Kолян.txt", &URI.char_unreserved?(&1))
     resp = Couch.post("/#{db_name}", body: @good_doc)
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     resp = Couch.get("/#{db_name}/good_doc/#{filename}")
     assert resp.body == "This is a base64 encoded text"

--- a/test/elixir/test/attachment_paths_test.exs
+++ b/test/elixir/test/attachment_paths_test.exs
@@ -53,7 +53,7 @@ defmodule AttachmentPathsTest do
     resp = Couch.post("/#{db_name}", body: @bin_att_doc)
     msg = "Should return 201-Created"
 
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     rev = resp.body["rev"]
 
@@ -91,7 +91,7 @@ defmodule AttachmentPathsTest do
         headers: ["Content-Type": "text/plain;charset=utf-8"]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/bin_doc")
     assert resp.status_code == 200
@@ -119,7 +119,7 @@ defmodule AttachmentPathsTest do
 
     create_db(db_name)
     resp = Couch.post("/#{db_name}", body: @design_att_doc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     rev = resp.body["rev"]
 
@@ -157,7 +157,7 @@ defmodule AttachmentPathsTest do
         headers: ["Content-Type": "text/plain;charset=utf-8"]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/_design/bin_doc")
     assert resp.status_code == 200

--- a/test/elixir/test/attachments_multipart_test.exs
+++ b/test/elixir/test/attachments_multipart_test.exs
@@ -55,7 +55,7 @@ defmodule AttachmentMultipartTest do
         headers: ["Content-Type": "multipart/related;boundary=\"abc123\""]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert resp.body["ok"] == true
 
     resp = Couch.get("/#{db_name}/multipart/foo.txt")
@@ -113,7 +113,7 @@ defmodule AttachmentMultipartTest do
         headers: ["Content-Type": "multipart/related;boundary=\"abc123\""]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/multipart/bar.txt")
 
@@ -278,7 +278,7 @@ defmodule AttachmentMultipartTest do
         headers: ["Content-Type": "application/binary"]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     second_rev = resp.body["rev"]
 
     resp =
@@ -289,7 +289,7 @@ defmodule AttachmentMultipartTest do
         headers: ["Content-Type": "text/plain"]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     third_rev = resp.body["rev"]
 
     resp =

--- a/test/elixir/test/attachments_test.exs
+++ b/test/elixir/test/attachments_test.exs
@@ -161,7 +161,7 @@ defmodule AttachmentsTest do
         body: bin_data
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     rev = resp.body["rev"]
 
@@ -213,7 +213,7 @@ defmodule AttachmentsTest do
         body: "This is a string"
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/bin_doc4/attachment.txt")
     assert resp.status_code == 200
@@ -315,7 +315,7 @@ defmodule AttachmentsTest do
         headers: ["Content-Type": "text/plain;charset=utf-8"]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     rev = resp.body["rev"]
 
     resp =
@@ -326,7 +326,7 @@ defmodule AttachmentsTest do
         headers: ["Content-Type": "text/plain;charset=utf-8"]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   @tag :with_db

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -67,7 +67,7 @@ defmodule BasicsTest do
   @tag :with_db
   test "Create a document and save it to the database", context do
     resp = Couch.post("/#{context[:db_name]}", body: %{:_id => "0", :a => 1, :b => 1})
-    assert resp.status_code == 201, "Should be 201 created"
+    assert resp.status_code in [201, 202], "Should be 201 created"
     assert resp.body["id"], "Id should be present"
     assert resp.body["rev"], "Rev should be present"
 

--- a/test/elixir/test/bulk_docs_test.exs
+++ b/test/elixir/test/bulk_docs_test.exs
@@ -54,7 +54,7 @@ defmodule BulkDocsTest do
     # Update just the first doc to create a conflict in subsequent bulk update
     doc = hd(docs)
     resp = Couch.put("/#{db}/#{doc._id}", body: doc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     # Attempt to delete all docs
     docs = Enum.map(docs, fn doc -> Map.put(doc, :_deleted, true) end)
 
@@ -133,7 +133,7 @@ defmodule BulkDocsTest do
     retry_until(fn ->
       resp = Couch.post("/#{db}/_bulk_docs", body: %{docs: docs})
 
-      assert resp.status_code == 201 and length(resp.body) == length(docs), """
+      assert resp.status_code in [201, 202] and length(resp.body) == length(docs), """
       Expected 201 and the same number of response rows as in request, but got
       #{pretty_inspect(resp)}
       """

--- a/test/elixir/test/cluster_with_quorum_test.exs
+++ b/test/elixir/test/cluster_with_quorum_test.exs
@@ -11,7 +11,7 @@ defmodule WithQuorumTest do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}")
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
     resp = Couch.delete("/#{db_name}")
     msg = "Should return 202-Acepted"
     assert resp.status_code == 202, msg
@@ -24,7 +24,7 @@ defmodule WithQuorumTest do
 
     resp = Couch.post("/#{context[:db_name]}", body: %{:_id => "0", :a => 1})
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     resp = Couch.get("/#{context[:db_name]}/0")
     rev = resp.body["_rev"]
@@ -33,7 +33,7 @@ defmodule WithQuorumTest do
       Couch.put("/#{context[:db_name]}/0", body: %{:_id => "0", :_rev => rev, :a => 2})
 
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     resp = Couch.get("/#{context[:db_name]}/0")
     rev = resp.body["_rev"]
@@ -95,7 +95,7 @@ defmodule WithQuorumTest do
     headers = [Destination: "1"]
     resp = Couch.request(:copy, "/#{context[:db_name]}/0", headers: headers)
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
     Couch.delete("/#{db_name}")
   end
 
@@ -108,7 +108,7 @@ defmodule WithQuorumTest do
     docs = create_docs(@doc_range)
     resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: docs})
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     Couch.delete("/#{db_name}")
   end
@@ -141,7 +141,7 @@ defmodule WithQuorumTest do
       )
 
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     rev = resp.body["rev"]
     resp = Couch.delete("/#{context[:db_name]}/0/foo.txt", query: %{:rev => rev})

--- a/test/elixir/test/cluster_without_quorum_test.exs
+++ b/test/elixir/test/cluster_without_quorum_test.exs
@@ -57,7 +57,7 @@ defmodule WithoutQuorumTest do
       )
 
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     resp = Couch.get("/#{context[:db_name]}/0")
     rev = resp.body["_rev"]
@@ -70,7 +70,7 @@ defmodule WithoutQuorumTest do
       )
 
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     resp = Couch.get("/#{context[:db_name]}/0")
     rev = resp.body["_rev"]
@@ -119,7 +119,7 @@ defmodule WithoutQuorumTest do
     docs = create_docs(@doc_range)
     resp = Couch.post("/#{db_name}/_bulk_docs", query: %{:w => 1}, body: %{docs: docs})
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     Couch.delete("/#{db_name}")
   end
@@ -166,7 +166,7 @@ defmodule WithoutQuorumTest do
       )
 
     msg = "Should return 201-Created"
-    assert resp.status_code == 201, msg
+    assert resp.status_code in [201, 202], msg
 
     rev = resp.body["rev"]
 

--- a/test/elixir/test/compact_test.exs
+++ b/test/elixir/test/compact_test.exs
@@ -60,7 +60,7 @@ defmodule CompactTest do
   defp populate(db) do
     docs = create_docs(0..19)
     resp = Couch.post("/#{db}/_bulk_docs", body: %{docs: docs})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     docs = rev(docs, resp.body)
 
     doc = %{
@@ -71,14 +71,14 @@ defmodule CompactTest do
     }
 
     resp = Couch.put("/#{db}/#{doc._id}", body: doc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     docs
   end
 
   defp delete(db, docs) do
     docs = Enum.map(docs, &Map.put(&1, :_deleted, true))
     resp = Couch.post("/#{db}/_bulk_docs", body: %{docs: docs})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert Couch.post("/#{db}/_ensure_full_commit").body["ok"] == true
   end
 

--- a/test/elixir/test/copy_doc_test.exs
+++ b/test/elixir/test/copy_doc_test.exs
@@ -20,7 +20,7 @@ defmodule CopyDocTest do
       )
 
     assert resp.body["ok"]
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     assert Couch.get("/#{db_name}/doc_that_was_copied").body["v"] == 1
 
@@ -63,7 +63,7 @@ defmodule CopyDocTest do
         headers: [Destination: "doc_to_be_overwritten?rev=#{rev}"]
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     resp = Couch.get("/#{db_name}/doc_to_be_overwritten")
     assert resp.body["_rev"] != rev
     assert resp.body["v"] == 1

--- a/test/elixir/test/lots_of_docs_test.exs
+++ b/test/elixir/test/lots_of_docs_test.exs
@@ -106,7 +106,7 @@ defmodule LotsOfDocsTest do
   defp bulk_post(docs, db) do
     resp = Couch.post("/#{db}/_bulk_docs", query: [w: 3], body: %{docs: docs})
 
-    assert resp.status_code == 201 and length(resp.body) == length(docs), """
+    assert resp.status_code in [201, 202] and length(resp.body) == length(docs), """
     Expected 201 and the same number of response rows as in request, but got
     #{pretty_inspect(resp)}
     """

--- a/test/elixir/test/partition_crud_test.exs
+++ b/test/elixir/test/partition_crud_test.exs
@@ -17,7 +17,7 @@ defmodule PartitionCrudTest do
 
     resp = Couch.put(url, body: %{partitioned_doc: true})
     %{body: doc} = resp
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert doc["id"] == id
 
     resp = Couch.get(url)
@@ -85,7 +85,7 @@ defmodule PartitionCrudTest do
     url = "/#{db_name}"
 
     resp = Couch.post(url, body: %{_id: id, partitioned_doc: true})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("#{url}/#{id}")
     assert resp.status_code == 200
@@ -110,7 +110,7 @@ defmodule PartitionCrudTest do
     url = "/#{db_name}"
 
     resp = Couch.post(url, body: %{_id: id, partitioned_doc: true})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.post("#{url}/_bulk_get", body: %{docs: [%{id: id}]})
     assert resp.status_code == 200
@@ -185,7 +185,7 @@ defmodule PartitionCrudTest do
 
     url = "/#{db_name}"
     resp = Couch.post("#{url}/_bulk_docs", body: %{:docs => docs})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("#{url}/foo:1")
     assert resp.status_code == 200
@@ -268,7 +268,7 @@ defmodule PartitionCrudTest do
 
     resp = Couch.put("/#{db_name}/#{id}", body: doc)
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/#{id}")
     assert resp.status_code == 200
@@ -298,7 +298,7 @@ defmodule PartitionCrudTest do
         body: "This is another document"
       )
 
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{:body => body} = resp
     assert body["ok"] == true
     assert body["id"] == id
@@ -314,7 +314,7 @@ defmodule PartitionCrudTest do
     }
 
     resp = Couch.post("/#{db_name}", query: [w: 3], body: doc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{body: body} = resp
     rev = body["rev"]
 
@@ -323,7 +323,7 @@ defmodule PartitionCrudTest do
 
     body = %{"foo:bar" => [rev]}
     resp = Couch.post("/#{db_name}/_purge", query: [w: 3], body: body)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/foo:bar")
     assert resp.status_code == 404
@@ -353,7 +353,7 @@ defmodule PartitionCrudTest do
   test "can create unpartitioned system db", _context do
     Couch.delete("/_replicator")
     resp = Couch.put("/_replicator")
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert resp.body == %{"ok" => true}
   end
 

--- a/test/elixir/test/partition_ddoc_test.exs
+++ b/test/elixir/test/partition_ddoc_test.exs
@@ -16,7 +16,7 @@ defmodule PartitionDDocTest do
   test "PUT /dbname/_design/foo", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   test "PUT /dbname/_design/foo to update", context do
@@ -29,13 +29,13 @@ defmodule PartitionDDocTest do
     }
 
     resp = Couch.put("/#{db_name}/#{ddoc_id}", body: ddoc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{body: body} = resp
 
     ddoc = Map.put(ddoc, :_rev, body["rev"])
     ddoc = Map.put(ddoc, :other, "attribute")
     resp = Couch.put("/#{db_name}/#{ddoc_id}", body: ddoc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   test "PUT /dbname/_design/foo/readme.txt", context do
@@ -48,7 +48,7 @@ defmodule PartitionDDocTest do
     }
 
     resp = Couch.put("/#{db_name}/#{ddoc_id}", body: ddoc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{body: body} = resp
 
     att = "This is a readme.txt"
@@ -60,7 +60,7 @@ defmodule PartitionDDocTest do
     ]
 
     resp = Couch.put("/#{db_name}/#{ddoc_id}/readme.txt", opts)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   test "DELETE /dbname/_design/foo", context do
@@ -73,7 +73,7 @@ defmodule PartitionDDocTest do
     }
 
     resp = Couch.put("/#{db_name}/#{ddoc_id}", body: ddoc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{body: body} = resp
 
     resp = Couch.delete("/#{db_name}/#{ddoc_id}", query: [rev: body["rev"]])
@@ -84,20 +84,20 @@ defmodule PartitionDDocTest do
     db_name = context[:db_name]
     body = %{_id: "_design/foo", stuff: "here"}
     resp = Couch.post("/#{db_name}", body: body)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   test "POST /dbname/_bulk_docs with design doc", context do
     db_name = context[:db_name]
     body = %{:docs => [%{_id: "_design/foo", stuff: "here"}]}
     resp = Couch.post("/#{db_name}/_bulk_docs", body: body)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   test "GET /dbname/_design/foo", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/_design/foo")
     assert resp.status_code == 200
@@ -106,7 +106,7 @@ defmodule PartitionDDocTest do
   test "GET /dbname/_design/foo?rev=$rev", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{body: body} = resp
 
     resp = Couch.get("/#{db_name}/_design/foo", query: [rev: body["rev"]])
@@ -116,7 +116,7 @@ defmodule PartitionDDocTest do
   test "GET /dbname/_bulk_get", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     body = %{docs: [%{id: "_design/foo"}]}
     resp = Couch.post("/#{db_name}/_bulk_get", body: body)
@@ -131,7 +131,7 @@ defmodule PartitionDDocTest do
   test "GET /dbname/_bulk_get with rev", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{body: body} = resp
 
     body = %{docs: [%{id: "_design/foo", rev: body["rev"]}]}
@@ -146,7 +146,7 @@ defmodule PartitionDDocTest do
   test "GET /dbname/_all_docs?key=$ddoc_id", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"}, query: [w: 3])
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get("/#{db_name}/_all_docs", query: [key: "\"_design/foo\""])
     assert resp.status_code == 200
@@ -163,7 +163,7 @@ defmodule PartitionDDocTest do
     retry_until(
       fn ->
         resp = Couch.put("/#{db_name}/_design/foo", body: %{stuff: "here"})
-        assert resp.status_code == 201
+        assert resp.status_code in [201, 202]
 
         resp = Couch.get("/#{db_name}/_design_docs")
         assert resp.status_code == 200

--- a/test/elixir/test/partition_helpers.exs
+++ b/test/elixir/test/partition_helpers.exs
@@ -27,7 +27,7 @@ defmodule PartitionHelpers do
       end
 
     resp = Couch.post("/#{db_name}/_bulk_docs", body: %{:w => 3, :docs => docs})
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
   end
 
   def create_partition_ddoc(db_name, opts \\ %{}) do
@@ -50,7 +50,7 @@ defmodule PartitionHelpers do
     ddoc = Enum.into(opts, default_ddoc)
 
     resp = Couch.put("/#{db_name}/_design/mrtest", body: ddoc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert Map.has_key?(resp.body, "ok") == true
   end
 

--- a/test/elixir/test/partition_size_test.exs
+++ b/test/elixir/test/partition_size_test.exs
@@ -53,13 +53,13 @@ defmodule PartitionSizeTest do
 
     retry_until(fn ->
       resp = Couch.post("/#{db_name}/_bulk_docs", body: body)
-      assert resp.status_code == 201
+      assert resp.status_code in [201, 202]
     end)
   end
 
   def save_doc(db_name, doc) do
     resp = Couch.post("/#{db_name}", query: [w: 3], body: doc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{:body => body} = resp
     body["rev"]
   end
@@ -350,7 +350,7 @@ defmodule PartitionSizeTest do
       end)
 
     resp = Couch.post("/#{db_name}/_purge", query: [w: 3], body: pbody)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     post_info = get_partition_info(db_name, partition)
     assert post_info["doc_count"] == pre_info["doc_count"] - 50

--- a/test/elixir/test/partition_view_update_test.exs
+++ b/test/elixir/test/partition_view_update_test.exs
@@ -96,7 +96,7 @@ defmodule PartitionViewUpdateTest do
 
     body = %{"foo:2" => [rev]}
     resp = Couch.post("/#{db_name}/_purge", query: [w: 3], body: body)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get(url)
     assert resp.status_code == 200
@@ -128,7 +128,7 @@ defmodule PartitionViewUpdateTest do
 
     doc = %{_id: "foo:2", _rev: rev1, value: 4096, some: "field"}
     resp = Couch.post("/#{db_name}", query: [w: 3], body: doc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     %{body: body} = resp
     rev2 = body["rev"]
 
@@ -136,7 +136,7 @@ defmodule PartitionViewUpdateTest do
     conflict_rev = "1-4a75b4efa0804859b3dfd327cbc1c2f9"
     doc = %{_id: "foo:2", _rev: conflict_rev, value: 8192, some: "field"}
     resp = Couch.put("/#{db_name}/foo:2", query: query, body: doc)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     # Check that our expected row exists
     resp = Couch.get(url, query: [key: 4096])
@@ -149,7 +149,7 @@ defmodule PartitionViewUpdateTest do
     # a row from the conflict
     body = %{"foo:2" => [rev2]}
     resp = Couch.post("/#{db_name}/_purge", query: [w: 3], body: body)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp = Couch.get(url, query: [key: 8192])
     assert resp.status_code == 200

--- a/test/elixir/test/reduce_test.exs
+++ b/test/elixir/test/reduce_test.exs
@@ -31,8 +31,8 @@ defmodule ReduceTest do
     assert Couch.put("/#{db_name}/_design/foo", body: red_doc).body["ok"]
     docs = make_docs(1..num_docs)
 
-    assert Couch.post("/#{db_name}/_bulk_docs", body: %{:docs => docs}, query: %{w: 3}).status_code ==
-             201
+    assert Couch.post("/#{db_name}/_bulk_docs", body: %{:docs => docs}, query: %{w: 3}).status_code in
+             [201, 202]
 
     rows = Couch.get(view_url).body["rows"]
     assert hd(rows)["value"] == 2 * summate(num_docs)
@@ -92,8 +92,8 @@ defmodule ReduceTest do
           %{keys: ["d", "c"]}
         ]
 
-        assert Couch.post("/#{db_name}/_bulk_docs", body: %{docs: docs}, query: %{w: 3}).status_code ==
-                 201
+        assert Couch.post("/#{db_name}/_bulk_docs", body: %{docs: docs}, query: %{w: 3}).status_code in
+                 [201, 202]
 
         total_docs = 1 + (i - 1) * 10 * 11 + (j + 1) * 11
         assert Couch.get("/#{db_name}").body["doc_count"] == total_docs
@@ -193,8 +193,8 @@ defmodule ReduceTest do
     Enum.each(1..10, fn _ ->
       docs = for i <- 1..10, do: %{val: i * 10}
 
-      assert Couch.post("/#{db_name}/_bulk_docs", body: %{:docs => docs}, query: %{w: 3}).status_code ==
-               201
+      assert Couch.post("/#{db_name}/_bulk_docs", body: %{:docs => docs}, query: %{w: 3}).status_code in
+               [201, 202]
     end)
 
     rows = Couch.get(view_url).body["rows"]
@@ -226,8 +226,9 @@ defmodule ReduceTest do
     assert Couch.put("/#{db_name}/_design/foo", body: ddoc).body["ok"]
     docs = for i <- 0..1122, do: %{_id: Integer.to_string(i), int: i}
 
-    assert Couch.post("/#{db_name}/_bulk_docs", body: %{:docs => docs}, query: %{w: 3}).status_code ==
-             201
+    assert Couch.post("/#{db_name}/_bulk_docs", body: %{:docs => docs}, query: %{w: 3}).status_code in
+             [201, 202]
+
 
     rand_val = fn -> :rand.uniform(100_000_000) end
 

--- a/test/elixir/test/reshard_all_docs_test.exs
+++ b/test/elixir/test/reshard_all_docs_test.exs
@@ -27,7 +27,7 @@ defmodule ReshardAllDocsTest do
     assert docs == before_split_all_docs
 
     resp = post_job_node(db, node1)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     jobid = hd(resp.body)["id"]
     wait_job_completed(jobid)
 
@@ -44,7 +44,7 @@ defmodule ReshardAllDocsTest do
     assert docs == before_split_all_docs
 
     resp = post_job_range(db, "00000000-7fffffff")
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp.body
     |> Enum.map(fn j -> j["id"] end)
@@ -61,7 +61,7 @@ defmodule ReshardAllDocsTest do
     docs = create_docs(range)
     w3 = %{:w => 3}
     resp = Couch.post("/#{db}/_bulk_docs", body: %{docs: docs}, query: w3)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert length(resp.body) == length(docs)
 
     docs

--- a/test/elixir/test/reshard_basic_test.exs
+++ b/test/elixir/test/reshard_basic_test.exs
@@ -69,7 +69,7 @@ defmodule ReshardBasicTest do
     node1 = get_first_node()
 
     resp = post_job_node(db, node1)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     body = resp.body
     assert is_list(body)
@@ -109,7 +109,7 @@ defmodule ReshardBasicTest do
     resp = Couch.get("/#{db}/_shards")
     assert resp.status_code == 200
     shards = resp.body["shards"]
-    assert node1 not in shards["00000000-ffffffff"]
+    assert node1 not in Map.get(shards, "00000000-ffffffff", [])
     assert shards["00000000-7fffffff"] == [node1]
     assert shards["80000000-ffffffff"] == [node1]
 
@@ -132,7 +132,7 @@ defmodule ReshardBasicTest do
     node1 = get_first_node()
 
     resp = post_job_node(db, node1)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     body = resp.body
     assert is_list(body)
@@ -156,8 +156,8 @@ defmodule ReshardBasicTest do
     resp = Couch.get("/#{db}/_shards")
     assert resp.status_code == 200
     shards = resp.body["shards"]
-    assert node1 not in shards["00000000-7fffffff"]
-    assert node1 not in shards["80000000-ffffffff"]
+    assert node1 not in Map.get(shards, "00000000-7fffffff", [])
+    assert node1 not in Map.get(shards, "80000000-ffffffff", [])
     assert shards["00000000-3fffffff"] == [node1]
     assert shards["40000000-7fffffff"] == [node1]
     assert shards["80000000-bfffffff"] == [node1]

--- a/test/elixir/test/reshard_changes_feed.exs
+++ b/test/elixir/test/reshard_changes_feed.exs
@@ -29,7 +29,7 @@ defmodule ReshardChangesFeedTest do
     since_last_before = docset(changes(db, %{:since => last_seq}))
 
     resp = post_job_range(db, "00000000-7fffffff")
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
 
     resp.body
     |> Enum.map(fn j -> j["id"] end)
@@ -64,7 +64,7 @@ defmodule ReshardChangesFeedTest do
     docs = create_docs(range)
     w3 = %{:w => 3}
     resp = Couch.post("/#{db}/_bulk_docs", body: %{docs: docs}, query: w3)
-    assert resp.status_code == 201
+    assert resp.status_code in [201, 202]
     assert length(resp.body) == length(docs)
 
     docs

--- a/test/elixir/test/rewrite_test.exs
+++ b/test/elixir/test/rewrite_test.exs
@@ -289,13 +289,13 @@ defmodule RewriteTest do
                  "/#{db_name}/_bulk_docs",
                  body: %{:docs => docs1},
                  query: %{w: 3}
-               ).status_code == 201
+               ).status_code in [201, 202]
 
         assert Couch.post(
                  "/#{db_name}/_bulk_docs",
                  body: %{:docs => docs2},
                  query: %{w: 3}
-               ).status_code == 201
+               ).status_code in [201, 202]
 
         # Test simple rewriting
         resp = Couch.get("/#{db_name}/_design/test/_rewrite/foo")
@@ -315,7 +315,7 @@ defmodule RewriteTest do
         assert doc_id
 
         resp = Couch.put("/#{db_name}/_design/test/_rewrite/hello/#{doc_id}")
-        assert resp.status_code == 201
+        assert resp.status_code in [201, 202]
         assert resp.body == "hello doc"
         assert String.match?(resp.headers["Content-Type"], ~r/charset=utf-8/)
 
@@ -331,7 +331,7 @@ defmodule RewriteTest do
         assert resp.body == "Welcome user"
 
         resp = Couch.put("/#{db_name}/_design/test/_rewrite/welcome3/test")
-        assert resp.status_code == 201
+        assert resp.status_code in [201, 202]
         assert resp.body == "New World"
         assert String.match?(resp.headers["Content-Type"], ~r/charset=utf-8/)
 


### PR DESCRIPTION
## Overview

Switch `make elixir` to use n = 1. This matches how the javascript tests are run and hopefully should make the elixir tests a little more consistent and less flaky.

## Testing recommendations

Tests should pass on Travis and Jenkins

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
