### PR TITLE
Remove pause after Erlang version warning

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -59,8 +59,7 @@ NotSupported = fun(Ver) ->
         "See https://docs.couchdb.org/en/stable/install/unix.html#dependencies~n"
         "for the latest information on dependencies.",
         [Ver]
-    ),
-    timer:sleep(5000)
+    )
 end.
 
 BadErlang = fun(Ver) ->


### PR DESCRIPTION
This adds 5 minutes to the 19.x Travis job.

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
