### PR TITLE
Fix js tests

### DIFF
--- a/test/javascript/tests/design_docs.js
+++ b/test/javascript/tests/design_docs.js
@@ -45,6 +45,7 @@ couchTests.design_docs = function(debug) {
     var designDoc = {
       _id: "_design/test",
       language: "javascript",
+      autoupdate: false,
       whatever : {
         stringzone : "exports.string = 'plankton';",
         commonjs : {


### PR DESCRIPTION
## Overview

Fix `make javascript` on macOS. Found this while testing the SpiderMonkey 60 PR. Apparently something changed recently that broke really old code which admittedly had free after use bugs.

## Testing recommendations

`make javascript`

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
