### PR TITLE
Improve transaction name setting when tracing FDB transactions

### DIFF
--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -118,7 +118,10 @@ do_transaction(Fun, LayerPrefix) when is_function(Fun, 1) ->
         erlfdb:transactional(Db, fun(Tx) ->
             case get(erlfdb_trace) of
                 Name when is_binary(Name) ->
-                    erlfdb:set_option(Tx, transaction_logging_enable, Name);
+                    UId = erlang:unique_integer([positive]),
+                    UIdBin = integer_to_binary(UId, 36),
+                    TxId = <<Name/binary, "_", UIdBin/binary>>,
+                    erlfdb:set_option(Tx, transaction_logging_enable, TxId);
                 _ ->
                     ok
             end,


### PR DESCRIPTION
Previously the per-request nonce value was set as the transaction name and so
in the trace logs multiple transactions ended up having the same `TransactionID`
which was pretty confusing.

To fix the issue, append a transaction ID to the name. The ID is guaranteed to
be unique for the life of the VM node.