### PR TITLE
Switch replicator "info" error message to be an object

### DIFF
--- a/src/couch_replicator/src/couch_replicator.erl
+++ b/src/couch_replicator/src/couch_replicator.erl
@@ -250,8 +250,9 @@ info_from_doc(RepDb, {Props}) ->
                         end
             end;
         failed ->
-            Info = get_value(<<"_replication_state_reason">>, Props, null),
-            {State0, Info, 1, StateTime};
+            Info = get_value(<<"_replication_state_reason">>, Props, nil),
+            EJsonInfo = couch_replicator_utils:ejson_state_info(Info),
+            {State0, EJsonInfo, 1, StateTime};
         _OtherState ->
             {null, null, 0, null}
     end,

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -1472,7 +1472,8 @@ t_job_summary_crashing_once() ->
         setup_jobs([Job]),
         Summary = job_summary(job1, ?DEFAULT_HEALTH_THRESHOLD_SEC),
         ?assertEqual(crashing, proplists:get_value(state, Summary)),
-        ?assertEqual(<<"some_reason">>, proplists:get_value(info, Summary)),
+        Info = proplists:get_value(info, Summary),
+        ?assertEqual({[{<<"error">>, <<"some_reason">>}]}, Info),
         ?assertEqual(0, proplists:get_value(error_count, Summary))
     end).
 
@@ -1487,7 +1488,8 @@ t_job_summary_crashing_many_times() ->
         setup_jobs([Job]),
         Summary = job_summary(job1, ?DEFAULT_HEALTH_THRESHOLD_SEC),
         ?assertEqual(crashing, proplists:get_value(state, Summary)),
-        ?assertEqual(<<"some_reason">>, proplists:get_value(info, Summary)),
+        Info = proplists:get_value(info, Summary),
+        ?assertEqual({[{<<"error">>, <<"some_reason">>}]}, Info),
         ?assertEqual(2, proplists:get_value(error_count, Summary))
     end).
 

--- a/src/couch_replicator/src/couch_replicator_utils.erl
+++ b/src/couch_replicator/src/couch_replicator_utils.erl
@@ -181,13 +181,14 @@ normalize_rep(#rep{} = Rep)->
 ejson_state_info(nil) ->
     null;
 ejson_state_info(Info) when is_binary(Info) ->
-    Info;
+    {[{<<"error">>, Info}]};
 ejson_state_info([]) ->
     null;  % Status not set yet => null for compatibility reasons
 ejson_state_info([{_, _} | _] = Info) ->
     {Info};
 ejson_state_info(Info) ->
-    couch_replicator_utils:rep_error_to_binary(Info).
+    ErrMsg = couch_replicator_utils:rep_error_to_binary(Info),
+    {[{<<"error">>, ErrMsg}]}.
 
 
 -ifdef(TEST).


### PR DESCRIPTION
Instead of a string, null or object, it should now be only a null or an object.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] A PR for documentation changes has been made in 
https://github.com/apache/couchdb-documentation/pull/465