### PR TITLE
Speedup test suite

### DIFF
--- a/src/chttpd/src/chttpd_view.erl
+++ b/src/chttpd/src/chttpd_view.erl
@@ -123,13 +123,18 @@ assert_no_queries_param(_) ->
 
 check_multi_query_reduce_view_overrides_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            t_check_include_docs_throw_validation_error(),
-            t_check_user_can_override_individual_query_type()
-        ]
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                t_check_include_docs_throw_validation_error(),
+                t_check_user_can_override_individual_query_type()
+            ]
+        }
     }.
 
 
@@ -153,7 +158,7 @@ t_check_user_can_override_individual_query_type() ->
     end).
 
 
-setup() ->
+setup_all() ->
     Views = [#mrview{reduce_funs = [{<<"v">>, <<"_count">>}]}],
     meck:expect(couch_mrview_util, ddoc_to_mrst, 2, {ok, #mrst{views = Views}}),
     meck:expect(chttpd, start_delayed_json_response, 4, {ok, resp}),
@@ -162,8 +167,20 @@ setup() ->
     meck:expect(chttpd, end_delayed_json_response, 1, ok).
 
 
-teardown(_) ->
+teardown_all(_) ->
     meck:unload().
+
+
+setup() ->
+    meck:reset([
+        chttpd,
+        couch_mrview_util,
+        fabric
+    ]).
+
+
+teardown(_) ->
+    ok.
 
 
 -endif.

--- a/src/chttpd/test/eunit/chttpd_db_bulk_get_test.erl
+++ b/src/chttpd/test/eunit/chttpd_db_bulk_get_test.erl
@@ -18,45 +18,51 @@
 -define(TIMEOUT, 3000).
 
 
-setup() ->
+setup_all() ->
     mock(config),
     mock(chttpd),
     mock(couch_epi),
     mock(couch_httpd),
     mock(couch_stats),
     mock(fabric),
-    mock(mochireq),
-    Pid = spawn_accumulator(),
-    Pid.
+    mock(mochireq).
+
+
+teardown_all(_) ->
+    meck:unload().
+
+
+setup() ->
+    spawn_accumulator().
 
 
 teardown(Pid) ->
-    ok = stop_accumulator(Pid),
-    meck:unload(config),
-    meck:unload(chttpd),
-    meck:unload(couch_epi),
-    meck:unload(couch_httpd),
-    meck:unload(couch_stats),
-    meck:unload(fabric),
-    meck:unload(mochireq).
+    ok = stop_accumulator(Pid).
 
 
 bulk_get_test_() ->
     {
         "/db/_bulk_get tests",
         {
-            foreach, fun setup/0, fun teardown/1,
-            [
-                fun should_require_docs_field/1,
-                fun should_not_accept_specific_query_params/1,
-                fun should_return_empty_results_on_no_docs/1,
-                fun should_get_doc_with_all_revs/1,
-                fun should_validate_doc_with_bad_id/1,
-                fun should_validate_doc_with_bad_rev/1,
-                fun should_validate_missing_doc/1,
-                fun should_validate_bad_atts_since/1,
-                fun should_include_attachments_when_atts_since_specified/1
-            ]
+            setup,
+            fun setup_all/0,
+            fun teardown_all/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    fun should_require_docs_field/1,
+                    fun should_not_accept_specific_query_params/1,
+                    fun should_return_empty_results_on_no_docs/1,
+                    fun should_get_doc_with_all_revs/1,
+                    fun should_validate_doc_with_bad_id/1,
+                    fun should_validate_doc_with_bad_rev/1,
+                    fun should_validate_missing_doc/1,
+                    fun should_validate_bad_atts_since/1,
+                    fun should_include_attachments_when_atts_since_specified/1
+                ]
+            }
         }
     }.
 
@@ -69,12 +75,10 @@ should_require_docs_field(_) ->
 should_not_accept_specific_query_params(_) ->
     Req = fake_request({[{<<"docs">>, []}]}),
     lists:map(fun (Param) ->
-        {Param, ?_assertThrow({bad_request, _},
-                              begin
-                                  ok = meck:expect(chttpd, qs,
-                                                   fun(_) -> [{Param, ""}] end),
-                                  chttpd_db:db_req(Req, nil)
-                              end)}
+        {Param, ?_assertThrow({bad_request, _}, begin
+            BadReq = Req#httpd{qs = [{Param, ""}]},
+            chttpd_db:db_req(BadReq, nil)
+        end)}
     end, ["rev", "open_revs", "atts_since", "w", "new_edits"]).
 
 

--- a/src/chttpd/test/eunit/chttpd_prefer_header_test.erl
+++ b/src/chttpd/test/eunit/chttpd_prefer_header_test.erl
@@ -51,7 +51,7 @@ minimal_options_headers() ->
 
 default_no_exclude_header_test() ->
     Headers = chttpd_prefer_header:maybe_return_minimal(
-        mock_request([]), 
+        mock_request([]),
         default_headers()
         ),
     ?assertEqual(default_headers(), Headers).
@@ -68,30 +68,45 @@ empty_header_test() ->
     Headers = chttpd_prefer_header:maybe_return_minimal(Req, default_headers()),
     ?assertEqual(default_headers(), Headers).
 
-setup() ->
+setup_all() ->
     ok = meck:new(config),
-    ok = meck:expect(config, get, fun("chttpd", "prefer_minimal",  _) -> 
+    ok = meck:expect(config, get, fun("chttpd", "prefer_minimal",  _) ->
         "Cache-Control, Content-Length, Content-Type, ETag, Server, Vary"
     end),
     ok.
 
 
+teardown_all(_) ->
+    meck:unload().
+
+
+setup() ->
+    meck:reset([config]).
+
+
 teardown(_) ->
-    meck:unload(config).
+    ok.
 
 
 exclude_headers_test_() ->
-     {
-         "Test Prefer headers",
-         {
-             foreach, fun setup/0, fun teardown/1,
-             [
-                 fun minimal_options/1,
-                 fun minimal_options_check_header_case/1,
-                 fun minimal_options_check_header_value_case/1
-             ]
-         }
-     }.
+    {
+        "Test Prefer headers",
+        {
+            setup,
+            fun setup_all/0,
+            fun teardown_all/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    fun minimal_options/1,
+                    fun minimal_options_check_header_case/1,
+                    fun minimal_options_check_header_value_case/1
+                ]
+            }
+        }
+    }.
 
 
 minimal_options(_) ->

--- a/src/chttpd/test/eunit/chttpd_xframe_test.erl
+++ b/src/chttpd/test/eunit/chttpd_xframe_test.erl
@@ -4,13 +4,19 @@
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-setup() ->
+setup_all() ->
     ok = meck:new(config),
     ok = meck:expect(config, get, fun(_, _, _) -> "X-Forwarded-Host" end),
     ok.
 
+teardown_all(_) ->
+    meck:unload().
+
+setup() ->
+    meck:reset([config]).
+
 teardown(_) ->
-    meck:unload(config).
+    ok.
 
 mock_request() ->
     Headers = mochiweb_headers:make([{"Host", "examples.com"}]),
@@ -62,12 +68,19 @@ xframe_host_test_() ->
     {
         "xframe host tests",
         {
-            foreach, fun setup/0, fun teardown/1,
-            [
-                fun allow_with_wildcard_host/1,
-                fun allow_with_specific_host/1,
-                fun deny_with_different_host/1
-            ]
+            setup,
+            fun setup_all/0,
+            fun teardown_all/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    fun allow_with_wildcard_host/1,
+                    fun allow_with_specific_host/1,
+                    fun deny_with_different_host/1
+                ]
+            }
         }
     }.
 

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -1263,8 +1263,8 @@ maybe_add_default_headers_test_() ->
     {"Tests adding default headers", Tests}.
 
 log_request_test_() ->
-    {foreachx,
-        fun(_) ->
+    {setup,
+        fun() ->
             ok = meck:new([couch_log]),
             ok = meck:expect(couch_log, error, fun(Fmt, Args) ->
                 case catch io_lib_format:fwrite(Fmt, Args) of
@@ -1273,13 +1273,16 @@ log_request_test_() ->
                 end
             end)
         end,
-        fun(_, _) ->
-            meck:unload([couch_log])
+        fun(_) ->
+            meck:unload()
         end,
-        [{Flag, fun should_accept_code_and_message/2} || Flag <- [true, false]]
+        [
+            fun() -> should_accept_code_and_message(true) end,
+            fun() -> should_accept_code_and_message(false) end
+        ]
     }.
 
-should_accept_code_and_message(DontLogFlag, _) ->
+should_accept_code_and_message(DontLogFlag) ->
     erlang:put(dont_log_response, DontLogFlag),
     {"with dont_log_response = " ++ atom_to_list(DontLogFlag),
         [

--- a/src/couch/src/couch_multidb_changes.erl
+++ b/src/couch/src/couch_multidb_changes.erl
@@ -342,41 +342,46 @@ is_design_doc_id(_) ->
 
 couch_multidb_changes_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            t_handle_call_change(),
-            t_handle_call_change_filter_design_docs(),
-            t_handle_call_checkpoint_new(),
-            t_handle_call_checkpoint_existing(),
-            t_handle_info_created(),
-            t_handle_info_deleted(),
-            t_handle_info_updated(),
-            t_handle_info_other_event(),
-            t_handle_info_created_other_db(),
-            t_handle_info_scanner_exit_normal(),
-            t_handle_info_scanner_crashed(),
-            t_handle_info_event_server_exited(),
-            t_handle_info_unknown_pid_exited(),
-            t_handle_info_change_feed_exited(),
-            t_handle_info_change_feed_exited_and_need_rescan(),
-            t_spawn_changes_reader(),
-            t_changes_reader_cb_change(),
-            t_changes_reader_cb_stop(),
-            t_changes_reader_cb_other(),
-            t_handle_call_resume_scan_no_chfeed_no_ets_entry(),
-            t_handle_call_resume_scan_chfeed_no_ets_entry(),
-            t_handle_call_resume_scan_chfeed_ets_entry(),
-            t_handle_call_resume_scan_no_chfeed_ets_entry(),
-            t_start_link(),
-            t_start_link_no_ddocs(),
-            t_misc_gen_server_callbacks()
-        ]
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                t_handle_call_change(),
+                t_handle_call_change_filter_design_docs(),
+                t_handle_call_checkpoint_new(),
+                t_handle_call_checkpoint_existing(),
+                t_handle_info_created(),
+                t_handle_info_deleted(),
+                t_handle_info_updated(),
+                t_handle_info_other_event(),
+                t_handle_info_created_other_db(),
+                t_handle_info_scanner_exit_normal(),
+                t_handle_info_scanner_crashed(),
+                t_handle_info_event_server_exited(),
+                t_handle_info_unknown_pid_exited(),
+                t_handle_info_change_feed_exited(),
+                t_handle_info_change_feed_exited_and_need_rescan(),
+                t_spawn_changes_reader(),
+                t_changes_reader_cb_change(),
+                t_changes_reader_cb_stop(),
+                t_changes_reader_cb_other(),
+                t_handle_call_resume_scan_no_chfeed_no_ets_entry(),
+                t_handle_call_resume_scan_chfeed_no_ets_entry(),
+                t_handle_call_resume_scan_chfeed_ets_entry(),
+                t_handle_call_resume_scan_no_chfeed_ets_entry(),
+                t_start_link(),
+                t_start_link_no_ddocs(),
+                t_misc_gen_server_callbacks()
+            ]
+        }
     }.
 
 
-setup() ->
+setup_all() ->
     mock_logs(),
     mock_callback_mod(),
     meck:expect(couch_event, register_all, 1, ok),
@@ -397,10 +402,24 @@ setup() ->
     EvtPid.
 
 
-teardown(EvtPid) ->
+teardown_all(EvtPid) ->
     unlink(EvtPid),
     exit(EvtPid, kill),
     meck:unload().
+
+
+setup() ->
+    meck:reset([
+        ?MOD,
+        couch_changes,
+        couch_db,
+        couch_event,
+        couch_log
+    ]).
+
+
+teardown(_) ->
+    ok.
 
 
 t_handle_call_change() ->
@@ -728,38 +747,41 @@ t_misc_gen_server_callbacks() ->
 
 scan_dbs_test_() ->
 {
-    foreach,
-    fun() -> test_util:start_couch([mem3, fabric]) end,
-    fun(Ctx) -> test_util:stop_couch(Ctx) end,
-    [
-        t_find_shard(),
-        t_shard_not_found(),
-        t_pass_local(),
-        t_fail_local()
-    ]
+    setup,
+    fun() ->
+        Ctx = test_util:start_couch([mem3, fabric]),
+        GlobalDb = ?tempdb(),
+        ok = fabric:create_db(GlobalDb, [?CTX]),
+        #shard{name = LocalDb} = hd(mem3:local_shards(GlobalDb)),
+        {Ctx, GlobalDb, LocalDb}
+    end,
+    fun({Ctx, GlobalDb, _LocalDb}) ->
+        fabric:delete_db(GlobalDb, [?CTX]),
+        test_util:stop_couch(Ctx)
+    end,
+    {with, [
+        fun t_find_shard/1,
+        fun t_shard_not_found/1,
+        fun t_pass_local/1,
+        fun t_fail_local/1
+    ]}
 }.
 
 
-t_find_shard() ->
+t_find_shard({_, DbName, _}) ->
     ?_test(begin
-        DbName = ?tempdb(),
-        ok = fabric:create_db(DbName, [?CTX]),
-        ?assertEqual(2, length(local_shards(DbName))),
-        fabric:delete_db(DbName, [?CTX])
+        ?assertEqual(2, length(local_shards(DbName)))
     end).
 
 
-t_shard_not_found() ->
+t_shard_not_found(_) ->
     ?_test(begin
         ?assertEqual([], local_shards(?tempdb()))
     end).
 
 
-t_pass_local() ->
+t_pass_local({_, _, LocalDb}) ->
     ?_test(begin
-        LocalDb = ?tempdb(),
-        {ok, Db} = couch_db:create(LocalDb, [?CTX]),
-        ok = couch_db:close(Db),
         scan_local_db(self(), LocalDb),
         receive
             {'$gen_cast', Msg} ->
@@ -770,11 +792,8 @@ t_pass_local() ->
     end).
 
 
-t_fail_local() ->
+t_fail_local({_, _, LocalDb}) ->
     ?_test(begin
-        LocalDb = ?tempdb(),
-        {ok, Db} = couch_db:create(LocalDb, [?CTX]),
-        ok = couch_db:close(Db),
         scan_local_db(self(), <<"some_other_db">>),
         receive
             {'$gen_cast', Msg} ->

--- a/src/couch/src/test_util.erl
+++ b/src/couch/src/test_util.erl
@@ -98,6 +98,8 @@ start_applications([App|Apps], Acc) when App == kernel; App == stdlib ->
     start_applications(Apps, Acc);
 start_applications([App|Apps], Acc) ->
     case application:start(App) of
+    {error, {already_started, crypto}} ->
+        start_applications(Apps, [crypto | Acc]);
     {error, {already_started, App}} ->
         io:format(standard_error, "Application ~s was left running!~n", [App]),
         application:stop(App),

--- a/src/couch/test/eunit/chttpd_endpoints_tests.erl
+++ b/src/couch/test/eunit/chttpd_endpoints_tests.erl
@@ -15,28 +15,27 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
-setup("mocked") ->
-    fun setup_mocked/1;
-setup("not_mocked") ->
-    fun setup_not_mocked/1.
 
-setup_mocked({Endpoint, {_Path, Module, Function}}) ->
-    catch meck:unload(Module),
-    meck:new(Module, [passthrough, non_strict]),
-    Expected = mock_handler(Endpoint, Module, Function),
-    Expected.
+endpoints_test_() ->
+    {
+        "Checking dynamic endpoints",
+        {
+            setup,
+            fun() ->
+                test_util:start_couch([chttpd])
+            end,
+            fun test_util:stop/1,
+            [
+                fun url_handlers/0,
+                fun db_handlers/0,
+                fun design_handlers/0
+            ]
+        }
+    }.
 
-setup_not_mocked({_Endpoint, {_Path, Module, _Function}}) ->
-    catch meck:unload(Module),
-    meck:new(Module, [non_strict]),
-    ok.
 
-teardown({_Endpoint, {Module, _F, _A}}, _) ->
-    catch meck:unload(Module),
-    ok.
-
-handlers(url_handler) ->
-    [
+url_handlers() ->
+    Handlers = [
         {<<"">>, chttpd_misc, handle_welcome_req},
         {<<"favicon.ico">>, chttpd_misc, handle_favicon_req},
         {<<"_utils">>, chttpd_misc, handle_utils_dir_req},
@@ -51,11 +50,20 @@ handlers(url_handler) ->
         {<<"_up">>, chttpd_misc, handle_up_req},
         {<<"_membership">>, mem3_httpd, handle_membership_req},
         {<<"_db_updates">>, global_changes_httpd, handle_global_changes_req},
-        {<<"_cluster_setup">>, setup_httpd, handle_setup_req},
-        {<<"anything">>, chttpd_db, handle_request}
-    ];
-handlers(db_handler) ->
-    [
+        {<<"_cluster_setup">>, setup_httpd, handle_setup_req}
+    ],
+
+    lists:foreach(fun({Path, Mod, Fun}) ->
+        Handler = chttpd_handlers:url_handler(Path, undefined),
+        Expect = fun Mod:Fun/1,
+        ?assertEqual(Expect, Handler)
+    end, Handlers),
+
+    ?assertEqual(undefined, chttpd_handlers:url_handler("foo", undefined)).
+
+
+db_handlers() ->
+    Handlers = [
         {<<"_view_cleanup">>, chttpd_db, handle_view_cleanup_req},
         {<<"_compact">>, chttpd_db, handle_compact_req},
         {<<"_design">>, chttpd_db, handle_design_req},
@@ -65,120 +73,31 @@ handlers(db_handler) ->
         {<<"_index">>, mango_httpd, handle_req},
         {<<"_explain">>, mango_httpd, handle_req},
         {<<"_find">>, mango_httpd, handle_req}
-    ];
-handlers(design_handler) ->
-    [
+    ],
+
+    lists:foreach(fun({Path, Mod, Fun}) ->
+        Handler = chttpd_handlers:db_handler(Path, undefined),
+        Expect = fun Mod:Fun/2,
+        ?assertEqual(Expect, Handler)
+    end, Handlers),
+
+    ?assertEqual(undefined, chttpd_handlers:db_handler("bam", undefined)).
+
+
+design_handlers() ->
+    Handlers = [
         {<<"_view">>, chttpd_view, handle_view_req},
         {<<"_show">>, chttpd_show, handle_doc_show_req},
         {<<"_list">>, chttpd_show, handle_view_list_req},
         {<<"_update">>, chttpd_show, handle_doc_update_req},
         {<<"_info">>, chttpd_db, handle_design_info_req},
         {<<"_rewrite">>, chttpd_rewrite, handle_rewrite_req}
-    ].
+    ],
 
-endpoints_test_() ->
-    {
-        "Checking dynamic endpoints",
-        {
-            setup,
-            fun() -> test_util:start_couch([chttpd, mem3, global_changes, mango, setup]) end,
-            fun test_util:stop/1,
-            [
-                check_dynamic_endpoints(
-                    "mocked", url_handler, fun ensure_called/2),
-                check_dynamic_endpoints(
-                    "mocked", db_handler, fun ensure_called/2),
-                check_dynamic_endpoints(
-                    "mocked", design_handler, fun ensure_called/2),
-                check_dynamic_endpoints(
-                    "not_mocked", url_handler, fun verify_we_fail_if_missing/2),
-                check_dynamic_endpoints(
-                    "not_mocked", db_handler, fun verify_we_fail_if_missing/2),
-                check_dynamic_endpoints(
-                    "not_mocked", design_handler, fun verify_we_fail_if_missing/2)
-            ]
-        }
-    }.
+    lists:foreach(fun({Path, Mod, Fun}) ->
+        Handler = chttpd_handlers:design_handler(Path, undefined),
+        Expect = fun Mod:Fun/3,
+        ?assertEqual(Expect, Handler)
+    end, Handlers),
 
-check_dynamic_endpoints(Setup, EndpointType, TestFun) ->
-    {
-        "Checking '"
-            ++ atom_to_list(EndpointType)
-            ++ "' [" ++ Setup ++ "] dynamic endpoints",
-        [
-            make_test_case(Setup, EndpointType, Spec, TestFun)
-               || Spec <- handlers(EndpointType)
-        ]
-    }.
-
-make_test_case(Setup, EndpointType, {Path, Module, Function}, TestFun) ->
-    {
-        lists:flatten(io_lib:format("~s -- \"~s\"", [EndpointType, ?b2l(Path)])),
-        {
-            foreachx, setup(Setup), fun teardown/2,
-            [
-                {{EndpointType, {Path, Module, Function}}, TestFun}
-            ]
-        }
-    }.
-
-
-mock_handler(url_handler = Endpoint, M, F) ->
-    meck:expect(M, F, fun(X) -> {return, Endpoint, X} end),
-    fun M:F/1;
-mock_handler(db_handler = Endpoint, M, F) ->
-    meck:expect(M, F, fun(X, Y) -> {return, Endpoint, X, Y} end),
-    fun M:F/2;
-mock_handler(design_handler = Endpoint, M, F) ->
-    meck:expect(M, F, fun(X, Y, Z) -> {return, Endpoint, X, Y, Z} end),
-    fun M:F/3.
-
-ensure_called({url_handler = Endpoint, {Path, _M, _Fun}}, ExpectedFun) ->
-    HandlerFun = handler(Endpoint, Path),
-    ?_test(begin
-        ?assertEqual(ExpectedFun, HandlerFun),
-        ?assertMatch({return, Endpoint, x}, HandlerFun(x))
-     end);
-ensure_called({db_handler = Endpoint, {Path, _M, _Fun}}, ExpectedFun) ->
-    HandlerFun = handler(Endpoint, Path),
-    ?_test(begin
-        ?assertEqual(ExpectedFun, HandlerFun),
-        ?assertMatch({return, Endpoint, x, y}, HandlerFun(x, y))
-     end);
-ensure_called({design_handler = Endpoint, {Path, _M, _Fun}}, ExpectedFun) ->
-    HandlerFun = handler(Endpoint, Path),
-    ?_test(begin
-        ?assertEqual(ExpectedFun, HandlerFun),
-        ?assertMatch({return, Endpoint, x, y, z}, HandlerFun(x, y, z))
-     end).
-
-%% Test the test: when the final target function is missing,
-%% the Fun call must fail.
-verify_we_fail_if_missing({url_handler = Endpoint, {Path, _M, _Fun}}, _) ->
-    HandlerFun = handler(Endpoint, Path),
-    ?_test(begin
-        ?assert(is_function(HandlerFun)),
-        ?assertError(undef, HandlerFun(x))
-    end);
-verify_we_fail_if_missing({db_handler = Endpoint, {Path, _M, _Fun}}, _) ->
-    HandlerFun = handler(Endpoint, Path),
-    ?_test(begin
-        ?assert(is_function(HandlerFun)),
-        ?assertError(undef, HandlerFun(x, y))
-    end);
-verify_we_fail_if_missing({design_handler = Endpoint, {Path, _M, _Fun}}, _) ->
-    HandlerFun = handler(Endpoint, Path),
-    ?_test(begin
-        ?assert(is_function(HandlerFun)),
-        ?assertError(undef, HandlerFun(x, y, z))
-    end).
-
-handler(url_handler, HandlerKey) ->
-    chttpd_handlers:url_handler(HandlerKey, fun chttpd_db:handle_request/1);
-handler(db_handler, HandlerKey) ->
-    chttpd_handlers:db_handler(HandlerKey, fun chttpd_db:db_req/2);
-handler(design_handler, HandlerKey) ->
-    chttpd_handlers:design_handler(HandlerKey, fun dummy/3).
-
-dummy(_, _, _) ->
-    throw(error).
+    ?assertEqual(undefined, chttpd_handlers:design_handler("baz", undefined)).

--- a/src/couch/test/eunit/couch_file_tests.erl
+++ b/src/couch/test/eunit/couch_file_tests.erl
@@ -327,45 +327,53 @@ delete_test_() ->
     {
         "File delete tests",
         {
-            foreach,
+            setup,
             fun() ->
-                meck:new(config, [passthrough]),
-                File = ?tempfile() ++ ".couch",
-                RootDir = filename:dirname(File),
-                ok = couch_file:init_delete_dir(RootDir),
-                ok = file:write_file(File, <<>>),
-                {RootDir, File}
+                meck:new(config, [passthrough])
             end,
-            fun({_, File}) ->
-                meck:unload(config),
-                file:delete(File)
+            fun(_) ->
+                meck:unload()
             end,
-            [
-                fun(Cfg) ->
-                    {"enable_database_recovery = false, context = delete",
-                    make_enable_recovery_test_case(Cfg, false, delete)}
+            {
+                foreach,
+                fun() ->
+                    meck:reset([config]),
+                    File = ?tempfile() ++ ".couch",
+                    RootDir = filename:dirname(File),
+                    ok = couch_file:init_delete_dir(RootDir),
+                    ok = file:write_file(File, <<>>),
+                    {RootDir, File}
                 end,
-                fun(Cfg) ->
-                    {"enable_database_recovery = true, context = delete",
-                    make_enable_recovery_test_case(Cfg, true, delete)}
+                fun({_, File}) ->
+                    file:delete(File)
                 end,
-                fun(Cfg) ->
-                    {"enable_database_recovery = false, context = compaction",
-                    make_enable_recovery_test_case(Cfg, false, compaction)}
-                end,
-                fun(Cfg) ->
-                    {"enable_database_recovery = true, context = compaction",
-                    make_enable_recovery_test_case(Cfg, true, compaction)}
-                end,
-                fun(Cfg) ->
-                    {"delete_after_rename = true",
-                    make_delete_after_rename_test_case(Cfg, true)}
-                end,
-                fun(Cfg) ->
-                    {"delete_after_rename = false",
-                    make_delete_after_rename_test_case(Cfg, false)}
-                end
-            ]
+                [
+                    fun(Cfg) ->
+                        {"enable_database_recovery = false, context = delete",
+                        make_enable_recovery_test_case(Cfg, false, delete)}
+                    end,
+                    fun(Cfg) ->
+                        {"enable_database_recovery = true, context = delete",
+                        make_enable_recovery_test_case(Cfg, true, delete)}
+                    end,
+                    fun(Cfg) ->
+                        {"enable_database_recovery = false, context = compaction",
+                        make_enable_recovery_test_case(Cfg, false, compaction)}
+                    end,
+                    fun(Cfg) ->
+                        {"enable_database_recovery = true, context = compaction",
+                        make_enable_recovery_test_case(Cfg, true, compaction)}
+                    end,
+                    fun(Cfg) ->
+                        {"delete_after_rename = true",
+                        make_delete_after_rename_test_case(Cfg, true)}
+                    end,
+                    fun(Cfg) ->
+                        {"delete_after_rename = false",
+                        make_delete_after_rename_test_case(Cfg, false)}
+                    end
+                ]
+            }
         }
     }.
 
@@ -412,49 +420,57 @@ nuke_dir_test_() ->
     {
         "Nuke directory tests",
         {
-            foreach,
+            setup,
             fun() ->
-                meck:new(config, [passthrough]),
-                File0 = ?tempfile() ++ ".couch",
-                RootDir = filename:dirname(File0),
-                BaseName = filename:basename(File0),
-                Seed = couch_rand:uniform(8999999999) + 999999999,
-                DDocDir = io_lib:format("db.~b_design", [Seed]),
-                ViewDir = filename:join([RootDir, DDocDir]),
-                file:make_dir(ViewDir),
-                File = filename:join([ViewDir, BaseName]),
-                file:rename(File0, File),
-                ok = couch_file:init_delete_dir(RootDir),
-                ok = file:write_file(File, <<>>),
-                {RootDir, ViewDir}
+                meck:new(config, [passthrough])
             end,
-            fun({RootDir, ViewDir}) ->
-                meck:unload(config),
-                remove_dir(ViewDir),
-                Ext = filename:extension(ViewDir),
-                case filelib:wildcard(RootDir ++ "/*.deleted" ++ Ext) of
-                    [DelDir] -> remove_dir(DelDir);
-                    _ -> ok
-                end
+            fun(_) ->
+                meck:unload()
             end,
-            [
-                fun(Cfg) ->
-                    {"enable_database_recovery = false",
-                    make_rename_dir_test_case(Cfg, false)}
+            {
+                foreach,
+                fun() ->
+                    meck:reset([config]),
+                    File0 = ?tempfile() ++ ".couch",
+                    RootDir = filename:dirname(File0),
+                    BaseName = filename:basename(File0),
+                    Seed = couch_rand:uniform(8999999999) + 999999999,
+                    DDocDir = io_lib:format("db.~b_design", [Seed]),
+                    ViewDir = filename:join([RootDir, DDocDir]),
+                    file:make_dir(ViewDir),
+                    File = filename:join([ViewDir, BaseName]),
+                    file:rename(File0, File),
+                    ok = couch_file:init_delete_dir(RootDir),
+                    ok = file:write_file(File, <<>>),
+                    {RootDir, ViewDir}
                 end,
-                fun(Cfg) ->
-                    {"enable_database_recovery = true",
-                    make_rename_dir_test_case(Cfg, true)}
+                fun({RootDir, ViewDir}) ->
+                    remove_dir(ViewDir),
+                    Ext = filename:extension(ViewDir),
+                    case filelib:wildcard(RootDir ++ "/*.deleted" ++ Ext) of
+                        [DelDir] -> remove_dir(DelDir);
+                        _ -> ok
+                    end
                 end,
-                fun(Cfg) ->
-                    {"delete_after_rename = true",
-                    make_delete_dir_test_case(Cfg, true)}
-                end,
-                fun(Cfg) ->
-                    {"delete_after_rename = false",
-                    make_delete_dir_test_case(Cfg, false)}
-                end
-            ]
+                [
+                    fun(Cfg) ->
+                        {"enable_database_recovery = false",
+                        make_rename_dir_test_case(Cfg, false)}
+                    end,
+                    fun(Cfg) ->
+                        {"enable_database_recovery = true",
+                        make_rename_dir_test_case(Cfg, true)}
+                    end,
+                    fun(Cfg) ->
+                        {"delete_after_rename = true",
+                        make_delete_dir_test_case(Cfg, true)}
+                    end,
+                    fun(Cfg) ->
+                        {"delete_after_rename = false",
+                        make_delete_dir_test_case(Cfg, false)}
+                    end
+                ]
+            }
         }
     }.
 
@@ -462,7 +478,8 @@ nuke_dir_test_() ->
 make_rename_dir_test_case({RootDir, ViewDir}, EnableRecovery) ->
     meck:expect(config, get_boolean, fun
         ("couchdb", "enable_database_recovery", _) -> EnableRecovery;
-        ("couchdb", "delete_after_rename", _) -> true
+        ("couchdb", "delete_after_rename", _) -> true;
+        (_, _, Default) -> Default
     end),
     DirExistsBefore = filelib:is_dir(ViewDir),
     couch_file:nuke_dir(RootDir, ViewDir),
@@ -479,7 +496,8 @@ make_rename_dir_test_case({RootDir, ViewDir}, EnableRecovery) ->
 make_delete_dir_test_case({RootDir, ViewDir}, DeleteAfterRename) ->
     meck:expect(config, get_boolean, fun
         ("couchdb", "enable_database_recovery", _) -> false;
-        ("couchdb", "delete_after_rename", _) -> DeleteAfterRename
+        ("couchdb", "delete_after_rename", _) -> DeleteAfterRename;
+        (_, _, Default) -> Default
     end),
     DirExistsBefore = filelib:is_dir(ViewDir),
     couch_file:nuke_dir(RootDir, ViewDir),

--- a/src/couch/test/eunit/couch_flags_config_tests.erl
+++ b/src/couch/test/eunit/couch_flags_config_tests.erl
@@ -16,8 +16,10 @@ couch_flags_config_test_() ->
     {
         "test couch_flags_config",
         {
-            setup, fun setup/0, fun teardown/1,
-            all_combinations_return_same_result()
+            setup,
+            fun setup/0,
+            fun teardown/1,
+                [fun all_combinations_return_same_result/0]
                 ++ latest_overide_wins()
                 ++ [
                     {"rules_are_sorted", fun rules_are_sorted/0}
@@ -41,8 +43,9 @@ all_combinations_return_same_result() ->
         {{<<"*">>},{<<"*">>, 1, [bar, foo]}}
     ],
     Combinations = couch_tests_combinatorics:permutations(Config),
-    [{test_id(Items), ?_assertEqual(Expected, couch_flags_config:data(Items))}
-        || Items <- Combinations].
+    lists:foreach(fun(Items) ->
+        ?assertEqual(Expected, couch_flags_config:data(Items))
+    end, Combinations).
 
 rules_are_sorted() ->
     Expected = [

--- a/src/couch_peruser/test/eunit/couch_peruser_test.erl
+++ b/src/couch_peruser/test/eunit/couch_peruser_test.erl
@@ -18,7 +18,7 @@
 -define(ADMIN_USERNAME, "admin").
 -define(ADMIN_PASSWORD, "secret").
 
--define(WAIT_FOR_USER_DELETE_TIMEOUT, 3000).
+-define(WAIT_FOR_USER_DELETE_TIMEOUT, 1000).
 
 setup_all() ->
     TestCtx = test_util:start_couch([chttpd]),
@@ -37,8 +37,8 @@ setup() ->
     do_request(put, get_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     do_request(put, get_cluster_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     set_config("couch_httpd_auth", "authentication_db", ?b2l(TestAuthDb)),
-    set_config("couch_peruser", "cluster_quiet_period", "1"),
-    set_config("couch_peruser", "cluster_start_period", "1"),
+    set_config("couch_peruser", "cluster_quiet_period", "0"),
+    set_config("couch_peruser", "cluster_start_period", "0"),
     set_config("couch_peruser", "enable", "true"),
     set_config("cluster", "n", "1"),
     TestAuthDb.

--- a/src/couch_peruser/test/eunit/couch_peruser_test.erl
+++ b/src/couch_peruser/test/eunit/couch_peruser_test.erl
@@ -145,297 +145,316 @@ get_cluster_base_url() ->
 
 
 should_create_user_db_with_default(TestAuthDb) ->
-    create_user(TestAuthDb, "foo"),
-    wait_for_db_create(<<"userdb-666f6f">>),
-    {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f">>),
-    {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
-    [
-        ?_assert(lists:member(<<"userdb-666f6f">>, all_dbs())),
-        ?_assertEqual(1, couch_util:get_value(q, ClusterInfo))
-    ].
+    ?_test(begin
+        create_user(TestAuthDb, "foo"),
+        wait_for_db_create(<<"userdb-666f6f">>),
+        {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f">>),
+        {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
+        ?assert(lists:member(<<"userdb-666f6f">>, all_dbs())),
+        ?assertEqual(1, couch_util:get_value(q, ClusterInfo))
+    end).
 
 should_create_user_db_with_custom_prefix(TestAuthDb) ->
-    set_config("couch_peruser", "database_prefix", "newuserdb-"),
-    create_user(TestAuthDb, "fooo"),
-    wait_for_db_create(<<"newuserdb-666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix"),
-    ?_assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs())).
+    ?_test(begin
+        set_config("couch_peruser", "database_prefix", "newuserdb-"),
+        create_user(TestAuthDb, "fooo"),
+        wait_for_db_create(<<"newuserdb-666f6f6f">>),
+        delete_config("couch_peruser", "database_prefix"),
+        ?assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs()))
+    end).
 
 should_create_user_db_with_custom_special_prefix(TestAuthDb) ->
-    set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
-    create_user(TestAuthDb, "fooo"),
-    wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix"),
-    ?_assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs())).
+    ?_test(begin
+        set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+        create_user(TestAuthDb, "fooo"),
+        wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
+        delete_config("couch_peruser", "database_prefix"),
+        ?assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs()))
+    end).
 
 should_create_anon_user_db_with_default(TestAuthDb) ->
-    create_anon_user(TestAuthDb, "fooo"),
-    wait_for_db_create(<<"userdb-666f6f6f">>),
-    {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f6f">>),
-    {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
-    [
-        ?_assert(lists:member(<<"userdb-666f6f6f">>, all_dbs())),
-        ?_assertEqual(1, couch_util:get_value(q, ClusterInfo))
-    ].
+    ?_test(begin
+        create_anon_user(TestAuthDb, "fooo"),
+        wait_for_db_create(<<"userdb-666f6f6f">>),
+        {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f6f">>),
+        {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
+        ?assert(lists:member(<<"userdb-666f6f6f">>, all_dbs())),
+        ?assertEqual(1, couch_util:get_value(q, ClusterInfo))
+    end).
 
 should_create_anon_user_db_with_custom_prefix(TestAuthDb) ->
-    set_config("couch_peruser", "database_prefix", "newuserdb-"),
-    create_anon_user(TestAuthDb, "fooo"),
-    wait_for_db_create(<<"newuserdb-666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix"),
-    ?_assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs())).
+    ?_test(begin
+        set_config("couch_peruser", "database_prefix", "newuserdb-"),
+        create_anon_user(TestAuthDb, "fooo"),
+        wait_for_db_create(<<"newuserdb-666f6f6f">>),
+        delete_config("couch_peruser", "database_prefix"),
+        ?assert(lists:member(<<"newuserdb-666f6f6f">>, all_dbs()))
+    end).
 
 should_create_anon_user_db_with_custom_special_prefix(TestAuthDb) ->
-    set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
-    create_anon_user(TestAuthDb, "fooo"),
-    wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
-    delete_config("couch_peruser", "database_prefix"),
-    ?_assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs())).
+    ?_test(begin
+        set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+        create_anon_user(TestAuthDb, "fooo"),
+        wait_for_db_create(<<"userdb_$()+--/666f6f6f">>),
+        delete_config("couch_peruser", "database_prefix"),
+        ?assert(lists:member(<<"userdb_$()+--/666f6f6f">>, all_dbs()))
+    end).
 
 should_create_user_db_with_q4(TestAuthDb) ->
-    set_config("couch_peruser", "q", "4"),
-    create_user(TestAuthDb, "foo"),
-    wait_for_db_create(<<"userdb-666f6f">>),
-    {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f">>),
-    {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
-    delete_config("couch_peruser", "q"),
-    [
-        ?_assert(lists:member(<<"userdb-666f6f">>, all_dbs())),
-        ?_assertEqual(4, couch_util:get_value(q, ClusterInfo))
-    ].
+    ?_test(begin
+        set_config("couch_peruser", "q", "4"),
+        create_user(TestAuthDb, "foo"),
+        wait_for_db_create(<<"userdb-666f6f">>),
+        {ok, DbInfo} = fabric:get_db_info(<<"userdb-666f6f">>),
+        {ClusterInfo} = couch_util:get_value(cluster, DbInfo),
+        delete_config("couch_peruser", "q"),
+        ?assert(lists:member(<<"userdb-666f6f">>, all_dbs())),
+        ?assertEqual(4, couch_util:get_value(q, ClusterInfo))
+    end).
 
 should_create_anon_user_db_with_q4(TestAuthDb) ->
-    set_config("couch_peruser", "q", "4"),
-    create_anon_user(TestAuthDb, "fooo"),
-    wait_for_db_create(<<"userdb-666f6f6f">>),
-    {ok, TargetInfo} = fabric:get_db_info(<<"userdb-666f6f6f">>),
-    {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
-    delete_config("couch_peruser", "q"),
-    [
-        ?_assert(lists:member(<<"userdb-666f6f6f">>, all_dbs())),
-        ?_assertEqual(4, couch_util:get_value(q, ClusterInfo))
-    ].
+    ?_test(begin
+        set_config("couch_peruser", "q", "4"),
+        create_anon_user(TestAuthDb, "fooo"),
+        wait_for_db_create(<<"userdb-666f6f6f">>),
+        {ok, TargetInfo} = fabric:get_db_info(<<"userdb-666f6f6f">>),
+        {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
+        delete_config("couch_peruser", "q"),
+        ?assert(lists:member(<<"userdb-666f6f6f">>, all_dbs())),
+        ?assertEqual(4, couch_util:get_value(q, ClusterInfo))
+    end).
 
 should_not_delete_user_db(TestAuthDb) ->
-    User = "foo",
-    UserDbName = <<"userdb-666f6f">>,
-    create_user(TestAuthDb, User),
-    wait_for_db_create(<<"userdb-666f6f">>),
-    AfterCreate = lists:member(UserDbName, all_dbs()),
-    delete_user(TestAuthDb, User),
-    timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
-    AfterDelete = lists:member(UserDbName, all_dbs()),
-    [?_assert(AfterCreate), ?_assert(AfterDelete)].
+    ?_test(begin
+        User = "foo",
+        UserDbName = <<"userdb-666f6f">>,
+        create_user(TestAuthDb, User),
+        wait_for_db_create(<<"userdb-666f6f">>),
+        AfterCreate = lists:member(UserDbName, all_dbs()),
+        delete_user(TestAuthDb, User),
+        timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
+        AfterDelete = lists:member(UserDbName, all_dbs()),
+        ?assert(AfterCreate),
+        ?assert(AfterDelete)
+    end).
 
 should_delete_user_db(TestAuthDb) ->
-    User = "bar",
-    UserDbName = <<"userdb-626172">>,
-    set_config("couch_peruser", "delete_dbs", "true"),
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    AfterCreate = lists:member(UserDbName, all_dbs()),
-    delete_user(TestAuthDb, User),
-    wait_for_db_delete(UserDbName),
-    AfterDelete = lists:member(UserDbName, all_dbs()),
-    [?_assert(AfterCreate), ?_assertNot(AfterDelete)].
+    ?_test(begin
+        User = "bar",
+        UserDbName = <<"userdb-626172">>,
+        set_config("couch_peruser", "delete_dbs", "true"),
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        AfterCreate = lists:member(UserDbName, all_dbs()),
+        delete_user(TestAuthDb, User),
+        wait_for_db_delete(UserDbName),
+        AfterDelete = lists:member(UserDbName, all_dbs()),
+        ?assert(AfterCreate),
+        ?assertNot(AfterDelete)
+    end).
 
 should_delete_user_db_with_custom_prefix(TestAuthDb) ->
-    User = "bar",
-    UserDbName = <<"newuserdb-626172">>,
-    set_config("couch_peruser", "delete_dbs", "true"),
-    set_config("couch_peruser", "database_prefix", "newuserdb-"),
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    AfterCreate = lists:member(UserDbName, all_dbs()),
-    delete_user(TestAuthDb, User),
-    wait_for_db_delete(UserDbName),
-    delete_config("couch_peruser", "database_prefix"),
-    AfterDelete = lists:member(UserDbName, all_dbs()),
-    [
-        ?_assert(AfterCreate),
-        ?_assertNot(AfterDelete)
-    ].
+    ?_test(begin
+        User = "bar",
+        UserDbName = <<"newuserdb-626172">>,
+        set_config("couch_peruser", "delete_dbs", "true"),
+        set_config("couch_peruser", "database_prefix", "newuserdb-"),
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        AfterCreate = lists:member(UserDbName, all_dbs()),
+        delete_user(TestAuthDb, User),
+        wait_for_db_delete(UserDbName),
+        delete_config("couch_peruser", "database_prefix"),
+        AfterDelete = lists:member(UserDbName, all_dbs()),
+        ?assert(AfterCreate),
+        ?assertNot(AfterDelete)
+    end).
 
 should_delete_user_db_with_custom_special_prefix(TestAuthDb) ->
-    User = "bar",
-    UserDbName = <<"userdb_$()+--/626172">>,
-    set_config("couch_peruser", "delete_dbs", "true"),
-    set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    AfterCreate = lists:member(UserDbName, all_dbs()),
-    delete_user(TestAuthDb, User),
-    wait_for_db_delete(UserDbName),
-    delete_config("couch_peruser", "database_prefix"),
-    AfterDelete = lists:member(UserDbName, all_dbs()),
-    [
-        ?_assert(AfterCreate),
-        ?_assertNot(AfterDelete)
-    ].
+    ?_test(begin
+        User = "bar",
+        UserDbName = <<"userdb_$()+--/626172">>,
+        set_config("couch_peruser", "delete_dbs", "true"),
+        set_config("couch_peruser", "database_prefix", "userdb_$()+--/"),
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        AfterCreate = lists:member(UserDbName, all_dbs()),
+        delete_user(TestAuthDb, User),
+        wait_for_db_delete(UserDbName),
+        delete_config("couch_peruser", "database_prefix"),
+        AfterDelete = lists:member(UserDbName, all_dbs()),
+        ?assert(AfterCreate),
+        ?assertNot(AfterDelete)
+    end).
 
 should_reflect_config_changes(TestAuthDb) ->
-    User = "baz",
-    UserDbName = <<"userdb-62617a">>,
-    set_config("couch_peruser", "delete_dbs", "true"),
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    AfterCreate1 = lists:member(UserDbName, all_dbs()),
-    delete_user(TestAuthDb, User),
-    timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
-    wait_for_db_delete(UserDbName),
-    AfterDelete1 = lists:member(UserDbName, all_dbs()),
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    AfterCreate2 = lists:member(UserDbName, all_dbs()),
-    set_config("couch_peruser", "delete_dbs", "false"),
-    delete_user(TestAuthDb, User),
-    timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
-    AfterDelete2 = lists:member(UserDbName, all_dbs()),
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    set_config("couch_peruser", "delete_dbs", "true"),
-    delete_user(TestAuthDb, User),
-    wait_for_db_delete(UserDbName),
-    AfterDelete3 = lists:member(UserDbName, all_dbs()),
-    set_config("couch_peruser", "enable", "false"),
-    create_user(TestAuthDb, User),
-    timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
-    AfterCreate3 = lists:member(UserDbName, all_dbs()),
-    [
-        ?_assert(AfterCreate1),
-        ?_assertNot(AfterDelete1),
-        ?_assert(AfterCreate2),
-        ?_assert(AfterDelete2),
-        ?_assertNot(AfterDelete3),
-        ?_assertNot(AfterCreate3)
-    ].
+    {timeout, 10000, ?_test(begin
+        User = "baz",
+        UserDbName = <<"userdb-62617a">>,
+        set_config("couch_peruser", "delete_dbs", "true"),
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        AfterCreate1 = lists:member(UserDbName, all_dbs()),
+        delete_user(TestAuthDb, User),
+        timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
+        wait_for_db_delete(UserDbName),
+        AfterDelete1 = lists:member(UserDbName, all_dbs()),
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        AfterCreate2 = lists:member(UserDbName, all_dbs()),
+        set_config("couch_peruser", "delete_dbs", "false"),
+        delete_user(TestAuthDb, User),
+        timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
+        AfterDelete2 = lists:member(UserDbName, all_dbs()),
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        set_config("couch_peruser", "delete_dbs", "true"),
+        delete_user(TestAuthDb, User),
+        wait_for_db_delete(UserDbName),
+        AfterDelete3 = lists:member(UserDbName, all_dbs()),
+        set_config("couch_peruser", "enable", "false"),
+        create_user(TestAuthDb, User),
+        timer:sleep(?WAIT_FOR_USER_DELETE_TIMEOUT),
+        AfterCreate3 = lists:member(UserDbName, all_dbs()),
+        ?assert(AfterCreate1),
+        ?assertNot(AfterDelete1),
+        ?assert(AfterCreate2),
+        ?assert(AfterDelete2),
+        ?assertNot(AfterDelete3),
+        ?assertNot(AfterCreate3)
+    end)}.
 
 
 should_add_user_to_db_admins(TestAuthDb) ->
-    User = "qux",
-    UserDbName = <<"userdb-717578">>,
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    ?_assertEqual(
-        {[{<<"names">>,[<<"qux">>]}]},
-        proplists:get_value(<<"admins">>, get_security(UserDbName))).
+    ?_test(begin
+        User = "qux",
+        UserDbName = <<"userdb-717578">>,
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        ?assertEqual(
+            {[{<<"names">>,[<<"qux">>]}]},
+            proplists:get_value(<<"admins">>, get_security(UserDbName)))
+    end).
 
 should_add_user_to_db_members(TestAuthDb) ->
-    User = "qux",
-    UserDbName = <<"userdb-717578">>,
-    create_user(TestAuthDb, User),
-    wait_for_db_create(UserDbName),
-    ?_assertEqual(
-        {[{<<"names">>,[<<"qux">>]}]},
-        proplists:get_value(<<"members">>, get_security(UserDbName))).
+    ?_test(begin
+        User = "qux",
+        UserDbName = <<"userdb-717578">>,
+        create_user(TestAuthDb, User),
+        wait_for_db_create(UserDbName),
+        ?assertEqual(
+            {[{<<"names">>,[<<"qux">>]}]},
+            proplists:get_value(<<"members">>, get_security(UserDbName)))
+    end).
 
 should_not_remove_existing_db_admins(TestAuthDb) ->
-    User = "qux",
-    UserDbName = <<"userdb-717578">>,
-    SecurityProperties = [
-        {<<"admins">>,{[{<<"names">>,[<<"foo">>,<<"bar">>]}]}},
-        {<<"members">>,{[{<<"names">>,[<<"baz">>,<<"pow">>]}]}}
-    ],
-    create_db(UserDbName),
-    set_security(UserDbName, SecurityProperties),
-    create_user(TestAuthDb, User),
-    wait_for_security_create(<<"admins">>, User, UserDbName),
-    {AdminProperties} = proplists:get_value(<<"admins">>,
-        get_security(UserDbName)),
-    AdminNames = proplists:get_value(<<"names">>, AdminProperties),
-    [
-      ?_assert(lists:member(<<"foo">>, AdminNames)),
-      ?_assert(lists:member(<<"bar">>, AdminNames)),
-      ?_assert(lists:member(<<"qux">>, AdminNames))
-    ].
+    ?_test(begin
+        User = "qux",
+        UserDbName = <<"userdb-717578">>,
+        SecurityProperties = [
+            {<<"admins">>,{[{<<"names">>,[<<"foo">>,<<"bar">>]}]}},
+            {<<"members">>,{[{<<"names">>,[<<"baz">>,<<"pow">>]}]}}
+        ],
+        create_db(UserDbName),
+        set_security(UserDbName, SecurityProperties),
+        create_user(TestAuthDb, User),
+        wait_for_security_create(<<"admins">>, User, UserDbName),
+        {AdminProperties} = proplists:get_value(<<"admins">>,
+            get_security(UserDbName)),
+        AdminNames = proplists:get_value(<<"names">>, AdminProperties),
+        ?assert(lists:member(<<"foo">>, AdminNames)),
+        ?assert(lists:member(<<"bar">>, AdminNames)),
+        ?assert(lists:member(<<"qux">>, AdminNames))
+    end).
 
 should_not_remove_existing_db_members(TestAuthDb) ->
-    User = "qux",
-    UserDbName = <<"userdb-717578">>,
-    SecurityProperties = [
-        {<<"admins">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}},
-        {<<"members">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}}
-    ],
-    create_db(UserDbName),
-    set_security(UserDbName, SecurityProperties),
-    create_user(TestAuthDb, User),
-    wait_for_security_create(<<"members">>, User, UserDbName),
-    {MemberProperties} = proplists:get_value(<<"members">>,
-        get_security(UserDbName)),
-    MemberNames = proplists:get_value(<<"names">>, MemberProperties),
-    [
-      ?_assert(lists:member(<<"pow">>, MemberNames)),
-      ?_assert(lists:member(<<"wow">>, MemberNames)),
-      ?_assert(lists:member(<<"qux">>, MemberNames))
-    ].
+    ?_test(begin
+        User = "qux",
+        UserDbName = <<"userdb-717578">>,
+        SecurityProperties = [
+            {<<"admins">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}},
+            {<<"members">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}}
+        ],
+        create_db(UserDbName),
+        set_security(UserDbName, SecurityProperties),
+        create_user(TestAuthDb, User),
+        wait_for_security_create(<<"members">>, User, UserDbName),
+        {MemberProperties} = proplists:get_value(<<"members">>,
+            get_security(UserDbName)),
+        MemberNames = proplists:get_value(<<"names">>, MemberProperties),
+        ?assert(lists:member(<<"pow">>, MemberNames)),
+        ?assert(lists:member(<<"wow">>, MemberNames)),
+        ?assert(lists:member(<<"qux">>, MemberNames))
+    end).
 
 should_remove_user_from_db_admins(TestAuthDb) ->
-    User = "qux",
-    UserDbName = <<"userdb-717578">>,
-    SecurityProperties = [
-        {<<"admins">>,{[{<<"names">>,[<<"foo">>,<<"bar">>]}]}},
-        {<<"members">>,{[{<<"names">>,[<<"baz">>,<<"pow">>]}]}}
-    ],
-    create_db(UserDbName),
-    set_security(UserDbName, SecurityProperties),
-    create_user(TestAuthDb, User),
-    wait_for_security_create(<<"admins">>, User, UserDbName),
-    {AdminProperties} = proplists:get_value(<<"admins">>,
-        get_security(UserDbName)),
-    AdminNames = proplists:get_value(<<"names">>, AdminProperties),
-    FooBefore = lists:member(<<"foo">>, AdminNames),
-    BarBefore = lists:member(<<"bar">>, AdminNames),
-    QuxBefore = lists:member(<<"qux">>, AdminNames),
-    delete_user(TestAuthDb, User),
-    wait_for_security_delete(<<"admins">>, User, UserDbName),
-    {NewAdminProperties} = proplists:get_value(<<"admins">>,
-        get_security(UserDbName)),
-    NewAdminNames = proplists:get_value(<<"names">>, NewAdminProperties),
-    FooAfter = lists:member(<<"foo">>, NewAdminNames),
-    BarAfter = lists:member(<<"bar">>, NewAdminNames),
-    QuxAfter = lists:member(<<"qux">>, NewAdminNames),
-    [
-      ?_assert(FooBefore),
-      ?_assert(BarBefore),
-      ?_assert(QuxBefore),
-      ?_assert(FooAfter),
-      ?_assert(BarAfter),
-      ?_assertNot(QuxAfter)
-    ].
+    ?_test(begin
+        User = "qux",
+        UserDbName = <<"userdb-717578">>,
+        SecurityProperties = [
+            {<<"admins">>,{[{<<"names">>,[<<"foo">>,<<"bar">>]}]}},
+            {<<"members">>,{[{<<"names">>,[<<"baz">>,<<"pow">>]}]}}
+        ],
+        create_db(UserDbName),
+        set_security(UserDbName, SecurityProperties),
+        create_user(TestAuthDb, User),
+        wait_for_security_create(<<"admins">>, User, UserDbName),
+        {AdminProperties} = proplists:get_value(<<"admins">>,
+            get_security(UserDbName)),
+        AdminNames = proplists:get_value(<<"names">>, AdminProperties),
+        FooBefore = lists:member(<<"foo">>, AdminNames),
+        BarBefore = lists:member(<<"bar">>, AdminNames),
+        QuxBefore = lists:member(<<"qux">>, AdminNames),
+        delete_user(TestAuthDb, User),
+        wait_for_security_delete(<<"admins">>, User, UserDbName),
+        {NewAdminProperties} = proplists:get_value(<<"admins">>,
+            get_security(UserDbName)),
+        NewAdminNames = proplists:get_value(<<"names">>, NewAdminProperties),
+        FooAfter = lists:member(<<"foo">>, NewAdminNames),
+        BarAfter = lists:member(<<"bar">>, NewAdminNames),
+        QuxAfter = lists:member(<<"qux">>, NewAdminNames),
+        ?assert(FooBefore),
+        ?assert(BarBefore),
+        ?assert(QuxBefore),
+        ?assert(FooAfter),
+        ?assert(BarAfter),
+        ?assertNot(QuxAfter)
+    end).
 
 should_remove_user_from_db_members(TestAuthDb) ->
-    User = "qux",
-    UserDbName = <<"userdb-717578">>,
-    SecurityProperties = [
-        {<<"admins">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}},
-        {<<"members">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}}
-    ],
-    create_db(UserDbName),
-    set_security(UserDbName, SecurityProperties),
-    create_user(TestAuthDb, User),
-    wait_for_security_create(<<"members">>, User, UserDbName),
-    {MemberProperties} = proplists:get_value(<<"members">>,
-        get_security(UserDbName)),
-    MemberNames = proplists:get_value(<<"names">>, MemberProperties),
-    PowBefore = lists:member(<<"pow">>, MemberNames),
-    WowBefore = lists:member(<<"wow">>, MemberNames),
-    QuxBefore = lists:member(<<"qux">>, MemberNames),
-    delete_user(TestAuthDb, User),
-    wait_for_security_delete(<<"members">>, User, UserDbName),
-    {NewMemberProperties} = proplists:get_value(<<"members">>,
-        get_security(UserDbName)),
-    NewMemberNames = proplists:get_value(<<"names">>, NewMemberProperties),
-    PowAfter = lists:member(<<"pow">>, NewMemberNames),
-    WowAfter = lists:member(<<"wow">>, NewMemberNames),
-    QuxAfter = lists:member(<<"qux">>, NewMemberNames),
-    [
-      ?_assert(PowBefore),
-      ?_assert(WowBefore),
-      ?_assert(QuxBefore),
-      ?_assert(PowAfter),
-      ?_assert(WowAfter),
-      ?_assertNot(QuxAfter)
-    ].
+    ?_test(begin
+        User = "qux",
+        UserDbName = <<"userdb-717578">>,
+        SecurityProperties = [
+            {<<"admins">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}},
+            {<<"members">>,{[{<<"names">>,[<<"pow">>,<<"wow">>]}]}}
+        ],
+        create_db(UserDbName),
+        set_security(UserDbName, SecurityProperties),
+        create_user(TestAuthDb, User),
+        wait_for_security_create(<<"members">>, User, UserDbName),
+        {MemberProperties} = proplists:get_value(<<"members">>,
+            get_security(UserDbName)),
+        MemberNames = proplists:get_value(<<"names">>, MemberProperties),
+        PowBefore = lists:member(<<"pow">>, MemberNames),
+        WowBefore = lists:member(<<"wow">>, MemberNames),
+        QuxBefore = lists:member(<<"qux">>, MemberNames),
+        delete_user(TestAuthDb, User),
+        wait_for_security_delete(<<"members">>, User, UserDbName),
+        {NewMemberProperties} = proplists:get_value(<<"members">>,
+            get_security(UserDbName)),
+        NewMemberNames = proplists:get_value(<<"names">>, NewMemberProperties),
+        PowAfter = lists:member(<<"pow">>, NewMemberNames),
+        WowAfter = lists:member(<<"wow">>, NewMemberNames),
+        QuxAfter = lists:member(<<"qux">>, NewMemberNames),
+        ?assert(PowBefore),
+        ?assert(WowBefore),
+        ?assert(QuxBefore),
+        ?assert(PowAfter),
+        ?assert(WowAfter),
+        ?assertNot(QuxAfter)
+    end).
+
 
 
 wait_for_db_create(UserDbName) ->

--- a/src/couch_replicator/src/couch_replicator.erl
+++ b/src/couch_replicator/src/couch_replicator.erl
@@ -346,11 +346,13 @@ expect_rep_user_ctx(Name, Role) ->
 
 strip_url_creds_test_() ->
      {
-        foreach,
-        fun () -> meck:expect(config, get,
-            fun(_, _, Default) -> Default end)
+        setup,
+        fun() ->
+            meck:expect(config, get, fun(_, _, Default) -> Default end)
         end,
-        fun (_) -> meck:unload() end,
+        fun(_) ->
+            meck:unload()
+        end,
         [
             t_strip_http_basic_creds(),
             t_strip_http_props_creds(),

--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -631,24 +631,29 @@ extract_creds_success_test_() ->
 
 cookie_update_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            t_do_refresh_without_max_age(),
-            t_do_refresh_with_max_age(),
-            t_dont_refresh(),
-            t_process_auth_failure(),
-            t_process_auth_failure_stale_epoch(),
-            t_process_auth_failure_too_frequent(),
-            t_process_ok_update_cookie(),
-            t_process_ok_no_cookie(),
-            t_init_state_fails_on_401(),
-            t_init_state_401_with_require_valid_user(),
-            t_init_state_404(),
-            t_init_state_no_creds(),
-            t_init_state_http_error()
-        ]
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                t_do_refresh_without_max_age(),
+                t_do_refresh_with_max_age(),
+                t_dont_refresh(),
+                t_process_auth_failure(),
+                t_process_auth_failure_stale_epoch(),
+                t_process_auth_failure_too_frequent(),
+                t_process_ok_update_cookie(),
+                t_process_ok_no_cookie(),
+                t_init_state_fails_on_401(),
+                t_init_state_401_with_require_valid_user(),
+                t_init_state_404(),
+                t_init_state_no_creds(),
+                t_init_state_http_error()
+            ]
+        }
     }.
 
 
@@ -774,7 +779,7 @@ t_init_state_http_error() ->
     end).
 
 
-setup() ->
+setup_all() ->
     meck:expect(couch_replicator_httpc_pool, get_worker, 1, {ok, worker}),
     meck:expect(couch_replicator_httpc_pool, release_worker_sync, 2, ok),
     meck:expect(config, get, fun(_, _, Default) -> Default end),
@@ -782,8 +787,20 @@ setup() ->
     ok.
 
 
-teardown(_) ->
+teardown_all(_) ->
     meck:unload().
+
+
+setup() ->
+    meck:reset([
+        config,
+        couch_replicator_httpc_pool,
+        ibrowse
+    ]).
+
+
+teardown(_) ->
+    ok.
 
 
 mock_http_cookie_response(Cookie) ->

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -1037,42 +1037,47 @@ longest_running_test() ->
 
 scheduler_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            t_pending_jobs_simple(),
-            t_pending_jobs_skip_crashed(),
-            t_one_job_starts(),
-            t_no_jobs_start_if_max_is_0(),
-            t_one_job_starts_if_max_is_1(),
-            t_max_churn_does_not_throttle_initial_start(),
-            t_excess_oneshot_only_jobs(),
-            t_excess_continuous_only_jobs(),
-            t_excess_prefer_continuous_first(),
-            t_stop_oldest_first(),
-            t_start_oldest_first(),
-            t_jobs_churn_even_if_not_all_max_jobs_are_running(),
-            t_jobs_dont_churn_if_there_are_available_running_slots(),
-            t_start_only_pending_jobs_do_not_churn_existing_ones(),
-            t_dont_stop_if_nothing_pending(),
-            t_max_churn_limits_number_of_rotated_jobs(),
-            t_existing_jobs(),
-            t_if_pending_less_than_running_start_all_pending(),
-            t_running_less_than_pending_swap_all_running(),
-            t_oneshot_dont_get_rotated(),
-            t_rotate_continuous_only_if_mixed(),
-            t_oneshot_dont_get_starting_priority(),
-            t_oneshot_will_hog_the_scheduler(),
-            t_if_excess_is_trimmed_rotation_still_happens(),
-            t_if_transient_job_crashes_it_gets_removed(),
-            t_if_permanent_job_crashes_it_stays_in_ets(),
-            t_job_summary_running(),
-            t_job_summary_pending(),
-            t_job_summary_crashing_once(),
-            t_job_summary_crashing_many_times(),
-            t_job_summary_proxy_fields()
-         ]
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                t_pending_jobs_simple(),
+                t_pending_jobs_skip_crashed(),
+                t_one_job_starts(),
+                t_no_jobs_start_if_max_is_0(),
+                t_one_job_starts_if_max_is_1(),
+                t_max_churn_does_not_throttle_initial_start(),
+                t_excess_oneshot_only_jobs(),
+                t_excess_continuous_only_jobs(),
+                t_excess_prefer_continuous_first(),
+                t_stop_oldest_first(),
+                t_start_oldest_first(),
+                t_jobs_churn_even_if_not_all_max_jobs_are_running(),
+                t_jobs_dont_churn_if_there_are_available_running_slots(),
+                t_start_only_pending_jobs_do_not_churn_existing_ones(),
+                t_dont_stop_if_nothing_pending(),
+                t_max_churn_limits_number_of_rotated_jobs(),
+                t_existing_jobs(),
+                t_if_pending_less_than_running_start_all_pending(),
+                t_running_less_than_pending_swap_all_running(),
+                t_oneshot_dont_get_rotated(),
+                t_rotate_continuous_only_if_mixed(),
+                t_oneshot_dont_get_starting_priority(),
+                t_oneshot_will_hog_the_scheduler(),
+                t_if_excess_is_trimmed_rotation_still_happens(),
+                t_if_transient_job_crashes_it_gets_removed(),
+                t_if_permanent_job_crashes_it_stays_in_ets(),
+                t_job_summary_running(),
+                t_job_summary_pending(),
+                t_job_summary_crashing_once(),
+                t_job_summary_crashing_many_times(),
+                t_job_summary_proxy_fields()
+            ]
+        }
     }.
 
 
@@ -1521,7 +1526,7 @@ t_job_summary_proxy_fields() ->
 
 % Test helper functions
 
-setup() ->
+setup_all() ->
     catch ets:delete(?MODULE),
     meck:expect(couch_log, notice, 2, ok),
     meck:expect(couch_log, warning, 2, ok),
@@ -1533,9 +1538,21 @@ setup() ->
     meck:expect(couch_replicator_scheduler_sup, start_child, 1, {ok, Pid}).
 
 
-teardown(_) ->
+teardown_all(_) ->
     catch ets:delete(?MODULE),
     meck:unload().
+
+
+setup() ->
+    meck:reset([
+        couch_log,
+        couch_replicator_scheduler_sup,
+        couch_stats
+    ]).
+
+
+teardown(_) ->
+    ok.
 
 
 setup_jobs(Jobs) when is_list(Jobs) ->

--- a/src/ddoc_cache/test/eunit/ddoc_cache_no_cache_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_no_cache_test.erl
@@ -40,10 +40,12 @@ no_cache_test_() ->
         "ddoc_cache no cache test",
         {
             setup,
-            fun ddoc_cache_tutil:start_couch/0, fun ddoc_cache_tutil:stop_couch/1,
+            fun setup_all/0,
+            fun teardown_all/1,
             {
                 foreachx,
-                fun setup/1, fun teardown/2,
+                fun setup/1,
+                fun teardown/2,
                 [
                     {fun ddoc/1, fun no_cache_open_ok_test/2},
                     {fun not_found/1, fun no_cache_open_not_found_test/2},
@@ -53,8 +55,16 @@ no_cache_test_() ->
         }
     }.
 
-setup(Resp) ->
+setup_all() ->
+    Ctx = ddoc_cache_tutil:start_couch(),
     meck:new(fabric),
+    Ctx.
+
+teardown_all(Ctx) ->
+    meck:unload(),
+    ddoc_cache_tutil:stop_couch(Ctx).
+
+setup(Resp) ->
     meck:expect(fabric, open_doc, fun(_, DDocId, _) ->
         Resp(DDocId)
     end).

--- a/src/fabric/src/fabric_db_create.erl
+++ b/src/fabric/src/fabric_db_create.erl
@@ -188,30 +188,41 @@ db_exists(DbName) -> is_list(catch mem3:shards(DbName)).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
-db_exists_for_existing_db_test() ->
-    start_meck_(),
+db_exists_test_() ->
+    {
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        [
+            fun db_exists_for_existing_db/0,
+            fun db_exists_for_missing_db/0
+        ]
+    }.
+
+
+setup_all() ->
+    meck:new(mem3).
+
+
+teardown_all(_) ->
+    meck:unload().
+
+
+db_exists_for_existing_db() ->
     Mock = fun(DbName) when is_binary(DbName) ->
         [#shard{dbname = DbName, range = [0,100]}]
     end,
     ok = meck:expect(mem3, shards, Mock),
     ?assertEqual(true, db_exists(<<"foobar">>)),
-    ?assertEqual(true, meck:validate(mem3)),
-    stop_meck_().
+    ?assertEqual(true, meck:validate(mem3)).
 
-db_exists_for_missing_db_test() ->
-    start_meck_(),
+
+db_exists_for_missing_db() ->
     Mock = fun(DbName) ->
         erlang:error(database_does_not_exist, DbName)
     end,
     ok = meck:expect(mem3, shards, Mock),
     ?assertEqual(false, db_exists(<<"foobar">>)),
-    ?assertEqual(false, meck:validate(mem3)),
-    stop_meck_().
-
-start_meck_() ->
-    ok = meck:new(mem3).
-
-stop_meck_() ->
-    ok = meck:unload(mem3).
+    ?assertEqual(false, meck:validate(mem3)).
 
 -endif.

--- a/src/fabric/src/fabric_doc_open.erl
+++ b/src/fabric/src/fabric_doc_open.erl
@@ -185,38 +185,53 @@ format_reply(Else, _) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+-define(MECK_MODS, [
+    couch_log,
+    couch_stats,
+    fabric,
+    fabric_util,
+    mem3,
+    rexi,
+    rexi_monitor
+]).
+
+
+setup_all() ->
+    meck:new(?MECK_MODS, [passthrough]).
+
+
+teardown_all(_) ->
+    meck:unload().
+
 
 setup() ->
-    meck:new([
-        couch_log,
-        couch_stats,
-        fabric,
-        fabric_util,
-        mem3,
-        rexi,
-        rexi_monitor
-    ], [passthrough]).
+    meck:reset(?MECK_MODS).
 
 
 teardown(_) ->
-    meck:unload().
+    ok.
 
 
 open_doc_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            t_is_r_met(),
-            t_handle_message_down(),
-            t_handle_message_exit(),
-            t_handle_message_reply(),
-            t_store_node_revs(),
-            t_read_repair(),
-            t_handle_response_quorum_met(),
-            t_get_doc_info()
-        ]
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                t_is_r_met(),
+                t_handle_message_down(),
+                t_handle_message_exit(),
+                t_handle_message_reply(),
+                t_store_node_revs(),
+                t_read_repair(),
+                t_handle_response_quorum_met(),
+                t_get_doc_info()
+            ]
+        }
     }.
 
 

--- a/src/fabric/src/fabric_doc_open_revs.erl
+++ b/src/fabric/src/fabric_doc_open_revs.erl
@@ -317,7 +317,7 @@ collapse_duplicate_revs_int([Reply | Rest]) ->
 -include_lib("eunit/include/eunit.hrl").
 
 
-setup() ->
+setup_all() ->
     config:start_link([]),
     meck:new([fabric, couch_stats, couch_log]),
     meck:new(fabric_util, [passthrough]),
@@ -328,9 +328,22 @@ setup() ->
 
 
 
-teardown(_) ->
-    (catch meck:unload([fabric, couch_stats, couch_log, fabric_util])),
+teardown_all(_) ->
+    meck:unload(),
     config:stop().
+
+
+setup() ->
+    meck:reset([
+        couch_log,
+        couch_stats,
+        fabric,
+        fabric_util
+    ]).
+
+
+teardown(_) ->
+    ok.
 
 
 state0(Revs, Latest) ->
@@ -361,39 +374,44 @@ baz1() -> {ok, #doc{revs = {1, [<<"baz">>]}}}.
 
 open_doc_revs_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            check_empty_response_not_quorum(),
-            check_basic_response(),
-            check_finish_quorum(),
-            check_finish_quorum_newer(),
-            check_no_quorum_on_second(),
-            check_done_on_third(),
-            check_specific_revs_first_msg(),
-            check_revs_done_on_agreement(),
-            check_latest_true(),
-            check_ancestor_counted_in_quorum(),
-            check_not_found_counts_for_descendant(),
-            check_worker_error_skipped(),
-            check_quorum_only_counts_valid_responses(),
-            check_empty_list_when_no_workers_reply(),
-            check_node_rev_stored(),
-            check_node_rev_store_head_only(),
-            check_node_rev_store_multiple(),
-            check_node_rev_dont_store_errors(),
-            check_node_rev_store_non_errors(),
-            check_node_rev_store_concatenate(),
-            check_node_rev_store_concantenate_multiple(),
-            check_node_rev_unmodified_on_down_or_exit(),
-            check_not_found_replies_are_removed_when_doc_found(),
-            check_not_found_returned_when_one_of_docs_not_found(),
-            check_not_found_returned_when_doc_not_found(),
-            check_longer_rev_list_returned(),
-            check_longer_rev_list_not_combined(),
-            check_not_found_removed_and_longer_rev_list()
-        ]
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                check_empty_response_not_quorum(),
+                check_basic_response(),
+                check_finish_quorum(),
+                check_finish_quorum_newer(),
+                check_no_quorum_on_second(),
+                check_done_on_third(),
+                check_specific_revs_first_msg(),
+                check_revs_done_on_agreement(),
+                check_latest_true(),
+                check_ancestor_counted_in_quorum(),
+                check_not_found_counts_for_descendant(),
+                check_worker_error_skipped(),
+                check_quorum_only_counts_valid_responses(),
+                check_empty_list_when_no_workers_reply(),
+                check_node_rev_stored(),
+                check_node_rev_store_head_only(),
+                check_node_rev_store_multiple(),
+                check_node_rev_dont_store_errors(),
+                check_node_rev_store_non_errors(),
+                check_node_rev_store_concatenate(),
+                check_node_rev_store_concantenate_multiple(),
+                check_node_rev_unmodified_on_down_or_exit(),
+                check_not_found_replies_are_removed_when_doc_found(),
+                check_not_found_returned_when_one_of_docs_not_found(),
+                check_not_found_returned_when_doc_not_found(),
+                check_longer_rev_list_returned(),
+                check_longer_rev_list_not_combined(),
+                check_not_found_removed_and_longer_rev_list()
+            ]
+        }
     }.
 
 

--- a/src/fabric/src/fabric_doc_purge.erl
+++ b/src/fabric/src/fabric_doc_purge.erl
@@ -225,12 +225,11 @@ has_quorum(Resps, Count, W) ->
 
 
 -ifdef(TEST).
-
 -include_lib("eunit/include/eunit.hrl").
 
 purge_test_() ->
     {
-        foreach,
+        setup,
         fun setup/0,
         fun teardown/1,
         [

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -880,7 +880,7 @@ doc_() ->
 
 targets_map_test_() ->
     {
-        foreach,
+        setup,
         fun() -> meck:new(mem3, [passthrough]) end,
         fun(_) -> meck:unload() end,
         [

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -525,25 +525,30 @@ filter_shards_by_range(Range, Shards)->
 
 mem3_shards_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            t_maybe_spawn_shard_writer_already_exists(),
-            t_maybe_spawn_shard_writer_new(),
-            t_flush_writer_exists_normal(),
-            t_flush_writer_times_out(),
-            t_flush_writer_crashes(),
-            t_writer_deletes_itself_when_done(),
-            t_writer_does_not_delete_other_writers_for_same_shard(),
-            t_spawn_writer_in_load_shards_from_db(),
-            t_cache_insert_takes_new_update(),
-            t_cache_insert_ignores_stale_update_and_kills_worker()
-        ]
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                t_maybe_spawn_shard_writer_already_exists(),
+                t_maybe_spawn_shard_writer_new(),
+                t_flush_writer_exists_normal(),
+                t_flush_writer_times_out(),
+                t_flush_writer_crashes(),
+                t_writer_deletes_itself_when_done(),
+                t_writer_does_not_delete_other_writers_for_same_shard(),
+                t_spawn_writer_in_load_shards_from_db(),
+                t_cache_insert_takes_new_update(),
+                t_cache_insert_ignores_stale_update_and_kills_worker()
+            ]
+        }
     }.
 
 
-setup() ->
+setup_all() ->
     ets:new(?SHARDS, [bag, public, named_table, {keypos, #shard.dbname}]),
     ets:new(?OPENERS, [bag, public, named_table]),
     ets:new(?DBS, [set, public, named_table]),
@@ -552,12 +557,23 @@ setup() ->
     ok.
 
 
-teardown(_) ->
+teardown_all(_) ->
     meck:unload(),
     ets:delete(?ATIMES),
     ets:delete(?DBS),
     ets:delete(?OPENERS),
     ets:delete(?SHARDS).
+
+
+setup() ->
+    ets:delete_all_objects(?ATIMES),
+    ets:delete_all_objects(?DBS),
+    ets:delete_all_objects(?OPENERS),
+    ets:delete_all_objects(?SHARDS).
+
+
+teardown(_) ->
+    ok.
 
 
 t_maybe_spawn_shard_writer_already_exists() ->
@@ -653,7 +669,9 @@ t_spawn_writer_in_load_shards_from_db() ->
         ?assertMatch({cache_insert, ?DB, Pid, 1} when is_pid(Pid), Cast),
         {cache_insert, _, WPid, _} = Cast,
         exit(WPid, kill),
-        ?assertEqual([{?DB, WPid}], ets:tab2list(?OPENERS))
+        ?assertEqual([{?DB, WPid}], ets:tab2list(?OPENERS)),
+        meck:unload(couch_db),
+        meck:unload(mem3_util)
     end).
 
 

--- a/src/smoosh/src/smoosh_server.erl
+++ b/src/smoosh/src/smoosh_server.erl
@@ -446,18 +446,22 @@ needs_upgrade(Props) ->
 -include_lib("eunit/include/eunit.hrl").
 
 
-setup() ->
+setup_all() ->
     meck:new([config, couch_index, couch_index_server], [passthrough]),
     Pid = list_to_pid("<0.0.0>"),
     meck:expect(couch_index_server, get_index, 3, {ok, Pid}),
-    meck:expect(config, get, fun(_, _, Default) -> Default end),
+    meck:expect(config, get, fun(_, _, Default) -> Default end).
+
+teardown_all(_) ->
+    meck:unload().
+
+setup() ->
     Shard = <<"shards/00000000-1fffffff/test.1529510412">>,
     GroupId = <<"_design/ddoc">>,
     {ok, Shard, GroupId}.
 
-
 teardown(_) ->
-    meck:unload().
+    ok.
 
 config_change_test_() ->
     {
@@ -474,20 +478,25 @@ config_change_test_() ->
 
 get_priority_test_() ->
     {
-        foreach,
-        fun setup/0,
-        fun teardown/1,
-        [
-            fun t_ratio_view/1,
-            fun t_slack_view/1,
-            fun t_no_data_view/1,
-            fun t_below_min_priority_view/1,
-            fun t_below_min_size_view/1,
-            fun t_timeout_view/1,
-            fun t_missing_view/1,
-            fun t_invalid_view/1
-        ]
-}.
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                fun t_ratio_view/1,
+                fun t_slack_view/1,
+                fun t_no_data_view/1,
+                fun t_below_min_priority_view/1,
+                fun t_below_min_size_view/1,
+                fun t_timeout_view/1,
+                fun t_missing_view/1,
+                fun t_invalid_view/1
+            ]
+        }
+    }.
 
 t_restart_config_listener(_) ->
     ?_test(begin

--- a/test/javascript/cli_runner.js
+++ b/test/javascript/cli_runner.js
@@ -22,6 +22,10 @@ function runTest() {
   var count = 0;
   var start = new Date().getTime();
 
+  if(couchTests.skip) {
+      quit(2);
+  }
+
   for(var name in couchTests) {
       count++;
   }

--- a/test/javascript/cli_runner.js
+++ b/test/javascript/cli_runner.js
@@ -26,6 +26,10 @@ function runTest() {
       quit(2);
   }
 
+  if(couchTests.elixir) {
+      quit(3);
+  }
+
   for(var name in couchTests) {
       count++;
   }

--- a/test/javascript/run
+++ b/test/javascript/run
@@ -44,14 +44,17 @@ RUNNER = "test/javascript/cli_runner.js"
 def mkformatter(tests):
     longest = max([len(x) for x in tests])
     green = "\033[32m"
+    orange = "\033[33m"
     red = "\033[31m"
     clear = "\033[0m"
     if not sys.stderr.isatty():
-        green, read, clear = "", "", ""
+        green, orange, red, clear = "", "", "", ""
 
-    def _colorized(passed):
-        if passed:
+    def _colorized(rval):
+        if rval == 0:
             return green + "pass" + clear
+        elif rval == 2:
+            return orange + "skipped" + clear
         else:
             return red + "fail" + clear
 
@@ -60,7 +63,7 @@ def mkformatter(tests):
             padding = (longest - len(test)) * " "
             sys.stderr.write(test + "   " + padding)
             sys.stderr.flush()
-        elif isinstance(test, bool):
+        elif isinstance(test, int):
             if test:
                 sys.stderr.write(_colorized(test) + os.linesep)
             else:
@@ -86,7 +89,7 @@ def run_couchjs(test, fmt):
         line = line.decode()
         sys.stderr.write(line)
     p.wait()
-    fmt(p.returncode == 0)
+    fmt(p.returncode)
     return p.returncode
 
 
@@ -163,7 +166,7 @@ def main():
         fmt = mkformatter(tests)
         for test in tests:
             result = run_couchjs(test, fmt)
-            if result == 0:
+            if result == 0 or result == 2:
                 passed += 1
             else:
                 failed += 1

--- a/test/javascript/run
+++ b/test/javascript/run
@@ -55,6 +55,8 @@ def mkformatter(tests):
             return green + "pass" + clear
         elif rval == 2:
             return orange + "skipped" + clear
+        elif rval == 3:
+            return green + "ported to elixir" + clear
         else:
             return red + "fail" + clear
 
@@ -166,7 +168,7 @@ def main():
         fmt = mkformatter(tests)
         for test in tests:
             result = run_couchjs(test, fmt)
-            if result == 0 or result == 2:
+            if result == 0 or result == 2 or result == 3:
                 passed += 1
             else:
                 failed += 1

--- a/test/javascript/tests-cluster/with-quorum/attachments_delete_overridden_quorum.js
+++ b/test/javascript/tests-cluster/with-quorum/attachments_delete_overridden_quorum.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.attachments_delete_overridden_quorum= function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"},{"w":3});
@@ -25,7 +26,7 @@ couchTests.attachments_delete_overridden_quorum= function(debug) {
   var rev = JSON.parse(xhr.responseText).rev;
 
   xhr = CouchDB.request("DELETE", "/" + db_name + "/dummy/foo.txt?rev=" + rev);
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status);
+  console.log("TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status);
   // TODO: Define correct behaviour
   //T(xhr.status == 202,"Should return 202 but returns "+xhr.status);
 

--- a/test/javascript/tests-cluster/with-quorum/attachments_overridden_quorum.js
+++ b/test/javascript/tests-cluster/with-quorum/attachments_overridden_quorum.js
@@ -11,6 +11,7 @@
 // the License.
 
 //Test attachments operations with an overridden quorum parameter
+couchTests.skip = true;
 couchTests.attachments_overriden_quorum= function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"},{"w":3});
@@ -32,7 +33,7 @@ couchTests.attachments_overriden_quorum= function(debug) {
     body:"This is no base64 encoded text-2",
     headers:{"Content-Type": "text/plain;charset=utf-8"}
   });
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status);
+  console.log("TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status);
   //TODO: Define correct behaviour
   //T(xhr.status == 202,"Should return 202");
 

--- a/test/javascript/tests-cluster/with-quorum/db_creation_overridden_quorum.js
+++ b/test/javascript/tests-cluster/with-quorum/db_creation_overridden_quorum.js
@@ -11,6 +11,7 @@
 // the License.
 
 // Do DB creation under cluster with quorum conditions but overriding write quorum.
+couchTests.skip = true;
 couchTests.db_creation_overridden_quorum = function(debug) {
 
   if (debug) debugger;
@@ -20,7 +21,7 @@ couchTests.db_creation_overridden_quorum = function(debug) {
 
   // DB Creation should return 202 - Accepted
   xhr = CouchDB.request("PUT", "/" + db_name + "/");
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status)
+  console.log("TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status)
   //T(xhr.status == 202,"Should return 202");
 
   // cleanup

--- a/test/javascript/tests-cluster/with-quorum/doc_copy_overridden_quorum.js
+++ b/test/javascript/tests-cluster/with-quorum/doc_copy_overridden_quorum.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.doc_copy_overriden_quorum = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"},{"w":3});
@@ -23,7 +24,7 @@ couchTests.doc_copy_overriden_quorum = function(debug) {
   });
   //TODO: Define correct behaviour
   //T(xhr.status=="202","Should return 202");
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status);
+  console.log("TODO: Clarify correct behaviour. Is not considering overridden quorum. 202->"+xhr.status);
 
   db.deleteDb();
 

--- a/test/javascript/tests-cluster/without-quorum/attachments_delete.js
+++ b/test/javascript/tests-cluster/without-quorum/attachments_delete.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.attachments_delete= function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
@@ -26,7 +27,7 @@ couchTests.attachments_delete= function(debug) {
   var rev = JSON.parse(xhr.responseText).rev;
 
   xhr = CouchDB.request("DELETE", "/" + db_name + "/dummy/foo.txt?rev=" + rev);
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering quorum. 202->"+xhr.status);
+  console.log("TODO: Clarify correct behaviour. Is not considering quorum. 202->"+xhr.status);
   //TODO: Define correct behaviour
   //T(xhr.status == 202,"Should return 202 Accepted but returns "+xhr.status);
 

--- a/test/javascript/tests-cluster/without-quorum/attachments_delete_overridden_quorum.js
+++ b/test/javascript/tests-cluster/without-quorum/attachments_delete_overridden_quorum.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.attachments_delete_overridden_quorum= function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"},{"w":1});
@@ -25,7 +26,7 @@ couchTests.attachments_delete_overridden_quorum= function(debug) {
   var rev = JSON.parse(xhr.responseText).rev;
 
   xhr = CouchDB.request("DELETE", "/" + db_name + "/dummy/foo.txt?rev=" + rev);
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering quorum. 202->"+xhr.status);
+  console.log("TODO: Clarify correct behaviour. Is not considering quorum. 202->"+xhr.status);
   //TODO: Define correct behaviour
   //T(xhr.status == 200,"Should return 200 but returns "+xhr.status);
 

--- a/test/javascript/tests-cluster/without-quorum/db_creation_overridden_quorum.js
+++ b/test/javascript/tests-cluster/without-quorum/db_creation_overridden_quorum.js
@@ -11,6 +11,7 @@
 // the License.
 
 // Do DB creation under cluster with quorum conditions but overriding write quorum.
+couchTests.skip = true;
 couchTests.db_creation_overridden_quorum = function(debug) {
 
   if (debug) debugger;
@@ -20,7 +21,7 @@ couchTests.db_creation_overridden_quorum = function(debug) {
 
   // DB Creation should return 201 - Created
   xhr = CouchDB.request("PUT", "/" + db_name + "/");
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering overridden quorum. 201->"+xhr.status)
+  console.log("TODO: Clarify correct behaviour. Is not considering overridden quorum. 201->"+xhr.status)
   //T(xhr.status == 201,"Should return 201");
 
   //db.deleteDb();

--- a/test/javascript/tests-cluster/without-quorum/doc_copy_overridden_quorum.js
+++ b/test/javascript/tests-cluster/without-quorum/doc_copy_overridden_quorum.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.doc_copy_overriden_quorum = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"},{"w":1});
@@ -21,7 +22,7 @@ couchTests.doc_copy_overriden_quorum = function(debug) {
   var xhr = CouchDB.request("COPY", "/" + db_name + "/dummy", {
     headers: {"Destination":"dummy2"}
   });
-  console.log("Skipped-TODO: Clarify correct behaviour. Is not considering overridden quorum. 201->"+xhr.status);
+  console.log("TODO: Clarify correct behaviour. Is not considering overridden quorum. 201->"+xhr.status);
   //TODO Defie correct behaviour
   //T(xhr.status=="201","Should return 201");
 

--- a/test/javascript/tests/all_docs.js
+++ b/test/javascript/tests/all_docs.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.all_docs = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"}, {w: 3});
@@ -79,7 +80,7 @@ couchTests.all_docs = function(debug) {
   })[0];
   TEquals("1", deleted_doc.id, "deletes");
 
-  // (remember old seq) 
+  // (remember old seq)
   var orig_doc = changes.results.filter(function(row) {
     return row.id == "3"
   })[0];

--- a/test/javascript/tests/attachment_names.js
+++ b/test/javascript/tests/attachment_names.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.attachment_names = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"}, {w: 3});

--- a/test/javascript/tests/attachment_paths.js
+++ b/test/javascript/tests/attachment_paths.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.attachment_paths = function(debug) {
   if (debug) debugger;
   var r_db_name = get_random_db_name()

--- a/test/javascript/tests/attachment_ranges.js
+++ b/test/javascript/tests/attachment_ranges.js
@@ -14,6 +14,7 @@ function cacheBust() {
     return "?anti-cache=" + String(Math.round(Math.random() * 1000000));
 };
 
+couchTests.elixir = true;
 couchTests.attachment_ranges = function(debug) {
     var db_name = get_random_db_name();
     var db = new CouchDB(db_name, {
@@ -132,7 +133,7 @@ couchTests.attachment_ranges = function(debug) {
     TEquals("ext", xhr.responseText);
     TEquals("3", xhr.getResponseHeader("Content-Length"));
     TEquals("bytes 26-28/29", xhr.getResponseHeader("Content-Range"));
-    
+
     // backward range is 416
     var xhr = CouchDB.request("GET", "/" + db_name + "/bin_doc/foo.txt" + cacheBust(), {
        headers: {

--- a/test/javascript/tests/attachment_views.js
+++ b/test/javascript/tests/attachment_views.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.attachment_views= function(debug) {
 
   var db_name = get_random_db_name()

--- a/test/javascript/tests/attachments.js
+++ b/test/javascript/tests/attachments.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.attachments= function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
@@ -301,7 +302,7 @@ couchTests.attachments= function(debug) {
   T(db.save(bin_doc6).ok == true);
 
   // wrong rev pos specified
-  
+
   // stub out the attachment with the wrong revpos
   bin_doc6._attachments["foo.txt"] = { stub: true, revpos: 10};
   try {

--- a/test/javascript/tests/attachments_multipart.js
+++ b/test/javascript/tests/attachments_multipart.js
@@ -10,14 +10,15 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.attachments_multipart= function(debug) {
   var db_name = get_random_db_name()
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
   db.createDb();
   if (debug) debugger;
-  
+
   // mime multipart
-            
+
   var xhr = CouchDB.request("PUT", "/" + db_name + "/multipart", {
     headers: {"Content-Type": "multipart/related;boundary=\"abc123\""},
     body:
@@ -55,39 +56,39 @@ couchTests.attachments_multipart= function(debug) {
       "this is 19 chars lo" +
       "\r\n--abc123--epilogue"
     });
-    
+
   var result = JSON.parse(xhr.responseText);
-  
+
   T(result.ok);
-  
-  
-    
+
+
+
   TEquals(201, xhr.status, "should send 201 Accepted");
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart/foo.txt");
-  
+
   T(xhr.responseText == "this is 21 chars long");
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart/bar.txt");
-  
+
   T(xhr.responseText == "this is 20 chars lon");
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart/baz.txt");
-  
+
   T(xhr.responseText == "this is 19 chars lo");
-  
+
   // now edit an attachment
-  
+
   var doc = db.open("multipart", {att_encoding_info: true});
   var firstrev = doc._rev;
-  
+
   T(doc._attachments["foo.txt"].stub == true);
   T(doc._attachments["bar.txt"].stub == true);
   T(doc._attachments["baz.txt"].stub == true);
   TEquals("undefined", typeof doc._attachments["foo.txt"].encoding);
   TEquals("undefined", typeof doc._attachments["bar.txt"].encoding);
   TEquals("gzip", doc._attachments["baz.txt"].encoding);
-  
+
   //lets change attachment bar
   delete doc._attachments["bar.txt"].stub; // remove stub member (or could set to false)
   delete doc._attachments["bar.txt"].digest; // remove the digest (it's for the gzip form)
@@ -95,7 +96,7 @@ couchTests.attachments_multipart= function(debug) {
   doc._attachments["bar.txt"].follows = true;
   //lets delete attachment baz:
   delete doc._attachments["baz.txt"];
-  
+
   var xhr = CouchDB.request("PUT", "/" + db_name + "/multipart", {
     headers: {"Content-Type": "multipart/related;boundary=\"abc123\""},
     body:
@@ -109,16 +110,16 @@ couchTests.attachments_multipart= function(debug) {
       "\r\n--abc123--"
     });
   TEquals(201, xhr.status);
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart/bar.txt");
-  
+
   T(xhr.responseText == "this is 18 chars l");
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart/baz.txt");
   T(xhr.status == 404);
-  
+
   // now test receiving multipart docs
-  
+
   function getBoundary(xhr) {
     var ctype = CouchDB.xhrheader(xhr, "Content-Type");
     var ctypeArgs = ctype.split("; ").slice(1);
@@ -127,7 +128,7 @@ couchTests.attachments_multipart= function(debug) {
       if (ctypeArgs[i].indexOf("boundary=") == 0) {
         boundary = ctypeArgs[i].split("=")[1];
         if (boundary.charAt(0) == '"') {
-          // stringified boundary, parse as json 
+          // stringified boundary, parse as json
           // (will maybe not if there are escape quotes)
           boundary = JSON.parse(boundary);
         }
@@ -135,22 +136,22 @@ couchTests.attachments_multipart= function(debug) {
     }
     return boundary;
   }
-  
+
   function parseMultipart(xhr) {
     var boundary = getBoundary(xhr);
     var mimetext = CouchDB.xhrbody(xhr);
     // strip off leading boundary
     var leading = "--" + boundary + "\r\n";
     var last = "\r\n--" + boundary + "--";
-    
+
     // strip off leading and trailing boundary
     var leadingIdx = mimetext.indexOf(leading) + leading.length;
     var trailingIdx = mimetext.indexOf(last);
     mimetext = mimetext.slice(leadingIdx, trailingIdx);
-    
+
     // now split the sections
     var sections = mimetext.split(new RegExp("\\r\\n--" + boundary));
-    
+
     // spilt out the headers for each section
     for(var i=0; i < sections.length; i++) {
       var section = sections[i];
@@ -160,20 +161,20 @@ couchTests.attachments_multipart= function(debug) {
       var headers = {};
       for(var j=0; j<headersraw.length; j++) {
         var tmp = headersraw[j].split(": ");
-        headers[tmp[0]] = tmp[1]; 
+        headers[tmp[0]] = tmp[1];
       }
       sections[i] = {"headers":headers, "body":body};
     }
-    
+
     return sections;
   }
-  
-  
+
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart?attachments=true",
     {headers:{"accept": "multipart/related,*/*;"}});
-  
+
   T(xhr.status == 200);
-  
+
   // parse out the multipart
   var sections = parseMultipart(xhr);
   TEquals("790", xhr.getResponseHeader("Content-Length"),
@@ -199,30 +200,30 @@ couchTests.attachments_multipart= function(debug) {
     "Content-Disposition should be bar.txt section[2]");
 
   var doc = JSON.parse(sections[0].body);
-  
+
   T(doc._attachments['foo.txt'].follows == true);
   T(doc._attachments['bar.txt'].follows == true);
-  
+
   T(sections[1].body == "this is 21 chars long");
   TEquals("this is 18 chars l", sections[2].body, "should be 18 chars long");
-  
+
   // now get attachments incrementally (only the attachments changes since
   // a certain rev).
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart?atts_since=[\"" + firstrev + "\"]",
     {headers:{"accept": "multipart/related, */*"}});
-  
+
   T(xhr.status == 200);
 
   var sections = parseMultipart(xhr);
-  
+
   T(sections.length == 2);
-  
+
   var doc = JSON.parse(sections[0].body);
-  
+
   T(doc._attachments['foo.txt'].stub == true);
   T(doc._attachments['bar.txt'].follows == true);
-  
+
   TEquals("this is 18 chars l", sections[1].body, "should be 18 chars long 2");
 
   // try the atts_since parameter together with the open_revs parameter
@@ -259,39 +260,39 @@ couchTests.attachments_multipart= function(debug) {
   T(innerSections[2].body === "this is 18 chars l");
 
   // try it with a rev that doesn't exist (should get all attachments)
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart?atts_since=[\"1-2897589\"]",
     {headers:{"accept": "multipart/related,*/*;"}});
-  
+
   T(xhr.status == 200);
-  
+
   var sections = parseMultipart(xhr);
-  
+
   T(sections.length == 3);
-  
+
   var doc = JSON.parse(sections[0].body);
-  
+
   T(doc._attachments['foo.txt'].follows == true);
   T(doc._attachments['bar.txt'].follows == true);
-  
+
   T(sections[1].body == "this is 21 chars long");
   TEquals("this is 18 chars l", sections[2].body, "should be 18 chars long 3");
   // try it with a rev that doesn't exist, and one that does
-  
+
   xhr = CouchDB.request("GET", "/" + db_name + "/multipart?atts_since=[\"1-2897589\",\"" + firstrev + "\"]",
     {headers:{"accept": "multipart/related,*/*;"}});
-  
+
   T(xhr.status == 200);
-  
+
   var sections = parseMultipart(xhr);
-  
+
   T(sections.length == 2);
-  
+
   var doc = JSON.parse(sections[0].body);
-  
+
   T(doc._attachments['foo.txt'].stub == true);
   T(doc._attachments['bar.txt'].follows == true);
-  
+
   TEquals("this is 18 chars l", sections[1].body, "should be 18 chars long 4");
 
   // check that with the document multipart/mixed API it's possible to receive

--- a/test/javascript/tests/basics.js
+++ b/test/javascript/tests/basics.js
@@ -11,6 +11,7 @@
 // the License.
 
 // Do some basic tests.
+couchTests.elixir = true;
 couchTests.basics = function(debug) {
 
   if (debug) debugger;

--- a/test/javascript/tests/batch_save.js
+++ b/test/javascript/tests/batch_save.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.batch_save = function(debug) {
   var db_name = get_random_db_name()
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
@@ -19,19 +20,19 @@ couchTests.batch_save = function(debug) {
   var i
   for(i=0; i < 100; i++) {
     T(db.save({_id:i.toString(),a:i,b:i},  {batch : "ok"}).ok);
-    
+
     // test that response is 202 Accepted
     T(db.last_req.status == 202);
   }
-  
+
   for(i=0; i < 100; i++) {
     // attempt to save the same document a bunch of times
     T(db.save({_id:"foo",a:i,b:i},  {batch : "ok"}).ok);
-    
+
     // test that response is 202 Accepted
     T(db.last_req.status == 202);
   }
-  
+
   while(db.allDocs().total_rows != 101){};
 
   // repeat the tests for POST
@@ -42,7 +43,7 @@ couchTests.batch_save = function(debug) {
     });
     T(JSON.parse(resp.responseText).ok);
   }
-  
+
   while(db.allDocs().total_rows != 201){};
 
   // cleanup

--- a/test/javascript/tests/bulk_docs.js
+++ b/test/javascript/tests/bulk_docs.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.bulk_docs = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/coffee.js
+++ b/test/javascript/tests/coffee.js
@@ -11,6 +11,7 @@
 // the License.
 
 // test basic coffeescript functionality
+couchTests.elixir = true;
 couchTests.coffee = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/compact.js
+++ b/test/javascript/tests/compact.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.compact = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/config.js
+++ b/test/javascript/tests/config.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.config = function(debug) {
   if (debug) debugger;
 

--- a/test/javascript/tests/conflicts.js
+++ b/test/javascript/tests/conflicts.js
@@ -11,6 +11,7 @@
 // the License.
 
 // Do some edit conflict detection tests
+couchTests.elixir = true;
 couchTests.conflicts = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/copy_doc.js
+++ b/test/javascript/tests/copy_doc.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.copy_doc = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/etags_views.js
+++ b/test/javascript/tests/etags_views.js
@@ -10,8 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+// TODO: https://issues.apache.org/jira/browse/COUCHDB-2859
+couchTests.skip = true;
 couchTests.etags_views = function(debug) {
-  return console.log('TODO: see https://issues.apache.org/jira/browse/COUCHDB-2859');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"true"});
   db.createDb();
@@ -79,7 +80,7 @@ couchTests.etags_views = function(debug) {
   xhr = CouchDB.request("GET", "/" + db_name + "/_design/etags/_view/basicView?include_docs=true");
   var etag2 = xhr.getResponseHeader("etag");
   T(etag1 != etag2);
- 
+
   // Verify that purges affect etags
   xhr = CouchDB.request("GET", "/" + db_name + "/_design/etags/_view/fooView");
   var foo_etag = xhr.getResponseHeader("etag");
@@ -180,7 +181,7 @@ couchTests.etags_views = function(debug) {
   );
   etag2 = xhr.getResponseHeader("etag");
   T(etag1 != etag2, "POST to reduce view generates key-depdendent ETags");
-  
+
   // all docs
   xhr = CouchDB.request("GET", "/" + db_name + "/_all_docs");
   T(xhr.status == 200);
@@ -201,21 +202,21 @@ couchTests.etags_views = function(debug) {
 
   // list etag
   // in the list test for now
-  
-  // A new database should have unique _all_docs etags. 
-  db.deleteDb(); 
+
+  // A new database should have unique _all_docs etags.
+  db.deleteDb();
   db.createDb(); // TODO: when re-activating try having a new DB name
-  db.save({a: 1}); 
-  xhr = CouchDB.request("GET", "/" + db_name + "/_all_docs"); 
-  var etag = xhr.getResponseHeader("etag"); 
-  db.deleteDb(); 
+  db.save({a: 1});
+  xhr = CouchDB.request("GET", "/" + db_name + "/_all_docs");
+  var etag = xhr.getResponseHeader("etag");
+  db.deleteDb();
   db.createDb(); // TODO: when re-activating try having a new DB name
-  db.save({a: 2}); 
-  xhr = CouchDB.request("GET", "/" + db_name + "/_all_docs"); 
+  db.save({a: 2});
+  xhr = CouchDB.request("GET", "/" + db_name + "/_all_docs");
   var new_etag = xhr.getResponseHeader("etag");
   T(etag != new_etag);
   // but still be cacheable
-  xhr = CouchDB.request("GET", "/" + db_name + "/_all_docs"); 
+  xhr = CouchDB.request("GET", "/" + db_name + "/_all_docs");
   T(new_etag == xhr.getResponseHeader("etag"));
 
   // cleanup

--- a/test/javascript/tests/invalid_docids.js
+++ b/test/javascript/tests/invalid_docids.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.invalid_docids = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/large_docs.js
+++ b/test/javascript/tests/large_docs.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.large_docs = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/lots_of_docs.js
+++ b/test/javascript/tests/lots_of_docs.js
@@ -11,6 +11,7 @@
 // the License.
 
 // test saving a semi-large quanitity of documents and do some view queries.
+couchTests.elixir = true;
 couchTests.lots_of_docs = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/multiple_rows.js
+++ b/test/javascript/tests/multiple_rows.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.multiple_rows = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/reduce.js
+++ b/test/javascript/tests/reduce.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.reduce = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/replicator_db_compact_rep_db.js
+++ b/test/javascript/tests/replicator_db_compact_rep_db.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_compact_rep_db = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_continuous.js
+++ b/test/javascript/tests/replicator_db_continuous.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_continuous = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_credential_delegation.js
+++ b/test/javascript/tests/replicator_db_credential_delegation.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_credential_delegation = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_field_validation.js
+++ b/test/javascript/tests/replicator_db_field_validation.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_field_validation = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_filtered.js
+++ b/test/javascript/tests/replicator_db_filtered.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_filtered = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_identical.js
+++ b/test/javascript/tests/replicator_db_identical.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_identical = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_identical_continuous.js
+++ b/test/javascript/tests/replicator_db_identical_continuous.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_identical_continuous = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_invalid_filter.js
+++ b/test/javascript/tests/replicator_db_invalid_filter.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_invalid_filter = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_security.js
+++ b/test/javascript/tests/replicator_db_security.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_security = function(debug) {
-  return console.log('TODO');
-
   var reset_dbs = function(dbs) {
     dbs.forEach(function(db) {
       db.deleteDb();
@@ -166,7 +165,7 @@ couchTests.replicator_db_security = function(debug) {
         names : ["benoitc"]
       }
     }).ok);
-    
+
     run_on_modified_server([
         {
           section: "admins",

--- a/test/javascript/tests/replicator_db_simple.js
+++ b/test/javascript/tests/replicator_db_simple.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_simple = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_successive.js
+++ b/test/javascript/tests/replicator_db_successive.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_successive = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_survives.js
+++ b/test/javascript/tests/replicator_db_survives.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_survives = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_swap_rep_db.js
+++ b/test/javascript/tests/replicator_db_swap_rep_db.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_swap_rep_db = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_update_security.js
+++ b/test/javascript/tests/replicator_db_update_security.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_update_security = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_user_ctx.js
+++ b/test/javascript/tests/replicator_db_user_ctx.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_user_ctx = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/replicator_db_write_auth.js
+++ b/test/javascript/tests/replicator_db_write_auth.js
@@ -10,9 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.replicator_db_survives = function(debug) {
-  return console.log('TODO');
-
   if (debug) debugger;
 
   var populate_db = replicator_db.populate_db;

--- a/test/javascript/tests/stats.js
+++ b/test/javascript/tests/stats.js
@@ -10,10 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+// test has become very flaky - needs complete rewrite
+couchTests.skip = true;
 couchTests.stats = function(debug) {
-
-  // test has become very flaky - needs complete rewrite
-  return console.log('TODO');
 
   function newDb(doSetup) {
     var db_name = get_random_db_name();
@@ -65,14 +64,14 @@ couchTests.stats = function(debug) {
   (function() {
     var db = newDb(false);
     db.deleteDb();
-  
+
     var before = getStat(["couchdb", "open_databases"]);
     db.createDb();
     var after = getStat(["couchdb", "open_databases"]);
     TEquals(before+8, after, "Creating a db increments open db count.");
     db.deleteDb();
   })();
-  
+
   runTest(["couchdb", "open_databases"], {
     setup: function() {restartServer();},
     run: function(db) {db.open("123");},
@@ -80,7 +79,7 @@ couchTests.stats = function(debug) {
       T(before<after, "Opening a db increases open db count.");
     }
   });
-  
+
   runTest(["couchdb", "open_databases"], {
     setup: function(db) {restartServer(); db.open("123");},
     run: function(db) {db.deleteDb();},
@@ -88,16 +87,16 @@ couchTests.stats = function(debug) {
       T(before>after, "Deleting a db decrements open db count.");
     }
   });
-  
-  /* Improvements in LRU has made this test difficult... 
+
+  /* Improvements in LRU has made this test difficult...
   (function() {
     restartServer();
     var max = 5;
-    
+
     var testFun = function() {
       var pre_dbs = getStat(["couchdb", "open_databases"]) || 0;
       var pre_files = getStat(["couchdb", "open_os_files"]) || 0;
-     
+
       var triggered = false;
       var db = null;
       var dbs = [];
@@ -117,15 +116,15 @@ couchTests.stats = function(debug) {
         db.save({"a": "1"});
       }
       T(triggered, "We managed to force a all_dbs_active error.");
-      
+
       var open_dbs = getStat(["couchdb", "open_databases"]);
       TEquals(open_dbs > 0, true, "We actually opened some dbs.");
       TEquals(max, open_dbs, "We only have max db's open.");
-      
+
       for (var i = 0; i < dbs.length; i++) {
         dbs[i].deleteDb();
       }
-      
+
       var post_dbs = getStat(["couchdb", "open_databases"]);
       var post_files = getStat(["couchdb", "open_os_files"]);
       TEquals(pre_dbs, post_dbs, "We have the same number of open dbs.");
@@ -134,14 +133,14 @@ couchTests.stats = function(debug) {
         dbs[ctr].deleteDb();
       }
     };
-    
+
     run_on_modified_server(
       [{section: "couchdb", key: "max_dbs_open", value: "40"}],
       testFun
     );
   })();
   */
-  
+
   // Just fetching the before value is the extra +1 in test
   runTest(["couchdb", "httpd", "requests"], {
     run: function() {CouchDB.request("GET", "/");},
@@ -149,7 +148,7 @@ couchTests.stats = function(debug) {
       TEquals(before+2, after, "Request counts are incremented properly.");
     }
   });
-  
+
   runTest(["couchdb", "database_reads"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {db.open("test");},
@@ -157,7 +156,7 @@ couchTests.stats = function(debug) {
       T(before<after, "Reading a doc increments docs reads.");
     }
   });
-  
+
   runTest(["couchdb", "database_reads"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {db.request("GET", "/");},
@@ -165,7 +164,7 @@ couchTests.stats = function(debug) {
       TEquals(before, after, "Only doc reads increment doc reads.");
     }
   });
-  
+
   runTest(["couchdb", "database_reads"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {db.open("test", {"open_revs": "all"});},
@@ -173,14 +172,14 @@ couchTests.stats = function(debug) {
       T(before<after, "Reading doc revs increments docs reads.");
     }
   });
-  
+
   runTest(["couchdb", "database_writes"], {
     run: function(db) {db.save({"a": "1"});},
     test: function(before, after) {
       T(before<after, "Saving docs incrememnts doc writes.");
     }
   });
-  
+
   runTest(["couchdb", "database_writes"], {
     run: function(db) {
       CouchDB.request("POST", "/" + db.name + "", {
@@ -192,7 +191,7 @@ couchTests.stats = function(debug) {
       T(before<after, "POST'ing new docs increments doc writes.");
     }
   });
-  
+
   runTest(["couchdb", "database_writes"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {var doc = db.open("test"); db.save(doc);},
@@ -200,7 +199,7 @@ couchTests.stats = function(debug) {
       T(before<after, "Updating docs incrememnts doc writes.");
     }
   });
-  
+
   runTest(["couchdb", "database_writes"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {var doc = db.open("test"); db.deleteDoc(doc);},
@@ -208,7 +207,7 @@ couchTests.stats = function(debug) {
       T(before<after, "Deleting docs increments doc writes.");
     }
   });
-  
+
   runTest(["couchdb", "database_writes"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {
@@ -220,7 +219,7 @@ couchTests.stats = function(debug) {
       T(before<after, "Copying docs increments doc writes.");
     }
   });
-  
+
   runTest(["couchdb", "database_writes"], {
     run: function(db) {
       CouchDB.request("PUT", "/" + db.name + "/bin_doc2/foo2.txt", {
@@ -232,7 +231,7 @@ couchTests.stats = function(debug) {
       T(before<after, "Create with attachment increments doc writes.");
     }
   });
-  
+
   runTest(["couchdb", "database_writes"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {
@@ -246,21 +245,21 @@ couchTests.stats = function(debug) {
       T(before<after, "Adding attachment increments doc writes.");
     }
   });
-  
+
   runTest(["couchdb", "httpd", "bulk_requests"], {
     run: function(db) {db.bulkSave(makeDocs(5));},
     test: function(before, after) {
       TEquals(before+1, after, "The bulk_requests counter is incremented.");
     }
   });
-  
+
   runTest(["couchdb", "httpd", "view_reads"], {
     run: function(db) {doView(db);},
     test: function(before, after) {
       T(before<after, "Reading a view increments view reads.");
     }
   });
-  
+
   runTest(["couchdb", "httpd", "view_reads"], {
     setup: function(db) {db.save({"_id": "test"});},
     run: function(db) {db.open("test");},
@@ -268,35 +267,35 @@ couchTests.stats = function(debug) {
       TEquals(before, after, "Reading a doc doesn't increment view reads.");
     }
   });
-  
+
   // Relies on getting the stats values being GET requests.
   runTest(["couchdb", "httpd_request_methods", "GET"], {
     test: function(before, after) {
       TEquals(before+1, after, "Get requests are incremented properly.");
     }
   });
-  
+
   runTest(["couchdb", "httpd_request_methods", "GET"], {
     run: function() {CouchDB.request("POST", "/");},
     test: function(before, after) {
       TEquals(before+1, after, "POST requests don't affect GET counter.");
     }
   });
-  
+
   runTest(["couchdb", "httpd_request_methods", "POST"], {
     run: function() {CouchDB.request("POST", "/");},
     test: function(before, after) {
       TEquals(before+1, after, "POST requests are incremented properly.");
     }
   });
-  
+
   runTest(["couchdb", "httpd_status_codes", "404"], {
     run: function() {CouchDB.request("GET", "/nonexistant_db");},
     test: function(before, after) {
       TEquals(before+1, after, "Increments 404 counter on db not found.");
     }
   });
-  
+
   runTest(["couchdb", "httpd_status_codes", "404"], {
     run: function() {CouchDB.request("GET", "/");},
     test: function(before, after) {

--- a/test/javascript/tests/uuids.js
+++ b/test/javascript/tests/uuids.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.uuids = function(debug) {
   var etags = [];
   var testHashBustingHeaders = function(xhr) {
@@ -19,7 +20,7 @@ couchTests.uuids = function(debug) {
     var newetag = xhr.getResponseHeader("ETag");
     T(etags.indexOf(newetag) < 0);
     etags[etags.length] = newetag;
-    
+
     // Removing the time based tests as they break easily when
     // running CouchDB on a remote server in regards to the browser
     // running the Futon test suite.

--- a/test/javascript/tests/view_collation.js
+++ b/test/javascript/tests/view_collation.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.view_collation = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
@@ -103,12 +104,12 @@ couchTests.view_collation = function(debug) {
   var rows = db.query(queryFun, null, {endkey : "b",
     descending:true, inclusive_end:false}).rows;
   T(rows[rows.length-1].key == "B");
-  
+
   var rows = db.query(queryFun, null, {
     endkey : "b", endkey_docid: "10",
     inclusive_end:false}).rows;
   T(rows[rows.length-1].key == "aa");
-  
+
   var rows = db.query(queryFun, null, {
     endkey : "b", endkey_docid: "11",
     inclusive_end:false}).rows;


### PR DESCRIPTION
## Overview

This is some work to speed up the test suites to try and reduce our build times. The work on the JavaScript tests is to avoid a hardcoded 1.2s delay between tests for the various config changes to settles.

For most of the eunit tests all of these changes are to move the `meck:new/1` calls into a setup function and *out* of the `foreach` setup fixture. It turns out that creating and unloading meck modules is somewhat expensive. This ends up saving about a total of 2m out of the total 10m it takes to run before this PR (eunit alone to be clear).

All in all this shaves about 3-4m off the full `make check` run on my laptop.

I've left all of the EUnit test changes as separate commits in case any of these turn out to be flaky when run in CI. This way we can revert individual test changes more easily if need be.

## Testing recommendations

`make check`

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
