### PR TITLE
Fix double "make clean" again

### DIFF
--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -63,7 +63,9 @@ SMVsn = case lists:keyfind(spidermonkey_version, 1, CouchConfig) of
         "1.8.5";
     {_, Unsupported} ->
         io:format(standard_error, "Unsupported SpiderMonkey version: ~s~n", [Unsupported]),
-        erlang:halt(1)
+        erlang:halt(1);
+    false ->
+        "1.8.5"
 end.
 
 ConfigH = [


### PR DESCRIPTION
This is a recurrence of #1450 caused by ec416c3
(SpiderMonkey 60 PR), where a case clause in
rebar.config.script lacks a match when configure
has not yet been run yet. Not being able to run 
make clean|distclean on a new checkout breaks
package building under Debian.

/cc @jiangphcn 