### PR TITLE
Allow special document member _access

### DIFF
--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -300,6 +300,11 @@ transfer_fields([{<<"_conflicts">>, _} | Rest], Doc, DbName) ->
 transfer_fields([{<<"_deleted_conflicts">>, _} | Rest], Doc, DbName) ->
     transfer_fields(Rest, Doc, DbName);
 
+% special field for per doc access control, for future compatibility
+transfer_fields([{<<"_access">>, _} = Field | Rest],
+    #doc{body=Fields} = Doc, DbName) ->
+    transfer_fields(Rest, Doc#doc{body=[Field|Fields]}, DbName);
+
 % special fields for replication documents
 transfer_fields([{<<"_replication_state">>, _} = Field | Rest],
     #doc{body=Fields} = Doc, DbName) ->

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -226,6 +226,9 @@ init([]) ->
     % Mark partitioned databases as a supported feature
     config:enable_feature(partitioned),
 
+    % Mark being able to receive documents with an _access property as a supported feature
+    config:enable_feature('access-ready'),
+
     % read config and register for configuration changes
 
     % just stop if one of the config settings change. couch_server_sup

--- a/src/couch/test/eunit/couch_db_doc_tests.erl
+++ b/src/couch/test/eunit/couch_db_doc_tests.erl
@@ -43,7 +43,8 @@ couch_db_doc_test_() ->
                 fun setup/0, fun teardown/1,
                 [
                     fun should_truncate_number_of_revisions/1,
-                    fun should_raise_bad_request_on_invalid_rev/1
+                    fun should_raise_bad_request_on_invalid_rev/1,
+                    fun should_allow_access_in_doc_keys_test/1
                 ]
             }
         }
@@ -77,6 +78,15 @@ should_raise_bad_request_on_invalid_rev(DbName) ->
         ?_assertThrow(Expect, add_revisions(Db, DocId, InvalidRev3, 1))}
     ].
 
+should_allow_access_in_doc_keys_test(_DbName) ->
+    Json = <<"{\"_id\":\"foo\",\"_access\":[\"test\"]}">>,
+    EJson = couch_util:json_decode(Json),
+    Expected = {[{<<"_id">>,<<"foo">>}, {<<"_access">>, [<<"test">>]}]},
+    EJson = Expected,
+    Doc = couch_doc:from_json_obj(EJson),
+    NewEJson = couch_doc:to_json_obj(Doc),
+    NewEJson = Expected,
+    ok.
 
 open_db(DbName) ->
     {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),

--- a/src/couch/test/eunit/couch_db_doc_tests.erl
+++ b/src/couch/test/eunit/couch_db_doc_tests.erl
@@ -84,9 +84,8 @@ should_allow_access_in_doc_keys_test(_DbName) ->
     Expected = {[{<<"_id">>,<<"foo">>}, {<<"_access">>, [<<"test">>]}]},
     EJson = Expected,
     Doc = couch_doc:from_json_obj(EJson),
-    NewEJson = couch_doc:to_json_obj(Doc),
-    NewEJson = Expected,
-    ok.
+    NewEJson = couch_doc:to_json_obj(Doc, []),
+    ?_assertEqual(NewEJson, Expected).
 
 open_db(DbName) ->
     {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),


### PR DESCRIPTION
This is in preparation for [per-document access control](https://github.com/apache/couchdb/issues/assigned/janl) which is
going to use this field. We are adding this in 3.0 because per-
document access control will not be ready for 3.0, but added in
3.1 or later.

This commit allows a future version of CouchDB with per-document
access control to replicate with CouchDB 3.0, to make upgrades and
interoperability easy.

The per-documnet access control code is not going to store the
_access property in the document body like this patch does, but
is going to store it in an extra field inside of #doc and
assert access control for a document without having to load the
entire document body.