### PR TITLE
feat: add metric counter for unindexed mango queries. Closes #1913

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -298,3 +298,7 @@
     {type, counter},
     {desc, <<"number of the attempts to read beyond set limit">>}
 ]}.
+{[mango, unindexed_queries], [
+    {type, counter},
+    {desc, <<"number of mango queries that could not use an index">>}
+]}.

--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -182,6 +182,7 @@ maybe_add_warning_int(ok, _, UserAcc) ->
    UserAcc;
 
 maybe_add_warning_int(Warning, UserFun, UserAcc) ->
+    couch_stats:increment_counter([mango, unindexed_queries]),
     Arg = {add_key, warning, Warning},
     {_Go, UserAcc0} = UserFun(Arg, UserAcc),
     UserAcc0.


### PR DESCRIPTION
see https://github.com/apache/couchdb/issues/1913