### PR TITLE
Fix JS tests on SpiderMonkey 60

### DIFF
--- a/share/server/state.js
+++ b/share/server/state.js
@@ -16,6 +16,7 @@ var State = {
     State.funs = [];
     State.lib = null;
     State.query_config = config || {};
+    Views.reset();
     gc();
     print("true"); // indicates success
   },

--- a/share/server/views.js
+++ b/share/server/views.js
@@ -56,6 +56,7 @@ var Views = (function() {
   };
 
   function handleViewError(err, doc) {
+    map_results = [];
     if (err == "fatal_error") {
       // Only if it's a "fatal_error" do we exit. What's a fatal error?
       // That's for the query to decide.
@@ -82,6 +83,9 @@ var Views = (function() {
 
   return {
     // view helper functions
+    reset : function() {
+        map_results = [];
+    },
     emit : function(key, value) {
       map_results.push([key, value]);
     },

--- a/src/couch/test/eunit/couch_js_tests.erl
+++ b/src/couch/test/eunit/couch_js_tests.erl
@@ -1,0 +1,47 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_js_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+
+-define(FUNC, <<
+  "function(doc) {\n"
+  "  var val = \"0123456789ABCDEF\";\n"
+  "  while(true) {emit(val, val);}\n"
+  "}\n"
+>>).
+
+
+couch_js_test_() ->
+    {
+        "Test couchjs",
+        {
+            setup,
+            fun test_util:start_couch/0,
+            fun test_util:stop_couch/1,
+            [
+                fun should_recover_from_oom/0
+            ]
+        }
+    }.
+
+
+should_recover_from_oom() ->
+    Proc = couch_query_servers:get_os_process(<<"javascript">>),
+    R1 = couch_query_servers:proc_prompt(Proc, [<<"add_fun">>, ?FUNC]),
+    R2 = couch_query_servers:proc_prompt(Proc, [<<"map_doc">>, <<"{}">>]),
+    R3 = couch_query_servers:proc_prompt(Proc, [<<"add_fun">>, ?FUNC]),
+
+    ?assertEqual(true, R1),
+    ?assertEqual([[]], R2),
+    ?assertEqual(true, R3).

--- a/test/javascript/tests/auth_cache.js
+++ b/test/javascript/tests/auth_cache.js
@@ -10,8 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.auth_cache = function(debug) {
-  return console.log('done in test/elixir/test/auth_cache_test.exs');
   if (debug) debugger;
 
   // Simple secret key generator

--- a/test/javascript/tests/cookie_auth.js
+++ b/test/javascript/tests/cookie_auth.js
@@ -10,9 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.cookie_auth = function(debug) {
   // This tests cookie-based authentication.
-  return console.log('done in test/elixir/test/cookie_auth_test.exs');
 
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/users_db.js
+++ b/test/javascript/tests/users_db.js
@@ -10,8 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.users_db = function(debug) {
-  return console.log('done in test/elixir/test/users_db_test.exs');
 
   // This tests the users db, especially validations
   // this should also test that you can log into the couch

--- a/test/javascript/tests/utf8.js
+++ b/test/javascript/tests/utf8.js
@@ -10,8 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.utf8 = function(debug) {
-  return console.log('done in test/elixir/test/utf8_test.exs');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
   db.createDb();

--- a/test/javascript/tests/view_errors.js
+++ b/test/javascript/tests/view_errors.js
@@ -145,7 +145,7 @@ couchTests.view_errors = function(debug) {
         _id:"_design/infinite",
         language: "javascript",
         views: {
-          "infinite_loop" :{map:"function(doc) {while(true){emit(doc,doc);}};"}
+          "infinite_loop" :{map:"function(doc) {while(true){};}"}
         }
       };
       T(db.save(designDoc3).ok);
@@ -154,7 +154,7 @@ couchTests.view_errors = function(debug) {
           db.view("infinite/infinite_loop");
           T(0 == 1);
       } catch(e) {
-          T(e.error == "os_process_error" || e.error == "unnamed_error");
+          T(e.error == "os_process_error");
       }
 
       // Check error responses for invalid multi-get bodies.


### PR DESCRIPTION
It turns out the infinite loop can now run fast enough that we exhaust
the stack space in a given couchjs process. This ends up leaving a
couchjs process that can't be used for other things as the `map_results`
buffer doesn't get reset inbetween calls.

## Testing recommendations

`./configure --dev --spidermonkey-version 60 && make && make javascript` 

On Debian Buster this fails occasionally.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
