### PR TITLE
Mango metrics

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -317,6 +317,10 @@ os_process_limit = 100
 ;index_all_disabled = false
 ; Default limit value for mango _find queries.
 ;default_limit = 25
+; Ratio between documents scanned and results matched that will
+; generate a warning in the _find response. Setting this to 0 disables
+; the warning.
+;index_scan_warning_threshold = 10
 
 [indexers]
 couch_mrview = true

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -302,3 +302,7 @@
     {type, counter},
     {desc, <<"number of mango queries that could not use an index">>}
 ]}.
+{[mango, query_invalid_index], [
+    {type, counter},
+    {desc, <<"number of mango queries that generated an invalid index warning">>}
+]}.

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -306,3 +306,7 @@
     {type, counter},
     {desc, <<"number of mango queries that generated an invalid index warning">>}
 ]}.
+{[mango, too_many_docs_scanned], [
+    {type, counter},
+    {desc, <<"number of mango queries that generated an index scan warning">>}
+]}.

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -310,3 +310,23 @@
     {type, counter},
     {desc, <<"number of mango queries that generated an index scan warning">>}
 ]}.
+{[mango, docs_examined], [
+    {type, counter},
+    {desc, <<"number of documents examined by mango queries coordinated by this node">>}
+]}.
+{[mango, quorum_docs_examined], [
+    {type, counter},
+    {desc, <<"number of documents examined by mango queries, using cluster quorum">>}
+]}.
+{[mango, results_returned], [
+    {type, counter},
+    {desc, <<"number of rows returned by mango queries">>}
+]}.
+{[mango, query_time], [
+    {type, histogram},
+    {desc, <<"length of time processing a mango query">>}
+]}.
+{[mango, evaluate_selector], [
+    {type, counter},
+    {desc, <<"number of mango selector evaluations">>}
+]}.

--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -166,6 +166,7 @@ invalid_index_warning(Index, Opts) ->
 invalid_index_warning_int(Index, {use_index, [DesignId]}) ->
     case filter_indexes([Index], DesignId) of
         [] ->
+            couch_stats:increment_counter([mango, query_invalid_index]),
             Reason = fmt("_design/~s was not used because it does not contain a valid index for this query.",
                 [ddoc_name(DesignId)]),
             [Reason];
@@ -175,6 +176,7 @@ invalid_index_warning_int(Index, {use_index, [DesignId]}) ->
 invalid_index_warning_int(Index, {use_index, [DesignId, ViewName]}) ->
     case filter_indexes([Index], DesignId, ViewName) of
         [] ->
+            couch_stats:increment_counter([mango, query_invalid_index]),
             Reason = fmt("_design/~s, ~s was not used because it is not a valid index for this query.",
                 [ddoc_name(DesignId), ViewName]),
             [Reason];

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -184,6 +184,7 @@ handle_hit(CAcc0, Sort, Doc) ->
     } = CAcc0,
     CAcc1 = update_bookmark(CAcc0, Sort),
     Stats1 = mango_execution_stats:incr_docs_examined(Stats),
+    couch_stats:increment_counter([mango, docs_examined]),
     CAcc2 = CAcc1#cacc{execution_stats = Stats1},
     case mango_selector:match(CAcc2#cacc.selector, Doc) of
         true when Skip > 0 ->

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -132,7 +132,7 @@ execute(Cursor, UserFun, UserAcc) ->
             Arg = {add_key, bookmark, JsonBM},
             {_Go, FinalUserAcc} = UserFun(Arg, LastUserAcc),
             FinalUserAcc0 = mango_execution_stats:maybe_add_stats(Opts, UserFun, Stats0, FinalUserAcc),
-            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, FinalUserAcc0),
+            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, Stats0, FinalUserAcc0),
             {ok, FinalUserAcc1}
     end.
 

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -155,7 +155,7 @@ execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFu
                     {_Go, FinalUserAcc} = UserFun(Arg, LastCursor#cursor.user_acc),
                     Stats0 = LastCursor#cursor.execution_stats,
                     FinalUserAcc0 = mango_execution_stats:maybe_add_stats(Opts, UserFun, Stats0, FinalUserAcc),
-                    FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, FinalUserAcc0),
+                    FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, Stats0, FinalUserAcc0),
                     {ok, FinalUserAcc1};
                 {error, Reason} ->
                     {error, Reason}

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -249,6 +249,7 @@ view_cb({row, Row}, #mrargs{extra = Options} = Acc) ->
         Doc ->
             put(mango_docs_examined, get(mango_docs_examined) + 1),
             Selector = couch_util:get_value(selector, Options),
+            couch_stats:increment_counter([mango, docs_examined]),
             case mango_selector:match(Selector, Doc) of
                 true ->
                     ok = rexi:stream2(ViewRow),
@@ -433,6 +434,7 @@ doc_member(Cursor, RowProps) ->
             % an undefined doc was returned, indicating we should
             % perform a quorum fetch
             ExecutionStats1 = mango_execution_stats:incr_quorum_docs_examined(ExecutionStats),
+            couch_stats:increment_counter([mango, quorum_docs_examined]),
             Id = couch_util:get_value(id, RowProps),
             case mango_util:defer(fabric, open_doc, [Db, Id, Opts]) of
                 {ok, #doc{}=DocProps} ->

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -84,7 +84,7 @@ class IndexSelectionTests:
         ddocid = "_design/age"
         r = self.db.find({}, use_index=ddocid, return_raw=True)
         self.assertEqual(
-            r["warning"],
+            r["warning"][0].lower(),
             "{0} was not used because it does not contain a valid index for this query.".format(
                 ddocid
             ),
@@ -107,7 +107,7 @@ class IndexSelectionTests:
         selector = {"company": "Pharmex"}
         r = self.db.find(selector, use_index=ddocid, return_raw=True)
         self.assertEqual(
-            r["warning"],
+            r["warning"][0].lower(),
             "{0} was not used because it does not contain a valid index for this query.".format(
                 ddocid
             ),
@@ -124,7 +124,7 @@ class IndexSelectionTests:
 
         resp = self.db.find(selector, use_index=[ddocid, name], return_raw=True)
         self.assertEqual(
-            resp["warning"],
+            resp["warning"][0].lower(),
             "{0}, {1} was not used because it is not a valid index for this query.".format(
                 ddocid, name
             ),
@@ -162,7 +162,7 @@ class IndexSelectionTests:
             selector, sort=["foo", "bar"], use_index=ddocid_invalid, return_raw=True
         )
         self.assertEqual(
-            resp["warning"],
+            resp["warning"][0].lower(),
             "{0} was not used because it does not contain a valid index for this query.".format(
                 ddocid_invalid
             ),

--- a/src/mango/test/12-use-correct-index-test.py
+++ b/src/mango/test/12-use-correct-index-test.py
@@ -93,8 +93,8 @@ class ChooseCorrectIndexForDocs(mango.DbPerClass):
         self.assertEqual(explain_resp["index"]["type"], "special")
         resp = self.db.find(selector, return_raw=True)
         self.assertEqual(
-            resp["warning"],
-            "no matching index found, create an index to optimize query time",
+            resp["warning"][0].lower(),
+            "no matching index found, create an index to optimize query time.",
         )
 
     def test_chooses_idxA(self):


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Improve instrumentation of Mango with the following metrics:

 * `mango.query_invalid_index`: number of mango queries that generated an invalid index warning
 * `mango, docs_examined`: number of documents examined by mango queries (the same value returned by execution_stats for individual queries). This is counted on the shard level (i.e. where the work occurs) rather than at the query coordinator.
 * `mango.quorum_docs_examined`: number of documents examined by mango queries, using cluster quorum. These are always evaluated by the query coordinator.
 * `mango.results_returned`: number of rows returned by mango queries
 * `mango.query_time`: histogram of the length of time processing mango queries
 * `mango.too_many_docs_scanned`: number of mango queries that generated an index scan warning
 * `mango.evaluate_selector`: number of calls to `mango_selector:match`

## Testing recommendations

Make some Mango queries and call `_node/_local/_stats/mango` to view the metrics. Note that there is a bug in execution stats which means documents read are only counted when documents are matched (see #2412, which should ideally land before this).

## Related Issues or Pull Requests

 * Prior art: https://github.com/apache/couchdb/issues/1913
 * Documentation PR: https://github.com/apache/couchdb-documentation/pull/469
 * Fauxton PR: https://github.com/apache/couchdb-fauxton/pull/1245

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
