### PR TITLE
Set the session correctly

### DIFF
--- a/test/elixir/test/cookie_auth_test.exs
+++ b/test/elixir/test/cookie_auth_test.exs
@@ -95,12 +95,9 @@ defmodule CookieAuthTest do
     session = use_session || login_as(user)
 
     resp =
-      Couch.get(
-        "/#{db_name}/#{URI.encode(doc_id)}",
-        headers: [
-          Cookie: session.cookie,
-          "X-CouchDB-www-Authenticate": "Cookie"
-        ]
+      Couch.Session.get(
+        session,
+        "/#{db_name}/#{URI.encode(doc_id)}"
       )
 
     if use_session == nil do
@@ -125,12 +122,9 @@ defmodule CookieAuthTest do
     session = use_session || login_as(user)
 
     resp =
-      Couch.put(
+      Couch.Session.put(
+        session,
         "/#{db_name}/#{URI.encode(doc["_id"])}",
-        headers: [
-          Cookie: session.cookie,
-          "X-CouchDB-www-Authenticate": "Cookie"
-        ],
         body: doc
       )
 
@@ -160,12 +154,9 @@ defmodule CookieAuthTest do
     session = use_session || login_as(user)
 
     resp =
-      Couch.delete(
-        "/#{db_name}/#{URI.encode(doc["_id"])}",
-        headers: [
-          Cookie: session.cookie,
-          "X-CouchDB-www-Authenticate": "Cookie"
-        ]
+      Couch.Session.delete(
+        session,
+        "/#{db_name}/#{URI.encode(doc["_id"])}"
       )
 
     if use_session == nil do


### PR DESCRIPTION
Adam K noticed that we aren't setting the session cookie correctly which
appears to have made this test fail randomly. Why its random and not
consistent is currently unknown.

## Testing recommendations

Run on Jenkins

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
