### PR TITLE
Address flaky test failure on t_invalid_view/1

### DIFF
--- a/src/smoosh/src/smoosh_server.erl
+++ b/src/smoosh/src/smoosh_server.erl
@@ -447,13 +447,16 @@ needs_upgrade(Props) ->
 
 
 setup_all() ->
+    Ctx = test_util:start_couch([couch_log]),
     meck:new([config, couch_index, couch_index_server], [passthrough]),
     Pid = list_to_pid("<0.0.0>"),
     meck:expect(couch_index_server, get_index, 3, {ok, Pid}),
-    meck:expect(config, get, fun(_, _, Default) -> Default end).
+    meck:expect(config, get, fun(_, _, Default) -> Default end),
+    Ctx.
 
-teardown_all(_) ->
-    meck:unload().
+teardown_all(Ctx) ->
+    meck:unload(),
+    test_util:stop_couch(Ctx).
 
 setup() ->
     Shard = <<"shards/00000000-1fffffff/test.1529510412">>,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Start couch_log to make sure that couch_log_server process exists and is able to write log instead of getting noproc error during test.

```
  smoosh_server:585: t_invalid_view...*failed*
in function gen_server:call/2 (gen_server.erl, line 206)
in call from couch_log:log/3 (src/couch_log.erl, line 73)
in call from smoosh_server:get_priority/2 (src/smoosh_server.erl, line 329)
in call from smoosh_server:'-t_invalid_view/1-fun-0-'/2 (src/smoosh_server.erl, line 587)
in call from smoosh_server:'-t_invalid_view/1-fun-3-'/2 (src/smoosh_server.erl, line 587)
**exit:{noproc,{gen_server,call,
                    [couch_log_server,
                     {log,{log_entry,warning,<0.32767.3>,
                                     [70,97,105,108,101,100|...],
                                     "--------",
                                     ["2020",45,[[...]|...],45|...]}}]}}
  output:<<"">>
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make check apps=smoosh
  smoosh_server:520: t_ratio_view...[0.007 s] ok
  smoosh_server:530: t_slack_view...[0.007 s] ok
  smoosh_server:540: t_no_data_view...[0.007 s] ok
  smoosh_server:550: t_below_min_priority_view...[0.007 s] ok
  smoosh_server:560: t_below_min_size_view...[0.007 s] ok
  smoosh_server:570: t_timeout_view...[0.008 s] ok
  smoosh_server:580: t_missing_view...[0.007 s] ok
  smoosh_server:588: t_invalid_view...[0.007 s] ok
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
