### PR TITLE
Reset a view shard if the signature is wrong

### DIFF
--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -127,6 +127,12 @@ open(Db, State0) ->
                     NewSt = couch_mrview_util:init_state(Db, Fd, State, Header),
                     ensure_local_purge_doc(Db, NewSt),
                     {ok, NewSt};
+                {ok, {WrongSig, _}} ->
+                    couch_log:error("~s has the wrong signature: expected: ~p but got ~p",
+                        [IndexFName, Sig, WrongSig]),
+                    NewSt = couch_mrview_util:reset_index(Db, Fd, State),
+                    ensure_local_purge_doc(Db, NewSt),
+                    {ok, NewSt};
                 no_valid_header ->
                     NewSt = couch_mrview_util:reset_index(Db, Fd, State),
                     ensure_local_purge_doc(Db, NewSt),

--- a/src/mem3/src/mem3_sync_event_listener.erl
+++ b/src/mem3/src/mem3_sync_event_listener.erl
@@ -297,7 +297,7 @@ should_terminate(Pid) ->
         Ref = erlang:monitor(process, Pid),
 
         RestartFun = fun() -> exit(EventMgr, kill) end,
-        test_util:with_process_restart(config_event, RestartFun),
+        {_, _} = test_util:with_process_restart(config_event, RestartFun),
 
         ?assertNot(is_process_alive(EventMgr)),
 


### PR DESCRIPTION
We encountered a case_clause error when reading the header for a .view
file as the response was {ok, {Sig, nil}} where Sig is neither the
expected sig or the pre-upgrade sig (though surely the pre-1.2 goop is
not firing anymore).

We now log this specific issue and then proceed as if we found no
valid header.
