### PR TITLE
Eliminate multiple compiler warnings

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -994,7 +994,7 @@ upgrade_purge_info(Fd, Header) ->
                 _ ->
                     {ok, PurgedIdsRevs} = couch_file:pread_term(Fd, Ptr),
 
-                    {Infos, NewSeq} = lists:foldl(fun({Id, Revs}, {InfoAcc, PSeq}) ->
+                    {Infos, _} = lists:foldl(fun({Id, Revs}, {InfoAcc, PSeq}) ->
                         Info = {PSeq, couch_uuids:random(), Id, Revs},
                         {[Info | InfoAcc], PSeq + 1}
                     end, {[], PurgeSeq}, PurgedIdsRevs),

--- a/src/dreyfus/src/dreyfus_httpd.erl
+++ b/src/dreyfus/src/dreyfus_httpd.erl
@@ -73,8 +73,6 @@ handle_search_req(#httpd{method=Method, path_parts=[_, _, _, _, IndexName]}=Req
             end;
         _ ->
             % ensure limit in group query >0
-            LimitValue = parse_positive_int_param("limit", QueryArgs#index_query_args.limit,
-                                                  "max_limit", "200"),
             UseNewApi = Grouping#grouping.new_api,
             case dreyfus_fabric_group1:go(DbName, DDoc, IndexName, QueryArgs) of
                 {ok, []} ->

--- a/src/dreyfus/src/dreyfus_index_updater.erl
+++ b/src/dreyfus/src/dreyfus_index_updater.erl
@@ -59,7 +59,7 @@ update(IndexPid, Index) ->
             true = proc_prompt(Proc, [<<"add_fun">>, Index#index.def]),
             EnumFun = fun ?MODULE:load_docs/2,
             [Changes] = couch_task_status:get([changes_done]),
-            Acc0 = {Changes, IndexPid, Db, Proc, TotalChanges, now(), ExcludeIdRevs},
+            Acc0 = {Changes, IndexPid, Db, Proc, TotalChanges, erlang:timestamp(), ExcludeIdRevs},
             {ok, _} = couch_db:fold_changes(Db, CurSeq, EnumFun, Acc0, []),
             ok = clouseau_rpc:commit(IndexPid, NewCurSeq)
         after
@@ -80,7 +80,7 @@ load_docs(FDI, {I, IndexPid, Db, Proc, Total, LastCommitTime, ExcludeIdRevs}=Acc
         false -> update_or_delete_index(IndexPid, Db, DI, Proc)
     end,
     %% Force a commit every minute
-    case timer:now_diff(Now = now(), LastCommitTime) >= 60000000 of
+    case timer:now_diff(Now = erlang:timestamp(), LastCommitTime) >= 60000000 of
         true ->
             ok = clouseau_rpc:commit(IndexPid, Seq),
             {ok, {I+1, IndexPid, Db, Proc, Total, Now, ExcludeIdRevs}};

--- a/src/dreyfus/src/dreyfus_util.erl
+++ b/src/dreyfus/src/dreyfus_util.erl
@@ -342,7 +342,7 @@ get_signature_from_idxdir(IdxDir) ->
         false -> undefined
     end.
 
-get_local_purge_doc_body(Db, LocalDocId, PurgeSeq, Index) ->
+get_local_purge_doc_body(_, LocalDocId, PurgeSeq, Index) ->
     #index{
         name = IdxName,
         ddoc_id = DDocId,

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -749,7 +749,6 @@ targets_map(#shard{name = <<"shards/", _/binary>> = SrcName} = Src,
     Shards0 = mem3:shards(mem3:dbname(SrcName)),
     Shards1 = [S || S <- Shards0, not shard_eq(S, Src)],
     Shards2 = [S || S <- Shards1, check_overlap(SrcRange, TgtNode, S)],
-    TMap = maps:from_list([{R, S} || #shard{range = R} = S <- Shards2]),
     case [{R, S} || #shard{range = R} = S <- Shards2] of
         [] ->
             % If target map is empty, create a target map with just


### PR DESCRIPTION
We now only support OTP 20+, with 19 at a stretch. erlang:now/0
was deprecated in OTP 18, so we can now suppress these warnings:

```
/home/joant/couchdb/src/dreyfus/src/dreyfus_index_updater.erl:62: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
/home/joant/couchdb/src/dreyfus/src/dreyfus_index_updater.erl:83: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
```

Also, some unused variables were removed:

```
/home/joant/couchdb/src/couch/src/couch_bt_engine.erl:997: Warning: variable 'NewSeq' is unused
/home/joant/couchdb/src/mem3/src/mem3_rep.erl:752: Warning: variable 'TMap' is unused
/home/joant/couchdb/src/dreyfus/src/dreyfus_httpd.erl:76: Warning: variable 'LimitValue' is unused
/home/joant/couchdb/src/dreyfus/src/dreyfus_util.erl:345: Warning: variable 'Db' is unused
```

PRs to follow in ets_lru, hyper, ibrowse to track the rest of `erlang:now/0`
deprecations.

If someone else wants to tackle these, we sure could use it:

```
/home/joant/couchdb/src/meck/src/meck_code_gen.erl:198: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/triq/src/triq.erl:181: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/chttpd/src/chttpd.erl:279: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/chttpd/src/chttpd.erl:354: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/chttpd/src/chttpd_stats.erl:54: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/couch/src/couch_httpd.erl:366: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/couch/src/couch_httpd.erl:371: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/couch/src/couch_httpd.erl:376: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/couch/src/couch_httpd.erl:381: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/couch/src/couch_proc_manager.erl:312: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/couch_replicator/src/couch_replicator_scheduler_job.erl:319: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/ddoc_cache/src/ddoc_cache_entry.erl:301: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/fabric/src/fabric_view_all_docs.erl:300: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/fabric/src/fabric_rpc.erl:600: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/mango/src/mango_util.erl:142: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/mango/src/mango_util.erl:146: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/mango/src/mango_util.erl:150: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/mango/src/mango_httpd.erl:43: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/rexi/src/rexi_server.erl:165: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
/home/joant/couchdb/src/smoosh/src/smoosh_server.erl:251: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
```