### PR TITLE
Disable JIT compiler on SpiderMonkey 60

### DIFF
--- a/src/couch/priv/couch_js/60/main.cpp
+++ b/src/couch/priv/couch_js/60/main.cpp
@@ -416,6 +416,9 @@ main(int argc, const char* argv[])
     if(cx == NULL)
         return 1;
 
+    JS_SetGlobalJitCompilerOption(cx, JSJITCOMPILER_BASELINE_ENABLE, 0);
+    JS_SetGlobalJitCompilerOption(cx, JSJITCOMPILER_ION_ENABLE, 0);
+
     if (!JS::InitSelfHostedCode(cx))
         return 1;
 


### PR DESCRIPTION
We've had a number of segfaults in the `make javascript` test suite. The
few times we've been able to get core dumps all appear to indicate
something wrong in the JIT compiler. Disabling the JIT compilers appears
to prevent these segfaults.
