### PR TITLE
Adjust way to detect presence of hastings for Ken

### DIFF
--- a/src/ken/rebar.config.script
+++ b/src/ken/rebar.config.script
@@ -11,7 +11,9 @@
 % the License.
 
 HaveDreyfus = element(1, file:list_dir("../dreyfus")) == ok.
-HaveHastings = element(1, file:list_dir("../hastings")) == ok.
+
+HastingsHome = os:getenv("HASTINGS_HOME", "../hastings").
+HaveHastings = element(1, file:list_dir(HastingsHome)) == ok.
 
 CurrOpts = case lists:keyfind(erl_opts, 1, CONFIG) of
     {erl_opts, Opts} -> Opts;


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
After moving ken from https://github.com/apache/couchdb-ken to https://github.com/apache/couchdb/tree/master/src/ken. The directory structure related to ken is changed for downstream including Cloudant. Increase more way to detect presence of hastings for Ken so that Ken can work correctly for geospatial index.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check apps=hastings
```
======================== EUnit ========================
module 'hastings_bookmark'
module 'hastings_format_legacy_local'
module 'hastings_index_updater'
module 'hastings_purge_docs_test'
  Hastings Purge Tests
    hastings_purge_docs_test:69: test_purge_single...[0.494 s] ok
    hastings_purge_docs_test:84: test_purge_multiple...[1.115 s] ok
    hastings_purge_docs_test:103: test_purge_multiple2...[0.637 s] ok
    hastings_purge_docs_test:129: test_purge_local_purge_doc...[0.597 s] ok
    hastings_purge_docs_test:210: test_purge_verify_index...[0.454 s] ok
    hastings_purge_docs_test:240: test_purge_remove_local_purge_doc...[0.407 s] ok
    hastings_purge_docs_test:280: test_purge_hook_before_compaction...[0.837 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 5.866 s]
  [done in 8.896 s]
module 'hastings_format_view'
module 'hastings_index'
module 'hastings_util'
module 'hastings_fabric'
module 'hastings_httpd_handlers'
module 'hastings_rpc'
hastings_index_test: design_doc_to_index_int_test (module 'hastings_index_test')...[0.146 s] ok
module 'hastings_delete_db_test'
  Hastings Delete Database Tests
    hastings_delete_db_test:65: should_delete_index_after_deleting_database...[0.968 s] ok
    hastings_delete_db_test:104: should_rename_index_after_deleting_database...[0.776 s] ok
erl_child_setup: failed with error 32 on line 253
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
erl_child_setup: failed with error 32 on line 253
erl_child_setup: failed with error 32 on line 253
erl_child_setup: failed with error 32 on line 253
    [done in 2.349 s]
  [done in 2.543 s]
module 'hastings_plugin_couch_db'
module 'hastings_index_manager'
module 'hastings_fabric_info'
module 'hastings_vacuum'
module 'hastings_format_geojson'
module 'hastings_test_util'
module 'hastings_epi'
module 'hastings_httpd'
module 'hastings_app'
module 'hastings_format'
module 'hastings_httpd_util'
module 'hastings_fabric_search'
module 'hastings_format_legacy'
module 'hastings_sup'
module 'hastings_handle_info_tests'
  hastings handle info test
    hastings_handle_info_tests:52: handle_info_test...[1.059 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 1.181 s]
  [done in 1.432 s]
module 'hastings_ken_tests'
  Ken Tests
    hastings_ken_tests:55: ken...[0.093 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 0.343 s]
  [done in 0.528 s]
=======================================================
  All 12 tests passed.
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
