### PR TITLE
Add `external`  tag to opentrace events

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1250,6 +1250,7 @@ start_span(Req) ->
         [] -> <<"">>;
         [_ | _] -> filename:join(PathParts)
     end,
+    {IsExternalSpan, RootOptions} = root_span_options(MochiReq),
     Tags = maps:merge(#{
         peer => Peer,
         'http.method' => Method,
@@ -1257,21 +1258,22 @@ start_span(Req) ->
         'http.url' => MochiReq:get(raw_path),
         path_parts => Path,
         'span.kind' => <<"server">>,
-        component => <<"couchdb.chttpd">>
+        component => <<"couchdb.chttpd">>,
+        external => IsExternalSpan
     }, ExtraTags),
 
     ctrace:start_span(OperationName, [
         {tags, Tags},
         {time, Begin}
-    ] ++ maybe_root_span(MochiReq)).
+    ] ++ RootOptions).
 
-maybe_root_span(MochiReq) ->
+root_span_options(MochiReq) ->
     case get_trace_headers(MochiReq) of
         [undefined, _, _] ->
-            [];
+            {false, []};
         [TraceId, SpanId, ParentSpanId] ->
             Span = ctrace:external_span(TraceId, SpanId, ParentSpanId),
-            [{root, Span}]
+            {true, [{root, Span}]}
     end.
 
 parse_trace_id(undefined) ->

--- a/src/ctrace/README.md
+++ b/src/ctrace/README.md
@@ -146,7 +146,10 @@ and logged.
 
 ```ini
 [tracing.filters]
+; trace all events
 ; all = (#{}) -> true
+; trace all events with X-B3-... headers
+; all = (#{external := External}) when External == true -> true
 ; database-info.read = (#{'http.method' := Method}) when Method == 'GET' -> true
 ; view.build = (#{'view.name' := Name}) when Name == "foo" -> 0.25
 ```


### PR DESCRIPTION
## Overview

This PR adds an ability to selectively enable opentracing for HTTP requests
with X-B3-... headers. This is helpful in following cases:
- tracing all requests with X-B3-... headers
  `all = (#{external := E}) when E == true -> true`
- tracing all requests to specific database with X-B3-... headers
  ```
  all = (#{external := E, 'db.name' := Db})
    when E == true andalso Db == <<"foo">> -> true
  ```
- tracing requests to specific endpoint with X-B3-... headers
  ```
  db.design.view.read = (#{external := E, 'design.id' := Name})
    when E == true andalso Name == <<"bar">> -> true
  ```

I want to remind that we support following X-B3-... headers:

- `X-B3-TraceId`
- `X-B3-SpanId`
- `X-B3-ParentSpanId`
- `B3` which is in the following format
  `<TraceId>-<SpanId>-<1 | 0>-<ParentSpanId>`

## Testing recommendations

0. Run test suite 

```bash
$ make eunit apps=ctrace
```

1. Write connection string into fdb.cluster file
2. Start FDB server
3. Update rel/overlay/etc/default.ini similar to this:

```ini
[tracing]
enabled = true
thrift_format = compact ; compact | binary
agent_host = 127.0.0.1
agent_port = 6831
app_name = couchdb

[tracing.filters]
; Log all traces
all = (#{external := External}) when External == true -> true
```
4. Start jaeger `docker run -d -p 6831:6831/udp   -p 16686:16686   jaegertracing/all-in-one:1.14`
5. Start couchdb `dev/run --admin=adm:pass`
6. Create database `curl -X PUT -u adm:pass http://127.0.0.1:15984/test`
7. Query database `curl -X GET -u adm:pass http://127.0.0.1:15984/test -H 'X-B3-TraceId: 12345678901234567890123453782027'`
8. Open http://localhost:16686/ in the browser and search for spans
9. Query database `curl -X GET -u adm:pass http://127.0.0.1:15984/test`
10. Make sure there are no traces for the call from step `#9`

As an alternative to Step 4, you can run the `jaeger-all-in-one` binary without arguments in a separate shell. The Jaeger project provides prebuilt binaries for download.


## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
