### PR TITLE
 Update Mochiweb and add SameSite support to auth cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *~
 .venv
 .DS_Store
+.vscode
 .rebar/
 .eunit/
 cover/

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -158,7 +158,7 @@ DepDescs = [
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-4"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-2"}},
-{mochiweb,         "mochiweb",         {tag, "v2.19.0"}},
+{mochiweb,         "mochiweb",         {tag, "v2.20.0"}},
 {meck,             "meck",             {tag, "0.8.8"}}
 ],
 

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -245,6 +245,8 @@ iterations = 10 ; iterations for password hashing
 ; secret = 
 ; users_db_public = false
 ; cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+; same_site =
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -273,7 +273,7 @@ cookie_auth_cookie(Req, User, Secret, TimeStamp) ->
     Hash = crypto:hmac(sha, Secret, SessionData),
     mochiweb_cookies:cookie("AuthSession",
         couch_util:encodeBase64Url(SessionData ++ ":" ++ ?b2l(Hash)),
-        [{path, "/"}] ++ cookie_scheme(Req) ++ max_age() ++ cookie_domain()).
+        [{path, "/"}] ++ cookie_scheme(Req) ++ max_age() ++ cookie_domain() ++ same_site()).
 
 ensure_cookie_auth_secret() ->
     case config:get("couch_httpd_auth", "secret", undefined) of
@@ -456,6 +456,20 @@ cookie_domain() ->
         "" -> [];
         _ -> [{domain, Domain}]
     end.
+
+
+same_site() ->
+    SameSite = config:get("couch_httpd_auth", "same_site", ""),
+    case string:to_lower(SameSite) of
+        "" -> [];
+        "none" -> [{same_site, none}];
+        "lax" -> [{same_site, lax}];
+        "strict" -> [{same_site, strict}];
+        _ ->
+            couch_log:error("invalid config value couch_httpd_auth.same_site: ~p ",[SameSite]),
+            []
+    end.
+
 
 reject_if_totp(User) ->
     case get_totp_config(User) of

--- a/src/couch/test/exunit/same_site_cookie_tests.exs
+++ b/src/couch/test/exunit/same_site_cookie_tests.exs
@@ -1,0 +1,44 @@
+defmodule SameSiteCookieTests do
+  use CouchTestCase
+
+  @moduletag :authentication
+
+  def get_cookie(user, pass) do
+    resp = Couch.post("/_session", body: %{:username => user, :password => pass})
+
+    true = resp.body["ok"]
+    resp.headers[:"set-cookie"]
+  end
+
+  @tag config: [{"admins", "jan", "apple"}, {"couch_httpd_auth", "same_site", "None"}]
+  test "Set same_site None" do
+    cookie = get_cookie("jan", "apple")
+    assert cookie =~ "; SameSite=None"
+  end
+
+  @tag config: [{"admins", "jan", "apple"}, {"couch_httpd_auth", "same_site", ""}]
+  test "same_site not set" do
+    cookie = get_cookie("jan", "apple")
+    assert cookie
+    refute cookie =~ "; SameSite="
+  end
+
+  @tag config: [{"admins", "jan", "apple"}, {"couch_httpd_auth", "same_site", "Strict"}]
+  test "Set same_site Strict" do
+    cookie = get_cookie("jan", "apple")
+    assert cookie =~ "; SameSite=Strict"
+  end
+
+  @tag config: [{"admins", "jan", "apple"}, {"couch_httpd_auth", "same_site", "Lax"}]
+  test "Set same_site Lax" do
+    cookie = get_cookie("jan", "apple")
+    assert cookie =~ "; SameSite=Lax"
+  end
+
+  @tag config: [{"admins", "jan", "apple"}, {"couch_httpd_auth", "same_site", "Invalid"}]
+  test "Set same_site invalid" do
+    cookie = get_cookie("jan", "apple")
+    assert cookie
+    refute cookie =~ "; SameSite="
+  end
+end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Adds a new configuration field, `couch_httpd_auth.same_site` which sets the `SameSite` attribute of the CouchDB auth cookie. If no value is set (the default), no `SameSite` attribute is added.

This also updates Mochiweb to v2.20 as this is required for `SameSite` support.

## Testing recommendations

Set the `samesite: strict` value in default.ini and verify that the SameSite attribute is detected by a browser (e.g. Chrome dev tools).

## Related Issues or Pull Requests

 * Refs #2221
 * Documentation PR: https://github.com/apache/couchdb-documentation/pull/473

## Checklist

- [ ] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
