### PR TITLE
Change map indexes to be stored in one row

### DIFF
--- a/src/couch_views/include/couch_views.hrl
+++ b/src/couch_views/include/couch_views.hrl
@@ -19,8 +19,5 @@
 -define(VIEW_ROW_COUNT, 0).
 -define(VIEW_KV_SIZE, 1).
 
--define(VIEW_ROW_KEY, 0).
--define(VIEW_ROW_VALUE, 1).
-
 % jobs api
 -define(INDEX_JOB_TYPE, <<"views">>).

--- a/src/couch_views/src/couch_views_reader.erl
+++ b/src/couch_views/src/couch_views_reader.erl
@@ -183,7 +183,7 @@ mrargs_to_fdb_options(Args) ->
 
     [
         {dir, Direction},
-        {limit, Limit * 2 + Skip * 2},
+        {limit, Limit + Skip},
         {streaming_mode, want_all}
     ] ++ StartKeyOpts ++ EndKeyOpts.
 


### PR DESCRIPTION
## Overview

Changes map indexes to store the original key and value in a single
FDB row.

## Testing recommendations

All tests should pass

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
