### PR TITLE
[Jenkins] Revert to SM 1.8.5 for arm64

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -39,7 +39,10 @@ You should have the following installed:
  * Erlang OTP (>=R16B03-1, =<19.x) (http://erlang.org/)
  * ICU                          (http://icu-project.org/)
  * OpenSSL                      (http://www.openssl.org/)
- * Mozilla SpiderMonkey (1.8.5) (https://developer.mozilla.org/en/docs/Mozilla/Projects/SpiderMonkey/Releases/1.8.5)
+ * Mozilla SpiderMonkey - either 1.8.5 or 60
+   * 60 is not supported on ARM 64-bit (aarch64) at this time.
+   * https://developer.mozilla.org/en/docs/Mozilla/Projects/SpiderMonkey/Releases/1.8.5
+   * https://archive.mozilla.org/pub/firefox/releases/60.9.0esr/source/ (src/js)
  * GNU Make                     (http://www.gnu.org/software/make/)
  * GNU Compiler Collection      (http://gcc.gnu.org/)
  * libcurl                      (http://curl.haxx.se/libcurl/)

--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -478,7 +478,7 @@ pipeline {
           }
           environment {
             platform = 'buster'
-            sm_ver = '60'
+            sm_ver = '1.8.5'
           }
           stages {
             stage('Build from tarball & test') {

--- a/configure
+++ b/configure
@@ -31,6 +31,7 @@ SKIP_DEPS=0
 
 COUCHDB_USER="$(whoami 2>/dev/null || echo couchdb)"
 SM_VSN="1.8.5"
+ARCH="$(uname -m)"
 
 . ${rootdir}/version.mk
 COUCHDB_VERSION=${vsn_major}.${vsn_minor}.${vsn_patch}
@@ -176,6 +177,12 @@ parse_opts() {
 }
 
 parse_opts $@
+
+if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" != "1.8.5" ]
+then
+  echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use 1.8.5 instead."
+  exit 1
+fi
 
 echo "==> configuring couchdb in rel/couchdb.config"
 cat > rel/couchdb.config << EOF


### PR DESCRIPTION
Fixes #2449 and our "full" builds.

Includes modification to `configure` to disallow SM60+aarch64, and documents it in `INSTALL.Unix`.

What do you think @davisp @jiangphcn ? 