### PR TITLE
Handle not_found atom in mango text indexes

### DIFF
--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -176,6 +176,10 @@ handle_hits(CAcc0, [{Sort, Doc} | Rest]) ->
     handle_hits(CAcc1, Rest).
 
 
+handle_hit(CAcc0, Sort, not_found) ->
+    CAcc1 = update_bookmark(CAcc0, Sort),
+    CAcc1;
+
 handle_hit(CAcc0, Sort, Doc) ->
     #cacc{
         limit = Limit,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

When Mango text indexes fetch the doc object for each hit, a not_found atom may be returned if the indexed document revision no longer exists in the primary index (see [mango_cursor_text:get_json_docs/2](https://github.com/apache/couchdb/blob/bf6b98420c6a79c2f2d144edb4164b070b686afb/src/mango/src/mango_cursor_text.erl#L333)).

This manifests in the couchdb logs as:

```
req_err(2299526675) unknown_error : function_clause#012 [<<"mango_selector:match/2 L57">>,<<"mango_cursor_text:handle_hit/3 L182">>,<<"mango_cursor_text:handle_hits/2 L169">>,<<"mango_cursor_text:execute/1 L145">>,<<"mango_cursor_text:execute/3 L116">>,<<"mango_httpd:handle_find_req/2 L189">>,<<"mango_httpd:handle_req/2 L38">>,<<"chttpd:handle_req_after_auth/2 L322">>]
```

This commit handles this explicitly in `mango_cursor_text:handle_hit/3` to prevent the mango selector being evaluated against an invalid object.

cc @garrensmith @tonysun83 

## Testing recommendations

Tricky to test explicitly - there are some basic eunit tests to cover the change in behaviour.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
