### PR TITLE
Port etags tests to elixir

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -46,8 +46,8 @@ X means done, - means partially
   - [ ] Port design_options.js
   - [ ] Port design_paths.js
   - [X] Port erlang_views.js
-  - [ ] Port etags_head.js
-  - [ ] Port etags_views.js
+  - [X] Port etags_head.js
+  - [ ] ~~Port etags_views.js~~ (skipped in js test suite)
   - [ ] Port form_submit.js
   - [ ] Port http.js
   - [X] Port invalid_docids.js

--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -97,9 +97,9 @@ defmodule Couch do
 
   def process_options(options) do
     options
-      |> set_auth_options()
-      |> set_inactivity_timeout()
-      |> set_request_timeout()
+     |> set_auth_options()
+     |> set_inactivity_timeout()
+     |> set_request_timeout()
   end
 
   def process_request_body(body) do
@@ -108,6 +108,10 @@ defmodule Couch do
     else
       body
     end
+  end
+
+  def process_response_body(_headers, body) when body == [] do
+    ""
   end
 
   def process_response_body(headers, body) do
@@ -137,9 +141,14 @@ defmodule Couch do
   end
 
   def set_inactivity_timeout(options) do
-    Keyword.update(options, :ibrowse, [{:inactivity_timeout, @inactivity_timeout}], fn(ibrowse) ->
-      Keyword.put_new(ibrowse, :inactivity_timeout, @inactivity_timeout)
-    end)
+    Keyword.update(
+      options,
+      :ibrowse,
+      [{:inactivity_timeout, @inactivity_timeout}],
+      fn ibrowse ->
+        Keyword.put_new(ibrowse, :inactivity_timeout, @inactivity_timeout)
+      end
+    )
   end
 
   def set_request_timeout(options) do
@@ -165,5 +174,4 @@ defmodule Couch do
       %Couch.Session{error: resp.body["error"]}
     end
   end
-
 end

--- a/test/elixir/test/etags_head_test.exs
+++ b/test/elixir/test/etags_head_test.exs
@@ -1,0 +1,151 @@
+defmodule EtagsHeadTest do
+  use CouchTestCase
+
+  @moduletag :etags
+
+  @tag :with_db
+  test "etag header on creation", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.put("/#{db_name}/1",
+        headers: ["Content-Type": "application/json"],
+        body: %{}
+      )
+
+    assert resp.status_code == 201
+    assert Map.has_key?(resp.headers.hdrs, "etag")
+  end
+
+  @tag :with_db
+  test "etag header on retrieval", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.put("/#{db_name}/1",
+        headers: ["Content-Type": "application/json"],
+        body: %{}
+      )
+
+    etag = resp.headers.hdrs["etag"]
+
+    # get the doc and verify the headers match
+    resp = Couch.get("/#{db_name}/1")
+    assert etag == resp.headers.hdrs["etag"]
+
+    # 'head' the doc and verify the headers match
+    resp =
+      Couch.head("/#{db_name}/1",
+        headers: ["if-none-match": "s"]
+      )
+
+    assert etag == resp.headers.hdrs["etag"]
+  end
+
+  @tag :with_db
+  test "etag header on head", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.put("/#{db_name}/1",
+        headers: ["Content-Type": "application/json"],
+        body: %{}
+      )
+
+    etag = resp.headers.hdrs["etag"]
+
+    # 'head' the doc and verify the headers match
+    resp =
+      Couch.head("/#{db_name}/1",
+        headers: ["if-none-match": "s"]
+      )
+
+    assert etag == resp.headers.hdrs["etag"]
+  end
+
+  @tag :with_db
+  test "etags head", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.put("/#{db_name}/1",
+        headers: ["Content-Type": "application/json"],
+        body: %{}
+      )
+
+    assert resp.status_code == 201
+    assert Map.has_key?(resp.headers.hdrs, "etag")
+
+    etag = resp.headers.hdrs["etag"]
+
+    # get the doc and verify the headers match
+    resp = Couch.get("/#{db_name}/1")
+    assert etag == resp.headers.hdrs["etag"]
+
+    # 'head' the doc and verify the headers match
+    resp =
+      Couch.head("/#{db_name}/1",
+        headers: ["if-none-match": "s"]
+      )
+
+    assert etag == resp.headers.hdrs["etag"]
+
+    # replace a doc
+    resp =
+      Couch.put("/#{db_name}/1",
+        headers: ["if-match": etag],
+        body: %{}
+      )
+
+    assert resp.status_code == 201
+
+    # extract the new ETag value
+    previous_etag = etag
+    etag = resp.headers.hdrs["etag"]
+
+    # fail to replace a doc
+    resp =
+      Couch.put("/#{db_name}/1",
+        body: %{}
+      )
+
+    assert resp.status_code == 409
+
+    # verify get w/Etag
+    resp =
+      Couch.get("/#{db_name}/1",
+        headers: ["if-none-match": previous_etag]
+      )
+
+    assert resp.status_code == 200
+
+    resp =
+      Couch.get("/#{db_name}/1",
+        headers: ["if-none-match": etag]
+      )
+
+    assert resp.status_code == 304
+
+    resp =
+      Couch.get("/#{db_name}/1",
+        headers: ["if-none-match": "W/#{etag}"]
+      )
+
+    assert resp.status_code == 304
+
+    # fail to delete a doc
+    resp =
+      Couch.delete("/#{db_name}/1",
+        headers: ["if-match": previous_etag]
+      )
+
+    assert resp.status_code == 409
+
+    resp =
+      Couch.delete("/#{db_name}/1",
+        headers: ["if-match": etag]
+      )
+
+    assert resp.status_code == 200
+  end
+end

--- a/test/javascript/tests/etags_head.js
+++ b/test/javascript/tests/etags_head.js
@@ -10,7 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.etags_head = function(debug) {
+  return console.log('done in test/elixir/test/etags_head_test.exs');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
   db.createDb();


### PR DESCRIPTION
This fixes up the contribution from @jjrodrig 

https://github.com/apache/couchdb/pull/2464

Thank you!

A few minor updates to the original PR:

 * Rebased & squashed the commits
 * Disabled the javascript test
 * Fixed an unused var in `test/elixir/lib/couch.ex`
