### PR TITLE
Log clustered URIs at startup

### DIFF
--- a/src/couch/src/couch_sup.erl
+++ b/src/couch/src/couch_sup.erl
@@ -157,7 +157,7 @@ write_uris() ->
 
 
 get_uris() ->
-    Ip = config:get("httpd", "bind_address"),
+    Ip = config:get("chttpd", "bind_address"),
     lists:flatmap(fun(Uri) ->
         case get_uri(Uri, Ip) of
             undefined -> [];


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Changes the URI logged at startup to report the address(es) that
`chttpd` is bound to rather than `httpd`. Previously it was a bit
confusing that it always reported that Couch had started on
port 5986 which is deprecated and not intended to be user-facing.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Start CouchDB and check that the log reports the URI that you use to interact with Couch.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
