### PR TITLE
Fix infinite loop in default_authentication_handler

### DIFF
--- a/src/chttpd/src/chttpd_auth.erl
+++ b/src/chttpd/src/chttpd_auth.erl
@@ -55,10 +55,12 @@ party_mode_handler(#httpd{method='POST', path_parts=[<<"_session">>]} = Req) ->
     % See #1947 - users should always be able to attempt a login
     Req#httpd{user_ctx=#user_ctx{}};
 party_mode_handler(Req) ->
-    case config:get("chttpd", "require_valid_user", "false") of
-    "true" ->
+    RequireValidUser = config:get_boolean("chttpd", "require_valid_user", false),
+    ExceptUp = config:get_boolean("chttpd", "require_valid_user_except_for_up", true),
+    case RequireValidUser andalso not ExceptUp of
+    true ->
         throw({unauthorized, <<"Authentication required.">>});
-    "false" ->
+    false ->
         case config:get("admins") of
         [] ->
             Req#httpd{user_ctx = ?ADMIN_USER};

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -88,11 +88,6 @@ basic_name_pw(Req) ->
 default_authentication_handler(Req) ->
     default_authentication_handler(Req, couch_auth_cache).
 
-default_authentication_handler(#httpd{path_parts=[<<"_up">>]}=Req, AuthModule) ->
-    case config:get_boolean("chttpd", "require_valid_user_except_for_up", false) of
-        true -> Req#httpd{user_ctx=?ADMIN_USER};
-        _False -> default_authentication_handler(Req, AuthModule)
-    end;
 default_authentication_handler(Req, AuthModule) ->
     case basic_name_pw(Req) of
     {User, Pass} ->


### PR DESCRIPTION
## Overview

In #2411 we introduced a setting to allow _up to not require authentication when require_valid_user is set to true. However it was flawed and caused an infinite loop, rendering the /_up handler ineffective.

We move the check to the party_mode_handler and remove the infinite loop.

## Testing recommendations

dev/run with all combinations of the two config flags, _up handler called with curl to confirm behaviour.

## Related Issues or Pull Requests

#2411 for original PR that this corrects.

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
