### PR TITLE
Add POST /_node/<node>/_config/_reload

### DIFF
--- a/test/elixir/test/config_test.exs
+++ b/test/elixir/test/config_test.exs
@@ -174,4 +174,11 @@ defmodule ConfigTest do
       set_config(context, section, "wohali", "rules", 403)
     end)
   end
+
+  test "Reload config", context do
+    url = "#{context[:config_url]}/_reload"
+    resp = Couch.post(url)
+
+    assert resp.status_code == 200
+  end
 end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Using the backend port 5986 it was possible to reload config from disk
using the _config/_reload endpoint. This ports it to the `/_node` API on the frontend port.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Launch CouchDB e.g. using `./dev/run`. Change the `local.ini` somehow and run:

```
curl localhost:15984/_node/_local/_config/_reload -XPOST
```

Verify the change using 

```
curl localhost:15984/_node/_local/_config`
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
