### PR TITLE
Replace Triq with PropEr

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -109,7 +109,6 @@ defmodule CouchDBTest.Mixfile do
       "bear",
       "mochiweb",
       "snappy",
-      "triq",
       "rebar",
       "proper",
       "mochiweb",

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -155,7 +155,7 @@ DepDescs = [
                    {tag, "v1.2.2"}, [raw]},
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
-{hyper,            "hyper",            {tag, "CouchDB-2.2.0-4"}},
+{hyper,            "hyper",            {tag, "CouchDB-2.2.0-6"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-2"}},
 {mochiweb,         "mochiweb",         {tag, "v2.20.0"}},

--- a/src/couch/include/couch_eunit_proper.hrl
+++ b/src/couch/include/couch_eunit_proper.hrl
@@ -1,0 +1,29 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+
+-define(EUNIT_QUICKCHECK(QuickcheckTimeout),
+    [
+        {
+            atom_to_list(F),
+            {timeout, QuickcheckTimeout,
+                ?_assert(proper:quickcheck(?MODULE:F(), [
+                    {to_file, user},
+                    {start_size, 2},
+                    long_result
+                 ]))}
+            }
+        || {F, 0} <- ?MODULE:module_info(exports), F > 'prop_', F < 'prop`'
+    ]).

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -92,6 +92,11 @@ MD5Config = case lists:keyfind(erlang_md5, 1, CouchConfig) of
         []
 end,
 
+ProperConfig = case code:lib_dir(proper) of
+    {error, bad_name} -> [];
+    _ -> [{d, 'WITH_PROPER'}]
+end,
+
 {JS_CFLAGS, JS_LDFLAGS} = case os:type() of
     {win32, _} when SMVsn == "1.8.5" ->
         {
@@ -212,7 +217,7 @@ AddConfig = [
         {d, 'COUCHDB_VERSION', Version},
         {d, 'COUCHDB_GIT_SHA', GitSha},
         {i, "../"}
-    ] ++ MD5Config},
+    ] ++ MD5Config ++ ProperConfig},
     {eunit_compile_opts, PlatformDefines}
 ].
 

--- a/src/mem3/rebar.config.script
+++ b/src/mem3/rebar.config.script
@@ -1,0 +1,22 @@
+%% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+%% use this file except in compliance with the License. You may obtain a copy of
+%% the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+%% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+%% License for the specific language governing permissions and limitations under
+%% the License.
+
+WithProper = code:lib_dir(proper) /= {error, bad_name}.
+
+if not WithProper -> CONFIG; true ->
+    CurrOpts = case lists:keyfind(erl_opts, 1, CONFIG) of
+        {erl_opts, Opts} -> Opts;
+        false -> []
+    end,
+    NewOpts = [{d, 'WITH_PROPER'} | CurrOpts],
+    lists:keystore(erl_opts, 1, CONFIG, {erl_opts, NewOpts})
+end.

--- a/src/mem3/test/eunit/mem3_ring_prop_tests.erl
+++ b/src/mem3/test/eunit/mem3_ring_prop_tests.erl
@@ -13,8 +13,13 @@
 -module(mem3_ring_prop_tests).
 
 
--include_lib("triq/include/triq.hrl").
--triq(eunit).
+-ifdef(WITH_PROPER).
+
+-include_lib("couch/include/couch_eunit_proper.hrl").
+
+
+property_test_() ->
+    ?EUNIT_QUICKCHECK(60).
 
 
 % Properties
@@ -97,7 +102,7 @@ g_disconnected_intervals(Begin, End) ->
 g_disconnected_intervals(Begin, End, Split) when Begin =< End ->
     ?LET(Connected, g_non_trivial_connected_intervals(Begin, End, Split),
     begin
-        I = triq_rnd:uniform(length(Connected)) - 1,
+        I = rand:uniform(length(Connected)) - 1,
         {Before, [_ | After]} = lists:split(I, Connected),
         Before ++ After
     end).
@@ -131,14 +136,16 @@ rand_range(B, B) ->
     B;
 
 rand_range(B, E) ->
-    B + triq_rnd:uniform(E - B).
+    B + rand:uniform(E - B).
 
 
 shuffle(L) ->
-    Tagged = [{triq_rnd:uniform(), X} || X <- L],
+    Tagged = [{rand:uniform(), X} || X <- L],
     [X || {_, X} <- lists:sort(Tagged)].
 
 
 endpoints(Ranges) ->
     {Begins, Ends} = lists:unzip(Ranges),
     sets:from_list(Begins ++ Ends).
+
+-endif.


### PR DESCRIPTION
It was already used in the IOQ2 work so all the plumbing to pull it in during
dev testing was there and it seems awkward to have two different property
testing framework for just a handful of tests.

It is still an optional component and is not included in the release.

