### PR TITLE
Python black cleanups

### DIFF
--- a/build-aux/show-test-results.py
+++ b/build-aux/show-test-results.py
@@ -12,7 +12,7 @@ TEST_COLLECTIONS = {
     "EUnit": "src/**/.eunit/*.xml",
     "EXUnit": "_build/integration/lib/couchdbtest/*.xml",
     "Mango": "src/mango/*.xml",
-    "JavaScript": "test/javascript/*.xml"
+    "JavaScript": "test/javascript/*.xml",
 }
 
 

--- a/src/mango/test/15-execution-stats-test.py
+++ b/src/mango/test/15-execution-stats-test.py
@@ -54,9 +54,12 @@ class ExecutionStatsTests(mango.UserDocsTests):
         self.assertEqual(resp["execution_stats"]["results_returned"], len(resp["docs"]))
 
     def test_no_matches_index_scan(self):
-        resp = self.db.find({"age": {"$lt": 35}, "nomatch": "me"}, return_raw=True, executionStats=True)
+        resp = self.db.find(
+            {"age": {"$lt": 35}, "nomatch": "me"}, return_raw=True, executionStats=True
+        )
         self.assertEqual(resp["execution_stats"]["total_docs_examined"], 3)
         self.assertEqual(resp["execution_stats"]["results_returned"], 0)
+
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class ExecutionStatsTests_Text(mango.UserDocsTextTests):

--- a/src/mango/test/21-empty-selector-tests.py
+++ b/src/mango/test/21-empty-selector-tests.py
@@ -63,6 +63,7 @@ class EmptySelectorNoIndexTests(
 ):
     pass
 
+
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class EmptySelectorTextTests(make_empty_selector_suite(mango.UserDocsTextTests)):
     pass


### PR DESCRIPTION
```
would reformat /home/jenkins/couchdb/build-aux/show-test-results.py
would reformat /home/jenkins/couchdb/src/mango/test/15-execution-stats-test.py
would reformat /home/jenkins/couchdb/src/mango/test/21-empty-selector-tests.py
Oh no! 💥 💔 💥
3 files would be reformatted, 29 files would be left unchanged.
make[1]: *** [Makefile:214: python-black] Error 1
```