### PR TITLE
quote strings for all text values

### DIFF
--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -366,7 +366,8 @@ value_str(Value) when is_binary(Value) ->
         true ->
             <<"\"", Value/binary, "\"">>;
         false ->
-            mango_util:lucene_escape_query_value(Value)
+            Escaped = mango_util:lucene_escape_query_value(Value),
+            <<"\"", Escaped/binary, "\"">>
     end;
 value_str(Value) when is_integer(Value) ->
     list_to_binary(integer_to_list(Value));

--- a/src/mango/test/06-basic-text-test.py
+++ b/src/mango/test/06-basic-text-test.py
@@ -95,6 +95,9 @@ class BasicTextTests(mango.UserDocsTextTests):
         assert len(docs) == 1
         assert docs[0]["company"] == "Affluex"
 
+        docs = self.db.find({"foo": {"$lt": "bar car apple"}})
+        assert len(docs) == 0
+
     def test_lte(self):
         docs = self.db.find({"age": {"$lte": 21}})
         assert len(docs) == 0
@@ -112,6 +115,10 @@ class BasicTextTests(mango.UserDocsTextTests):
         assert len(docs) == 2
         for d in docs:
             assert d["user_id"] in (0, 11)
+
+        docs = self.db.find({"foo": {"$lte": "bar car apple"}})
+        assert len(docs) == 1
+        assert docs[0]["user_id"] == 14
 
     def test_eq(self):
         docs = self.db.find({"age": 21})
@@ -156,6 +163,13 @@ class BasicTextTests(mango.UserDocsTextTests):
         docs = self.db.find({"company": {"$gt": "Zialactic"}})
         assert len(docs) == 0
 
+        docs = self.db.find({"foo": {"$gt": "bar car apple"}})
+        assert len(docs) == 0
+
+        docs = self.db.find({"foo": {"$gt": "bar car"}})
+        assert len(docs) == 1
+        assert docs[0]["user_id"] == 14
+
     def test_gte(self):
         docs = self.db.find({"age": {"$gte": 77}})
         assert len(docs) == 2
@@ -177,6 +191,10 @@ class BasicTextTests(mango.UserDocsTextTests):
         docs = self.db.find({"company": {"$gte": "Zialactic"}})
         assert len(docs) == 1
         assert docs[0]["company"] == "Zialactic"
+
+        docs = self.db.find({"foo": {"$gte": "bar car apple"}})
+        assert len(docs) == 1
+        assert docs[0]["user_id"] == 14
 
     def test_and(self):
         docs = self.db.find({"age": 22, "manager": True})

--- a/src/mango/test/user_docs.py
+++ b/src/mango/test/user_docs.py
@@ -343,6 +343,7 @@ DOCS = [
             "city": "Axis",
             "address": {"street": "Brightwater Avenue", "number": 1106},
         },
+        "foo" : "bar car apple",
         "company": "Pharmex",
         "email": "faithhess@pharmex.com",
         "favorites": ["Erlang", "Python", "Lisp"],


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

When a user issues a range query $lt, $lte, $gt, $gte for text indexes,
the query is translated into a MIN, MAX range query against clouseau.
If not quoted, an error occurs:
```
{"error":"text_search_error","reason":"Cannot parse
'(a_3astring:[\"\" TO string\\ containing\\ space})'..}
```
This is because the string is broken up into 3 tokens which the parser
cannot parse. If we add quotes to the string, the the range query works
correctly.


## Testing recommendations

Tests added to mango test suites, but requires clouseau to be setup. Text tests have already
been run and passes.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
