### PR TITLE
Revert default priority change for couch_server

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -692,7 +692,7 @@ set_mqd_off_heap(Module) ->
 
 
 set_process_priority(Module, Level) ->
-    case config:get_boolean("process_priority", atom_to_list(Module), true) of
+    case config:get_boolean("process_priority", atom_to_list(Module), false) of
         true ->
             process_flag(priority, Level),
             ok;


### PR DESCRIPTION
## Overview

In a59540132 we introduced a default increase in process priority for `couch_server` to high.

While tracking down #2437 , I managed to git bisect the problem to this commit.

This lead me to this thread on erlang-questions:

http://erlang.org/pipermail/erlang-questions/2018-June/095677.html

Notably:

> a single high-priority process in a tight loop stops all other processes, including those of max priority.

This problem surfaces on Erlang 21 and 22 specifically - and is exactly what we're seeing.

While we could do a specific version check, I think it would be healthier for now to disable this specific optimization by default, and only re-enable once we can track down what's going on in 21/22 that is causing scheduler collapse in this fashion.

## Testing recommendations

`while true; do make eunit apps=mem3; done` should run for hours without a hang. Most commonly the hang occurs in the reshard tests (during which various `couchjs` processes are spawned.)

## Related Issues or Pull Requests

Closes #2437 and may help with #2423 - needs more testing.

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`