### PR TITLE
Revert prio flag in default.ini

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -94,9 +94,11 @@ users_db_security_editable = false
 couch = couch_bt_engine
 
 [process_priority]
-; Selectively disable altering process priorities
-; for modules that request it.
-; couch_server = true
+; Selectively disable altering process priorities for modules that request it.
+; * NOTE: couch_server priority has been shown to lead to CouchDB hangs and
+;         unexpected failures. Do not enable unless you're sure you can tolerate
+;         this possibility.
+;couch_server = false
 
 [cluster]
 q=2


### PR DESCRIPTION
Left this out of #2487 by accident - update to `default.ini`