### PR TITLE
bump ets_lru, khash revs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ src/couch_tests/ebin/
 src/global_changes/ebin/
 src/mango/ebin/
 src/mango/test/*.pyc
+src/mango/nosetests.xml
 src/mango/venv/
 test/javascript/junit.xml
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -144,8 +144,8 @@ DepDescs = [
 %% Independent Apps
 {config,           "config",           {tag, "2.1.7"}},
 {b64url,           "b64url",           {tag, "1.0.1"}},
-{ets_lru,          "ets-lru",          {tag, "1.0.0"}},
-{khash,            "khash",            {tag, "1.0.1"}},
+{ets_lru,          "ets-lru",          {tag, "1.1.0"}},
+{khash,            "khash",            {tag, "1.1.0"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.4"}},
 
 %% Non-Erlang deps


### PR DESCRIPTION
Closes #2391 except for bumping Fauxton and docs.

@willholley can you tell me if we need the last couple of changes in Fauxton in 3.0.0 or not?

@davisp Do we need the changes to jiffy in CouchDB? We're fairly far back on that dependency.