### PR TITLE
Jenkins: bump Erlang versions

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -81,7 +81,7 @@ pipeline {
       agent {
         docker {
           label 'docker'
-          image 'couchdbdev/debian-stretch-erlang-20.3.8.24-1:latest'
+          image 'couchdbdev/debian-stretch-erlang-20.3.8.25-1:latest'
           args "${DOCKER_ARGS}"
           alwaysPull true
         }
@@ -161,7 +161,7 @@ pipeline {
         stage('CentOS 6') {
           agent {
             docker {
-              image 'couchdbdev/centos-6-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/centos-6-erlang-20.3.8.25-1:latest'
               label 'docker'
               args "${DOCKER_ARGS}"
               alwaysPull true
@@ -205,7 +205,7 @@ pipeline {
         stage('CentOS 7') {
           agent {
             docker {
-              image 'couchdbdev/centos-7-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/centos-7-erlang-20.3.8.25-1:latest'
               label 'docker'
               args "${DOCKER_ARGS}"
               alwaysPull true
@@ -250,7 +250,7 @@ pipeline {
         stage('CentOS 8') {
           agent {
             docker {
-              image 'couchdbdev/centos-8-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/centos-8-erlang-20.3.8.25-1:latest'
               label 'docker'
               args "${DOCKER_ARGS}"
               alwaysPull true
@@ -295,7 +295,7 @@ pipeline {
         stage('Ubuntu Xenial') {
           agent {
             docker {
-              image 'couchdbdev/ubuntu-xenial-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/ubuntu-xenial-erlang-20.3.8.25-1:latest'
               label 'docker'
               args "${DOCKER_ARGS}"
               alwaysPull true
@@ -339,7 +339,7 @@ pipeline {
         stage('Ubuntu Bionic') {
           agent {
             docker {
-              image 'couchdbdev/ubuntu-bionic-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/ubuntu-bionic-erlang-20.3.8.25-1:latest'
               label 'docker'
               alwaysPull true
               args "${DOCKER_ARGS}"
@@ -383,7 +383,7 @@ pipeline {
         stage('Debian Stretch') {
           agent {
             docker {
-              image 'couchdbdev/debian-stretch-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/debian-stretch-erlang-20.3.8.25-1:latest'
               label 'docker'
               alwaysPull true
               args "${DOCKER_ARGS}"
@@ -427,7 +427,7 @@ pipeline {
         stage('Debian Buster amd64') {
           agent {
             docker {
-              image 'couchdbdev/debian-buster-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/debian-buster-erlang-20.3.8.25-1:latest'
               label 'docker'
               alwaysPull true
               args "${DOCKER_ARGS}"
@@ -471,7 +471,7 @@ pipeline {
         stage('Debian Buster arm64v8') {
           agent {
             docker {
-              image 'couchdbdev/arm64v8-debian-buster-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/arm64v8-debian-buster-erlang-20.3.8.25-1:latest'
               label 'arm64v8'
               alwaysPull true
               args "${DOCKER_ARGS}"
@@ -515,7 +515,7 @@ pipeline {
         stage('Debian Buster ppc64le') {
           agent {
             docker {
-              image 'couchdbdev/ppc64le-debian-buster-erlang-20.3.8.24-1:latest'
+              image 'couchdbdev/ppc64le-debian-buster-erlang-20.3.8.25-1:latest'
               label 'ppc64le'
               alwaysPull true
               args "${DOCKER_ARGS}"
@@ -584,12 +584,12 @@ pipeline {
             }
             stage('Pull latest docker image') {
               steps {
-                sh "docker pull couchdbdev/arm64v8-debian-buster-erlang-20.3.8.24-1:latest"
+                sh "docker pull couchdbdev/arm64v8-debian-buster-erlang-20.3.8.25-1:latest"
               }
             }
             stage('Build from tarball & test & packages') {
               steps {
-                withDockerContainer(image: "couchdbdev/arm64v8-debian-buster-erlang-20.3.8.24-1:latest", args: "${DOCKER_ARGS}") {
+                withDockerContainer(image: "couchdbdev/arm64v8-debian-buster-erlang-20.3.8.25-1:latest", args: "${DOCKER_ARGS}") {
                   unstash 'tarball'
                   withEnv(['MIX_HOME='+pwd(), 'HEX_HOME='+pwd()]) {
                     sh( script: build_and_test )
@@ -629,7 +629,7 @@ pipeline {
 
       agent {
         docker {
-          image 'couchdbdev/debian-buster-erlang-20.3.8.24-1:latest'
+          image 'couchdbdev/debian-buster-erlang-20.3.8.25-1:latest'
           label 'docker'
           alwaysPull true
           args "${DOCKER_ARGS}"

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -12,7 +12,6 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
 build_and_test = '''
 mkdir -p ${COUCHDB_IO_LOG_DIR} ${ERLANG_VERSION}
 cd ${ERLANG_VERSION}
@@ -46,11 +45,12 @@ pipeline {
     // npm config cache below deals with /home/jenkins not mapping correctly
     // inside the image
     DOCKER_ARGS = '-e npm_config_cache=npm-cache -e HOME=. -v=/etc/passwd:/etc/passwd -v /etc/group:/etc/group'
-    // Also be sure to change these values in the matrix below...
+    // *** BE SURE TO CHANGE THE ERLANG VERSION FARTHER DOWN S WELL ***
+    // Search for ERLANG_VERSION
     // see https://issues.jenkins-ci.org/browse/JENKINS-40986
     LOW_ERLANG_VER = '20.3.8.11'
-    MID_ERLANG_VER = '20.3.8.24'
-    HIGH_ERLANG_VER = '22.2'
+    MID_ERLANG_VER = '20.3.8.25'
+    HIGH_ERLANG_VER = '22.2.3'
   }
 
   options {
@@ -106,7 +106,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values "20.3.8.11", "20.3.8.24", "22.2"
+            values "20.3.8.11", "20.3.8.25", "22.2.3"
           }
         }
 


### PR DESCRIPTION
Docker images have updated versions of Erlang - so Jenkinsfile must follow.

Unfortunately this breaks PRs until this PR is merged, because now `couchdbdev/debian-buster-erlang-all` has different versions of Erlang in it than `Jenkinsfile.pr` does.

We can possibly factor some of this out and avoid the PR-blocking change by having the `-all` image have aliases like `/usr/local/kerl/{low,medium,high}/activate` to the three versions.

The `Jenkinsfile.full` version needs to be explicit so that packages are built appropriately for downstream.

At one point @kocolosk wanted to use tagging to improve build times and avoid the forced pull every time, but my experience was that when tags move, docker doesn't always pick it up, leading us back to having to merge a PR every time we want or need to update the Erlang in our containers.