### PR TITLE
Add http reporter

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -121,13 +121,13 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-4"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
-{jaeger_passage,   "jaeger-passage",   {tag, "CouchDB-0.1.13-1"}},
+{jaeger_passage,   "jaeger-passage",   {tag, "CouchDB-0.1.14-1"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-0.14.11-2"}},
 {local,            "local",            {tag, "0.2.1"}},
 {mochiweb,         "mochiweb",         {tag, "v2.19.0"}},
 {meck,             "meck",             {tag, "0.8.8"}},
 {passage,          "passage",          {tag, "0.2.6"}},
-{thrift_protocol,  "thrift-protocol",  {tag, "0.1.3"}},
+{thrift_protocol,  "thrift-protocol",  {tag, "0.1.5"}},
 
 %% TMP - Until this is moved to a proper Apache repo
 {erlfdb,           "erlfdb",           {branch, "master"}}

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -568,13 +568,19 @@ min_priority = 2.0
 [tracing]
 ;
 ; Configuration settings for the `ctrace` OpenTracing
-; API.
-;
+; API. There are two reporter which we support.
+;   - jaeger.thrift over udp
+;   - jaeger.thrift over http
+; ## Common settings
 ; enabled = false ; true | false
+; app_name = couchdb ; value to use for the `location.application` tag
+; protocol = udp ; udp | http - which reporter to use
+; ## jaeger.thrift over udp reporter
 ; thrift_format = compact ; compact | binary
 ; agent_host = 127.0.0.1
 ; agent_port = 6831
-; app_name = couchdb ; value to use for the `location.application` tag
+; ## jaeger.thrift over udp reporter
+; endpoint = http://127.0.0.1:14268
 
 [tracing.filters]
 ;

--- a/src/ctrace/README.md
+++ b/src/ctrace/README.md
@@ -120,9 +120,23 @@ Configuration
 Traces are configured using standard CouchDB ini file based configuration.
 There is a global toggle `[tracing] enabled = true | false` that switches
 tracing on or off completely. The `[tracing]` section also includes
-configuration for where to send trace data.
+configuration for where to send trace data. There are two reporters which we
+support.
 
-An example `[tracing]` section
+The thrift over udp reporter (this is the default) has following configuration
+options:
+
+- protocol = udp
+- thrift_format = compact | binary
+- agent_host = 127.0.0.1
+- agent_port = 6831
+
+The thrift over http has following options
+
+- protocol = http
+- endpoint = http://127.0.0.1:14268
+
+An example of `[tracing]` section
 
 ```ini
 [tracing]


### PR DESCRIPTION
## Overview

This PR adds support for http reporter for open tracing library. The http reporter is useful in following two cases:
- when you deployment doesn't include jaeger agents and you want to communicate directly to jaeger server
- when spans are greater than max udp packet size (65Kb).

## Testing recommendations

1. update rel/overlay/etc/default.ini as follows
```
diff --git a/rel/overlay/etc/default.ini b/rel/overlay/etc/default.ini
index 592445c28..69091eab3 100644
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -572,15 +572,15 @@ min_priority = 2.0
 ;   - jaeger.thrift over udp
 ;   - jaeger.thrift over http
 ; ## Common settings
-; enabled = false ; true | false
-; app_name = couchdb ; value to use for the `location.application` tag
-; protocol = udp ; udp | http - which reporter to use
+enabled = true ; true | false
+app_name = couchdb ; value to use for the `location.application` tag
+protocol = http ; udp | http - which reporter to use
 ; ## jaeger.thrift over udp reporter
 ; thrift_format = compact ; compact | binary
 ; agent_host = 127.0.0.1
 ; agent_port = 6831
 ; ## jaeger.thrift over udp reporter
-; endpoint = http://127.0.0.1:14268
+endpoint = http://127.0.0.1:14268
 [tracing.filters]
 ;
@@ -603,4 +603,4 @@ min_priority = 2.0
 ; corresponding operation name key configured. Thus, users can easily
 ; log every generated trace by including the following:
 ;
-; all = (#{}) -> true
+all = (#{}) -> true
```
2. start jaeger in docker container
```
docker run -d -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:1.14
```
3. Start couchdb dev/run --admin=adm:pass
4. Create database curl -X PUT -u adm:pass http://127.0.0.1:15984/test
5. Query database curl -X GET -u adm:pass http://127.0.0.1:15984/test -H 'X-B3-TraceId: 12345678901234567890123453782027'
6. Open http://localhost:16686/ in the browser and search for spans (you should find some traces)

## Related Issues or Pull Requests

This PR depends on 

- https://github.com/apache/couchdb-jaeger-passage/pull/1

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
