### PR TITLE
Setup wizard: do not create _global_changes

### DIFF
--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -75,7 +75,7 @@ is_single_node_enabled(Dbs) ->
     end.
 
 cluster_system_dbs() ->
-    ["_users", "_replicator", "_global_changes"].
+    ["_users", "_replicator"].
 
 
 has_cluster_system_dbs([]) ->


### PR DESCRIPTION
Per the topic and discussion over in #2463 , it's probably best if we don't auto-create this in the setup wizard anymore.