### PR TITLE
Delete unused ets table creation

### DIFF
--- a/src/couch_expiring_cache/src/couch_expiring_cache_server.erl
+++ b/src/couch_expiring_cache/src/couch_expiring_cache_server.erl
@@ -43,7 +43,6 @@ start_link(Name, Opts) when is_atom(Name) ->
 
 
 init(Opts) ->
-    ?MODULE = ets:new(?MODULE, [named_table, public, {read_concurrency, true}]),
     DefaultCacheName = atom_to_binary(maps:get(name, Opts), utf8),
     Period = maps:get(period, Opts, ?DEFAULT_PERIOD_MSEC),
     MaxJitter = maps:get(max_jitter, Opts, ?DEFAULT_MAX_JITTER_MSEC),


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This ets table was a holdover from when couch_expiring_cache was a non-
library OTP application. It is unused, and would prevent multiple users
of the library in the same project.

## Testing recommendations

```
make eunit apps=couch_expiring_cache
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
