### PR TITLE
Fix node-specific shard access via HTTP

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -154,12 +154,17 @@ recv_loop(Ref, ReqResp) ->
     receive
         {Ref, Code, Headers, _Args, start_response} ->
             recv_loop(Ref, ReqResp:start({Code, Headers}));
+        {Ref, Code, Headers, Len, start_response_length} ->
+            recv_loop(Ref, ReqResp:start_response_length({Code, Headers, Len}));
         {Ref, Code, Headers, chunked, respond} ->
             Resp = ReqResp:respond({Code, Headers, chunked}),
             recv_loop(Ref, Resp);
         {Ref, Code, Headers, Args, respond} ->
             Resp = ReqResp:respond({Code, Headers, Args}),
             {ok, Resp};
+        {Ref, send, Data} ->
+            ReqResp:send(Data),
+            {ok, ReqResp};
         {Ref, chunk, <<>>} ->
             ReqResp:write_chunk(<<>>),
             {ok, ReqResp};

--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -132,7 +132,7 @@ handle_node_req(#httpd{path_parts=[_, Node | PathParts],
     % strip /_node/{node} from Req0 before descending further
     RawUri = MochiReq0:get(raw_path),
     {_, Query, Fragment} = mochiweb_util:urlsplit_path(RawUri),
-    NewPath0 = "/" ++ lists:join("/", [?b2l(P) || P <- PathParts]),
+    NewPath0 = "/" ++ lists:join("/", [couch_util:url_encode(P) || P <- PathParts]),
     NewRawPath = mochiweb_util:urlunsplit_path({NewPath0, Query, Fragment}),
     MaxSize =  config:get_integer("httpd", "max_http_request_size", 4294967296),
     NewOpts = [{body, MochiReq0:recv_body(MaxSize)} | MochiReq0:get(opts)],

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -720,6 +720,9 @@ start_response(#httpd{mochi_req=MochiReq}=Req, Code, Headers0) ->
     end,
     {ok, Resp}.
 
+send({remote, Pid, Ref} = Resp, Data) ->
+    Pid ! {Ref, send, Data},
+    {ok, Resp};
 send(Resp, Data) ->
     Resp:send(Data),
     {ok, Resp}.


### PR DESCRIPTION
## Overview

In #2336 we removed node-local HTTP access and redirected all traffic through `/_node/{node-name}/...`. This sneakily routes a new MochiWeb request through to couch_httpd under the covers.

Unfortunately, in the process we ended up URL-decoding the URL, meaning the passed-through URL couldn't include `%2F` for accessing individual shards.

This reintroduces URL encoding to fix the problem.

It also introduces support to query a specific view shard through `/_node/{node-name}/{db-shard}/{ddoc}/`. This allows inspection of individual view shard sizes.

## Testing recommendations

```
dev/run -n 1 -a admin:password
curl -X PUT http://admin:password@localhost:15984/abc
curl -X PUT http://admin:password@localhost:15984/abc/_design%2ffoo -d '{"language":"javascript","views":{"all":{"map":"function(doc) { emit(doc._id, null);}"}}}'
curl -X PUT http://admin:password@localhost:15984/abc/def -d '{}'
curl -X PUT http://admin:password@localhost:15984/abc/qqq -d '{}'
curl http://admin:password@localhost:15984/_node/_local/_all_dbs
# substitute your timestamp code in the following lines...
curl http://admin:password@localhost:15984/_node/_local/shards%2f00000000-7fffffff%2fabc.1580273428
curl http://admin:password@localhost:15984/_node/_local/shards%2f00000000-7fffffff%2fabc.1580273428/def
curl http://admin:password@localhost:15984/_node/_local/shards%2f00000000-7fffffff%2fabc.1580273428/qqq

curl http://admin:password@localhost:15984/abc/_design/foo/_info
curl http://admin:password@localhost:15984/abc/_design/foo/_view/all
curl http://admin:password@localhost:15984/_node/_local/shards%2f00000000-7fffffff%2fabc.1580273428/_design/foo/_info
curl http://admin:password@localhost:15984/_node/_local/shards%2f80000000-ffffffff%2fabc.1580273428/_design/foo/_info
curl http://admin:password@localhost:15984/_node/_local/shards%2f00000000-7fffffff%2fabc.1580273428/_design/foo/_view/all
curl http://admin:password@localhost:15984/_node/_local/shards%2f80000000-ffffffff%2fabc.1580273428/_design/foo/_view/all
```

Example output for the last few lines (new per-view-shard endpoint):

```
$ curl http://admin:password@localhost:15984/_node/_local/shards%2f00000000-7fffffff%2fabc.1580515057/_design/foo/_info
{"name":"foo","view_index":{"signature":"de76da589940694f05807f0c4fb5d33a","language":"javascript","sizes":{"file":4190,"active":98,"external":24},"update_seq":1,"purge_seq":0,"update_options":[],"updater_running":false,"compact_running":false,"waiting_commit":false,"waiting_clients":0,"pending_updates":0}}
$ curl http://admin:password@localhost:15984/_node/_local/shards%2f80000000-ffffffff%2fabc.1580515057/_design/foo/_info
{"name":"foo","view_index":{"signature":"de76da589940694f05807f0c4fb5d33a","language":"javascript","sizes":{"file":8292,"active":98,"external":24},"update_seq":2,"purge_seq":0,"update_options":[],"updater_running":false,"compact_running":false,"waiting_commit":false,"waiting_clients":0,"pending_updates":0}}

$ curl http://admin:password@localhost:15984/_node/_local/shards%2f00000000-7fffffff%2fabc.1580515057/_design/foo/_view/all
{"total_rows":1,"offset":0,"rows":[
{"id":"def","key":"def","value":null}
]}
$ curl http://admin:password@localhost:15984/_node/_local/shards%2f80000000-ffffffff%2fabc.1580515057/_design/foo/_view/all
{"total_rows":1,"offset":0,"rows":[
{"id":"qqq","key":"qqq","value":null}
]}

```

## Related Issues or Pull Requests

Closes #2500 fully.