### PR TITLE
Stop propagating RC tags into dist archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,13 @@ IN_RC = $(shell git describe --tags --always --first-parent \
 # ON_TAG matches *ONLY* if we are on a release or RC tag
 ON_TAG = $(shell git describe --tags --always --first-parent \
         | grep -Eo -- '^[0-9]+\.[0-9]\.[0-9]+(-RC[0-9]+)?$$' 2>/dev/null)
-# RELTAG contains the #.#.# from git describe, which might be used
-RELTAG = $(shell git describe --tags --always --first-parent \
+# REL_TAG contains the #.#.# from git describe, which might be used
+REL_TAG = $(shell git describe --tags --always --first-parent \
         | grep -Eo -- '^[0-9]+\.[0-9]\.[0-9]+' 2>/dev/null)
 # DIRTY identifies if we're not on a commit
 DIRTY = $(shell git describe --dirty | grep -Eo -- '-dirty' 2>/dev/null)
 # COUCHDB_GIT_SHA is our current git hash.
-COUCHDB_GIT_SHA=$(shell git rev-parse --short --verify HEAD)
+COUCHDB_GIT_SHA=$(shell git rev-parse --short=7 --verify HEAD)
 
 ifeq ($(ON_TAG),)
 # 4. Not on a tag.
@@ -59,7 +59,7 @@ COUCHDB_VERSION_SUFFIX = $(COUCHDB_GIT_SHA)$(DIRTY)
 COUCHDB_VERSION = $(vsn_major).$(vsn_minor).$(vsn_patch)-$(COUCHDB_VERSION_SUFFIX)
 else
 # 2 and 3. On a tag.
-COUCHDB_VERSION = $(RELTAG)$(DIRTY)
+COUCHDB_VERSION = $(REL_TAG)$(DIRTY)
 endif
 endif
 
@@ -383,7 +383,7 @@ introspect:
 
 .PHONY: dist
 # target: dist - Make release tarball
-dist: all
+dist: all derived
 	@./build-aux/couchdb-build-release.sh $(COUCHDB_VERSION)
 
 	@cp -r share/www apache-couchdb-$(COUCHDB_VERSION)/share/
@@ -523,3 +523,15 @@ ifeq ($(with_fauxton), 1)
 	@echo "Building Fauxton"
 	@cd src/fauxton && npm install --production && ./node_modules/grunt-cli/bin/grunt couchdb
 endif
+
+
+derived:
+	@echo "COUCHDB_GIT_SHA:        $(COUCHDB_GIT_SHA)"
+	@echo "COUCHDB_VERSION:        $(COUCHDB_VERSION)"
+	@echo "COUCHDB_VERSION_SUFFIX: $(COUCHDB_VERSION_SUFFIX)"
+	@echo "DIRTY:                  $(DIRTY)"
+	@echo "IN_RC:                  $(IN_RC)"
+	@echo "IN_RELEASE:             $(IN_RELEASE)"
+	@echo "ON_TAG:                 $(ON_TAG)"
+	@echo "REL_TAG:                $(REL_TAG)"
+	@echo "SUB_VSN:                $(SUB_VSN)"

--- a/build-aux/couchdb-build-release.sh
+++ b/build-aux/couchdb-build-release.sh
@@ -2,63 +2,55 @@
 
 VERSION=$1
 
-if [ -z "$VERSION" ]; then
+if [ -z "${VERSION}" ]; then
   echo "NO VERSION"
   exit 1
 fi
 
-echo "Building Apache CouchDB $VERSION"
+echo "Building Apache CouchDB ${VERSION}"
 
-RELDIR=apache-couchdb-$VERSION
+REL_DIR=apache-couchdb-${VERSION}
 # make release dir
-rm -rf $RELDIR
-mkdir $RELDIR
+rm -rf ${REL_DIR}
+mkdir ${REL_DIR}
 
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 
 # copy sources over
-git archive $CURRENT_BRANCH | tar -xC $RELDIR/ -f -
+git archive ${CURRENT_BRANCH} | tar -xC ${REL_DIR}/ -f -
 cd src/
-
 for repo in *; do
-  cd $repo
+  cd ${repo}
   if [ -d ".git" ]; then
-    mkdir -p ../../$RELDIR/src/$repo
+    mkdir -p ../../${REL_DIR}/src/${repo}
     git_ish=`git rev-parse --short HEAD`
-    git archive $git_ish | tar --exclude '*do_not_compile.erl' -xC ../../$RELDIR/src/$repo/ -f -
+    git archive ${git_ish} \
+        | tar --exclude '*do_not_compile.erl' -xC ../../${REL_DIR}/src/${repo}/ -f -
   fi
   set +e
-  grep -rl '{vsn, git}' ../../$RELDIR/src/$repo/ | xargs sed -ie "s/{vsn, git}/{vsn, \"`git describe --always --tags`\"}/" 2> /dev/null
+  grep -rl '{vsn, git}' ../../${REL_DIR}/src/${repo}/ 2>/dev/null \
+      | xargs sed -ie "s/{vsn, git}/{vsn, \"${VERSION}\"}/" 2>/dev/null
   set -e
   cd ..
 done
 
 cd ..
 
-
 if test -e .git; then
-    # save git sha in version.mk
-    git_sha=`git rev-parse --short HEAD`
-    echo "git_sha=$git_sha" >> $RELDIR/version.mk
-    # create CONTRIBUTORS file
-    OS=`uname -s`
-    case "$OS" in
-    Linux|CYGWIN*) # GNU sed
-        SED_ERE_FLAG=-r
-    ;;
-    *) # BSD sed
-        SED_ERE_FLAG=-E
-    ;;
-    esac
+  # save git sha in version.mk
+  git_sha=`git rev-parse --short HEAD`
+  echo "git_sha=${git_sha}" >> ${REL_DIR}/version.mk
+  # create CONTRIBUTORS file
+  OS=`uname -s`
 
-    sed -e "/^#.*/d" CONTRIBUTORS.in > $RELDIR/CONTRIBUTORS
-    CONTRIB_EMAIL_SED_COMMAND="s/^[[:blank:]]{5}[[:digit:]]+[[:blank:]]/ * /"
-    git shortlog -se 6c976bd..HEAD \
-        | grep -v @apache.org \
-        | sed $SED_ERE_FLAG -e "$CONTRIB_EMAIL_SED_COMMAND" >> $RELDIR/CONTRIBUTORS
-    echo "" >> $RELDIR/CONTRIBUTORS # simplest portable newline
-    echo "For a list of authors see the \`AUTHORS\` file." >> $RELDIR/CONTRIBUTORS
+  sed -e "/^#.*/d" CONTRIBUTORS.in > ${REL_DIR}/CONTRIBUTORS
+  CONTRIB_EMAIL_SED_COMMAND="s/^[[:blank:]]{5}[[:digit:]]+[[:blank:]]/ * /"
+  git shortlog -se 6c976bd..HEAD \
+      | grep -v @apache.org \
+      | sed -E -e "${CONTRIB_EMAIL_SED_COMMAND}" >> ${REL_DIR}/CONTRIBUTORS
+  echo "" >> ${REL_DIR}/CONTRIBUTORS # simplest portable newline
+  echo "For a list of authors see the \`AUTHORS\` file." >> ${REL_DIR}/CONTRIBUTORS
 fi
 
 # copy our rebar
-cp bin/rebar $RELDIR/bin/rebar
+cp bin/rebar ${REL_DIR}/bin/rebar


### PR DESCRIPTION
## Overview

This ensures that the only place an RC tag is visible is in the final
tarball. To ensure we can identify CouchDB versions in the wild, each
OTP app has the original git sha placed in the {id, :hash} field.

Plus a little bit of style cleanup.

Big thanks to @dch for starting this in #1927.

## Testing recommendations

```
git tag -a 3.0.0-RC1 -m "3.0.0-RC1"
make dist
grep vsn apache-couchdb-3.0.0-RC1/src/couch/src/couch.app.src
git tag -d 3.0.0-RC1
rm -rf apache-couchdb-3.0.0-RC1*
```

## Related Issues or Pull Requests

Replaces #1927 

## Checklist

- [X] Code is written and works correctly
- [N/A] Changes are covered by tests
- [N/A] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [N/A] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
