### PR TITLE
Fix handling jiffy exceptions

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -501,7 +501,7 @@ json_decode(V) ->
     try
         jiffy:decode(V, [dedupe_keys])
     catch
-        throw:Error ->
+        error:Error ->
             throw({invalid_json, Error})
     end.
 


### PR DESCRIPTION
The 1.0 release of Jiffy changed from `throw` to `error` to match Erlang
style better.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Fix handling of Jiffy exceptions

## Testing recommendations

`make javascript`


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [N/A] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [N/A] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
