### PR TITLE
Add recon for user convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ src/oauth/
 src/parse_trans/
 src/proper/
 src/rebar/
+src/recon/
 src/smoosh/
 src/snappy/
 src/ssl_verify_fun/

--- a/LICENSE
+++ b/LICENSE
@@ -2236,3 +2236,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+For the src/recon component:
+
+Copyright (c) 2012-2017, Frédéric Trottier-Hébert
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+  The names of its contributors may not be used to endorse or promote
+  products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/NOTICE
+++ b/NOTICE
@@ -189,3 +189,7 @@ This product also includes the following third-party components:
 * hyper
 
   Copyright (c) 2014 Game Analytics ApS
+
+* recon
+
+  Copyright (c) 2012-2017, Frédéric Trottier-Hébert

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -159,7 +159,8 @@ DepDescs = [
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.1-1"}},
 {mochiweb,         "mochiweb",         {tag, "v2.20.0"}},
-{meck,             "meck",             {tag, "0.8.8"}}
+{meck,             "meck",             {tag, "0.8.8"}},
+{recon,            "recon",            {tag, "2.5.0"}}
 ],
 
 WithProper = lists:keyfind(with_proper, 1, CouchConfig) == {with_proper, true},

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -59,7 +59,9 @@
         rexi,
         setup,
         smoosh,
-        snappy
+        snappy,
+        %% extra
+        recon
     ]},
     {rel, "start_clean", "", [kernel, stdlib]},
     {boot_rel, "couchdb"},
@@ -116,7 +118,10 @@
     {app, rexi, [{incl_cond, include}]},
     {app, setup, [{incl_cond, include}]},
     {app, smoosh, [{incl_cond, include}]},
-    {app, snappy, [{incl_cond, include}]}
+    {app, snappy, [{incl_cond, include}]},
+
+    %% extra
+    {app, recon, [{incl_cond, include}]}
 ]}.
 
 {overlay_vars, "couchdb.config"}.


### PR DESCRIPTION
## Overview

Adds `recon` to our releases. 

## Testing recommendations

All of these should succeed:

```
make check
make release && rel/couchdb/bin/couchdb & && rel/couchdb/bin/remsh
# inside of remsh, try recon:port_types(). or recon_alloc:allocators().
make dist && ls apache-couchdb-*/src/recon
```

## Related Issues or Pull Requests

Closes #2510 .

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [N/A] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [Pending] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
