### PR TITLE
Makefile parity; remove [un]install tgts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,6 @@ fauxton: share/www
 .PHONY: check
 # target: check - Test everything
 check: all
-	# @$(MAKE) test-cluster-with-quorum
-	# @$(MAKE) test-cluster-without-quorum
 	@$(MAKE) python-black
 	@$(MAKE) eunit
 	@$(MAKE) javascript
@@ -157,15 +155,14 @@ check: all
 #	@$(MAKE) build-test
 
 
-.PHONY: eunit
-# target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
-
 ifdef apps
 subdirs = $(apps)
 else
 subdirs=$(shell ls src)
 endif
 
+.PHONY: eunit
+# target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
 eunit: export BUILDDIR = $(shell pwd)
 eunit: export ERL_AFLAGS = -config $(shell pwd)/rel/files/eunit.config
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell pwd)/bin/couchjs $(shell pwd)/share/server/main.js
@@ -432,9 +429,9 @@ endif
 
 .PHONY: install
 # target: install- install CouchDB :)
-install:
+install: release
 	@echo
-	@echo "Notice: There is no 'make install' command for CouchDB 2.x."
+	@echo "Notice: There is no 'make install' command for CouchDB 2.x+."
 	@echo
 	@echo "    To install CouchDB into your system, copy the rel/couchdb"
 	@echo "    to your desired installation location. For example:"
@@ -483,19 +480,6 @@ endif
 # target: devclean - Remove dev cluster artifacts
 devclean:
 	@rm -rf dev/lib/*/data
-
-
-.PHONY: uninstall
-# target: uninstall - Uninstall CouchDB :-(
-uninstall:
-	@rm -rf $(DESTDIR)/$(install_dir)
-	@rm -f $(DESTDIR)/$(bin_dir)/couchdb
-	@rm -f $(DESTDIR)/$(libexec_dir)
-	@rm -rf $(DESTDIR)/$(sysconf_dir)
-	@rm -rf $(DESTDIR)/$(data_dir)
-	@rm -rf $(DESTDIR)/$(doc_dir)
-	@rm -rf $(DESTDIR)/$(html_dir)
-	@rm -rf $(DESTDIR)/$(man_dir)
 
 
 ################################################################################

--- a/Makefile.win
+++ b/Makefile.win
@@ -28,6 +28,7 @@ REBAR?=$(shell where rebar.cmd)
 #   4. When not on a clean tag, use version.mk + git sha + dirty status.
 
 COUCHDB_GIT_SHA=$(git_sha)
+
 IN_RELEASE = $(shell if not exist .git echo true)
 
 ifeq ($(IN_RELEASE), true)
@@ -40,19 +41,19 @@ else
 # Gather some additional information.
 # We do it this way so we don't bake shell-isms into Makefile
 # to make it easier to port to Windows. I know, I know. -jst
-# COUCHDB_GIT_SHA is our current git hash.
-COUCHDB_GIT_SHA=$(shell git rev-parse --short --verify HEAD)
 # IN_RC contains the -RCx suffix in the name if present
 IN_RC = $(shell git describe --tags --always --first-parent \
         | grep -Eo -- '-RC[0-9]+' 2>nul)
 # ON_TAG matches *ONLY* if we are on a release or RC tag
 ON_TAG = $(shell git describe --tags --always --first-parent \
         | grep -Eo -- '^[0-9]+\.[0-9]\.[0-9]+(-RC[0-9]+)?$$' 2>nul)
-# RELTAG contains the #.#.# from git describe, which might be used
-RELTAG = $(shell git describe --tags --always --first-parent \
+# REL_TAG contains the #.#.# from git describe, which might be used
+REL_TAG = $(shell git describe --tags --always --first-parent \
         | grep -Eo -- '^[0-9]+\.[0-9]\.[0-9]+' 2>nul)
 # DIRTY identifies if we're not on a commit
 DIRTY = $(shell git describe --dirty | grep -Eo -- '-dirty' 2>nul)
+# COUCHDB_GIT_SHA is our current git hash.
+COUCHDB_GIT_SHA=$(shell git rev-parse --short=7 --verify HEAD)
 
 ifeq ($(ON_TAG),)
 # 4. Not on a tag.
@@ -60,7 +61,7 @@ COUCHDB_VERSION_SUFFIX = $(COUCHDB_GIT_SHA)$(DIRTY)
 COUCHDB_VERSION = $(vsn_major).$(vsn_minor).$(vsn_patch)-$(COUCHDB_VERSION_SUFFIX)
 else
 # 2 and 3. On a tag.
-COUCHDB_VERSION = $(RELTAG)$(DIRTY)
+COUCHDB_VERSION = $(REL_TAG)$(DIRTY)
 endif
 endif
 
@@ -73,7 +74,7 @@ DESTDIR=
 
 # Rebar options
 apps=
-skip_deps=folsom,meck,mochiweb,triq,snappy
+skip_deps=folsom,meck,mochiweb,triq,proper,snappy,bcrypt,hyper
 suites=
 tests=
 
@@ -82,6 +83,11 @@ EUNIT_OPTS=skip_deps=$(skip_deps)
 DIALYZE_OPTS=skip_deps=$(skip_deps)
 
 EXUNIT_OPTS=$(subst $(comma),$(space),$(tests))
+
+#ignore javascript tests
+ignore_js_suites=
+
+TEST_OPTS="-c 'startup_jitter=0' -c 'default_security=admin_local'"
 
 ################################################################################
 # Main commands
@@ -99,9 +105,9 @@ all: couch fauxton docs
 
 
 .PHONY: couch
-# target: couch - Build CouchDB core
+# target: couch - Build CouchDB core, use ERL_OPTS to provide custom compiler's options
 couch: config.erl
-	@set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) compile
+	@set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) compile $(COMPILE_OPTS)
 	@copy src\couch\priv\couchjs.exe bin
 
 
@@ -126,24 +132,28 @@ fauxton: share\www
 .PHONY: check
 # target: check - Test everything
 check: all
-	@$(MAKE) -f Makefile.win test-cluster-with-quorum
-	@$(MAKE) -f Makefile.win test-cluster-without-quorum
+	@$(MAKE) -f Makefile.win python-black
 	@$(MAKE) -f Makefile.win eunit
 	@$(MAKE) -f Makefile.win javascript
-	@$(MAKE) -f Makefile.win python-black
 	@$(MAKE) -f Makefile.win mango-test
-#	@$(MAKE) -f Makefile.win elixir
+	@$(MAKE) -f Makefile.win elixir
+#	@$(MAKE) -f Makefile.win build-test
 
+ifdef apps
+subdirs = $(apps)
+else
+subdirs=$(shell dir /b src)
+endif
 
 .PHONY: eunit
 # target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 eunit: export BUILDDIR = $(shell echo %cd%)
+eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 eunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 eunit: couch
 	@set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) setup_eunit 2> nul
-	@set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) -r eunit $(EUNIT_OPTS)
+	@FOR /F "tokens=*" %d IN ($(subdirs)) DO set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) -r eunit $(EUNIT_OPTS) apps=%dir
 
 .PHONY: exunit
 # target: exunit - Run ExUnit tests
@@ -176,7 +186,7 @@ python-black: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe --check \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
-		. dev\run test\javascript\run
+		. dev\run test\javascript\run src\mango src\docs
 
 python-black-update: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
@@ -184,78 +194,48 @@ python-black-update: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
-		. dev\run test\javascript\run
+		. dev\run test\javascript\run src\mango src\docs
 
 .PHONY: elixir
+elixir: export MIX_ENV=integration
 elixir: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 elixir: elixir-init elixir-check-formatted elixir-credo devclean
-	@dev\run -a adm:pass --enable-erlang-views --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+	@dev\run "$(TEST_OPTS)" -a adm:pass -n 1 --enable-erlang-views --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-init
-elixir-init:
+elixir-init: MIX_ENV=test
+elixir-init: config.erl
 	@mix local.rebar --force && mix local.hex --force && mix deps.get
 
 .PHONY: elixir-cluster-without-quorum
-elixir-cluster-without-quorum: elixir-check-formatted elixir-credo devclean
+elixir-cluster-without-quorum: export MIX_ENV=integration
+elixir-cluster-without-quorum: elixir-init elixir-check-formatted elixir-credo devclean
 	@dev\run -n 3 -q -a adm:pass \
-	         --degrade-cluster 2 \
-                 --no-eval 'mix test --trace --only without_quorum_test $(EXUNIT_OPTS)'
+	    --degrade-cluster 2 \
+        --no-eval 'mix test --trace --only without_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-cluster-with-quorum
-elixir-cluster-with-quorum: elixir-check-formatted elixir-credo devclean
+elixir-cluster-with-quorum: export MIX_ENV=integration
+elixir-cluster-with-quorum: elixir-init elixir-check-formatted elixir-credo devclean
 	@dev\run -n 3 -q -a adm:pass \
-	         --degrade-cluster 1 \
-		 --no-eval 'mix test --trace --only with_quorum_test $(EXUNIT_OPTS)'
+	    --degrade-cluster 1 \
+		--no-eval 'mix test --trace --only with_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-check-formatted
-elixir-check-formatted:
+elixir-check-formatted: elixir-init
 	@mix format --check-formatted
 
 # Credo is a static code analysis tool for Elixir.
 # We use it in our tests
 .PHONY: elixir-credo
-elixir-credo:
+elixir-credo: elixir-init
 	@mix credo
-
-.PHONY: test-cluster-with-quorum
-test-cluster-with-quorum: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
-test-cluster-with-quorum: devclean
-	-@mkdir share\www\script\test
-ifeq ($(IN_RELEASE), true)
-	@copy test\javascript\tests\lorem*.txt share\www\script\test
-else
-	-@mkdir src\fauxton\dist\release\test
-	@copy test\javascript\tests\lorem*.txt src\fauxton\dist\release\test
-endif
-	@dev\run -n 3 -q --with-admin-party-please \
-		--enable-erlang-views --degrade-cluster 1 \
-		-c "startup_jitter=0" \
-		"python test\javascript\run --suites \"$(suites)\" \
-		--ignore \"$(ignore_js_suites)\" \
-		--path test\javascript\tests-cluster\with-quorum"
-
-.PHONY: test-cluster-without-quorum
-test-cluster-without-quorum: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
-test-cluster-without-quorum: devclean
-	-@mkdir share\www\script\test
-ifeq ($(IN_RELEASE), true)
-	@copy test\javascript\tests\lorem*.txt share\www\script\test
-else
-	-@mkdir src\fauxton\dist\release\test
-	@copy test\javascript\tests\lorem*.txt src\fauxton\dist\release\test
-endif
-	@dev\run -n 3 -q --with-admin-party-please \
-		--enable-erlang-views --degrade-cluster 2 \
-		-c "startup_jitter=0" \
-		"python test\javascript\run --suites \"$(suites)\" \
-		--ignore \"$(ignore_js_suites)\" \
-		--path test\javascript\tests-cluster\without-quorum"
 
 
 .PHONY: javascript
 # target: javascript - Run JavaScript test suites or specific ones defined by suites option
 javascript: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
-javascript:
+javascript: devclean
 	-@mkdir share\www\script\test
 ifeq ($(IN_RELEASE), true)
 	@copy test\javascript\tests\lorem*.txt share\www\script\test
@@ -263,11 +243,17 @@ else
 	-@mkdir src\fauxton\dist\release\test
 	@copy test\javascript\tests\lorem*.txt src\fauxton\dist\release\test
 endif
-	-@rmdir /s/q dev\lib
 	@python dev\run -n 1 -q --with-admin-party-please \
-		--enable-erlang-views \
-		-c startup_jitter=0 \
-		python test\javascript\run $(suites)
+		    --enable-erlang-views \
+            "$(TEST_OPTS)" \
+            'test/javascript/run --suites "$(suites)" \
+            --ignore "$(ignore_js_suites)"'
+
+
+.PHONY: check-qs
+# target: check-qs - Run query server tests (ruby and rspec required!)
+check-qs:
+	@QS_LANG=js rspec test\view_server\query_server_spec.rb
 
 
 .PHONY: mango-test
@@ -277,12 +263,6 @@ mango-test: devclean all
 		python.exe -m venv .venv && \
 		.venv\Scripts\pip.exe install -r requirements.txt
 	@cd src\mango && .venv\Scripts\python.exe ..\..\dev\run -n 1 --admin=testuser:testpass .venv\Scripts\nosetests
-
-
-.PHONY: check-qs
-# target: check-qs - Run query server tests (ruby and rspec required!)
-check-qs:
-	@QS_LANG=js rspec test\view_server\query_server_spec.rb
 
 
 ################################################################################
@@ -322,7 +302,7 @@ introspect:
 
 .PHONY: dist
 # target: dist - Make release tarball
-dist: all
+dist: all derived
 	@.\build-aux\couchdb-build-release.sh $(COUCHDB_VERSION)
 
 	@copy -r share\www apache-couchdb-$(COUCHDB_VERSION)\share
@@ -370,13 +350,13 @@ endif
 
 .PHONY: install
 # target: install- install CouchDB :)
-install:
+install: release
 	@echo .
-	@echo Notice: There is no 'make install' command for CouchDB 2.0 yet.
+	@echo Notice: There is no 'make install' command for CouchDB 2.x+.
 	@echo .
 	@echo     To install CouchDB into your system, copy the rel\couchdb
 	@echo     to your desired installation location. For example:
-	@echo     xcopy /E rel\couchdb \usr\local\lib
+	@echo     xcopy /E rel\couchdb C:\CouchDB\ 
 	@echo .
 
 ################################################################################
@@ -427,19 +407,6 @@ devclean:
 	-@rmdir /s/q dev\lib\node3\data
 
 
-.PHONY: uninstall
-# target: uninstall - Uninstall CouchDB :-(
-uninstall:
-	-@rmdir /s/q $(DESTDIR)\$(install_dir)
-	-@del $(DESTDIR)\$(bin_dir)\couchdb
-	-@rmdir /s/q $(DESTDIR)\$(libexec_dir)
-	-@rmdir /s/q $(DESTDIR)\$(sysconf_dir)
-	-@rmdir /s/q $(DESTDIR)\$(data_dir)
-	-@rmdir /s/q $(DESTDIR)\$(doc_dir)
-	-@rmdir /s/q $(DESTDIR)\$(html_dir)
-	-@rmdir /s/q $(DESTDIR)\$(man_dir)
-
-
 ################################################################################
 # Misc
 ################################################################################
@@ -467,3 +434,14 @@ ifeq ($(with_fauxton), 1)
 	@echo "Building Fauxton"
 	@cd src\fauxton && npm install --production && .\node_modules\.bin\grunt couchdb
 endif
+
+derived:
+	@echo "COUCHDB_GIT_SHA:        $(COUCHDB_GIT_SHA)"
+	@echo "COUCHDB_VERSION:        $(COUCHDB_VERSION)"
+	@echo "COUCHDB_VERSION_SUFFIX: $(COUCHDB_VERSION_SUFFIX)"
+	@echo "DIRTY:                  $(DIRTY)"
+	@echo "IN_RC:                  $(IN_RC)"
+	@echo "IN_RELEASE:             $(IN_RELEASE)"
+	@echo "ON_TAG:                 $(ON_TAG)"
+	@echo "REL_TAG:                $(REL_TAG)"
+	@echo "SUB_VSN:                $(SUB_VSN)"


### PR DESCRIPTION
In progress - not yet tested - attempt to normalise `Makefile` and `Makefile.win` ahead of our 3.0.0 release.

Time permitting, Monday I'll get my Windows environment set up again, with the latest build chain and SM60, and make sure this does what we expect.