### PR TITLE
Return mango warnings as a delimited string

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -133,7 +133,7 @@ maybe_add_warning(UserFun, #cursor{index = Index, opts = Opts}, Stats, UserAcc) 
         [] ->
             UserAcc;
         _ ->
-            WarningStr = lists:join(<<"\n">>, Warnings),
+            WarningStr = iolist_to_binary(lists:join(<<"\n">>, Warnings)),
             Arg = {add_key, warning, WarningStr},
             {_Go, UserAcc1} = UserFun(Arg, UserAcc),
             UserAcc1

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -84,7 +84,7 @@ class IndexSelectionTests:
         ddocid = "_design/age"
         r = self.db.find({}, use_index=ddocid, return_raw=True)
         self.assertEqual(
-            r["warning"][0].lower(),
+            r["warning"].split('\n')[0].lower(),
             "{0} was not used because it does not contain a valid index for this query.".format(
                 ddocid
             ),
@@ -107,7 +107,7 @@ class IndexSelectionTests:
         selector = {"company": "Pharmex"}
         r = self.db.find(selector, use_index=ddocid, return_raw=True)
         self.assertEqual(
-            r["warning"][0].lower(),
+            r["warning"].split('\n')[0].lower(),
             "{0} was not used because it does not contain a valid index for this query.".format(
                 ddocid
             ),
@@ -124,7 +124,7 @@ class IndexSelectionTests:
 
         resp = self.db.find(selector, use_index=[ddocid, name], return_raw=True)
         self.assertEqual(
-            resp["warning"][0].lower(),
+            resp["warning"].split('\n')[0].lower(),
             "{0}, {1} was not used because it is not a valid index for this query.".format(
                 ddocid, name
             ),
@@ -162,7 +162,7 @@ class IndexSelectionTests:
             selector, sort=["foo", "bar"], use_index=ddocid_invalid, return_raw=True
         )
         self.assertEqual(
-            resp["warning"][0].lower(),
+            resp["warning"].split('\n')[0].lower(),
             "{0} was not used because it does not contain a valid index for this query.".format(
                 ddocid_invalid
             ),

--- a/src/mango/test/12-use-correct-index-test.py
+++ b/src/mango/test/12-use-correct-index-test.py
@@ -93,7 +93,7 @@ class ChooseCorrectIndexForDocs(mango.DbPerClass):
         self.assertEqual(explain_resp["index"]["type"], "special")
         resp = self.db.find(selector, return_raw=True)
         self.assertEqual(
-            resp["warning"][0].lower(),
+            resp["warning"].split('\n')[0].lower(),
             "no matching index found, create an index to optimize query time.",
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The CouchDB API defines the warning field returned by _find to be
a string (and this is what Fauxton expects). 5d55e289 was missing
a string conversion and returned the warning(s) as an array. This
restores the intended behaviour.

## Testing recommendations

Run the mango unit tests.

## Related Issues or Pull Requests

https://github.com/apache/couchdb/commit/5d55e289760959eb2fc228acb2ed00d57ddd4dee

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
