### PR TITLE
Fix b3 header

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule CouchDBTest.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps() do
     [
-      {:httpotion, "~> 3.0", only: [:dev, :test, :integration], runtime: false},
+      {:httpotion, ">= 3.1.3", only: [:dev, :test, :integration], runtime: false},
       {:jiffy, path: Path.expand("src/jiffy", __DIR__)},
       {:ibrowse,
        path: Path.expand("src/ibrowse", __DIR__), override: true, compile: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "1.0.5", "fdea745579f8845315fe6a3b43e2f9f8866839cfbc8562bb72778e9fdaa94214", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "httpotion": {:hex, :httpotion, "3.1.2", "50e3e559c2ffe8c8908c97e4ffb01efc1c18e8547cc7ce5dd173c9cf0a573a3b", [:mix], [{:ibrowse, "== 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
+  "httpotion": {:hex, :httpotion, "3.1.3", "fdaf1e16b9318dcb722de57e75ac368c93d4c6e3c9125f93e960f953a750fb77", [:mix], [{:ibrowse, "== 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jiffy": {:hex, :jiffy, "0.15.2", "de266c390111fd4ea28b9302f0bc3d7472468f3b8e0aceabfbefa26d08cd73b7", [:rebar3], [], "hexpm"},

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1302,7 +1302,7 @@ get_trace_headers(MochiReq) ->
                 parse_span_id(MochiReq:get_header_value("X-B3-ParentSpanId"))
             ];
         Value ->
-            case binary:split(Value, <<"-">>, [global]) of
+            case string:split(Value, "-", all) of
                 [TraceIdStr, SpanIdStr, _SampledStr, ParentSpanIdStr] ->
                     [
                         parse_trace_id(TraceIdStr),

--- a/src/chttpd/test/exunit/test_helper.exs
+++ b/src/chttpd/test/exunit/test_helper.exs
@@ -1,0 +1,2 @@
+ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
+ExUnit.start()

--- a/src/chttpd/test/exunit/tracing_test.exs
+++ b/src/chttpd/test/exunit/tracing_test.exs
@@ -1,0 +1,101 @@
+defmodule Couch.Test.OpenTracing do
+  use Couch.Test.ExUnit.Case
+  alias Couch.Test.Setup
+  alias Couch.Test.Setup.Step
+  alias Couch.Test.Utils
+  import Couch.DBTest, only: [retry_until: 1]
+
+  defp create_admin(user_name, password) do
+    hashed = String.to_charlist(:couch_passwords.hash_admin_password(password))
+    :config.set('admins', String.to_charlist(user_name), hashed, false)
+  end
+
+  defp base_url() do
+    addr = :config.get('chttpd', 'bind_address', '127.0.0.1')
+    port = :mochiweb_socket_server.get(:chttpd, :port)
+    "http://#{addr}:#{port}"
+  end
+
+  setup_all context do
+    test_ctx = :test_util.start_couch([:chttpd])
+    :ok = create_admin("adm", "pass")
+
+    Map.merge(context, %{
+      base_url: base_url(),
+      user: "adm",
+      pass: "pass"
+    })
+  end
+
+  setup context do
+    db_name = Utils.random_name("db")
+    session = Couch.login(context.base_url, context.user, context.pass)
+
+    on_exit(fn ->
+      delete_db(session, db_name)
+    end)
+
+    create_db(session, db_name)
+
+    Map.merge(context, %{
+      db_name: db_name,
+      session: session
+    })
+  end
+
+  def create_db(session, db_name, opts \\ []) do
+    retry_until(fn ->
+      resp = Couch.Session.put(session, "/#{db_name}", opts)
+      assert resp.status_code in [201, 202]
+      assert resp.body == %{"ok" => true}
+      {:ok, resp}
+    end)
+  end
+
+  def delete_db(session, db_name) do
+    retry_until(fn ->
+      resp = Couch.Session.delete(session, "/#{db_name}")
+      assert resp.status_code in [200, 202, 404]
+      {:ok, resp}
+    end)
+  end
+
+  def create_doc(session, db_name, body) do
+    retry_until(fn ->
+      resp = Couch.Session.post(session, "/#{db_name}", body: body)
+      assert resp.status_code in [201, 202]
+      assert resp.body["ok"]
+      {:ok, resp}
+    end)
+  end
+
+  defp trace_id() do
+    :couch_util.to_hex(:crypto.strong_rand_bytes(16))
+  end
+
+  defp span_id() do
+    :couch_util.to_hex(:crypto.strong_rand_bytes(8))
+  end
+
+  describe "Open Tracing" do
+    test "should return success with combined b3 header", ctx do
+      %{session: session, db_name: db_name} = ctx
+      doc = '{"mr": "rockoartischocko"}'
+      {:ok, _} = create_doc(session, db_name, doc)
+
+      resp =
+        retry_until(fn ->
+          b3 = "#{trace_id()}-#{span_id()}-#{span_id()}"
+
+          response =
+            Couch.Session.get(session, "/#{db_name}/_all_docs", headers: [b3: b3])
+
+          assert %HTTPotion.Response{} = response
+          response
+        end)
+
+      assert resp.status_code == 200, "Expected 200, got: #{resp.status_code}"
+      assert length(resp.body["rows"]) == 1
+    end
+  end
+end


### PR DESCRIPTION
## Overview

The B3 header parsing introduced in https://github.com/apache/couchdb/pull/2309 is broken. When b3 header is set the chttpd request is crashing with the following message:
```
[error] 2020-02-03T21:25:39.049590Z dbcore@172.30.138.101 <0.23004.0> -------- CRASH REPORT Process  (<0.23004.0>) with 0 neighbors crashed with reason: bad argument in call to binary:split("C10B5B9C9F06385D04BD6B3A57971D8C-1AEA26A4FE496E13-0000000000000000", <<"-">>, [global]) at 
   chttpd:get_trace_headers/1(line:1305) 
   <= chttpd:root_span_options/1(line:1271) 
   <= chttpd:start_span/1(line:1253) 
   <= chttpd:before_request/1(line:270) 
   <= chttpd:handle_request_int/1(line:243) 
   <= mochiweb_http:headers/6(line:128) 
   <= proc_lib:init_p_do_apply/3(line:247); 
initial_call: {mochiweb_acceptor,init,['Argument__1','Argument__2',...]}, 
ancestors: [chttpd,chttpd_sup,<0.452.0>], 
message_queue_len: 0, 
messages: [], 
links: [<0.455.0>,#Port<0.16978>], 
dictionary: [{dont_log_request,true},{ctrace_is_enabled,true},{nonce,"7f8a471..."},...], 
trap_exit: false, 
status: running, 
heap_size: 2586, 
stack_size: 27, 
reductions: 4211 
```

The reason for the crash is obvious. The `binary:split/3` is used in the place where we have string as an argument. According to the code in [mochiweb_headers.erl](https://github.com/apache/couchdb-mochiweb/blob/master/src/mochiweb_headers.erl#L196) the headers are always strings. This PR switches from `binary:split/3` to `string:split/3`. In order to make sure the change is working as expected the test is written. There was a need to adjust some testing plumbing to make test pass. This adjustment was done in the same PR since it is the very first test of this kind and testing adjustment in separate PR would be quite tricky. The adjustment to test plumbing consists of two changes:
- Update httpotion to 3.1.3 --- cherry pick from master 
- Support setting base_url in Couch test helper --- this is needed in the context of unit tests when http port is dynamic


## Testing recommendations

1. checkout PR
2. run test `make exunit apps=chttpd` - the test should pass
3. revert `3b9f04db97` locally and run test again - the test should timeout 

## Related Issues or Pull Requests

* https://github.com/apache/couchdb/pull/2309

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
