### PR TITLE
Fix highlight_post_tag parsing from json request body

### DIFF
--- a/src/dreyfus/src/dreyfus_httpd.erl
+++ b/src/dreyfus/src/dreyfus_httpd.erl
@@ -344,7 +344,7 @@ parse_json_index_param(<<"highlight_fields">>, Value) ->
     [{highlight_fields, Value}];
 parse_json_index_param(<<"highlight_pre_tag">>, Value) ->
     [{highlight_pre_tag, Value}];
-parse_json_index_param(<<"highlight_pos_tag">>, Value) ->
+parse_json_index_param(<<"highlight_post_tag">>, Value) ->
     [{highlight_post_tag, Value}];
 parse_json_index_param(<<"highlight_number">>, Value) ->
     [{highlight_number, parse_positive_int_param2("highlight_number", Value)}];

--- a/test/javascript/tests/view_errors.js
+++ b/test/javascript/tests/view_errors.js
@@ -154,6 +154,7 @@ couchTests.view_errors = function(debug) {
           db.view("infinite/infinite_loop");
           T(0 == 1);
       } catch(e) {
+        console.log("infinite sorrow: "  + e.error);
           T(e.error == "os_process_error");
       }
 


### PR DESCRIPTION
Fixes #2520
## Overview

we misspelled the key name for highlight_post_tag, so it was not translated into query params.

## Testing recommendations

Verify that the post tag substitution happens;

curl localhost:5984/db1/_design/bar/_search/bar -Hcontent-type:application/json -d '{"q":"foo:piece", "highlight_fields": ["foo"], "highlight_pre_tag":">", "highlight_post_tag":"<"}'

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/2520
## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
