### PR TITLE
Strip credentials from the traces we send to open tracing server.

### DIFF
--- a/src/fabric/src/fabric2_server.erl
+++ b/src/fabric/src/fabric2_server.erl
@@ -85,7 +85,7 @@ init(_) ->
             ClusterFileStr = config:get("erlfdb", "cluster_file", ?CLUSTER_FILE),
             {ok, ConnectionStr} = file:read_file(ClusterFileStr),
             DbHandle = erlfdb:open(iolist_to_binary(ClusterFileStr)),
-            {string:trim(ConnectionStr), DbHandle}
+            {strip_creds(string:trim(ConnectionStr)), DbHandle}
     end,
     application:set_env(fabric, ?FDB_CLUSTER, Cluster),
     application:set_env(fabric, db, Db),
@@ -139,4 +139,13 @@ get_env(Key) ->
             end;
         Value ->
             Value
+    end.
+
+strip_creds(ConnectionString) ->
+    case binary:split(ConnectionString, <<"@">>) of
+        [ConnectionString] ->
+            ConnectionString;
+        [Creds, Server] ->
+            Identity = hd(binary:split(Creds, <<":">>)),
+            <<Identity/binary, ":****@", Server/binary>>
     end.


### PR DESCRIPTION
## Overview

Previously the `db.instance` tag contained FDB connection string as is.
Which included password. This change masks the password so the `db.instance`
would look like `adm:****@127.0.0.1:4689`.

## Testing recommendations

1. checkout PR 
2. update rel/overlay/etc/default.ini
  ```
  [tracing]
  enabled = true
  app_name = couchdb
  protocol = http
  endpoint = http://127.0.0.1:14268

  [tracing.filters]
  all = (#{}) -> true
  ```
3. start jaeger `docker run -d -p 14268:14268/tcp -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:1.14`
4. start couchdb `make && dev/run --admin=adm:pass`
5. issue requests 
  ```
  curl -u "adm:pass" -X PUT http://localhost:15984/test
  ```
6. Go to jaeger UI http://127.0.0.1:16686/search and verify that db.instance tag has masked password

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
