### PR TITLE
Update Jiffy to fix CentOS builds

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -157,7 +157,7 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-6"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
-{jiffy,            "jiffy",            {tag, "CouchDB-1.0.1-1"}},
+{jiffy,            "jiffy",            {tag, "CouchDB-1.0.2-1"}},
 {mochiweb,         "mochiweb",         {tag, "v2.20.0"}},
 {meck,             "meck",             {tag, "0.8.8"}},
 {recon,            "recon",            {tag, "2.5.0"}}

--- a/test/javascript/tests/view_errors.js
+++ b/test/javascript/tests/view_errors.js
@@ -154,8 +154,13 @@ couchTests.view_errors = function(debug) {
           db.view("infinite/infinite_loop");
           T(0 == 1);
       } catch(e) {
-        console.log("infinite sorrow: "  + e.error);
-          T(e.error == "os_process_error");
+          // This test has two different races. The first is whether
+          // the while loop exhausts the JavaScript RAM limits before
+          // timing. The second is a race between which of two timeouts
+          // fires first. The first timeout is the couch_os_process
+          // waiting for data back from couchjs. The second is the
+          // gen_server call to couch_os_process.
+          T(e.error == "os_process_error" || e.error == "timeout");
       }
 
       // Check error responses for invalid multi-get bodies.


### PR DESCRIPTION
CentOS's compiler doesn't like -flto. Had to update Jiffy to avoid using it when not present.

[Edited to add: Closes #2517 ]