### PR TITLE
bump docs repo

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -150,7 +150,7 @@ DepDescs = [
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
-                   {tag, "2.3.0"}, [raw]},
+                   {tag, "3.0.0"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.2.2"}, [raw]},
 %% Third party deps


### PR DESCRIPTION
bump the docs repo to new 3.0.0 tag

closes #2509 