### PR TITLE
Fix race condition in couch_replicator_clustering eunit setup

### DIFF
--- a/src/couch_replicator/src/couch_replicator_clustering.erl
+++ b/src/couch_replicator/src/couch_replicator_clustering.erl
@@ -254,12 +254,26 @@ setup() ->
         couch_stats,
         couch_replicator_notifier
     ]),
+    stop_clustering_process(),
     {ok, Pid} = start_link(),
     Pid.
 
 
 teardown(Pid) ->
+    stop_clustering_process(Pid).
+
+
+stop_clustering_process() ->
+    stop_clustering_process(whereis(?MODULE)).
+
+
+stop_clustering_process(undefined) ->
+    ok;
+
+stop_clustering_process(Pid) when is_pid(Pid) ->
+    Ref = erlang:monitor(process, Pid),
     unlink(Pid),
-    exit(Pid, kill).
+    exit(Pid, kill),
+    receive {'DOWN', Ref, _, _, _} -> ok end.
 
 -endif.


### PR DESCRIPTION
Observed on FreeBSD Jenkins test runner:

```
function couch_replicator_clustering:setup/0 (src/couch_replicator_clustering.erl, line 257)
**error:{badmatch,{error,{already_started,<0.3165.0>}}} in module 'couch_replicator_clustering'
```
