### PR TITLE
Use multi-transactional iterators

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -57,7 +57,10 @@
 -define(PDICT_TX_ID_KEY, '$fabric_tx_id').
 -define(PDICT_TX_RES_KEY, '$fabric_tx_result').
 -define(PDICT_ON_COMMIT_FUN, '$fabric_on_commit_fun').
--define(COMMIT_UNKNOWN_RESULT, 1021).
+-define(PDICT_ITER_CHECKPOINT, '$fabric_iter_checkpoint').
+-define(PDICT_ITER_VALIDATE_DB, '$fabric_iter_validate_db').
 
+-define(COMMIT_UNKNOWN_RESULT, 1021).
+-define(TRANSACTION_TOO_OLD, 1007).
 
 -define(BINARY_CHUNK_SIZE, 100000).

--- a/src/fabric/src/fabric2_server.erl
+++ b/src/fabric/src/fabric2_server.erl
@@ -58,6 +58,7 @@ fetch(DbName) when is_binary(DbName) ->
 store(#{name := DbName} = Db0) when is_binary(DbName) ->
     Db1 = Db0#{
         tx := undefined,
+        tx_options := [],
         user_ctx := #user_ctx{},
         security_fun := undefined
     },

--- a/src/fabric/src/fabric2_util.erl
+++ b/src/fabric/src/fabric2_util.erl
@@ -31,6 +31,7 @@
 
     get_value/2,
     get_value/3,
+    replace_value/3,
     to_hex/1,
     from_hex/1,
     uuid/0
@@ -158,6 +159,10 @@ get_value(Key, List, Default) ->
         false ->
             Default
     end.
+
+
+replace_value(Key, Val, List) ->
+    lists:keyreplace(Key, 1, List, {Key, Val}).
 
 
 to_hex(Bin) ->


### PR DESCRIPTION
This is take 2.

We decided to move all the logic out of erlfdb and mostly into fabric2_fdb. This way we can make extra assumptions about our code and not needing it to be universal for every possible user of erlfdb.

Take 1 was:

https://github.com/cloudant-labs/couchdb-erlfdb/pull/13

https://github.com/apache/couchdb/pull/2508

