### PR TITLE
Encode startkey/endkey for all_docs

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -926,13 +926,13 @@ all_docs_view_opts(Args) ->
         EKey -> EKey
     end,
     StartKeyOpts = case StartKey of
-        <<_/binary>> -> [{start_key, StartKey}];
-        undefined -> []
+        undefined -> [];
+        _ -> [{start_key, fabric2_util:all_docs_encode(StartKey)}]
     end,
     EndKeyOpts = case {EndKey, Args#mrargs.inclusive_end} of
-        {<<_/binary>>, false} -> [{end_key_gt, EndKey}];
-        {<<_/binary>>, true} -> [{end_key, EndKey}];
-        {undefined, _} -> []
+        {undefined, _} -> [];
+        {_, false} -> [{end_key_gt, fabric2_util:all_docs_encode(EndKey)}];
+        {_, true} -> [{end_key, fabric2_util:all_docs_encode(EndKey)}]
     end,
     [
         {dir, Args#mrargs.direction},

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -927,12 +927,12 @@ all_docs_view_opts(Args) ->
     end,
     StartKeyOpts = case StartKey of
         undefined -> [];
-        _ -> [{start_key, fabric2_util:all_docs_encode(StartKey)}]
+        _ -> [{start_key, fabric2_util:encode_all_doc_key(StartKey)}]
     end,
     EndKeyOpts = case {EndKey, Args#mrargs.inclusive_end} of
         {undefined, _} -> [];
-        {_, false} -> [{end_key_gt, fabric2_util:all_docs_encode(EndKey)}];
-        {_, true} -> [{end_key, fabric2_util:all_docs_encode(EndKey)}]
+        {_, false} -> [{end_key_gt, fabric2_util:encode_all_doc_key(EndKey)}];
+        {_, true} -> [{end_key, fabric2_util:encode_all_doc_key(EndKey)}]
     end,
     [
         {dir, Args#mrargs.direction},

--- a/src/fabric/src/fabric2_util.erl
+++ b/src/fabric/src/fabric2_util.erl
@@ -33,7 +33,9 @@
     get_value/3,
     to_hex/1,
     from_hex/1,
-    uuid/0
+    uuid/0,
+
+    all_docs_encode/1
 ]).
 
 
@@ -235,3 +237,12 @@ hex_to_nibble(N) ->
 
 uuid() ->
     to_hex(crypto:strong_rand_bytes(16)).
+
+
+all_docs_encode(null) -> <<>>;
+all_docs_encode(true) -> <<>>;
+all_docs_encode(false) -> <<>>;
+all_docs_encode(N) when is_number(N) -> <<>>;
+all_docs_encode(B) when is_binary(B) -> B;
+all_docs_encode(L) when is_list(L) -> <<255>>;
+all_docs_encode({O}) when is_list(O) -> <<255>>.

--- a/src/fabric/src/fabric2_util.erl
+++ b/src/fabric/src/fabric2_util.erl
@@ -35,7 +35,7 @@
     from_hex/1,
     uuid/0,
 
-    all_docs_encode/1
+    encode_all_doc_key/1
 ]).
 
 
@@ -239,10 +239,10 @@ uuid() ->
     to_hex(crypto:strong_rand_bytes(16)).
 
 
-all_docs_encode(null) -> <<>>;
-all_docs_encode(true) -> <<>>;
-all_docs_encode(false) -> <<>>;
-all_docs_encode(N) when is_number(N) -> <<>>;
-all_docs_encode(B) when is_binary(B) -> B;
-all_docs_encode(L) when is_list(L) -> <<255>>;
-all_docs_encode({O}) when is_list(O) -> <<255>>.
+encode_all_doc_key(null) -> <<>>;
+encode_all_doc_key(true) -> <<>>;
+encode_all_doc_key(false) -> <<>>;
+encode_all_doc_key(N) when is_number(N) -> <<>>;
+encode_all_doc_key(B) when is_binary(B) -> B;
+encode_all_doc_key(L) when is_list(L) -> <<255>>;
+encode_all_doc_key({O}) when is_list(O) -> <<255>>.

--- a/test/elixir/test/all_docs_test.exs
+++ b/test/elixir/test/all_docs_test.exs
@@ -41,9 +41,9 @@ defmodule AllDocsTest do
     assert resp["total_rows"] == length(rows)
 
     # Check _all_docs offset
-      resp = Couch.get("/#{db_name}/_all_docs", query: %{:startkey => "\"2\""}).body
-      assert resp["offset"] == :null
-      assert Enum.at(resp["rows"], 0)["key"] == "2"
+    resp = Couch.get("/#{db_name}/_all_docs", query: %{:startkey => "\"2\""}).body
+    assert resp["offset"] == :null
+    assert Enum.at(resp["rows"], 0)["key"] == "2"
 
     # Confirm that queries may assume raw collation
     resp =
@@ -187,6 +187,7 @@ defmodule AllDocsTest do
   @tag :with_db
   test "all_docs ordering", context do
     db_name = context[:db_name]
+
     docs = [
       %{:_id => "a"},
       %{:_id => "m"},
@@ -213,9 +214,7 @@ defmodule AllDocsTest do
     resp = Couch.get("/#{db_name}/_all_docs", query: %{:end_key => 0}).body
     rows = resp["rows"]
     assert length(rows) === 0
-
   end
-
 
   defp get_ids(resp) do
     %{"rows" => rows} = resp


### PR DESCRIPTION
## Overview

Encodes the startkey/endkey so that if a startkey is not binary it will return the expected results.
## Testing recommendations

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
