### PR TITLE
Use multi-transactional iterators

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -57,6 +57,10 @@
 -define(PDICT_TX_ID_KEY, '$fabric_tx_id').
 -define(PDICT_TX_RES_KEY, '$fabric_tx_result').
 -define(PDICT_ON_COMMIT_FUN, '$fabric_on_commit_fun').
+-define(PDICT_FOLD_ACC_STATE, '$fabric_fold_acc_state').
+
+% Let's keep these in ascending order
+-define(TRANSACTION_TOO_OLD, 1007).
 -define(COMMIT_UNKNOWN_RESULT, 1021).
 
 

--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -872,6 +872,11 @@ fold_changes(Db, SinceSeq, UserFun, UserAcc, Options) ->
                 _ -> fwd
             end,
 
+            RestartTx = case fabric2_util:get_value(restart_tx, Options) of
+                undefined -> [{restart_tx, true}];
+                _AlreadySet -> []
+            end,
+
             StartKey = get_since_seq(TxDb, Dir, SinceSeq),
             EndKey = case Dir of
                 rev -> fabric2_util:seq_zero_vs();
@@ -880,7 +885,7 @@ fold_changes(Db, SinceSeq, UserFun, UserAcc, Options) ->
             FoldOpts = [
                 {start_key, StartKey},
                 {end_key, EndKey}
-            ] ++ Options,
+            ] ++ RestartTx ++ Options,
 
             {ok, fabric2_fdb:fold_range(TxDb, Prefix, fun({K, V}, Acc) ->
                 {SeqVS} = erlfdb_tuple:unpack(K, Prefix),

--- a/src/fabric/test/fabric2_changes_fold_tests.erl
+++ b/src/fabric/test/fabric2_changes_fold_tests.erl
@@ -21,28 +21,55 @@
 
 -define(DOC_COUNT, 25).
 
+-define(PDICT_ERROR_IN_FOLD_RANGE, '$fabric2_error_in_fold_range').
+-define(PDICT_ERROR_IN_USER_FUN, '$fabric2_error_throw_in_user_fun').
+
 
 changes_fold_test_() ->
     {
         "Test changes fold operations",
         {
             setup,
-            fun setup/0,
-            fun cleanup/1,
-            with([
-                ?TDEF(fold_changes_basic),
-                ?TDEF(fold_changes_since_now),
-                ?TDEF(fold_changes_since_seq),
-                ?TDEF(fold_changes_basic_rev),
-                ?TDEF(fold_changes_since_now_rev),
-                ?TDEF(fold_changes_since_seq_rev)
-            ])
+            fun setup_all/0,
+            fun teardown_all/1,
+            {
+                foreach,
+                fun setup/0,
+                fun cleanup/1,
+                [
+                    ?TDEF_FE(fold_changes_basic),
+                    ?TDEF_FE(fold_changes_since_now),
+                    ?TDEF_FE(fold_changes_since_seq),
+                    ?TDEF_FE(fold_changes_basic_rev),
+                    ?TDEF_FE(fold_changes_since_now_rev),
+                    ?TDEF_FE(fold_changes_since_seq_rev),
+                    ?TDEF_FE(fold_changes_basic_tx_too_long),
+                    ?TDEF_FE(fold_changes_reverse_tx_too_long),
+                    ?TDEF_FE(fold_changes_tx_too_long_with_single_row_emits),
+                    ?TDEF_FE(fold_changes_since_seq_tx_too_long),
+                    ?TDEF_FE(fold_changes_not_progressing)
+                ]
+            }
         }
     }.
 
 
-setup() ->
+setup_all() ->
     Ctx = test_util:start_couch([fabric]),
+    meck:new(erlfdb, [passthrough]),
+    Ctx.
+
+
+teardown_all(Ctx) ->
+    meck:unload(),
+    test_util:stop_couch(Ctx).
+
+
+setup() ->
+    meck:expect(erlfdb, fold_range, fun(Tx, Start, End, Callback, Acc, Opts) ->
+        maybe_tx_too_long(?PDICT_ERROR_IN_FOLD_RANGE),
+        meck:passthrough([Tx, Start, End, Callback, Acc, Opts])
+    end),
     {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),
     Rows = lists:map(fun(Val) ->
         DocId = fabric2_util:uuid(),
@@ -59,57 +86,193 @@ setup() ->
             rev_id => RevId
         }
     end, lists:seq(1, ?DOC_COUNT)),
-    {Db, Rows, Ctx}.
+    {Db, Rows}.
 
 
-cleanup({Db, _DocIdRevs, Ctx}) ->
-    ok = fabric2_db:delete(fabric2_db:name(Db), []),
-    test_util:stop_couch(Ctx).
+cleanup({Db, _DocIdRevs}) ->
+    reset_error_counts(),
+    ok = fabric2_db:delete(fabric2_db:name(Db), []).
 
 
-fold_changes_basic({Db, DocRows, _}) ->
-    {ok, Rows} = fabric2_db:fold_changes(Db, 0, fun fold_fun/2, []),
-    ?assertEqual(lists:reverse(DocRows), Rows).
+fold_changes_basic({Db, DocRows}) ->
+    ?assertEqual(lists:reverse(DocRows), changes(Db)).
 
 
-fold_changes_since_now({Db, _, _}) ->
-    {ok, Rows} = fabric2_db:fold_changes(Db, now, fun fold_fun/2, []),
-    ?assertEqual([], Rows).
+fold_changes_since_now({Db, _}) ->
+    ?assertEqual([], changes(Db, now, [])).
 
 
-fold_changes_since_seq({_, [], _}) ->
+fold_changes_since_seq({_, []}) ->
     ok;
 
-fold_changes_since_seq({Db, [Row | RestRows], _}) ->
+fold_changes_since_seq({Db, [Row | RestRows]}) ->
     #{sequence := Since} = Row,
-    {ok, Rows} = fabric2_db:fold_changes(Db, Since, fun fold_fun/2, []),
-    ?assertEqual(lists:reverse(RestRows), Rows),
-    fold_changes_since_seq({Db, RestRows, nil}).
+    ?assertEqual(lists:reverse(RestRows), changes(Db, Since, [])),
+    fold_changes_since_seq({Db, RestRows}).
 
 
-fold_changes_basic_rev({Db, _, _}) ->
-    Opts = [{dir, rev}],
-    {ok, Rows} = fabric2_db:fold_changes(Db, 0, fun fold_fun/2, [], Opts),
-    ?assertEqual([], Rows).
+fold_changes_basic_rev({Db, _}) ->
+    ?assertEqual([], changes(Db, 0, [{dir, rev}])).
 
 
-fold_changes_since_now_rev({Db, DocRows, _}) ->
-    Opts = [{dir, rev}],
-    {ok, Rows} = fabric2_db:fold_changes(Db, now, fun fold_fun/2, [], Opts),
-    ?assertEqual(DocRows, Rows).
+fold_changes_since_now_rev({Db, DocRows}) ->
+    ?assertEqual(DocRows, changes(Db, now, [{dir, rev}])).
 
 
-fold_changes_since_seq_rev({_, [], _}) ->
+fold_changes_since_seq_rev({_, []}) ->
     ok;
 
-fold_changes_since_seq_rev({Db, DocRows, _}) ->
+fold_changes_since_seq_rev({Db, DocRows}) ->
     #{sequence := Since} = lists:last(DocRows),
     Opts = [{dir, rev}],
-    {ok, Rows} = fabric2_db:fold_changes(Db, Since, fun fold_fun/2, [], Opts),
-    ?assertEqual(DocRows, Rows),
+    ?assertEqual(DocRows, changes(Db, Since, Opts)),
     RestRows = lists:sublist(DocRows, length(DocRows) - 1),
-    fold_changes_since_seq_rev({Db, RestRows, nil}).
+    fold_changes_since_seq_rev({Db, RestRows}).
+
+
+fold_changes_basic_tx_too_long({Db, DocRows0}) ->
+    DocRows = lists:reverse(DocRows0),
+
+    tx_too_long_errors(0, 1),
+    ?assertEqual(DocRows, changes(Db)),
+
+    tx_too_long_errors(1, 0),
+    ?assertEqual(DocRows, changes(Db)),
+
+    % Blow up in user fun but after emitting one row successfully.
+    tx_too_long_errors({1, 1}, 0),
+    ?assertEqual(DocRows, changes(Db)),
+
+    % Blow up before last document
+    tx_too_long_errors({?DOC_COUNT - 1, 1}, 0),
+    ?assertEqual(DocRows, changes(Db)),
+
+    % Emit one value, then blow up in user function and then blow up twice in
+    % fold_range. But it is not enough to stop the iteration.
+    tx_too_long_errors({1, 1}, {1, 2}),
+    ?assertEqual(DocRows, changes(Db)).
+
+
+fold_changes_reverse_tx_too_long({Db, DocRows}) ->
+    Opts = [{dir, rev}],
+
+    tx_too_long_errors(0, 1),
+    ?assertEqual([], changes(Db, 0, Opts)),
+
+    tx_too_long_errors(1, 0),
+    ?assertEqual([], changes(Db, 0, Opts)),
+
+    tx_too_long_errors(1, 0),
+    ?assertEqual(DocRows, changes(Db, now, Opts)),
+
+    tx_too_long_errors(1, 0),
+    ?assertEqual(DocRows, changes(Db, now, Opts)),
+
+    % Blow up in user fun but after emitting one row successfully.
+    tx_too_long_errors({1, 1}, 0),
+    ?assertEqual(DocRows, changes(Db, now, Opts)),
+
+    % Blow up before last document
+    tx_too_long_errors({?DOC_COUNT - 1, 1}, 0),
+    ?assertEqual(DocRows, changes(Db, now, Opts)),
+
+    % Emit value, blow up in user function, and twice in fold_range
+    tx_too_long_errors({1, 1}, {1, 2}),
+    ?assertEqual(DocRows, changes(Db, now, Opts)).
+
+
+fold_changes_tx_too_long_with_single_row_emits({Db, DocRows0}) ->
+    % This test does a few basic operations while forcing erlfdb range fold to
+    % emit a single row at a time, thus forcing it to use continuations while
+    % also inducing tx errors
+    Opts = [{target_bytes, 1}],
+    DocRows = lists:reverse(DocRows0),
+
+    tx_too_long_errors(0, 1),
+    ?assertEqual(DocRows, changes(Db, 0, Opts)),
+
+    tx_too_long_errors(1, 0),
+    ?assertEqual(DocRows, changes(Db, 0, Opts)),
+
+    % Blow up in user fun but after emitting one row successfully.
+    tx_too_long_errors({1, 1}, 0),
+    ?assertEqual(DocRows, changes(Db, 0, Opts)),
+
+    % Blow up before last document
+    tx_too_long_errors({?DOC_COUNT - 1, 1}, 0),
+    ?assertEqual(DocRows, changes(Db, 0, Opts)).
+
+
+fold_changes_since_seq_tx_too_long({Db, Rows}) ->
+    % Blow up after after a successful emit, then twice
+    % in range fold call. Also re-use already existing basic
+    % fold_changes_since_seq test function.
+    tx_too_long_errors({1, 1}, {1, 2}),
+    fold_changes_since_seq({Db, Rows}).
+
+
+fold_changes_not_progressing({Db, _}) ->
+    % Fail in first fold range call.
+    tx_too_long_errors(5, 0),
+    ?assertError(fold_range_not_progressing, changes(Db)),
+
+    % Fail in first user fun call.
+    tx_too_long_errors(0, 5),
+    ?assertError(fold_range_not_progressing, changes(Db)),
+
+    % Blow up in last user fun call
+    tx_too_long_errors({?DOC_COUNT - 1, 5}, 0),
+    ?assertError(fold_range_not_progressing, changes(Db)),
+
+    % Blow up in user function after one success.
+    tx_too_long_errors({1, 5}, 0),
+    ?assertError(fold_range_not_progressing, changes(Db)),
+
+    % Emit value, blow up in user function, then keep blowing up in fold_range.
+    tx_too_long_errors({1, 1}, {1, 4}),
+    ?assertError(fold_range_not_progressing, changes(Db)).
 
 
 fold_fun(#{} = Change, Acc) ->
+    maybe_tx_too_long(?PDICT_ERROR_IN_USER_FUN),
     {ok, [Change | Acc]}.
+
+
+tx_too_long_errors(UserFunCount, FoldErrors) when is_integer(UserFunCount) ->
+    tx_too_long_errors({0, UserFunCount}, FoldErrors);
+
+tx_too_long_errors(UserFunErrors, FoldCount) when is_integer(FoldCount) ->
+    tx_too_long_errors(UserFunErrors, {0, FoldCount});
+
+tx_too_long_errors({UserFunSkip, UserFunCount}, {FoldSkip, FoldCount}) ->
+    reset_error_counts(),
+    put(?PDICT_ERROR_IN_USER_FUN, {UserFunSkip, UserFunCount}),
+    put(?PDICT_ERROR_IN_FOLD_RANGE, {FoldSkip, FoldCount}).
+
+
+reset_error_counts() ->
+    erase(?PDICT_ERROR_IN_FOLD_RANGE),
+    erase(?PDICT_ERROR_IN_USER_FUN).
+
+
+changes(Db) ->
+    changes(Db, 0, []).
+
+
+changes(Db, Since, Opts) ->
+    {ok, Rows} = fabric2_db:fold_changes(Db, Since, fun fold_fun/2, [], Opts),
+    Rows.
+
+
+maybe_tx_too_long(Key) ->
+    case get(Key) of
+        {Skip, Count} when is_integer(Skip), Skip > 0 ->
+            put(Key, {Skip - 1, Count});
+        {0, Count} when is_integer(Count), Count > 0 ->
+            put(Key, {0, Count - 1}),
+            error({erlfdb_error, 1007});
+        {0, 0} ->
+            ok;
+        undefined ->
+            ok
+    end.

--- a/src/fabric/test/fabric2_test.hrl
+++ b/src/fabric/test/fabric2_test.hrl
@@ -10,8 +10,16 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
+
+% Some test modules do not use with, so squash the unused fun compiler warning
+-compile([{nowarn_unused_function, [{with, 1}]}]).
+
+
 -define(TDEF(Name), {atom_to_list(Name), fun Name/1}).
 -define(TDEF(Name, Timeout), {atom_to_list(Name), Timeout, fun Name/1}).
+
+-define(TDEF_FE(Name), fun(Arg) -> {atom_to_list(Name), ?_test(Name(Arg))} end).
+-define(TDEF_FE(Name, Timeout), fun(Arg) -> {atom_to_list(Name), {timeout, Timeout, ?_test(Name(Arg))}} end).
 
 
 with(Tests) ->


### PR DESCRIPTION
This is a 3rd approach.

Simplified even more after talking with @davisp 

This one is driven by an optioned passed in to fold_range. There is also just a single fold_range callback as opposed to two as before.

Previous approach: https://github.com/apache/couchdb/pull/2532