### PR TITLE
Bump SM to 60 on Centos 8

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -258,7 +258,7 @@ pipeline {
           }
           environment {
             platform = 'centos8'
-            sm_ver = '1.8.5'
+            sm_ver = '60'
           }
           stages {
             stage('Build from tarball & test') {


### PR DESCRIPTION
CentOS 8 now supports SM 60. This matches the changes over in couchdb-ci and couchdb-pkg:

https://github.com/apache/couchdb-ci/commit/1a6f6f7ec3590c13fa624c97deb5e78fea881ed7
https://github.com/apache/couchdb-pkg/commit/31a57df88666ab483cc81aee7e5abeb265c10767
