### PR TITLE
Use {restart_tx, false} option in view index builder changes feed

### DIFF
--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -211,7 +211,8 @@ fold_changes(State) ->
     } = State,
 
     Fun = fun process_changes/2,
-    fabric2_db:fold_changes(TxDb, SinceSeq, Fun, State, [{limit, Limit}]).
+    Opts = [{limit, Limit}, {restart_tx, false}],
+    fabric2_db:fold_changes(TxDb, SinceSeq, Fun, State, Opts).
 
 
 process_changes(Change, Acc) ->


### PR DESCRIPTION
Index builder performs writes in the same transaction as the changes feed so we can't use iterators as they disable writes.
