### PR TITLE
Reset if we don't get a view header

### DIFF
--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -133,6 +133,12 @@ open(Db, State0) ->
                     NewSt = couch_mrview_util:reset_index(Db, Fd, State),
                     ensure_local_purge_doc(Db, NewSt),
                     {ok, NewSt};
+                {ok, Else} ->
+                    couch_log:error("~s has a bad header: got ~p",
+                        [IndexFName, Else]),
+                    NewSt = couch_mrview_util:reset_index(Db, Fd, State),
+                    ensure_local_purge_doc(Db, NewSt),
+                    {ok, NewSt};
                 no_valid_header ->
                     NewSt = couch_mrview_util:reset_index(Db, Fd, State),
                     ensure_local_purge_doc(Db, NewSt),


### PR DESCRIPTION
## Overview

I found a .view file with a db_header in production (cause unknown but
I'm hoping it's manual intervention).

This patch means we'll reset the index if we find something other than
a view header when looking for one.

## Testing recommendations

Not entirely sure tbh, renaming and moving a .couch file to a .view maybe?

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/2438

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
