### PR TITLE
Handle possibly missing local _users db in mem3_sync:local_dbs()

### DIFF
--- a/src/mem3/src/mem3_sync.erl
+++ b/src/mem3/src/mem3_sync.erl
@@ -302,7 +302,12 @@ remove_entries(Dict, Entries) ->
     end, Dict, Entries).
 
 local_dbs() ->
-    [nodes_db(), shards_db(), users_db()].
+    UsersDb = users_db(),
+    % users db might not have been created so don't include it unless it exists
+    case couch_server:exists(UsersDb) of
+        true -> [nodes_db(), shards_db(), UsersDb];
+        false -> [nodes_db(), shards_db()]
+    end.
 
 nodes_db() ->
     ?l2b(config:get("mem3", "nodes_db", "_nodes")).

--- a/src/mem3/test/eunit/mem3_seeds_test.erl
+++ b/src/mem3/test/eunit/mem3_seeds_test.erl
@@ -18,7 +18,8 @@ a_test_() ->
     Tests = [
         {"empty seedlist should set status ok", fun empty_seedlist_status_ok/0},
         {"all seedlist nodes unreachable keeps status seeding", fun seedlist_misconfiguration/0},
-        {"seedlist entries should be present in _nodes", fun check_nodelist/0}
+        {"seedlist entries should be present in _nodes", fun check_nodelist/0},
+        {"optional local _users db in mem3_sync:local_dbs()", fun check_local_dbs/0}
     ],
     {setup, fun setup/0, fun teardown/1, Tests}.
 
@@ -57,10 +58,21 @@ check_nodelist() ->
         cleanup()
     end.
 
+check_local_dbs() ->
+    ?assertEqual([<<"_dbs">>, <<"_nodes">>],
+        lists:sort(mem3_sync:local_dbs())),
+    {ok, _} = couch_server:create(<<"_users">>, []),
+    ?assertEqual([<<"_dbs">>, <<"_nodes">>, <<"_users">>],
+        lists:sort(mem3_sync:local_dbs())).
+
 cleanup() ->
     application:stop(mem3),
     Filename = config:get("mem3", "nodes_db", "_nodes") ++ ".couch",
-    file:delete(filename:join([?BUILDDIR(), "tmp", "data", Filename])).
+    file:delete(filename:join([?BUILDDIR(), "tmp", "data", Filename])),
+    case config:get("couch_httpd_auth", "authentication_db") of
+        undefined -> ok;
+        DbName -> couch_server:delete(list_to_binary(DbName), [])
+    end.
 
 setup() ->
     test_util:start_couch([rexi]).


### PR DESCRIPTION
### Description

After commit 27bb45043435828915bdcbdc130b685e5533bbd8 local _users is only
created the first time it is used. So in most case it's expected to not exist.
Update local_dbs to return it only if it is actually created.

### Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
