### PR TITLE
Handle spurious 1009 (future_version) errors in couch_jobs pending

### DIFF
--- a/src/couch_jobs/src/couch_jobs_type_monitor.erl
+++ b/src/couch_jobs/src/couch_jobs_type_monitor.erl
@@ -55,7 +55,7 @@ loop(#st{vs = VS, timeout = Timeout} = St) ->
     try
         erlfdb:wait(Watch, [{timeout, Timeout}])
     catch
-        error:{erlfdb_error, 1009} ->
+        error:{erlfdb_error, ?FUTURE_VERSION} ->
             erlfdb:cancel(Watch, [flush]),
             ok;
         error:{timeout, _} ->

--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -66,6 +66,7 @@
 
 % Let's keep these in ascending order
 -define(TRANSACTION_TOO_OLD, 1007).
+-define(FUTURE_VERSION, 1009).
 -define(COMMIT_UNKNOWN_RESULT, 1021).
 
 


### PR DESCRIPTION
We already handle them in couch_jobs_type_monitor so let's do it in
`couch_jobs:wait_pending` as well. Recent fixes in FDB 6.2 didn't completely
fix the issue and there are still spurious 1009 errors dumped in the logs. They
seem to be benign as far as couch_jobs operation goes as type monitor code
already showed, so let's not pollute the logs with them.

