### PR TITLE
change couch_jobs ?COUCH_JOBS_CURRENT to ?PDICT_CHECKED_MD_IS_CURRENT

### DIFF
--- a/src/couch_jobs/src/couch_jobs_fdb.erl
+++ b/src/couch_jobs/src/couch_jobs_fdb.erl
@@ -631,12 +631,12 @@ init_jtx({erlfdb_transaction, _} = Tx) ->
 
 
 ensure_current(#{jtx := true, tx := Tx} = JTx) ->
-    case get(?COUCH_JOBS_CURRENT) of
+    case get(?PDICT_CHECKED_MD_IS_CURRENT) of
         Tx ->
             JTx;
         _ ->
             JTx1 = update_current(JTx),
-            put(?COUCH_JOBS_CURRENT, Tx),
+            put(?PDICT_CHECKED_MD_IS_CURRENT, Tx),
             JTx1
     end.
 


### PR DESCRIPTION

## Overview

Switch couch_jobs to check the same key as fabric2

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
