### PR TITLE
Let couch_jobs use its own metadata key

### DIFF
--- a/src/couch_jobs/src/couch_jobs.hrl
+++ b/src/couch_jobs/src/couch_jobs.hrl
@@ -35,6 +35,7 @@
 -define(ACTIVITY, 6).
 
 
+-define(COUCH_JOBS_MD_VERSION, <<"couch_jobs_md_version">>).
 -define(COUCH_JOBS_EVENT, '$couch_jobs_event').
 -define(COUCH_JOBS_CURRENT, '$couch_jobs_current').
 -define(UNDEFINED_MAX_SCHEDULED_TIME, 1 bsl 36).


### PR DESCRIPTION
Previously, if the metadata key is bumped in a transaction the same transaction
could not be used to add jobs with `couch_jobs`. That's because metadata is a
versionstamped value, and when set, it cannot be read back until that
transaction has committed. In `fabric2_fdb` there is a process dict key that is
set which declares that metadata was already read, which happens before any db
update, however `couch_jobs` uses it's own caching mechanism and doesn't know
about that pdict key.

It would be tempting to re-use the same pdict key and just set it from
whichever module calls `ensure_current`, however that would be incorrect, as
the two modules don't actually share the same `Db` handle objects, so they do
need to re-read the most recent key.

Ideally we'd implement a single `couch_fdb` module to be shared between
`couch_jobs` and `fabric2_db` but until then it maybe simpler to just let
`couch_jobs` use its own metadata key. This way, it doesn't get invalidated or
bumped every time dbs get recreated or design docs are updated. The only time
it would be bumped is if the FDB layer prefix changed at runtime.

