### PR TITLE
bump 3.x docs to actual 3.0.0 tag

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -150,7 +150,7 @@ DepDescs = [
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
-                   {tag, "3.0.0-RC2"}, [raw]},
+                   {tag, "3.0.0"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.2.2"}, [raw]},
 %% Third party deps

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -136,7 +136,7 @@ max_db_number_for_dbs_info_req = 100
 ; authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
 ; prevent non-admins from accessing /_all_dbs
-;admin_only_all_dbs = false
+; admin_only_all_dbs = true
 
 [couch_peruser]
 ; If enabled, couch_peruser ensures that a private per-user database

--- a/src/chttpd/src/chttpd_auth_request.erl
+++ b/src/chttpd/src/chttpd_auth_request.erl
@@ -34,7 +34,7 @@ authorize_request_int(#httpd{path_parts=[]}=Req) ->
 authorize_request_int(#httpd{path_parts=[<<"favicon.ico">>|_]}=Req) ->
     Req;
 authorize_request_int(#httpd{path_parts=[<<"_all_dbs">>|_]}=Req) ->
-   case config:get_boolean("chttpd", "admin_only_all_dbs", false) of
+   case config:get_boolean("chttpd", "admin_only_all_dbs", true) of
        true -> require_admin(Req);
        false -> Req
    end;


### PR DESCRIPTION
This diverges from `3.0.x` by riding `3.0.0`; we want the `-RC3` tag in `3.0.x` because it will be invariant. `3.0.0` as a tag may move with late breaking announcements / warnings about 3.0.0, possibly found after its release.

Now also with cherry-picked fix from #2576.