### PR TITLE
Improve validate_dbname test

### DIFF
--- a/src/fabric/test/fabric2_db_misc_tests.erl
+++ b/src/fabric/test/fabric2_db_misc_tests.erl
@@ -141,7 +141,15 @@ validate_dbname(_) ->
             Expect = {error, {Reason, DbName}},
             ?assertEqual(Expect, fabric2_db:validate_dbname(DbName))
     end,
-    lists:foreach(CheckFun, Tests).
+    try
+        % Don't allow epi plugins to interfere with test results
+        meck:new(couch_epi, [passthrough]),
+        meck:expect(couch_epi, decide, 5, no_decision),
+        lists:foreach(CheckFun, Tests)
+    after
+        % Unload within the test to minimize interference with other tests
+        meck:unload()
+    end.
 
 
 validate_doc_ids(_) ->


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

It's possible for other couch_epi plugins to interfere with this test,
so mock `couch_epi:decide/5` to always return `no_decision`.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=fabric suites=fabric2_db_misc_tests
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
