### PR TITLE
Add 410 status code to stats_descriptions

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -230,6 +230,10 @@
     {type, counter},
     {desc, <<"number of HTTP 409 Conflict responses">>}
 ]}.
+{[couchdb, httpd_status_codes, 410], [
+    {type, counter},
+    {desc, <<"number of HTTP 410 Gone responses">>}
+]}.
 {[couchdb, httpd_status_codes, 412], [
     {type, counter},
     {desc, <<"number of HTTP 412 Precondition Failed responses">>}


### PR DESCRIPTION
We started to emit that in CouchDB 4.x for temporary views and possibly other endpoints.
