### PR TITLE
Fix base url in tests

### DIFF
--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -4,7 +4,7 @@ defmodule Couch.Session do
   """
 
   @enforce_keys [:cookie]
-  defstruct [:cookie, :base_url]
+  defstruct [:cookie]
 
   def new(cookie) do
     %Couch.Session{cookie: cookie}
@@ -34,7 +34,6 @@ defmodule Couch.Session do
 
   def go(%Couch.Session{} = sess, method, url, opts) do
     opts = Keyword.merge(opts, cookie: sess.cookie)
-    opts = Keyword.merge(opts, base_url: sess.base_url)
     Couch.request(method, url, opts)
   end
 
@@ -55,13 +54,8 @@ defmodule Couch do
     url
   end
 
-  def process_url(url, options) do
-    base_url = case Keyword.get(options, :base_url) do
-      nil ->
-        System.get_env("EX_COUCH_URL") || "http://127.0.0.1:15984"
-      base_url ->
-        base_url
-    end
+  def process_url(url) do
+    base_url = System.get_env("EX_COUCH_URL") || "http://127.0.0.1:15984"
     base_url <> url
   end
 
@@ -120,16 +114,15 @@ defmodule Couch do
 
   def login(userinfo) do
     [user, pass] = String.split(userinfo, ":", parts: 2)
-    login(nil, user, pass)
+    login(user, pass)
   end
 
-  def login(base_url, user, pass) do
-    resp = Couch.post("/_session",
-      body: %{:username => user, :password => pass}, base_url: base_url)
+  def login(user, pass) do
+    resp = Couch.post("/_session", body: %{:username => user, :password => pass})
     true = resp.body["ok"]
     cookie = resp.headers[:"set-cookie"]
     [token | _] = String.split(cookie, ";")
-    %Couch.Session{cookie: token, base_url: base_url}
+    %Couch.Session{cookie: token}
   end
 
 end


### PR DESCRIPTION
## Overview

This PR fixes few replicator elixir tests. The tests were broken by https://github.com/apache/couchdb/pull/2519

## Testing recommendations

```
git clean -xffd && ./configure --dev && make && make elixir tests=test/elixir/test/replication_test.exs
```

I have two tests still failing locally. However these two were failing prior to https://github.com/apache/couchdb/pull/2519.


## Related Issues or Pull Requests

* https://github.com/apache/couchdb/pull/2519

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
