### PR TITLE
Do not use the ddoc cache to load filter design documents

### DIFF
--- a/src/chttpd/src/chttpd_changes.erl
+++ b/src/chttpd/src/chttpd_changes.erl
@@ -393,7 +393,7 @@ check_fields(_Fields) ->
 
 
 open_ddoc(Db, DDocId) ->
-    case ddoc_cache:open_doc(Db, DDocId) of
+    case fabric2_db:open_doc(Db, DDocId, [ejson_body, ?ADMIN_CTX]) of
         {ok, _} = Resp -> Resp;
         Else -> throw(Else)
     end.


### PR DESCRIPTION
### Overview

Since we started re-using the main changes feed transaction to open the docs 1bceb55, we also started to pass the transactional db handle to the ddoc cache. However ddoc cache uses a `spawn_monitor` to open docs, and since our transaction objects are tied to the owner process the open was failing with a `badarg` error from erlfdb.


### Testing recommendations

```
 make eunit apps=fabric,couch_jobs,couch_views
```
and
```
  make elixir tests=test/elixir/test/basics_test.exs,test/elixir/test/replication_test.exs,test/elixir/test/map_test.exs,test/elixir/test/all_docs_test.exs,test/elixir/test/bulk_docs_test.exs
```
