### PR TITLE
Clean up after mango tests

### DIFF
--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -324,6 +324,10 @@ class DbPerClass(unittest.TestCase):
         klass.db = Database(random_db_name())
         klass.db.create(q=1, n=1)
 
+    @classmethod
+    def tearDownClass(klass):
+        klass.db.delete()
+
     def setUp(self):
         self.db = self.__class__.db
 

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -314,6 +314,10 @@ class UsersDbTests(unittest.TestCase):
         klass.db = Database("_users")
         user_docs.setup_users(klass.db)
 
+    @classmethod
+    def tearDownClass(klass):
+        user_docs.teardown_users(klass.db)
+
     def setUp(self):
         self.db = self.__class__.db
 

--- a/src/mango/test/user_docs.py
+++ b/src/mango/test/user_docs.py
@@ -59,6 +59,10 @@ def setup_users(db, **kwargs):
     db.save_docs(copy.deepcopy(USERS_DOCS))
 
 
+def teardown_users(db):
+    [db.delete_doc(doc['_id']) for doc in USERS_DOCS]
+
+
 def setup(db, index_type="view", **kwargs):
     db.recreate()
     if index_type == "view":


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Mango Python tests don't always clean up after themselves. This deletes databases and documents created by the tests.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

```
nosetests --nocapture src/mango/test
```

Before this PR, running the tests as above will leave databases and users docs around. With this PR applied, those databases and docs get deleted.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
