### PR TITLE
Add support for X-Couch-Trace header

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1251,6 +1251,9 @@ start_span(Req) ->
         [_ | _] -> filename:join(PathParts)
     end,
     {IsExternalSpan, RootOptions} = root_span_options(MochiReq),
+
+    CouchTrace = header_value(Req, "X-Couch-Trace") /= undefined,
+
     Tags = maps:merge(#{
         peer => Peer,
         'http.method' => Method,
@@ -1259,7 +1262,7 @@ start_span(Req) ->
         path_parts => Path,
         'span.kind' => <<"server">>,
         component => <<"couchdb.chttpd">>,
-        external => IsExternalSpan
+        external => IsExternalSpan orelse CouchTrace
     }, ExtraTags),
 
     ctrace:start_span(OperationName, [


### PR DESCRIPTION
## Overview

Sometime it is useful to be able to trigger open tracing using single header in the request. 
For such cases this PR introduces `X-Couch-Trace` header. This header combined with the following config in `default.ini` would cause tracing of the request. 

```
[tracing.filters]
all = (#{external := External}) when External == true -> true
```

*Note*: 
  - We check for existence of the header and don't care about its value
  - This feature could allow malicious user to launch resource exhaustion attack on tracing infrastructure (elastic search backend of jaeger). You are absolutely safe if you don't use `(#{external := External}) when External == true`.

## Testing recommendations

1. update rel/overlay/etc/default.ini as follows
```
diff --git a/rel/overlay/etc/default.ini b/rel/overlay/etc/default.ini
index 592445c28..69091eab3 100644
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -572,15 +572,15 @@ min_priority = 2.0
 ;   - jaeger.thrift over udp
 ;   - jaeger.thrift over http
 ; ## Common settings
-; enabled = false ; true | false
-; app_name = couchdb ; value to use for the `location.application` tag
-; protocol = udp ; udp | http - which reporter to use
+enabled = true ; true | false
+app_name = couchdb ; value to use for the `location.application` tag
+protocol = http ; udp | http - which reporter to use
 ; ## jaeger.thrift over udp reporter
 ; thrift_format = compact ; compact | binary
 ; agent_host = 127.0.0.1
 ; agent_port = 6831
 ; ## jaeger.thrift over udp reporter
-; endpoint = http://127.0.0.1:14268
+endpoint = http://127.0.0.1:14268
 [tracing.filters]
 ;
@@ -603,4 +603,4 @@ min_priority = 2.0
 ; corresponding operation name key configured. Thus, users can easily
 ; log every generated trace by including the following:
 ;
-; all = (#{}) -> true
+all = (#{external := External}) when External == true -> true
```
2. start jaeger in docker container
```
docker run -d -p 6831:6831/udp -p 16686:16686 -p 14268:14268 jaegertracing/all-in-one:1.14
```
3. Start couchdb dev/run --admin=adm:pass
4. Create database curl -X PUT -u adm:pass http://127.0.0.1:15984/test
5. Query database curl -X GET -u adm:pass http://127.0.0.1:15984/test/_all_docs -H 'X-Couch-Trace: true'
6. Open http://localhost:16686/ in the browser and search for spans (you should find some traces)

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
