### PR TITLE
Fdb set view limits

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -252,7 +252,7 @@ iterations = 10 ; iterations for password hashing
 ; The maximum allowed key size emitted from a view for a document (in bytes)
 ; key_size_limit = 8000
 ; The maximum allowed value size emitted from a view for a document (in bytes)
-; key_size_limit = 64000
+; value_size_limit = 64000
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -249,6 +249,10 @@ iterations = 10 ; iterations for password hashing
 ; Settings for view indexing
 [couch_views]
 ; max_workers = 100
+; The maximum allowed key size emitted from a view for a document (in bytes)
+; key_size_limit = 8000
+; The maximum allowed value size emitted from a view for a document (in bytes)
+; key_size_limit = 64000
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]

--- a/src/couch_views/src/couch_views_fdb.erl
+++ b/src/couch_views/src/couch_views_fdb.erl
@@ -32,6 +32,8 @@
 -define(LIST_VALUE, 0).
 -define(JSON_VALUE, 1).
 -define(VALUE, 2).
+-define(MAX_KEY_SIZE_LIMIT, 8000).
+-define(MAX_VALUE_SIZE_LIMIT, 64000).
 
 
 -include("couch_views.hrl").
@@ -398,8 +400,8 @@ calculate_row_size(Rows) ->
 
 
 key_size_limit() ->
-    config:get_integer("couch_views", "key_size_limit", 8000).
+    config:get_integer("couch_views", "key_size_limit", ?MAX_KEY_SIZE_LIMIT).
 
 
 value_size_limit() ->
-    config:get_integer("couch_views", "value_size_limit", 64000).
+    config:get_integer("couch_views", "value_size_limit", ?MAX_VALUE_SIZE_LIMIT).

--- a/src/couch_views/src/couch_views_fdb.erl
+++ b/src/couch_views/src/couch_views_fdb.erl
@@ -107,7 +107,7 @@ fold_map_idx(TxDb, Sig, ViewId, Options, Callback, Acc0) ->
     Acc1.
 
 
-write_doc(TxDb, Sig, _ViewIds, #{deleted := true} = Doc) ->
+write_doc(TxDb, Sig, _Views, #{deleted := true} = Doc) ->
     #{
         id := DocId
     } = Doc,
@@ -115,13 +115,11 @@ write_doc(TxDb, Sig, _ViewIds, #{deleted := true} = Doc) ->
     ExistingViewKeys = get_view_keys(TxDb, Sig, DocId),
 
     clear_id_idx(TxDb, Sig, DocId),
-    lists:foreach(fun({ViewId, TotalKeys, TotalSize, UniqueKeys}) ->
-        clear_map_idx(TxDb, Sig, ViewId, DocId, UniqueKeys),
-        update_row_count(TxDb, Sig, ViewId, -TotalKeys),
-        update_kv_size(TxDb, Sig, ViewId, -TotalSize)
+    lists:foreach(fun(ExistingViewKey) ->
+        remove_doc_from_idx(TxDb, Sig, DocId, ExistingViewKey)
     end, ExistingViewKeys);
 
-write_doc(TxDb, Sig, ViewIds, Doc) ->
+write_doc(TxDb, Sig, Views, Doc) ->
     #{
         id := DocId,
         results := Results
@@ -130,26 +128,50 @@ write_doc(TxDb, Sig, ViewIds, Doc) ->
     ExistingViewKeys = get_view_keys(TxDb, Sig, DocId),
 
     clear_id_idx(TxDb, Sig, DocId),
+    lists:foreach(fun({View, NewRows}) ->
+        #mrview{
+            map_names = MNames,
+            id_num = ViewId
+        } = View,
 
-    lists:foreach(fun({ViewId, NewRows}) ->
-        update_id_idx(TxDb, Sig, ViewId, DocId, NewRows),
+        try
+            NewRowSize = calculate_row_size(NewRows),
+            update_id_idx(TxDb, Sig, ViewId, DocId, NewRows),
 
-        ExistingKeys = case lists:keyfind(ViewId, 1, ExistingViewKeys) of
-            {ViewId, TotalRows, TotalSize, EKeys} ->
-                RowChange = length(NewRows) - TotalRows,
-                SizeChange = calculate_row_size(NewRows) - TotalSize,
-                update_row_count(TxDb, Sig, ViewId, RowChange),
-                update_kv_size(TxDb, Sig, ViewId, SizeChange),
-                EKeys;
-            false ->
-                RowChange = length(NewRows),
-                SizeChange = calculate_row_size(NewRows),
-                update_row_count(TxDb, Sig, ViewId, RowChange),
-                update_kv_size(TxDb, Sig, ViewId, SizeChange),
-                []
-        end,
-        update_map_idx(TxDb, Sig, ViewId, DocId, ExistingKeys, NewRows)
-    end, lists:zip(ViewIds, Results)).
+            ExistingKeys = case lists:keyfind(ViewId, 1, ExistingViewKeys) of
+                {ViewId, TotalRows, TotalSize, EKeys} ->
+                    RowChange = length(NewRows) - TotalRows,
+                    SizeChange = NewRowSize - TotalSize,
+                    update_row_count(TxDb, Sig, ViewId, RowChange),
+                    update_kv_size(TxDb, Sig, ViewId, SizeChange),
+                    EKeys;
+                false ->
+                    RowChange = length(NewRows),
+                    SizeChange = NewRowSize,
+                    update_row_count(TxDb, Sig, ViewId, RowChange),
+                    update_kv_size(TxDb, Sig, ViewId, SizeChange),
+                    []
+            end,
+            update_map_idx(TxDb, Sig, ViewId, DocId, ExistingKeys, NewRows)
+        catch
+            throw:{size_exceeded, Type}  ->
+                case lists:keyfind(ViewId, 1, ExistingViewKeys) of
+                    false ->
+                        ok;
+                    ExistingViewKey ->
+                        remove_doc_from_idx(TxDb, Sig, DocId, ExistingViewKey)
+                end,
+                couch_log:error("Doc `~s` exceeded the ~s size for view `~s`"
+                    " and was not indexed.", [DocId, Type, MNames])
+        end
+    end, lists:zip(Views, Results)).
+
+
+remove_doc_from_idx(TxDb, Sig, DocId, {ViewId, TotalKeys, TotalSize,
+    UniqueKeys}) ->
+    clear_map_idx(TxDb, Sig, ViewId, DocId, UniqueKeys),
+    update_row_count(TxDb, Sig, ViewId, -TotalKeys),
+    update_kv_size(TxDb, Sig, ViewId, -TotalSize).
 
 
 % For each row in a map view we store the the key/value
@@ -352,6 +374,28 @@ process_rows(Rows) ->
 
 
 calculate_row_size(Rows) ->
+    KeyLimit = key_size_limit(),
+    ValLimit = value_size_limit(),
+
     lists:foldl(fun({K, V}, Acc) ->
-        Acc + erlang:external_size(K) + erlang:external_size(V)
+        KeySize = erlang:external_size(K),
+        ValSize = erlang:external_size(V),
+
+        if KeySize =< KeyLimit -> ok; true ->
+            throw({size_exceeded, key})
+        end,
+
+        if ValSize =< ValLimit -> ok; true ->
+            throw({size_exceeded, value})
+        end,
+
+        Acc + KeySize + ValSize
     end, 0, Rows).
+
+
+key_size_limit() ->
+    config:get_integer("couch_views", "key_size_limit", 8000).
+
+
+value_size_limit() ->
+    config:get_integer("couch_views", "value_size_limit", 64000).

--- a/src/couch_views/src/couch_views_fdb.erl
+++ b/src/couch_views/src/couch_views_fdb.erl
@@ -164,7 +164,7 @@ write_doc(TxDb, Sig, Views, Doc) ->
                 #{
                     name := DbName
                 } = TxDb,
-                couch_log:error("Db `~s` Doc `~s` exceeded the ~s size"
+                couch_log:error("Db `~s` Doc `~s` exceeded the ~s size "
                     "for view `~s` and was not indexed.",
                     [DbName, DocId, Type, MNames])
         end

--- a/src/couch_views/src/couch_views_fdb.erl
+++ b/src/couch_views/src/couch_views_fdb.erl
@@ -161,8 +161,12 @@ write_doc(TxDb, Sig, Views, Doc) ->
                     ExistingViewKey ->
                         remove_doc_from_idx(TxDb, Sig, DocId, ExistingViewKey)
                 end,
-                couch_log:error("Doc `~s` exceeded the ~s size for view `~s`"
-                    " and was not indexed.", [DocId, Type, MNames])
+                #{
+                    name := DbName
+                } = TxDb,
+                couch_log:error("Db `~s` Doc `~s` exceeded the ~s size"
+                    "for view `~s` and was not indexed.",
+                    [DbName, DocId, Type, MNames])
         end
     end, lists:zip(Views, Results)).
 

--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -297,10 +297,8 @@ write_docs(TxDb, Mrst, Docs, State) ->
         last_seq := LastSeq
     } = State,
 
-    ViewIds = [View#mrview.id_num || View <- Views],
-
     lists:foreach(fun(Doc) ->
-        couch_views_fdb:write_doc(TxDb, Sig, ViewIds, Doc)
+        couch_views_fdb:write_doc(TxDb, Sig, Views, Doc)
     end, Docs),
 
     couch_views_fdb:set_update_seq(TxDb, Sig, LastSeq).

--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -38,7 +38,9 @@ indexer_test_() ->
                     with([?TDEF(deleted_docs_are_unindexed)]),
                     with([?TDEF(multipe_docs_with_same_key)]),
                     with([?TDEF(multipe_keys_from_same_doc)]),
-                    with([?TDEF(multipe_identical_keys_from_same_doc)])
+                    with([?TDEF(multipe_identical_keys_from_same_doc)]),
+                    with([?TDEF(handle_size_key_limits)]),
+                    with([?TDEF(handle_size_value_limits)])
                 ]
             }
         }
@@ -65,6 +67,7 @@ foreach_setup() ->
 
 
 foreach_teardown(Db) ->
+    meck:unload(),
     ok = fabric2_db:delete(fabric2_db:name(Db), []).
 
 
@@ -385,6 +388,142 @@ multipe_identical_keys_from_same_doc(Db) ->
         ], Out).
 
 
+handle_size_key_limits(Db) ->
+    ok = meck:new(config, [passthrough]),
+    ok = meck:expect(config, get_integer, fun(Section, _, Default) ->
+        case Section of
+            "couch_views" -> 15;
+            _ -> Default
+        end
+    end),
+
+    DDoc = create_ddoc(multi_emit_key_limit),
+    Docs = [doc(1)] ++ [doc(2)],
+
+    {ok, _} = fabric2_db:update_docs(Db, [DDoc | Docs], []),
+
+    {ok, Out} = couch_views:query(
+        Db,
+        DDoc,
+        <<"map_fun1">>,
+        fun fold_fun/2,
+        [],
+        #mrargs{}
+    ),
+
+    ?assertEqual([
+        {row, [
+            {id, <<"1">>},
+            {key, 1},
+            {value, 1}
+        ]}
+    ], Out),
+
+    {ok, Doc} = fabric2_db:open_doc(Db, <<"2">>),
+    Doc2 = Doc#doc {
+        body = {[{<<"val">>,3}]}
+    },
+    {ok, _} = fabric2_db:update_doc(Db, Doc2),
+
+    {ok, Out1} = couch_views:query(
+        Db,
+        DDoc,
+        <<"map_fun1">>,
+        fun fold_fun/2,
+        [],
+        #mrargs{}
+    ),
+
+    ?assertEqual([
+        {row, [
+            {id, <<"1">>},
+            {key, 1},
+            {value, 1}
+        ]},
+        {row, [
+            {id, <<"2">>},
+            {key, 3},
+            {value, 3}
+        ]}
+    ], Out1).
+
+
+handle_size_value_limits(Db) ->
+    ok = meck:new(config, [passthrough]),
+    ok = meck:expect(config, get_integer, fun(Section, _, Default) ->
+        case Section of
+            "couch_views" -> 15;
+            _ -> Default
+        end
+    end),
+
+    DDoc = create_ddoc(multi_emit_key_limit),
+    Docs = [doc(1, 2)] ++ [doc(2, 3)],
+
+    {ok, _} = fabric2_db:update_docs(Db, [DDoc | Docs], []),
+
+    {ok, Out} = couch_views:query(
+        Db,
+        DDoc,
+        <<"map_fun2">>,
+        fun fold_fun/2,
+        [],
+        #mrargs{}
+    ),
+
+    ?assertEqual([
+        {row, [
+            {id, <<"1">>},
+            {key, 2},
+            {value, 2}
+        ]},
+        {row, [
+            {id, <<"2">>},
+            {key, 3},
+            {value, 3}
+        ]},
+        {row, [
+            {id, <<"1">>},
+            {key, 22},
+            {value, 2}
+        ]},
+        {row, [
+            {id, <<"2">>},
+            {key, 23},
+            {value, 3}
+        ]}
+    ], Out),
+
+
+    {ok, Doc} = fabric2_db:open_doc(Db, <<"1">>),
+    Doc2 = Doc#doc {
+        body = {[{<<"val">>,1}]}
+    },
+    {ok, _} = fabric2_db:update_doc(Db, Doc2),
+
+    {ok, Out1} = couch_views:query(
+        Db,
+        DDoc,
+        <<"map_fun2">>,
+        fun fold_fun/2,
+        [],
+        #mrargs{}
+    ),
+
+    ?assertEqual([
+        {row, [
+            {id, <<"2">>},
+            {key, 3},
+            {value, 3}
+        ]},
+        {row, [
+            {id, <<"2">>},
+            {key, 23},
+            {value, 3}
+        ]}
+    ], Out1).
+
+
 fold_fun({meta, _Meta}, Acc) ->
     {ok, Acc};
 fold_fun({row, _} = Row, Acc) ->
@@ -438,6 +577,32 @@ create_ddoc(multi_emit_same) ->
             ]}},
             {<<"map_fun2">>, {[
                 {<<"map">>, <<"function(doc) {}">>}
+            ]}}
+        ]}}
+    ]});
+
+create_ddoc(multi_emit_key_limit) ->
+    couch_doc:from_json_obj({[
+        {<<"_id">>, <<"_design/bar">>},
+        {<<"views">>, {[
+            {<<"map_fun1">>, {[
+                {<<"map">>, <<"function(doc) { "
+                    "if (doc.val === 2) { "
+                        "emit('a very long string to be limited', doc.val);"
+                    "} else {"
+                        "emit(doc.val, doc.val)"
+                    "}"
+                "}">>}
+            ]}},
+            {<<"map_fun2">>, {[
+                {<<"map">>, <<"function(doc) { "
+                    "emit(doc.val + 20, doc.val);"
+                    "if (doc.val === 1) { "
+                        "emit(doc.val, 'a very long string to be limited');"
+                    "} else {"
+                        "emit(doc.val, doc.val)"
+                    "}"
+                "}">>}
             ]}}
         ]}}
     ]}).

--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -16,10 +16,7 @@
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch_mrview/include/couch_mrview.hrl").
-
-
--define(I_HEART_EUNIT(Tests), [{with, [T]} || T <- Tests]).
-
+-include_lib("fabric/test/fabric2_test.hrl").
 
 indexer_test_() ->
     {
@@ -32,17 +29,17 @@ indexer_test_() ->
                 foreach,
                 fun foreach_setup/0,
                 fun foreach_teardown/1,
-                ?I_HEART_EUNIT([
-                    fun indexed_empty_db/1,
-                    fun indexed_single_doc/1,
-                    fun updated_docs_are_reindexed/1,
-                    fun updated_docs_without_changes_are_reindexed/1,
-                    fun deleted_docs_not_indexed/1,
-                    fun deleted_docs_are_unindexed/1,
-                    fun multipe_docs_with_same_key/1,
-                    fun multipe_keys_from_same_doc/1,
-                    fun multipe_identical_keys_from_same_doc/1
-                ])
+                [
+                    with([?TDEF(indexed_empty_db)]),
+                    with([?TDEF(indexed_single_doc)]),
+                    with([?TDEF(updated_docs_are_reindexed)]),
+                    with([?TDEF(updated_docs_without_changes_are_reindexed)]),
+                    with([?TDEF(deleted_docs_not_indexed)]),
+                    with([?TDEF(deleted_docs_are_unindexed)]),
+                    with([?TDEF(multipe_docs_with_same_key)]),
+                    with([?TDEF(multipe_keys_from_same_doc)]),
+                    with([?TDEF(multipe_identical_keys_from_same_doc)])
+                ]
             }
         }
     }.


### PR DESCRIPTION
# Overview

Limits the size that a key and value that can be indexed in a map function.
If the key or value exceeds the size the document is not indexed for the design document and an error is logged.

## Testing recommendations

`make eunit app=couch_views`

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
