### PR TITLE
Port form_submit.js test to Elixir

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -48,7 +48,7 @@ X means done, - means partially
   - [X] Port erlang_views.js
   - [X] Port etags_head.js
   - [ ] ~~Port etags_views.js~~ (skipped in js test suite)
-  - [ ] Port form_submit.js
+  - [X] Port form_submit.js
   - [ ] Port http.js
   - [X] Port invalid_docids.js
   - [ ] Port jsonp.js

--- a/test/elixir/test/form_submit_test.exs
+++ b/test/elixir/test/form_submit_test.exs
@@ -1,0 +1,29 @@
+defmodule FormSubmitTest do
+  use CouchTestCase
+
+  @moduletag :form_submit
+
+  @moduledoc """
+  Test that form submission is invalid
+  This is a port of form_submit.js
+  """
+
+  @tag :with_db
+  test "form submission gives back invalid content-type", context do
+    headers = [
+      Referer: "http://127.0.0.1:15984",
+      "Content-Type": "application/x-www-form-urlencoded"
+    ]
+
+    body = %{}
+
+    %{:body => response_body, :status_code => status_code} =
+      Couch.post("/#{context[:db_name]}/baz", headers: headers, body: body)
+
+    %{"error" => error, "reason" => reason} = response_body
+
+    assert status_code == 415
+    assert error == "bad_content_type"
+    assert reason == "Content-Type must be multipart/form-data"
+  end
+end

--- a/test/javascript/tests/form_submit.js
+++ b/test/javascript/tests/form_submit.js
@@ -12,6 +12,8 @@
 
 // Do some basic tests.
 couchTests.form_submit = function(debug) {
+    return console.log('done in test/elixir/test/form_summit_test.exs');
+
     var db_name = get_random_db_name();
     var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
     db.createDb();


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Ported `form_submit` js test to Elixir

## Testing recommendations
Just issue `make elixir`

## Related Issues or Pull Requests

None

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
