### PR TITLE
Fix mem3_sync_event_listener test

### DIFF
--- a/src/mem3/src/mem3_sync_event_listener.erl
+++ b/src/mem3/src/mem3_sync_event_listener.erl
@@ -236,7 +236,7 @@ teardown_all(_) ->
 setup() ->
     {ok, Pid} = ?MODULE:start_link(),
     erlang:unlink(Pid),
-    meck:wait(config_notifier, subscribe, '_', 1000),
+    wait_config_subscribed(Pid),
     Pid.
 
 teardown(Pid) ->
@@ -334,6 +334,18 @@ wait_state(Pid, Field, Val) when is_pid(Pid), is_integer(Field) ->
                 true;
             _ ->
                 wait
+        end
+    end,
+    test_util:wait(WaitFun).
+
+
+wait_config_subscribed(Pid) ->
+    WaitFun = fun() ->
+        Handlers = gen_event:which_handlers(config_event),
+        Pids = [Id || {config_notifier, Id} <- Handlers],
+        case lists:member(Pid, Pids) of
+            true -> true;
+            false -> wait
         end
     end,
     test_util:wait(WaitFun).


### PR DESCRIPTION
There's a race between the meck:wait call in setup and killing the
config_event process. Its possible that we could kill and restart the
config_event process after meck:wait returns, but before
gen_event:add_sup_handler is called. More likely, we could end up
killing the config_event gen_event process before its fully handled the
add_sup_handler message and linked the notifier pid.

This avoids the race by waiting for config_event to return that it has
processed the add_sup_handler message instead of relying on meck:wait
for the subscription call.
