### PR TITLE
feat: add mac ci

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -158,6 +158,43 @@ pipeline {
           } // post
         } // stage FreeBSD
 
+        stage('macOS') {
+          agent {
+            label 'macos'
+          }
+          steps {
+            // deleteDir is OK here because we're not inside of a Docker container!
+            deleteDir()
+            unstash 'tarball'
+            withEnv(['HOME='+pwd()]) {
+              sh '''
+                PATH=/usr/local/bin:$PATH
+                export PATH
+                mkdir -p $COUCHDB_IO_LOG_DIR
+
+                # Build CouchDB from tarball & test
+                mkdir build
+                cd build
+                tar -xzf $WORKSPACE/apache-couchdb-*.tar.gz
+                cd apache-couchdb-*
+                ./configure --with-curl --spidermonkey-version 60
+                make check || (build-aux/logfile-uploader.py && false)
+
+                # No package build for macOS at this time
+              '''
+            } // withEnv
+          } // steps
+          post {
+            always {
+              junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
+            }
+            cleanup {
+              sh 'killall -9 beam.smp || true'
+              sh 'rm -rf ${WORKSPACE}/* ${COUCHDB_IO_LOG_DIR} || true'
+            }
+          } // post
+        } // stage macOS
+
         stage('CentOS 6') {
           agent {
             docker {


### PR DESCRIPTION
[21:53:08]  <+Wohali>	jan____: If you want to add Mac build support, you need to edit apache/couchdb:build-aux/Jenkinsfile.full
[21:53:18]  <+Wohali>	I don't think you want to add a Mac build to every PR, do you? Just the main builds, yeah?
[21:53:51]  <+Wohali>	You'll want to clone the section for FreeBSD:  https://github.com/apache/couchdb/blob/master/build-aux/Jenkinsfile.full#L126-L159