### PR TITLE
Remove sensitive data from log files

### DIFF
--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -219,3 +219,15 @@
 -type sec_props() :: [tuple()].
 -type sec_obj() :: {sec_props()}.
 
+-define(record_to_map(RecordName, Record),
+    element(1, lists:foldl(fun(Field, {Map, Idx}) ->
+        {
+            maps:put(Field, element(Idx, Record), Map),
+            Idx + 1
+        }
+    end, {#{}, 2}, record_info(fields, RecordName)))).
+
+-define(record_without(RecordName, Record, Keys),
+    maps:without(Keys,
+        ?record_to_map(RecordName, Record), Keys)).
+

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -221,7 +221,12 @@ hash_admin_passwords(Persist) ->
     lists:foreach(
         fun({User, ClearPassword}) ->
             HashedPassword = couch_passwords:hash_admin_password(ClearPassword),
-            config:set("admins", User, ?b2l(HashedPassword), Persist)
+            config:set(
+                "admins",
+                User,
+                ?b2l(HashedPassword),
+                #{persist => Persist, sensitive => true}
+            )
         end, couch_passwords:get_unhashed_admins()).
 
 close_db_if_idle(DbName) ->

--- a/src/couch_log/test/eunit/couch_log_formatter_test.erl
+++ b/src/couch_log/test/eunit/couch_log_formatter_test.erl
@@ -113,6 +113,37 @@ gen_server_error_with_extra_args_test() ->
         "extra: \\[sad,args\\]"
     ]).
 
+gen_server_error_with_sensitive_test() ->
+    Pid = self(),
+    Event = {
+        error,
+        erlang:group_leader(),
+        {
+            Pid,
+            "** Generic server and some stuff",
+            [
+                a_gen_server,
+                {last, message},
+                {server_state, #{sensitive => true}},
+                some_reason,
+                sad,
+                args
+            ]
+        }
+    },
+    ?assertMatch(
+        #log_entry{
+            level = error,
+            pid = Pid
+        },
+        do_format(Event)
+    ),
+    do_matches(do_format(Event), [
+        "gen_server a_gen_server terminated",
+        "with reason: some_reason",
+        "state: server_state",
+        "extra: \\[sad,args\\]"
+    ]).
 
 gen_fsm_error_test() ->
     Pid = self(),
@@ -196,6 +227,37 @@ gen_event_error_test() ->
         "gen_event handler_id installed in a_gen_event",
         "reason: barf",
         "last msg: {ohai,there}",
+        "state: curr_state"
+    ]).
+
+
+gen_event_error_sensitive_test() ->
+    Pid = self(),
+    Event = {
+        error,
+        erlang:group_leader(),
+        {
+            Pid,
+            "** gen_event handler did a thing",
+            [
+                handler_id,
+                a_gen_event,
+                {last, message},
+                {curr_state, #{sensitive => true}},
+                barf
+            ]
+        }
+    },
+    ?assertMatch(
+        #log_entry{
+            level = error,
+            pid = Pid
+        },
+        do_format(Event)
+    ),
+    do_matches(do_format(Event), [
+        "gen_event handler_id installed in a_gen_event",
+        "reason: barf",
         "state: curr_state"
     ]).
 

--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -20,6 +20,7 @@
 -export([index_file_exists/1]).
 -export([update_local_purge_doc/2, verify_index_exists/2]).
 -export([ensure_local_purge_docs/2]).
+-export([format_status/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch_mrview/include/couch_mrview.hrl").
@@ -324,3 +325,8 @@ update_local_purge_doc(Db, State, PSeq) ->
             BaseDoc
     end,
     couch_db:update_doc(Db, Doc, []).
+
+format_status(_Opt, [_PDict, State]) ->
+    ?record_without(mrst, State, [
+        lib, views, id_btree, doc_acc, doc_queue, write_queue
+    ]).

--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -184,12 +184,12 @@ code_change(_OldVsn, State, _Extra) ->
 
 
 format_status(_Opt, [_PDict, State]) ->
-    [
+    {[
         {epoch, State#state.epoch},
         {user, State#state.user},
         {session_url, State#state.session_url},
         {refresh_tstamp, State#state.refresh_tstamp}
-    ].
+    ], #{sensitive => true}}.
 
 
 %% Private helper functions

--- a/src/couch_replicator/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor.erl
@@ -25,7 +25,8 @@
    handle_call/3,
    handle_info/2,
    handle_cast/2,
-   code_change/3
+   code_change/3,
+   format_status/2
 ]).
 
 -export([
@@ -256,6 +257,8 @@ handle_info(_Msg, State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+format_status(_Opt, [_PDict, State]) ->
+    {State, #{sensitive => true}}.
 
 % Doc processor gen_server private helper functions
 

--- a/src/couch_replicator/src/couch_replicator_httpc_pool.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc_pool.erl
@@ -20,7 +20,7 @@
 
 % gen_server API
 -export([init/1, handle_call/3, handle_info/2, handle_cast/2]).
--export([code_change/3, terminate/2]).
+-export([code_change/3, terminate/2, format_status/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -144,6 +144,18 @@ code_change(_OldVsn, #state{}=State, _Extra) ->
 
 terminate(_Reason, _State) ->
     ok.
+
+format_status(_Opt, [_PDict, State]) ->
+    #state{
+        url = Url,
+        proxy_url = ProxyURL,
+        limit = Limit
+    } = State,
+    {[
+        {url, couch_util:url_strip_password(Url)},
+        {proxy_url, ProxyURL},
+        {limit, Limit}
+    ], #{sensitive => true}}.
 
 monitor_client(Callers, Worker, {ClientPid, _}) ->
     [{Worker, erlang:monitor(process, ClientPid)} | Callers].

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -344,11 +344,11 @@ terminate(_Reason, _State) ->
 
 
 format_status(_Opt, [_PDict, State]) ->
-    [
+    {[
          {max_jobs, State#state.max_jobs},
          {running_jobs, running_job_count()},
          {pending_jobs, pending_job_count()}
-    ].
+    ], #{sensitive => true}}.
 
 
 %% config listener functions

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -430,7 +430,7 @@ format_status(_Opt, [_PDict, State]) ->
        doc_id = DocId,
        db_name = DbName
     } = RepDetails,
-    [
+    {[
         {rep_id, RepId},
         {source, couch_replicator_api_wrap:db_uri(Source)},
         {target, couch_replicator_api_wrap:db_uri(Target)},
@@ -443,7 +443,7 @@ format_status(_Opt, [_PDict, State]) ->
         {committed_seq, CommitedSeq},
         {current_through_seq, ThroughSeq},
         {highest_seq_done, HighestSeqDone}
-    ].
+    ], #{sensitive => true}}.
 
 
 startup_jitter() ->
@@ -1072,7 +1072,7 @@ scheduler_job_format_status_test() ->
         current_through_seq = <<"4">>,
         highest_seq_done = <<"5">>
     },
-    Format = format_status(opts_ignored, [pdict, State]),
+    {Format, Opts} = format_status(opts_ignored, [pdict, State]),
     ?assertEqual("http://u:*****@h1/d1/", proplists:get_value(source, Format)),
     ?assertEqual("http://u:*****@h2/d2/", proplists:get_value(target, Format)),
     ?assertEqual({"base", "+ext"}, proplists:get_value(rep_id, Format)),
@@ -1084,7 +1084,8 @@ scheduler_job_format_status_test() ->
     ?assertEqual(<<"2">>, proplists:get_value(source_seq, Format)),
     ?assertEqual(<<"3">>, proplists:get_value(committed_seq, Format)),
     ?assertEqual(<<"4">>, proplists:get_value(current_through_seq, Format)),
-    ?assertEqual(<<"5">>, proplists:get_value(highest_seq_done, Format)).
+    ?assertEqual(<<"5">>, proplists:get_value(highest_seq_done, Format)),
+    ?assert(maps:get(sensitive, Opts)).
 
 
 -endif.

--- a/src/couch_replicator/src/couch_replicator_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_worker.erl
@@ -195,7 +195,7 @@ format_status(_Opt, [_PDict, State]) ->
         pending_fetch = PendingFetch,
         batch = #batch{size = BatchSize}
     } = State,
-    [
+    {[
         {main_pid, MainJobPid},
         {loop, LoopPid},
         {source, couch_replicator_api_wrap:db_uri(Source)},
@@ -203,7 +203,7 @@ format_status(_Opt, [_PDict, State]) ->
         {num_readers, length(Readers)},
         {pending_fetch, PendingFetch},
         {batch_size, BatchSize}
-    ].
+    ], #{sensitive => true}}.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -478,13 +478,14 @@ replication_worker_format_status_test() ->
         pending_fetch = nil,
         batch = #batch{size = 5}
     },
-    Format = format_status(opts_ignored, [pdict, State]),
+    {Format, Opts} = format_status(opts_ignored, [pdict, State]),
     ?assertEqual(self(), proplists:get_value(main_pid, Format)),
     ?assertEqual(self(), proplists:get_value(loop, Format)),
     ?assertEqual("http://u:*****@h/d1", proplists:get_value(source, Format)),
     ?assertEqual("http://u:*****@h/d2", proplists:get_value(target, Format)),
     ?assertEqual(3, proplists:get_value(num_readers, Format)),
     ?assertEqual(nil, proplists:get_value(pending_fetch, Format)),
-    ?assertEqual(5, proplists:get_value(batch_size, Format)).
+    ?assertEqual(5, proplists:get_value(batch_size, Format)),
+    ?assert(maps:get(sensitive, Opts)).
 
 -endif.

--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -29,7 +29,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 
@@ -126,6 +127,14 @@ handle_info(Msg, St) ->
 
 code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
+
+format_status(_Opt, [_PDict, State]) ->
+    #st{
+        timeout = Timeout
+    } = State,
+    {[
+        timeout = Timeout
+    ], #{sensitive => true}}.
 
 
 map_doc(#st{indexes=Indexes}, Doc) ->

--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -165,7 +165,12 @@ enable_cluster_int(Options, false) ->
     couch_log:debug("Enable Cluster: ~p~n", [Options]).
 
 set_admin(Username, Password) ->
-    config:set("admins", binary_to_list(Username), binary_to_list(Password)).
+    config:set(
+        "admins",
+        binary_to_list(Username),
+        binary_to_list(Password),
+        #{sensitive => true}
+    ).
 
 setup_node(NewCredentials, NewBindAddress, NodeCount, Port) ->
     case NewCredentials of

--- a/src/setup/src/setup_httpd.erl
+++ b/src/setup/src/setup_httpd.erl
@@ -19,7 +19,7 @@ handle_setup_req(#httpd{method='POST'}=Req) ->
     ok = chttpd:verify_is_server_admin(Req),
     couch_httpd:validate_ctype(Req, "application/json"),
     Setup = get_body(Req),
-    couch_log:notice("Setup: ~p~n", [Setup]),
+    couch_log:notice("Setup: ~p~n", [remove_sensitive(Setup)]),
     Action = binary_to_list(couch_util:get_value(<<"action">>, Setup, <<"missing">>)),
     case handle_action(Action, Setup) of
     ok ->
@@ -91,7 +91,7 @@ handle_action("enable_cluster", Setup) ->
 
 
 handle_action("finish_cluster", Setup) ->
-    couch_log:notice("finish_cluster: ~p~n", [Setup]),
+    couch_log:notice("finish_cluster: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {ensure_dbs_exist, <<"ensure_dbs_exist">>}
@@ -105,7 +105,7 @@ handle_action("finish_cluster", Setup) ->
     end;
 
 handle_action("enable_single_node", Setup) ->
-    couch_log:notice("enable_single_node: ~p~n", [Setup]),
+    couch_log:notice("enable_single_node: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {ensure_dbs_exist, <<"ensure_dbs_exist">>},
@@ -125,7 +125,7 @@ handle_action("enable_single_node", Setup) ->
 
 
 handle_action("add_node", Setup) ->
-    couch_log:notice("add_node: ~p~n", [Setup]),
+    couch_log:notice("add_node: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {username, <<"username">>},
@@ -147,10 +147,10 @@ handle_action("add_node", Setup) ->
     end;
 
 handle_action("remove_node", Setup) ->
-    couch_log:notice("remove_node: ~p~n", [Setup]);
+    couch_log:notice("remove_node: ~p~n", [remove_sensitive(Setup)]);
 
 handle_action("receive_cookie", Setup) ->
-    couch_log:notice("receive_cookie: ~p~n", [Setup]),
+    couch_log:notice("receive_cookie: ~p~n", [remove_sensitive(Setup)]),
     Options = get_options([
        {cookie, <<"cookie">>}
     ], Setup),
@@ -173,3 +173,8 @@ get_body(Req) ->
         couch_log:notice("Body Fail: ~p~n", [Else]),
         couch_httpd:send_error(Req, 400, <<"bad_request">>, <<"Missing JSON body'">>)
     end.
+
+remove_sensitive(KVList0) ->
+    KVList1 = lists:keyreplace(<<"username">>, 1, KVList0, {<<"username">>, <<"****">>}),
+    KVList2 = lists:keyreplace(<<"password">>, 1, KVList1, {<<"password">>, <<"****">>}),
+    KVList2.


### PR DESCRIPTION
## Overview

There are cases where sensitive data can leak into a log file. This PR makes a first stab at the problem. The sensitive data can end up in the log when process implementing `gen_server` or `gen_event` behavior crashes. The erlang implementation of a `gen_server` support a `format_status/2` callback to remove sensitive data from `state` term. However the last message (`LastMsg`) recveived by the process is still logged. In order to solve this problem this PR modifies `couch_log_formatter` to remove `LastMsg` in case when formatted state is a tupple with arity 2 and second element of a tuple is map containing `sensitive` key with value `true`. This allows us to remove sensitive information from both `LastMsg` and `State` via `format_status/2` callback. Here is an example:
```
format_status(_Opt, [_PDict, State]) ->
    #state{
        url = Url,
        proxy_url = ProxyURL,
        limit = Limit
    } = State,
    {[
        {url, couch_util:url_strip_password(Url)},
        {proxy_url, ProxyURL},
        {limit, Limit}
    ], #{sensitive => true}}.
```

## Testing recommendations

1. Make sure all dependent PRs are pulled
2. Run `make eunit`
3. Run `make elixir`

## Related Issues or Pull Requests

This PR depends on the following:

* https://github.com/apache/couchdb-config/pull/30
* https://github.com/apache/couchdb-ibrowse/pull/3
* https://github.com/apache/couchdb-mochiweb/compare/master...iilyak:implement-format-status?expand=1 <-- I need an advise which base branch to use. 

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
