### PR TITLE
Clean up view size limit enforcement

### DIFF
--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -398,7 +398,7 @@ handle_size_key_limits(Db) ->
     end),
 
     DDoc = create_ddoc(multi_emit_key_limit),
-    Docs = [doc(1)] ++ [doc(2)],
+    Docs = [doc(1, 2)] ++ [doc(2, 1)],
 
     {ok, _} = fabric2_db:update_docs(Db, [DDoc | Docs], []),
 
@@ -412,12 +412,12 @@ handle_size_key_limits(Db) ->
     ),
 
     ?assertEqual([
-        row(<<"1">>, 1, 1)
+        row(<<"1">>, 2, 2)
     ], Out),
 
     {ok, Doc} = fabric2_db:open_doc(Db, <<"2">>),
     Doc2 = Doc#doc {
-        body = {[{<<"val">>,3}]}
+        body = {[{<<"val">>, 2}]}
     },
     {ok, _} = fabric2_db:update_doc(Db, Doc2),
 
@@ -431,8 +431,8 @@ handle_size_key_limits(Db) ->
     ),
 
     ?assertEqual([
-        row(<<"1">>, 1, 1),
-        row(<<"2">>, 3, 3)
+        row(<<"1">>, 2, 2),
+        row(<<"2">>, 2, 2)
     ], Out1).
 
 
@@ -558,7 +558,7 @@ create_ddoc(multi_emit_key_limit) ->
         {<<"views">>, {[
             {<<"map_fun1">>, {[
                 {<<"map">>, <<"function(doc) { "
-                    "if (doc.val === 2) { "
+                    "if (doc.val === 1) { "
                         "emit('a very long string to be limited', doc.val);"
                     "} else {"
                         "emit(doc.val, doc.val)"


### PR DESCRIPTION
## Overview

Clean up view size limit enforcement

Both a performance and style cleanup. This reduces the number of ets
calls by roughly `2 * 2 * $num_docs * $num_views`. The first factor of
two is because this avoids re-calculating the size twice for both the id
and map indexes. The second factor of two is because we have to lookup
two different settings.

Stylistically this also moves the logic out of the fdb modules. Keeping
key/value structure and update logic is already pretty complicated so we
should avoid mixing external application logic into those modules as
much as possible for our sanity.

The behavior is slightly changed vs the original patch as well.
Originally only the view that contained the errant key or value was
affected. However, pre-existing behavior where a document fails to be
mapped correctly resulted in it being excluded from all view indexes
defined in the design document. That behavior has been restored.

## Testing recommendations

make check-fdb

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
