### PR TITLE
Make "validate_security_can_be_edited" use the correct configuration values

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1889,8 +1889,8 @@ extract_header_rev(Req, ExplicitRev) ->
     end.
 
 validate_security_can_be_edited(DbName) ->
-    UserDbName = config:get("chttpd_auth", "authentication_db", "_users"),
-    CanEditUserSecurityObject = config:get("couchdb","users_db_security_editable","false"),
+    UserDbName = config:get("couch_httpd_auth", "authentication_db", "_users"),
+    CanEditUserSecurityObject = config:get("purge","users_db_security_editable","false"),
     case {DbName,CanEditUserSecurityObject} of
         {UserDbName,"false"} ->
             Msg = "You can't edit the security object of the user database.",


### PR DESCRIPTION
## Overview

This PR makes `validate_security_can_be_edited` use the correct configuration values when checking if the user database is editable.

## Testing recommendations

I have not been able to test this locally but this PR should hopefully fix issue #2643 
