### PR TITLE
Move "users_db_security_editable" to the correct location in the ini file

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -73,6 +73,9 @@ default_engine = couch
 ; on startup if not present.
 ;single_node = false
 
+; Allow edits on the _security object in the user db. By default, it's disabled.
+users_db_security_editable = false
+
 [purge]
 ; Allowed maximum number of documents in one purge request
 ;max_document_id_number = 100
@@ -83,9 +86,6 @@ default_engine = couch
 ; Allowed durations when index is not updated for local purge checkpoint
 ; document. Default is 24 hours.
 ;index_lag_warn_seconds = 86400
-
-; Allow edits on the _security object in the user db. By default, it's disabled.
-users_db_security_editable = false
 
 [couchdb_engines]
 ; The keys in this section are the filename extension that


### PR DESCRIPTION
## Overview
This PR makes puts the "users_db_security_editable" configuration option in the correct location in the ini file.

## Related Issues
This PR fixes issue #2643