### PR TITLE
couch_jobs resubmit updates job data

### DIFF
--- a/src/couch_jobs/src/couch_jobs.erl
+++ b/src/couch_jobs/src/couch_jobs.erl
@@ -152,10 +152,10 @@ resubmit(Tx, #{jlock := <<_/binary>>} = Job, SchedTime) ->
     end).
 
 
--spec resubmit(jtx(), job(), job_data(), scheduled_time()) -> {ok, job()} | {error, any()}.
-resubmit(Tx, #{jlock := <<_/binary>>} = Job, Data, SchedTime) ->
+-spec resubmit(jtx(), job(), scheduled_time(), job_data()) -> {ok, job()} | {error, any()}.
+resubmit(Tx, #{jlock := <<_/binary>>} = Job, SchedTime, Data) ->
     couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(Tx), fun(JTx) ->
-        couch_jobs_fdb:resubmit(JTx, Job, Data, SchedTime)
+        couch_jobs_fdb:resubmit(JTx, Job, SchedTime, Data)
     end).
 
 

--- a/src/couch_jobs/src/couch_jobs.erl
+++ b/src/couch_jobs/src/couch_jobs.erl
@@ -27,6 +27,7 @@
     finish/3,
     resubmit/2,
     resubmit/3,
+    resubmit/4,
     is_resubmitted/1,
     update/2,
     update/3,
@@ -148,6 +149,13 @@ resubmit(Tx, Job) ->
 resubmit(Tx, #{jlock := <<_/binary>>} = Job, SchedTime) ->
     couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(Tx), fun(JTx) ->
         couch_jobs_fdb:resubmit(JTx, Job, SchedTime)
+    end).
+
+
+-spec resubmit(jtx(), job(), job_data(), scheduled_time()) -> {ok, job()} | {error, any()}.
+resubmit(Tx, #{jlock := <<_/binary>>} = Job, Data, SchedTime) ->
+    couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(Tx), fun(JTx) ->
+        couch_jobs_fdb:resubmit(JTx, Job, Data, SchedTime)
     end).
 
 

--- a/src/couch_jobs/src/couch_jobs_fdb.erl
+++ b/src/couch_jobs/src/couch_jobs_fdb.erl
@@ -99,7 +99,7 @@ add(#{jtx := true} = JTx0, Type, JobId, Data, STime) ->
             Key = job_key(JTx, Job),
             case erlfdb:wait(erlfdb:get(Tx, Key)) of
                 <<_/binary>> ->
-                    {ok, Job1} = resubmit(JTx, Job, Data, STime),
+                    {ok, Job1} = resubmit(JTx, Job, STime, Data),
                     #{seq := Seq, state := State, data := Data1} = Job1,
                     {ok, State, Seq, Data1};
                 not_found ->
@@ -207,10 +207,10 @@ finish(#{jtx := true} = JTx0, #{jlock := <<_/binary>>} = Job, Data) when
     end.
 
 resubmit(JTx0, Job, NewSTime) ->
-    resubmit(JTx0, Job, undefined, NewSTime).
+    resubmit(JTx0, Job, NewSTime, undefined).
 
 
-resubmit(#{jtx := true} = JTx0, #{job := true} = Job, NewData, NewSTime) ->
+resubmit(#{jtx := true} = JTx0, #{job := true} = Job, NewSTime, NewData) ->
     #{tx := Tx} = JTx = get_jtx(JTx0),
     #{type := Type, id := JobId} = Job,
     Key = job_key(JTx, Job),


### PR DESCRIPTION
## Overview

When a job is either pending or finished and the job is resubmitted
with new data the job data is updated.

## Testing recommendations

Tests should pass

## Related Issues or Pull Requests

This is needed for #2585 

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
