### PR TITLE
Fix bug in reverse folding with startkey_docid

### DIFF
--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -1470,6 +1470,9 @@ get_fold_acc(Db, RangePrefix, UserCallback, UserAcc, Options)
     EndKey2 = case EndKey1 of
         undefined ->
             <<RangePrefix/binary, 16#FF>>;
+        EK2 when Reverse ->
+            PackedEK = erlfdb_tuple:pack({EK2}, RangePrefix),
+            <<PackedEK/binary, 16#FF>>;
         EK2 ->
             erlfdb_tuple:pack({EK2}, RangePrefix)
     end,

--- a/test/elixir/test/map_test.exs
+++ b/test/elixir/test/map_test.exs
@@ -535,6 +535,22 @@ defmodule ViewMapTest do
     assert error == "foundationdb_error"
   end
 
+  test "descending=true query with startkey_docid", context do
+    db_name = context[:db_name]
+
+    url = "/#{db_name}/_design/map/_view/some"
+
+    resp =
+      Couch.get(url,
+        query: %{descending: true, startkey: 8, startkey_docid: "doc-id-8", limit: 3}
+      )
+
+    ids = get_ids(resp)
+
+    assert resp.status_code == 200
+    assert ids == ["doc-id-8", "doc-id-7", "doc-id-6"]
+  end
+
   def update_doc_value(db_name, id, value) do
     resp = Couch.get("/#{db_name}/#{id}")
     doc = convert(resp.body)


### PR DESCRIPTION

## Overview

Fixes an issue where the first k/v was skipped if the startkey_docid
was included.

## Testing recommendations

tests should pass
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

This is needed for #2585 

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
