### PR TITLE
Send correct seq values for filtered changes

### DIFF
--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -515,7 +515,8 @@ changes_enumerator(DocInfo, Acc) ->
     [] ->
         ChangesRow = {no_pass, [
             {pending, Pending-1},
-            {seq, Seq}]};
+            {seq, {Seq, uuid(Db), couch_db:owner_of(Epochs, Seq)}}
+        ]};
     Results ->
         Opts = if Conflicts -> [conflicts | DocOptions]; true -> DocOptions end,
         ChangesRow = {change, [


### PR DESCRIPTION
If a filtered changes feed hit a rewind we would send a bare `integer()`
value for the Seq. If this was used again during a rewind it causes a
competely rewind to zero due to not having the `node()` and UUID
`binary()` values to calculate a new start seq.
