### PR TITLE
Set cookie domain when DELETE'ing

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -365,7 +365,8 @@ handle_session_req(#httpd{method='GET', user_ctx=UserCtx}=Req, _AuthModule) ->
     end;
 % logout by deleting the session
 handle_session_req(#httpd{method='DELETE'}=Req, _AuthModule) ->
-    Cookie = mochiweb_cookies:cookie("AuthSession", "", [{path, "/"}] ++ cookie_scheme(Req)),
+    Cookie = mochiweb_cookies:cookie("AuthSession", "", [{path, "/"}] ++
+        cookie_domain() ++ cookie_scheme(Req)),
     {Code, Headers} = case couch_httpd:qs_value(Req, "next", nil) of
         nil ->
             {200, [Cookie]};

--- a/src/couch/test/eunit/couchdb_cookie_domain_tests.erl
+++ b/src/couch/test/eunit/couchdb_cookie_domain_tests.erl
@@ -43,7 +43,8 @@ cookie_test_() ->
             fun({ok, Url, ContentType, Payload, _}) ->
                 [
                     should_set_cookie_domain(Url, ContentType, Payload),
-                    should_not_set_cookie_domain(Url, ContentType, Payload)
+                    should_not_set_cookie_domain(Url, ContentType, Payload),
+                    should_delete_cookie_domain(Url, ContentType, Payload)
                 ]
             end
         }
@@ -66,4 +67,14 @@ should_not_set_cookie_domain(Url, ContentType, Payload) ->
         ?assertEqual(200, Code),
         Cookie = proplists:get_value("Set-Cookie", Headers),
         ?assertEqual(0, string:str(Cookie, "; Domain="))
+    end).
+
+should_delete_cookie_domain(Url, ContentType, Payload) ->
+    ?_test(begin
+        ok = config:set("couch_httpd_auth", "cookie_domain",
+            "example.com", false),
+        {ok, Code, Headers, _} = test_request:delete(Url, ContentType, Payload),
+        ?assertEqual(200, Code),
+        Cookie = proplists:get_value("Set-Cookie", Headers),
+        ?assert(string:str(Cookie, "; Domain=example.com") > 0)
     end).


### PR DESCRIPTION
## Overview

We failed to set the domain attribute when deleting the session cookie, resulting in the creation of an empty cookie without a domain attribute instead.

## Testing recommendations

Follow the steps in the related case and note that the cookie is deleted with this patch.

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/2655

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
