### PR TITLE
Handle transaction timeouts in list_dbs and list_dbs_info

### DIFF
--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -340,7 +340,11 @@ get_dir(Tx) ->
     erlfdb_directory:get_name(CouchDB).
 
 
-list_dbs(Tx, Callback, AccIn, Options) ->
+list_dbs(Tx, Callback, AccIn, Options0) ->
+    Options = case fabric2_util:get_value(restart_tx, Options0) of
+        undefined -> [{restart_tx, true} | Options0];
+        _AlreadySet -> Options0
+    end,
     LayerPrefix = get_dir(Tx),
     Prefix = erlfdb_tuple:pack({?ALL_DBS}, LayerPrefix),
     fold_range({tx, Tx}, Prefix, fun({K, _V}, Acc) ->
@@ -349,7 +353,11 @@ list_dbs(Tx, Callback, AccIn, Options) ->
     end, AccIn, Options).
 
 
-list_dbs_info(Tx, Callback, AccIn, Options) ->
+list_dbs_info(Tx, Callback, AccIn, Options0) ->
+    Options = case fabric2_util:get_value(restart_tx, Options0) of
+        undefined -> [{restart_tx, true} | Options0];
+        _AlreadySet -> Options0
+    end,
     LayerPrefix = get_dir(Tx),
     Prefix = erlfdb_tuple:pack({?ALL_DBS}, LayerPrefix),
     fold_range({tx, Tx}, Prefix, fun({DbNameKey, DbPrefix}, Acc) ->


### PR DESCRIPTION
Previously those endoints would break when transactions time-out and are retried. To fix it we re-use the mechanism from changes feeds.

There is a longer discussion about this on the mailing list:

https://lists.apache.org/thread.html/r02cee7045cac4722e1682bb69ba0ec791f5cce025597d0099fb34033%40%3Cdev.couchdb.apache.org%3E

