### PR TITLE
Port elixir proxyauth tests from js to elixir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,10 @@ python-black-update: .venv/bin/black
 elixir: export MIX_ENV=integration
 elixir: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 elixir: elixir-init elixir-check-formatted elixir-credo devclean
-	@dev/run "$(TEST_OPTS)" -a adm:pass -n 1 --enable-erlang-views --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+	@dev/run "$(TEST_OPTS)" -a adm:pass -n 1 \
+		--enable-erlang-views \
+		--locald-config test/elixir/test/config/test-config.ini \
+		--no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-init
 elixir-init: MIX_ENV=test

--- a/dev/run
+++ b/dev/run
@@ -211,6 +211,14 @@ def get_args_parser():
         default=None,
         help="Extra arguments to pass to beam process",
     )
+    parser.add_option(
+        "-l",
+        "--locald-config",
+        dest="locald_configs",
+        action="append",
+        default=[],
+        help="Path to config to place in 'local.d'. Can be repeated",
+    )
     return parser
 
 
@@ -238,6 +246,7 @@ def setup_context(opts, args):
         "reset_logs": True,
         "procs": [],
         "auto_ports": opts.auto_ports,
+        "locald_configs": opts.locald_configs,
     }
 
 
@@ -279,7 +288,22 @@ def setup_configs(ctx):
             "_default": "",
         }
         write_config(ctx, node, env)
+        write_locald_configs(ctx, node, env)
     generate_haproxy_config(ctx)
+
+
+def write_locald_configs(ctx, node, env):
+    for locald_config in ctx["locald_configs"]:
+        config_src = os.path.join(ctx["rootdir"], locald_config)
+        if os.path.exists(config_src):
+            config_filename = os.path.basename(config_src)
+            config_tgt = os.path.join(
+                ctx["devdir"], "lib", node, "etc", "local.d", config_filename
+            )
+            with open(config_src) as handle:
+                content = handle.read()
+            with open(config_tgt, "w") as handle:
+                handle.write(content)
 
 
 def generate_haproxy_config(ctx):
@@ -381,6 +405,8 @@ def write_config(ctx, node, env):
 
         with open(tgt, "w") as handle:
             handle.write(content)
+
+    ensure_dir_exists(etc_tgt, "local.d")
 
 
 def boot_haproxy(ctx):
@@ -580,6 +606,7 @@ def boot_node(ctx, node):
         "-couch_ini",
         os.path.join(node_etcdir, "default.ini"),
         os.path.join(node_etcdir, "local.ini"),
+        os.path.join(node_etcdir, "local.d"),
         "-reltool_config",
         os.path.join(reldir, "reltool.config"),
         "-parent_pid",

--- a/src/mango/test/user_docs.py
+++ b/src/mango/test/user_docs.py
@@ -60,7 +60,7 @@ def setup_users(db, **kwargs):
 
 
 def teardown_users(db):
-    [db.delete_doc(doc['_id']) for doc in USERS_DOCS]
+    [db.delete_doc(doc["_id"]) for doc in USERS_DOCS]
 
 
 def setup(db, index_type="view", **kwargs):

--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -60,7 +60,7 @@ X means done, - means partially
   - [X] Port lots_of_docs.js
   - [ ] Port method_override.js
   - [X] Port multiple_rows.js
-  - [ ] Port proxyauth.js
+  - [X] Port proxyauth.js
   - [ ] Port purge.js
   - [ ] Port reader_acl.js
   - [ ] Port recreate_doc.js

--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -127,8 +127,8 @@ defmodule Couch do
   def set_auth_options(options) do
     if Keyword.get(options, :cookie) == nil do
       headers = Keyword.get(options, :headers, [])
-
-      if headers[:basic_auth] != nil or headers[:authorization] != nil do
+      if headers[:basic_auth] != nil or headers[:authorization] != nil
+         or List.keymember?(headers, :"X-Auth-CouchDB-UserName", 0) do
         options
       else
         username = System.get_env("EX_USERNAME") || "adm"

--- a/test/elixir/test/config/test-config.ini
+++ b/test/elixir/test/config/test-config.ini
@@ -1,0 +1,2 @@
+[chttpd]
+authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}

--- a/test/elixir/test/proxyauth_test.exs
+++ b/test/elixir/test/proxyauth_test.exs
@@ -1,0 +1,163 @@
+defmodule ProxyAuthTest do
+  use CouchTestCase
+
+  @moduletag :authentication
+
+  @tag :with_db
+  test "proxy auth with secret", context do
+    db_name = context[:db_name]
+
+    design_doc = %{
+      _id: "_design/test",
+      language: "javascript",
+      shows: %{
+        welcome: """
+           function(doc,req) {
+          return "Welcome " + req.userCtx["name"];
+        }
+        """,
+        role: """
+          function(doc, req) {
+          return req.userCtx['roles'][0];
+        }
+        """
+      }
+    }
+
+    {:ok, _} = create_doc(db_name, design_doc)
+
+    users_db_name = random_db_name()
+    create_db(users_db_name)
+
+    secret = generate_secret(64)
+
+    server_config = [
+      %{
+        :section => "chttpd_auth",
+        :key => "authentication_db",
+        :value => users_db_name
+      },
+      %{
+        :section => "couch_httpd_auth",
+        :key => "proxy_use_secret",
+        :value => "true"
+      },
+      %{
+        :section => "couch_httpd_auth",
+        :key => "secret",
+        :value => secret
+      }
+    ]
+
+    run_on_modified_server(server_config, fn ->
+      test_fun(db_name, users_db_name, secret)
+    end)
+    delete_db(users_db_name)
+  end
+
+  defp generate_secret(len) do
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    |> String.splitter("", trim: true)
+    |> Enum.take_random(len)
+    |> Enum.join("")
+  end
+
+  defp hex_hmac_sha1(secret, message) do
+    signature = :crypto.hmac(:sha, secret, message)
+    Base.encode16(signature, case: :lower)
+  end
+
+  def test_fun(db_name, users_db_name, secret) do
+    user = prepare_user_doc(name: "couch@apache.org", password: "test")
+    create_doc(users_db_name, user)
+
+    resp =
+      Couch.get("/_session",
+        headers: [authorization: "Basic Y291Y2hAYXBhY2hlLm9yZzp0ZXN0"]
+      )
+
+    assert resp.body["userCtx"]["name"] == "couch@apache.org"
+    assert resp.body["info"]["authenticated"] == "default"
+
+    headers = [
+      "X-Auth-CouchDB-UserName": "couch@apache.org",
+      "X-Auth-CouchDB-Roles": "test",
+      "X-Auth-CouchDB-Token": hex_hmac_sha1(secret, "couch@apache.org")
+    ]
+    resp = Couch.get("/#{db_name}/_design/test/_show/welcome", headers: headers)
+    assert resp.body == "Welcome couch@apache.org"
+
+    resp = Couch.get("/#{db_name}/_design/test/_show/role", headers: headers)
+    assert resp.body == "test"
+  end
+
+  @tag :with_db
+  test "proxy auth without secret", context do
+    db_name = context[:db_name]
+
+    design_doc = %{
+      _id: "_design/test",
+      language: "javascript",
+      shows: %{
+        welcome: """
+           function(doc,req) {
+          return "Welcome " + req.userCtx["name"];
+        }
+        """,
+        role: """
+          function(doc, req) {
+          return req.userCtx['roles'][0];
+        }
+        """
+      }
+    }
+
+    {:ok, _} = create_doc(db_name, design_doc)
+
+    users_db_name = random_db_name()
+    create_db(users_db_name)
+
+    server_config = [
+      %{
+        :section => "chttpd_auth",
+        :key => "authentication_db",
+        :value => users_db_name
+      },
+      %{
+        :section => "couch_httpd_auth",
+        :key => "proxy_use_secret",
+        :value => "false"
+      }
+    ]
+
+    run_on_modified_server(server_config, fn ->
+      test_fun_no_secret(db_name, users_db_name)
+    end)
+
+    delete_db(users_db_name)
+  end
+
+  def test_fun_no_secret(db_name, users_db_name) do
+    user = prepare_user_doc(name: "couch@apache.org", password: "test")
+    create_doc(users_db_name, user)
+
+    resp =
+      Couch.get("/_session",
+        headers: [authorization: "Basic Y291Y2hAYXBhY2hlLm9yZzp0ZXN0"]
+      )
+
+    assert resp.body["userCtx"]["name"] == "couch@apache.org"
+    assert resp.body["info"]["authenticated"] == "default"
+
+    headers = [
+      "X-Auth-CouchDB-UserName": "couch@apache.org",
+      "X-Auth-CouchDB-Roles": "test"
+    ]
+
+    resp = Couch.get("/#{db_name}/_design/test/_show/welcome", headers: headers)
+    assert resp.body == "Welcome couch@apache.org"
+
+    resp = Couch.get("/#{db_name}/_design/test/_show/role", headers: headers)
+    assert resp.body == "test"
+  end
+end

--- a/test/elixir/test/users_db_test.exs
+++ b/test/elixir/test/users_db_test.exs
@@ -147,7 +147,8 @@ defmodule UsersDbTest do
     assert resp.body["userCtx"]["name"] == "jchris@apache.org"
     assert resp.body["info"]["authenticated"] == "default"
     assert resp.body["info"]["authentication_db"] == @users_db_name
-    assert resp.body["info"]["authentication_handlers"] == ["cookie", "default"]
+    assert Enum.member?(resp.body["info"]["authentication_handlers"], "cookie")
+    assert Enum.member?(resp.body["info"]["authentication_handlers"], "default")
 
     resp =
       Couch.get(

--- a/test/javascript/tests/proxyauth.js
+++ b/test/javascript/tests/proxyauth.js
@@ -9,12 +9,11 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
- 
- 
- 
+
+couchTests.elixir = true;
 couchTests.proxyauth = function(debug) {
   // this test proxy authentification handler
-
+  return console.log('done in test/elixir/test/proxyauth_test.exs');
   var users_db_name = get_random_db_name();
   var usersDb = new CouchDB(users_db_name, {"X-Couch-Full-Commit":"false"});
   usersDb.createDb();
@@ -22,9 +21,9 @@ couchTests.proxyauth = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
   db.createDb();
-  
+
   if (debug) debugger;
- 
+
   // Simple secret key generator
   function generateSecret(length) {
     var tab = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -34,16 +33,16 @@ couchTests.proxyauth = function(debug) {
     }
     return secret;
   }
-  
+
   var secret = generateSecret(64);
-  
+
   function TestFun() {
-    
+
     var benoitcUserDoc = CouchDB.prepareUserDoc({
       name: "benoitc@apache.org"
     }, "test");
     T(usersDb.save(benoitcUserDoc).ok);
-    
+
     T(CouchDB.session().userCtx.name == null);
 
     // test that you can use basic auth aginst the users db
@@ -54,20 +53,20 @@ couchTests.proxyauth = function(debug) {
     });
     T(s.userCtx.name == "benoitc@apache.org");
     T(s.info.authenticated == "default");
-    
+
     CouchDB.logout();
 
-/*  XXX: None of the rest of this is supported yet in 2.0    
+/*  XXX: None of the rest of this is supported yet in 2.0
     var headers = {
       "X-Auth-CouchDB-UserName": "benoitc@apache.org",
       "X-Auth-CouchDB-Roles": "test",
       "X-Auth-CouchDB-Token": hex_hmac_sha1(secret, "benoitc@apache.org")
     };
-    
+
     var designDoc = {
       _id:"_design/test",
       language: "javascript",
-       
+
       shows: {
         "welcome": stringFun(function(doc,req) {
           return "Welcome " + req.userCtx["name"];
@@ -79,53 +78,53 @@ couchTests.proxyauth = function(debug) {
     };
 
     db.save(designDoc);
-    
+
     var req = CouchDB.request("GET", "/" + db_name + "/_design/test/_show/welcome",
                         {headers: headers});
     T(req.responseText == "Welcome benoitc@apache.org", req.responseText);
-    
+
     req = CouchDB.request("GET", "/" + db_name + "/_design/test/_show/role",
                         {headers: headers});
     T(req.responseText == "test");
-    
+
     var xhr = CouchDB.request("PUT", "/_node/node1@127.0.0.1/_config/couch_httpd_auth/proxy_use_secret",{
       body : JSON.stringify("true"),
       headers: {"X-Couch-Persist": "false"}
     });
     T(xhr.status == 200);
-    
+
     req = CouchDB.request("GET", "/" + db_name + "/_design/test/_show/welcome",
                         {headers: headers});
     T(req.responseText == "Welcome benoitc@apache.org");
-    
+
     req = CouchDB.request("GET", "/" + db_name + "/_design/test/_show/role",
                         {headers: headers});
     T(req.responseText == "test");
 */
 
   }
-  
+
   run_on_modified_server(
     [{section: "httpd",
       key: "authentication_handlers",
       value:"{chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}"},
       {section: "chttpd_auth",
-        key: "authentication_db", 
+        key: "authentication_db",
         value: users_db_name},
       {section: "chttpd_auth",
-        key: "secret", 
+        key: "secret",
         value: secret},
       {section: "chttpd_auth",
-        key: "x_auth_username", 
+        key: "x_auth_username",
         value: "X-Auth-CouchDB-UserName"},
       {section: "chttpd_auth",
-        key: "x_auth_roles", 
+        key: "x_auth_roles",
         value: "X-Auth-CouchDB-Roles"},
       {section: "chttpd_auth",
-        key: "x_auth_token", 
+        key: "x_auth_token",
         value: "X-Auth-CouchDB-Token"},
       {section: "chttpd_auth",
-        key: "proxy_use_secret", 
+        key: "proxy_use_secret",
         value: "false"}],
     TestFun
   );


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This PR ports the proxyauth tests from js to elixir. This test was disabled in the js test suite.

The proxy_authentication_handler should be enabled at startup as the changes on chttpd.authentication_handlers config property is not hot-reloaded by CouchDB. An option has ben added to the dev/run script in order to specify a config file to be placed at etc/local.d folder.

Makefile for elixir target now includes a custom config file that enables all the auth handlers for testing.
 
## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
 make elixir tests=test/elixir/test/proxyauth_test.exs
```
 for checking new dev/run option:
```
 dev/run -n 1 --locald-config test/elixir/test/config/test-config.ini
```
should place the test-config.ini file at dev/lib/node1/etc/local.d folder

## Related Issues or Pull Requests
This PR allows to #2648 to include integration tests for the new JWT auth handler
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
