### PR TITLE
soft-deletion for database

### DIFF
--- a/src/chttpd/src/chttpd_httpd_handlers.erl
+++ b/src/chttpd/src/chttpd_httpd_handlers.erl
@@ -28,6 +28,7 @@ url_handler(<<>>)                  -> fun chttpd_misc:handle_welcome_req/1;
 url_handler(<<"favicon.ico">>)     -> fun chttpd_misc:handle_favicon_req/1;
 url_handler(<<"_utils">>)          -> fun chttpd_misc:handle_utils_dir_req/1;
 url_handler(<<"_all_dbs">>)        -> fun chttpd_misc:handle_all_dbs_req/1;
+url_handler(<<"_deleted_dbs">>)    -> fun chttpd_misc:handle_deleted_dbs_req/1;
 url_handler(<<"_dbs_info">>)       -> fun chttpd_misc:handle_dbs_info_req/1;
 url_handler(<<"_active_tasks">>)   -> fun chttpd_misc:handle_task_status_req/1;
 url_handler(<<"_scheduler">>)      -> fun couch_replicator_httpd:handle_scheduler_req/1;
@@ -66,6 +67,15 @@ handler_info('GET', [<<"_active_tasks">>], _) ->
 
 handler_info('GET', [<<"_all_dbs">>], _) ->
     {'all_dbs.read', #{}};
+
+handler_info('GET', [<<"_deleted_dbs">>], _) ->
+    {'account-deleted-dbs.read', #{}};
+
+handler_info('POST', [<<"_deleted_dbs">>], _) ->
+    {'account-deleted-dbs.undelete', #{}};
+
+handler_info('DELETE', [<<"_deleted_dbs">>, Db], _) ->
+    {'account-deleted-dbs.delete', #{'db.name' => Db}};
 
 handler_info('POST', [<<"_dbs_info">>], _) ->
     {'dbs_info.read', #{}};

--- a/src/chttpd/test/eunit/chttpd_deleted_dbs_test.erl
+++ b/src/chttpd/test/eunit/chttpd_deleted_dbs_test.erl
@@ -1,0 +1,234 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_deleted_dbs_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(USER, "chttpd_db_test_admin").
+-define(PASS, "pass").
+-define(AUTH, {basic_auth, {?USER, ?PASS}}).
+-define(CONTENT_JSON, {"Content-Type", "application/json"}).
+
+
+setup() ->
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist=false),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    lists:concat(["http://", Addr, ":", Port, "/"]).
+
+
+teardown(_Url) ->
+    ok = config:delete("couchdb", "enable_database_recovery", false),
+    ok = config:delete("admins", ?USER, _Persist=false).
+
+
+create_db(Url) ->
+    {ok, Status, _, _} = http(put, Url, ""),
+    ?assert(Status =:= 201 orelse Status =:= 202).
+
+
+delete_db(Url) ->
+    {ok, 200, _, _} = http(delete, Url).
+
+
+deleted_dbs_test_() ->
+    {
+        "chttpd deleted dbs tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    fun should_return_error_for_unsupported_method/1,
+                    fun should_list_deleted_dbs/1,
+                    fun should_list_deleted_dbs_info/1,
+                    fun should_undelete_db/1,
+                    fun should_remove_deleted_db/1,
+                    fun should_undelete_db_to_target_db/1,
+                    fun should_not_undelete_db_to_existing_db/1
+                ]
+            }
+        }
+    }.
+
+
+should_return_error_for_unsupported_method(Url) ->
+    ?_test(begin
+        {ok, Code, _, Body} = http(delete, mk_url(Url)),
+
+        ?assertEqual(405, Code),
+        ?assertEqual(<<"method_not_allowed">>, get_json(<<"error">>, Body))
+    end).
+
+
+should_list_deleted_dbs(Url) ->
+    ?_test(begin
+        DbName1 = create_and_delete_db(Url),
+        DbName2 = create_and_delete_db(Url),
+        {ok, Code, _, Body} = http(get, mk_url(Url)),
+        DeletedDbs = get_db_names(Body),
+
+        ?assertEqual(200, Code),
+        ?assertEqual(true, lists:member(DbName1, DeletedDbs)),
+        ?assertEqual(true, lists:member(DbName2, DeletedDbs))
+    end).
+
+
+should_list_deleted_dbs_info(Url) ->
+    ?_test(begin
+         DbName = create_and_delete_db(Url),
+         {ok, _, _, Body} = http(get, mk_url(Url, DbName)),
+         [{Props}] = jiffy:decode(Body),
+
+         ?assertEqual(DbName, couch_util:get_value(<<"db_name">>, Props))
+     end).
+
+
+should_undelete_db(Url) ->
+    ?_test(begin
+        DbName = create_and_delete_db(Url),
+        {ok, _, _, ResultBody} = http(get, mk_url(Url, DbName)),
+        [{Props}] = jiffy:decode(ResultBody),
+        TimeStamp = couch_util:get_value(<<"timestamp">>, Props),
+
+        ErlJSON = {[
+            {undelete, {[
+                {source, DbName},
+                {timestamp, TimeStamp}
+            ]}}
+        ]},
+
+        {ok, Code1, _, _} = http(get, Url ++ DbName),
+        ?assertEqual(404, Code1),
+
+        {ok, Code2, _, _} = http(post, mk_url(Url), ErlJSON),
+        ?assertEqual(200, Code2),
+
+        {ok, Code3, _, _} = http(get, Url ++ DbName),
+        ?assertEqual(200, Code3)
+    end).
+
+
+should_remove_deleted_db(Url) ->
+    ?_test(begin
+        DbName = create_and_delete_db(Url),
+        {ok, _, _, Body1} = http(get, mk_url(Url, DbName)),
+        [{Props}] = jiffy:decode(Body1),
+        TimeStamp = couch_util:get_value(<<"timestamp">>, Props),
+
+        {ok, Code, _, _} = http(delete, mk_url(Url, DbName, TimeStamp)),
+        ?assertEqual(200, Code),
+
+        {ok, _, _, Body2} = http(get, mk_url(Url, DbName)),
+        ?assertEqual([], jiffy:decode(Body2))
+    end).
+
+
+should_undelete_db_to_target_db(Url) ->
+    ?_test(begin
+        DbName = create_and_delete_db(Url),
+        {ok, _, _, Body} = http(get, mk_url(Url, DbName)),
+        [{Props}] = jiffy:decode(Body),
+        TimeStamp = couch_util:get_value(<<"timestamp">>, Props),
+
+        NewDbName = ?tempdb(),
+        ErlJSON = {[
+            {undelete, {[
+                {source, DbName},
+                {timestamp, TimeStamp},
+                {target, NewDbName}
+            ]}}
+        ]},
+
+        {ok, Code1, _, _} = http(get, Url ++ NewDbName),
+        ?assertEqual(404, Code1),
+
+        {ok, Code2, _, _} = http(post, mk_url(Url), ErlJSON),
+        ?assertEqual(200, Code2),
+
+        {ok, Code3, _, _} = http(get, Url ++ NewDbName),
+        ?assertEqual(200, Code3)
+    end).
+
+
+should_not_undelete_db_to_existing_db(Url) ->
+    ?_test(begin
+        DbName = create_and_delete_db(Url),
+        {ok, _, _, ResultBody} = http(get, mk_url(Url, DbName)),
+        [{Props}] = jiffy:decode(ResultBody),
+        TimeStamp = couch_util:get_value(<<"timestamp">>, Props),
+
+        NewDbName = ?tempdb(),
+        create_db(Url ++ NewDbName),
+        ErlJSON = {[
+            {undelete, {[
+                {source, DbName},
+                {timestamp, TimeStamp},
+                {target, NewDbName}
+            ]}}
+        ]},
+        {ok, Code2, _, ResultBody2} = http(post, mk_url(Url), ErlJSON),
+        ?assertEqual(412, Code2),
+        ?assertEqual(<<"file_exists">>, get_json(<<"error">>, ResultBody2))
+    end).
+
+
+create_and_delete_db(BaseUrl) ->
+    DbName = ?tempdb(),
+    DbUrl = BaseUrl ++ DbName,
+    create_db(DbUrl),
+    ok = config:set("couchdb", "enable_database_recovery", "true", false),
+    delete_db(DbUrl),
+    DbName.
+
+
+http(Verb, Url) ->
+    Headers = [?CONTENT_JSON, ?AUTH],
+    test_request:Verb(Url, Headers).
+
+
+http(Verb, Url, Body) ->
+    Headers = [?CONTENT_JSON, ?AUTH],
+    test_request:Verb(Url, Headers, jiffy:encode(Body)).
+
+
+mk_url(Url) ->
+    Url ++ "/_deleted_dbs".
+
+
+mk_url(Url, DbName) ->
+    Url ++ "/_deleted_dbs?key=\"" ++ ?b2l(DbName) ++ "\"".
+
+
+mk_url(Url, DbName, TimeStamp) ->
+    Url ++ "/_deleted_dbs/" ++ ?b2l(DbName) ++ "?timestamp=\"" ++
+        ?b2l(TimeStamp) ++ "\"".
+
+
+get_json(Key, Body) ->
+    {Props} = jiffy:decode(Body),
+    couch_util:get_value(Key, Props).
+
+
+get_db_names(Body) ->
+    RevDbNames = lists:foldl(fun({DbInfo}, Acc) ->
+        DbName = couch_util:get_value(<<"db_name">>, DbInfo),
+        [DbName | Acc]
+    end, [], jiffy:decode(Body)),
+    lists:reverse(RevDbNames).

--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -22,6 +22,7 @@
 -define(CLUSTER_CONFIG, 0).
 -define(ALL_DBS, 1).
 -define(DB_HCA, 2).
+-define(DELETED_DBS, 3).
 -define(DBS, 15).
 -define(TX_IDS, 255).
 

--- a/src/fabric/src/fabric2_util.erl
+++ b/src/fabric/src/fabric2_util.erl
@@ -40,6 +40,9 @@
     encode_all_doc_key/1,
     all_docs_view_opts/1,
 
+    iso8601_timestamp/0,
+    do_recovery/0,
+
     pmap/2,
     pmap/3
 ]).
@@ -335,6 +338,19 @@ all_docs_view_opts(#mrargs{} = Args) ->
         {include_docs, Args#mrargs.include_docs},
         {doc_opts, DocOpts}
     ] ++ StartKeyOpts ++ EndKeyOpts.
+
+
+iso8601_timestamp() ->
+    Now = os:timestamp(),
+    {{Year, Month, Date}, {Hour, Minute, Second}} =
+        calendar:now_to_datetime(Now),
+    Format = "~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0BZ",
+    io_lib:format(Format, [Year, Month, Date, Hour, Minute, Second]).
+
+
+do_recovery() ->
+    config:get_boolean("couchdb",
+        "enable_database_recovery", false).
 
 
 pmap(Fun, Args) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Instead of automatically and immediately removing data and index in database after a delete operation, soft-deletion allows to restore the deleted data back to original state due to a “fat finger”or undesired delete operation, up to defined periods, such as 48 hours.

In CouchDB 3.0, soft-deletion of database is implemented in [1]. The .couch file is renamed with the .<timestamp>.deleted.couch file after soft-deletion is enabled, and such file can be changed back to .couch for the purpose of restore. If restore is not needed and some specified period passed, the .<timestamp>.deleted.couch file can be deleted to achieve deletion of database permanently.

In CouchDB 4.0, with the introduction of FoundationDB, the data model and storage is changed. In order to support soft-deletion, we propose below solution and then implement them.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

make check skip_deps+=couch_epi apps=fabric tests=crud_test_
```
======================== EUnit ========================
Test database CRUD operations
  fabric2_db_crud_tests:36: crud_test_ (create_db)...[0.032 s] ok
  fabric2_db_crud_tests:37: crud_test_ (open_db)...[0.020 s] ok
  fabric2_db_crud_tests:38: crud_test_ (delete_db)...[0.027 s] ok
  fabric2_db_crud_tests:39: crud_test_ (recreate_db)...[0.064 s] ok
  fabric2_db_crud_tests:40: crud_test_ (undelete_db)...[0.038 s] ok
  fabric2_db_crud_tests:41: crud_test_ (remove_deleted_db)...[0.037 s] ok
  fabric2_db_crud_tests:42: crud_test_ (old_db_handle)...[0.154 s] ok
  fabric2_db_crud_tests:43: crud_test_ (list_dbs)...[0.023 s] ok
  fabric2_db_crud_tests:44: crud_test_ (list_dbs_user_fun)...[0.014 s] ok
  fabric2_db_crud_tests:45: crud_test_ (list_dbs_user_fun_partial)...ok
  fabric2_db_crud_tests:46: crud_test_ (list_deleted_dbs)...[0.029 s] ok
  fabric2_db_crud_tests:47: crud_test_ (list_deleted_dbs_user_fun)...[0.027 s] ok
  fabric2_db_crud_tests:48: crud_test_ (list_deleted_dbs_user_fun_partial)...ok
  fabric2_db_crud_tests:49: crud_test_ (list_dbs_info)...[0.049 s] ok
  fabric2_db_crud_tests:50: crud_test_ (list_dbs_info_partial)...ok
  fabric2_db_crud_tests:51: crud_test_ (list_dbs_tx_too_old)...[0.078 s] ok
  fabric2_db_crud_tests:52: crud_test_ (list_dbs_info_tx_too_old)...[0.757 s] ok
  fabric2_db_crud_tests:53: crud_test_ (list_deleted_dbs_info)...[0.060 s] ok
  fabric2_db_crud_tests:54: crud_test_ (get_info_wait_retry_on_tx_too_old)...[0.098 s] ok
  fabric2_db_crud_tests:55: crud_test_ (get_info_wait_retry_on_tx_abort)...[0.072 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 2.674 s]
=======================================================
  All 20 tests passed.
```

make check skip_deps+=couch_epi apps=chttpd tests=deleted_dbs_test_
```
======================== EUnit ========================
chttpd deleted dbs tests
  chttpd_deleted_dbs_test:72: should_return_error_for_unsupported_method...[0.107 s] ok
  chttpd_deleted_dbs_test:82: should_list_deleted_dbs...[0.052 s] ok
  chttpd_deleted_dbs_test:95: should_list_deleted_dbs_info...[0.022 s] ok
  chttpd_deleted_dbs_test:105: should_undelete_db...[0.040 s] ok
  chttpd_deleted_dbs_test:130: should_remove_deleted_db...[0.040 s] ok
  chttpd_deleted_dbs_test:145: should_undelete_db_to_target_db...[0.040 s] ok
  chttpd_deleted_dbs_test:172: should_not_undelete_db_to_existing_db...[0.034 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 0.357 s]
=======================================================
  All 7 tests passed.
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/2707

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
