### PR TITLE
add _conflicts field to docs for views

### DIFF
--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -126,7 +126,9 @@
     validate_dbname/1,
 
     %% make_doc/5,
-    new_revid/2
+    new_revid/2,
+
+    apply_open_doc_opts/3
 ]).
 
 


### PR DESCRIPTION
## Overview
If a doc has more than 1 branch add the conflict revs to the _conflicts field of the view so that
it can be used when the doc is mapped.

## Testing recommendations

```
$ mix test test/elixir/test/maps_test.exs
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
