### PR TITLE
Throw if an unknown check is passed to jwtf:decode

### DIFF
--- a/src/jwtf/test/jwtf_tests.erl
+++ b/src/jwtf/test/jwtf_tests.erl
@@ -178,6 +178,10 @@ malformed_token_test() ->
     ?assertEqual({error, {bad_request, <<"Malformed token">>}},
         jwtf:decode(<<"a.b.c.d">>, [], nil)).
 
+unknown_check_test() ->
+    ?assertError({unknown_checks, [bar, foo]},
+        jwtf:decode(<<"a.b.c">>, [exp, foo, iss, bar, exp], nil)).
+
 
 %% jwt.io generated
 hs256_test() ->


### PR DESCRIPTION
## Overview

Throw if an unknown check is passed to jwtf:decode

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/2648

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
