### PR TITLE
A few minor cleanups in fabric2_db_crud_tests

### DIFF
--- a/src/fabric/test/fabric2_db_crud_tests.erl
+++ b/src/fabric/test/fabric2_db_crud_tests.erl
@@ -166,7 +166,7 @@ list_dbs_tx_too_old(_) ->
 
     UserFun = fun(Row, Acc) ->
         fabric2_test_util:tx_too_old_raise_in_user_fun(),
-        {ok, [Row, Acc]}
+        {ok, [Row | Acc]}
     end,
 
     % Get get expected output without any transactions timing out
@@ -181,7 +181,7 @@ list_dbs_tx_too_old(_) ->
     ?assertEqual(Dbs, fabric2_db:list_dbs(UserFun, [], [])),
 
     % Blow up in user fun
-    fabric2_test_util:tx_too_old_setup_errors(2, 2),
+    fabric2_test_util:tx_too_old_setup_errors(1, 0),
     ?assertEqual(Dbs, fabric2_db:list_dbs(UserFun, [], [])),
 
     % Blow up in user fun after emitting one row
@@ -209,7 +209,7 @@ list_dbs_info_tx_too_old(_) ->
 
     UserFun = fun(Row, Acc) ->
         fabric2_test_util:tx_too_old_raise_in_user_fun(),
-        {ok, [Row, Acc]}
+        {ok, [Row | Acc]}
     end,
 
     % This is the expected return with no tx timeouts


### PR DESCRIPTION
 * Made a silly error building the accumulator list:
   `[Row, Acc]` -> `[Row | Acc]`

 * Left some debugging code in `list_dbs_tx_too_old` test
   The test was supposed to setup only 1 failure in the user callback

Check with:

```
make eunit apps=fabric suites=fabric2_db_crud_tests
```