### PR TITLE
Handle transaction timeouts in _all_docs

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -867,7 +867,8 @@ all_docs_view(Req, Db, Keys, OP) ->
 
 
 send_all_docs(Db, #mrargs{keys = undefined} = Args, VAcc0) ->
-    Opts = all_docs_view_opts(Args),
+    Opts0 = all_docs_view_opts(Args),
+    Opts = Opts0 ++ [{restart_tx, true}],
     NS = couch_util:get_value(namespace, Opts),
     FoldFun = case NS of
         <<"_all_docs">> -> fold_docs;


### PR DESCRIPTION
#### Overview

Previously transactions could time-out, retry and re-emit the same data. Use
the same mechanism as the _list_dbs and _changes feeds to fix it. Additional
detail in the mailing list discussion:

https://lists.apache.org/thread.html/r02cee7045cac4722e1682bb69ba0ec791f5cce025597d0099fb34033%40%3Cdev.couchdb.apache.org%3E

#### Testing recommendations

```
make check-fdb
```