### PR TITLE
Update smoosh defaults, default.ini

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -523,11 +523,29 @@ writer = stderr
 ; Stats collection interval in seconds. Default 10 seconds.
 ;interval = 10
 
-[smoosh.ratio_dbs]
-min_priority = 2.0
-
-[smoosh.ratio_views]
-min_priority = 2.0
+[smoosh]
+;
+; More documentation on these is in the Automatic Compaction
+; section of the documentation.
+;
+;db_channels = upgrade_dbs,ratio_dbs,slack_dbs
+;view_channels = upgrade_views,ratio_views,slack_views
+;
+;[smoosh.ratio_dbs]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.ratio_views]
+;priority = ratio
+;min_priority = 2.0
+;
+;[smoosh.slack_dbs]
+;priority = slack
+;min_priority = 16777216
+;
+;[smoosh.slack_views]
+;priority = slack
+;min_priority = 16777216
 
 [ioq]
 ; The maximum number of concurrent in-flight IO requests that

--- a/src/smoosh/src/smoosh_server.erl
+++ b/src/smoosh/src/smoosh_server.erl
@@ -364,7 +364,7 @@ get_priority(Channel, DiskSize, DataSize, NeedsUpgrade) ->
     Priority = get_priority(Channel),
     MinSize = to_number(Channel, "min_size", "1048576"),
     MaxSize = to_number(Channel, "max_size", "infinity"),
-    DefaultMinPriority = case Priority of "slack" -> "16777216"; _ -> "5.0" end,
+    DefaultMinPriority = case Priority of "slack" -> "16777216"; _ -> "2.0" end,
     MinPriority = to_number(Channel, "min_priority", DefaultMinPriority),
     MaxPriority = to_number(Channel, "max_priority", "infinity"),
     if Priority =:= "upgrade", NeedsUpgrade ->
@@ -531,7 +531,7 @@ t_slack_view({ok, Shard, GroupId}) ->
         meck:expect(couch_index, get_info, fun(_) ->
             {ok, [{sizes, {[{file, 33554432}, {active, 16777215}]}}]}
         end),
-        ?assertEqual(0, get_priority("ratio_views", {Shard, GroupId})),
+        ?assertEqual(2.0000001192092967, get_priority("ratio_views", {Shard, GroupId})),
         ?assertEqual(16777217, get_priority("slack_views", {Shard, GroupId})),
         ?assertEqual(0, get_priority("upgrade_views", {Shard, GroupId}))
     end).
@@ -541,9 +541,9 @@ t_no_data_view({ok, Shard, GroupId}) ->
         meck:expect(couch_index, get_info, fun(_) ->
             {ok, [{sizes, {[{file, 5242880}, {active, 0}]}}]}
         end),
-        ?assertEqual(5.0, get_priority("ratio_views", {Shard, GroupId})),
+        ?assertEqual(2.0, get_priority("ratio_views", {Shard, GroupId})),
         ?assertEqual(16777216, get_priority("slack_views", {Shard, GroupId})),
-        ?assertEqual(5.0, get_priority("upgrade_views", {Shard, GroupId}))
+        ?assertEqual(2.0, get_priority("upgrade_views", {Shard, GroupId}))
     end).
 
 t_below_min_priority_view({ok, Shard, GroupId}) ->
@@ -551,7 +551,7 @@ t_below_min_priority_view({ok, Shard, GroupId}) ->
         meck:expect(couch_index, get_info, fun(_) ->
             {ok, [{sizes, {[{file, 5242880}, {active, 1048576}]}}]}
         end),
-        ?assertEqual(0, get_priority("ratio_views", {Shard, GroupId})),
+        ?assertEqual(5.0, get_priority("ratio_views", {Shard, GroupId})),
         ?assertEqual(0, get_priority("slack_views", {Shard, GroupId})),
         ?assertEqual(0, get_priority("upgrade_views", {Shard, GroupId}))
     end).


### PR DESCRIPTION
## Overview

1. Normalise code against 3.0 `default.ini` values
1. Fully specify the defaults in `default.ini` so there's no magic/disconnect

## Testing recommendations

Tests pass

## Related Issues or Pull Requests

To come: PR against the docs to reflect the new default ratio of 2.0, not 5.0.

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
