### PR TITLE
[WIP] Implement per database encryption for primary data

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -707,3 +707,18 @@ opts = #{budget => 100, target => 2500, window => 60000, sensitivity => 1000}
 
 [encryption]
 enabled = false
+;
+; To generate master key and initialization vector run the following command
+; ("secret" is an example passphrase here, use something else)
+;
+; `openssl enc -aes-256-ctr -k secret -P -md sha1`
+; output:
+;   salt=FC0D0243C5126FB5
+;   key=9B43A7711CDDE41FE065FC03A14BBD6A177CBD6A4B474A05DEC9798C79B98045
+;   iv =5B3C6478BBC698AAA8CA5BA51DB8FF95
+; Put key in "key.dat" file excluding "key" characters and a carriage return
+; Put iv in "iv.dat" file excluding "iv" characters and a carriage return
+;
+; Keep both files as read-only and owned by couch process.
+; key_file = /var/secured/mount/location/key.dat
+; iv_file = /var/secured/mount/location/iv.dat

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -708,17 +708,10 @@ opts = #{budget => 100, target => 2500, window => 60000, sensitivity => 1000}
 [encryption]
 enabled = false
 ;
-; To generate master key and initialization vector run the following command
-; ("secret" is an example passphrase here, use something else)
+; A key provider is an external script, that on call prints master key
+; in its binary form to standartd output. The master key must be 128, 192
+; or 256 (preferred) bites long. The master key cached in memory
+; for the length of CouchDB run, i.e. it key provider script executed
+; only once.
 ;
-; `openssl enc -aes-256-ctr -k secret -P -md sha1`
-; output:
-;   salt=FC0D0243C5126FB5
-;   key=9B43A7711CDDE41FE065FC03A14BBD6A177CBD6A4B474A05DEC9798C79B98045
-;   iv =5B3C6478BBC698AAA8CA5BA51DB8FF95
-; Put key in "key.dat" file excluding "key" characters and a carriage return
-; Put iv in "iv.dat" file excluding "iv" characters and a carriage return
-;
-; Keep both files as read-only and owned by couch process.
-; key_file = /var/secured/mount/location/key.dat
-; iv_file = /var/secured/mount/location/iv.dat
+;key_provider = /usr/local/bin/decrypt_master_key

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -704,3 +704,6 @@ compaction = false
 [couch_rate.views]
 limiter = couch_rate_limiter
 opts = #{budget => 100, target => 2500, window => 60000, sensitivity => 1000}
+
+[encryption]
+enabled = false

--- a/src/fabric/src/fabric2_encryption.erl
+++ b/src/fabric/src/fabric2_encryption.erl
@@ -1,0 +1,128 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_encryption).
+-behaviour(gen_server).
+-vsn(1).
+
+
+-export([
+    start_link/0,
+    encode/4,
+    decode/4
+]).
+
+
+-export([
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3
+]).
+
+
+-define(INIT_TIMEOUT, 60000).
+-define(LABEL, "couchdb-aes256-gcm-encryption-key").
+
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+
+encode(DbName, DocId, DocRev, DocBody)
+    when is_binary(DbName),
+         is_binary(DocId),
+         is_binary(DocRev),
+         is_binary(DocBody) ->
+    gen_server:call(?MODULE, {encode, DbName, DocId, DocRev, DocBody}).
+
+
+decode(DbName, DocId, DocRev, DocBody)
+    when is_binary(DbName),
+         is_binary(DocId),
+         is_binary(DocRev),
+         is_binary(DocBody) ->
+    gen_server:call(?MODULE, {decode, DbName, DocId, DocRev, DocBody}).
+
+
+
+init(_) ->
+    process_flag(sensitive, true),
+    process_flag(trap_exit, true),
+
+    case init_st() of
+        {ok, St} ->
+            proc_lib:init_ack({ok, self()}),
+            gen_server:enter_loop(?MODULE, [], St, ?INIT_TIMEOUT);
+        Error ->
+            proc_lib:init_ack(Error)
+    end.
+
+
+terminate(_, _St) ->
+    ok.
+
+
+handle_call({encode, DbName, DocId, DocRev, DocBody}, _From, St) ->
+    #{iid := InstanceId} = St,
+    {ok, AAD} = get_aad(InstanceId, DbName),
+    {ok, DEK} = get_dek(DbName, DocId, DocRev),
+    {CipherText, CipherTag} = crypto:crypto_one_time_aead(
+        aes_256_gcm, DEK, <<0:96>>, DocBody, AAD, 16, true),
+    Encoded = <<CipherTag/binary, CipherText/binary>>,
+    {reply, {ok, Encoded}, St};
+
+handle_call({decode, DbName, DocId, DocRev, Encoded}, _From, St) ->
+    #{iid := InstanceId} = St,
+    {ok, AAD} = get_aad(InstanceId, DbName),
+    {ok, DEK} = get_dek(DbName, DocId, DocRev),
+    <<CipherTag:16/binary, CipherText/binary>> = Encoded,
+    DocBody = crypto:crypto_one_time_aead(
+        aes_256_gcm, DEK, <<0:96>>, CipherText, AAD, CipherTag, false),
+    {reply, {ok, DocBody}, St}.
+
+
+handle_cast(Msg, St) ->
+    {stop, {bad_cast, Msg}, St}.
+
+
+handle_info(timeout, St) ->
+    {stop, normal, St}.
+
+
+code_change(_OldVsn, St, _Extra) ->
+    {ok, St}.
+
+
+
+init_st() ->
+    FdbDirs = fabric2_server:fdb_directory(),
+    {ok, #{iid => iolist_to_binary(FdbDirs)}}.
+
+
+get_aad(InstanceId, DbName) when is_binary(InstanceId), is_binary(DbName) ->
+    {ok, <<InstanceId/binary, 0:8, DbName/binary>>}.
+
+
+get_dek(DbName, DocId, DocRev) ->
+    {ok, KEK} = get_kek(DbName),
+    Context = <<DocId/binary, 0:8, DocRev/binary>>,
+    PlainText = <<1:16, ?LABEL, 0:8, Context/binary, 256:16>>,
+    <<_:256>> = DEK = crypto:mac(hmac, sha256, KEK, PlainText),
+    {ok, DEK}.
+
+
+get_kek(DbName) ->
+    KEK = crypto:hash(sha256, DbName),
+    {ok, KEK}.

--- a/src/fabric/src/fabric2_encryption.erl
+++ b/src/fabric/src/fabric2_encryption.erl
@@ -52,7 +52,10 @@ start_link() ->
 
 
 get_wrapped_kek(DbName) when is_binary(DbName) ->
-    gen_server:call(?MODULE, {get_wrapped_kek, DbName}).
+    case config:get_boolean("encryption", "enabled", false) of
+        true -> gen_server:call(?MODULE, {get_wrapped_kek, DbName});
+        false -> {ok, false}
+    end.
 
 
 encode(WrappedKEK, DbName, DocId, UpdateCounter, DocBody)

--- a/src/fabric/src/fabric2_encryption_plugin.erl
+++ b/src/fabric/src/fabric2_encryption_plugin.erl
@@ -1,0 +1,48 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_encryption_plugin).
+
+-export([
+    get_wrapped_kek/1,
+    unwrap_kek/1
+]).
+
+
+-define(SERVICE_ID, fabric2_encryption).
+
+
+-spec get_wrapped_kek(DbName :: binary()) ->
+    {ok, KEK :: binary(), WrappedKEK :: binary()} | {error, Error :: term()}.
+get_wrapped_kek(DbName) ->
+    Default = boom,
+    maybe_handle(get_kek, [DbName], Default).
+
+
+-spec unwrap_kek(WrappedKEK :: binary()) ->
+    {ok, KEK :: binary(), WrappedKEK :: binary()} | {error, Error :: term()}.
+unwrap_kek(WrappedKEK) ->
+    Default = boom,
+    maybe_handle(unwrap_kek, [WrappedKEK], Default).
+
+
+
+maybe_handle(Func, Args, Default) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    case couch_epi:decide(Handle, ?SERVICE_ID, Func, Args, []) of
+        no_decision when is_function(Default) ->
+            apply(Default, Args);
+        no_decision ->
+            Default;
+        {decided, Result} ->
+            Result
+    end.

--- a/src/fabric/src/fabric2_encryption_plugin.erl
+++ b/src/fabric/src/fabric2_encryption_plugin.erl
@@ -24,14 +24,14 @@
 -spec get_wrapped_kek(DbName :: binary()) ->
     {ok, KEK :: binary(), WrappedKEK :: binary()} | {error, Error :: term()}.
 get_wrapped_kek(DbName) ->
-    Default = boom,
+    Default = fun fabric2_encryption_provider:get_kek/1,
     maybe_handle(get_kek, [DbName], Default).
 
 
 -spec unwrap_kek(WrappedKEK :: binary()) ->
     {ok, KEK :: binary(), WrappedKEK :: binary()} | {error, Error :: term()}.
 unwrap_kek(WrappedKEK) ->
-    Default = boom,
+    Default = fun fabric2_encryption_provider:unwrap_kek/1,
     maybe_handle(unwrap_kek, [WrappedKEK], Default).
 
 

--- a/src/fabric/src/fabric2_encryption_plugin.erl
+++ b/src/fabric/src/fabric2_encryption_plugin.erl
@@ -13,12 +13,19 @@
 -module(fabric2_encryption_plugin).
 
 -export([
+    get_aad/1,
     get_wrapped_kek/1,
     unwrap_kek/1
 ]).
 
 
 -define(SERVICE_ID, fabric2_encryption).
+
+
+-spec get_aad(DbName :: binary()) -> {ok, AAD :: binary()}.
+get_aad(DbName) ->
+    Default = fun fabric2_encryption_provider:get_aad/1,
+    maybe_handle(get_aad, [DbName], Default).
 
 
 -spec get_wrapped_kek(DbName :: binary()) ->

--- a/src/fabric/src/fabric2_encryption_plugin.erl
+++ b/src/fabric/src/fabric2_encryption_plugin.erl
@@ -15,7 +15,7 @@
 -export([
     get_aad/1,
     get_wrapped_kek/1,
-    unwrap_kek/1
+    unwrap_kek/2
 ]).
 
 
@@ -35,11 +35,11 @@ get_wrapped_kek(DbName) ->
     maybe_handle(get_kek, [DbName], Default).
 
 
--spec unwrap_kek(WrappedKEK :: binary()) ->
+-spec unwrap_kek(DbName :: binary(), WrappedKEK :: binary()) ->
     {ok, KEK :: binary(), WrappedKEK :: binary()} | {error, Error :: term()}.
-unwrap_kek(WrappedKEK) ->
-    Default = fun fabric2_encryption_provider:unwrap_kek/1,
-    maybe_handle(unwrap_kek, [WrappedKEK], Default).
+unwrap_kek(DbName, WrappedKEK) ->
+    Default = fun fabric2_encryption_provider:unwrap_kek/2,
+    maybe_handle(unwrap_kek, [DbName, WrappedKEK], Default).
 
 
 

--- a/src/fabric/src/fabric2_encryption_provider.erl
+++ b/src/fabric/src/fabric2_encryption_provider.erl
@@ -1,0 +1,60 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_encryption_provider).
+
+-export([
+    get_kek/1,
+    unwrap_kek/1
+]).
+
+
+get_kek(_DbName) ->
+    case get_mek_iv() of
+        {ok, MEK, IV} ->
+            KEK = crypto:strong_rand_bytes(32),
+            Enc = crypto:stream_init(aes_ctr, MEK, IV),
+            {_, WrappedKEK} = crypto:stream_encrypt(Enc, KEK),
+            {decided, {ok, KEK, WrappedKEK}};
+        {error, Error} ->
+            {decided, {error, Error}}
+    end.
+
+
+unwrap_kek(WrappedKEK) ->
+    case get_mek_iv() of
+        {ok, MEK, IV} ->
+            Enc = crypto:stream_init(aes_ctr, MEK, IV),
+            {_, KEK} = crypto:stream_decrypt(Enc, WrappedKEK),
+            {decided, {ok, KEK, WrappedKEK}};
+        {error, Error} ->
+            {decided, {error, Error}}
+    end.
+
+
+
+get_mek_iv() ->
+    KeyFileReturn = file:read_file(config:get("encryption", "key_file")),
+    IVFileReturn = file:read_file(config:get("encryption", "iv_file")),
+    case {KeyFileReturn, IVFileReturn} of
+        {{ok, MEK}, {ok, IV}}
+                when bit_size(MEK) == 512, bit_size(IV) == 256 ->
+            {ok, <<<<I:4>> || <<I>> <= MEK>>, <<<<I:4>> || <<I>> <= IV>>};
+        {{ok, _}, _} ->
+            {error, invalid_key_length};
+        {{error, Error}, _} ->
+            {error, {invalid_key_file, Error}};
+        {_, {ok, _}} ->
+            {error, invalid_iv_length};
+        {_, {error, Error}} ->
+            {error, {invalid_iv_file, Error}}
+    end.

--- a/src/fabric/src/fabric2_encryption_provider.erl
+++ b/src/fabric/src/fabric2_encryption_provider.erl
@@ -15,7 +15,7 @@
 -export([
     get_aad/1,
     get_kek/1,
-    unwrap_kek/1
+    unwrap_kek/2
 ]).
 
 
@@ -42,7 +42,7 @@ get_kek(_DbName) ->
     end.
 
 
-unwrap_kek(WrappedKEK) ->
+unwrap_kek(_DbName, WrappedKEK) ->
     case get_mek() of
         {ok, MEK} ->
             case couch_keywrap:key_unwrap(MEK, WrappedKEK) of
@@ -132,7 +132,7 @@ get_unwrap_kek_test_() ->
                 {"should unwrap valid wrapped kek",
                 fun test_unwrap_kek/0},
                 {"should return error on invalid wrapped key",
-                ?_assertMatch({error, _}, unwrap_kek(<<0:320>>))}
+                ?_assertMatch({error, _}, unwrap_kek(<<"db">>, <<0:320>>))}
             ]
         end
     }.
@@ -156,7 +156,7 @@ test_get_kek() ->
 
 test_unwrap_kek() ->
     WrappedKEK = <<16#0c714838ba4b937fdde5a2ca8a318ead3c2c49ddfc77eef90e1a954f18962848f601d18f7cf32bb9:320>>,
-    Resp = unwrap_kek(WrappedKEK),
+    Resp = unwrap_kek(<<"db">>, WrappedKEK),
     ?assertMatch({ok, _, _}, Resp),
     {ok, KEK, WrappedKEK2} = Resp,
     ?assertEqual(256, bit_size(KEK)),

--- a/src/fabric/src/fabric2_encryption_provider.erl
+++ b/src/fabric/src/fabric2_encryption_provider.erl
@@ -13,9 +13,16 @@
 -module(fabric2_encryption_provider).
 
 -export([
+    get_aad/1,
     get_kek/1,
     unwrap_kek/1
 ]).
+
+
+get_aad(DbName) ->
+    FdbDirs = fabric2_server:fdb_directory(),
+    FdbDir = iolist_to_binary(FdbDirs),
+    {ok, <<FdbDir/binary, 0:8, DbName/binary>>}.
 
 
 get_kek(_DbName) ->

--- a/src/fabric/src/fabric2_encryption_provider.erl
+++ b/src/fabric/src/fabric2_encryption_provider.erl
@@ -19,6 +19,12 @@
 ]).
 
 
+-include_lib("syntax_tools/include/merl.hrl").
+
+
+-define(MEK_CACHE_MODULE, fabric2_encryption_master_key).
+
+
 get_aad(DbName) ->
     FdbDirs = fabric2_server:fdb_directory(),
     FdbDir = iolist_to_binary(FdbDirs),
@@ -26,11 +32,10 @@ get_aad(DbName) ->
 
 
 get_kek(_DbName) ->
-    case get_mek_iv() of
-        {ok, MEK, IV} ->
+    case get_mek() of
+        {ok, MEK} ->
             KEK = crypto:strong_rand_bytes(32),
-            Enc = crypto:stream_init(aes_ctr, MEK, IV),
-            {_, WrappedKEK} = crypto:stream_encrypt(Enc, KEK),
+            WrappedKEK = couch_keywrap:key_wrap(MEK, KEK),
             {ok, KEK, WrappedKEK};
         {error, Error} ->
             {error, Error}
@@ -38,39 +43,123 @@ get_kek(_DbName) ->
 
 
 unwrap_kek(WrappedKEK) ->
-    case get_mek_iv() of
-        {ok, MEK, IV} ->
-            Enc = crypto:stream_init(aes_ctr, MEK, IV),
-            {_, KEK} = crypto:stream_decrypt(Enc, WrappedKEK),
-            {ok, KEK, WrappedKEK};
+    case get_mek() of
+        {ok, MEK} ->
+            case couch_keywrap:key_unwrap(MEK, WrappedKEK) of
+                fail ->
+                    {error, unable_to_unwrap_kek};
+                KEK ->
+                    {ok, KEK, WrappedKEK}
+            end;
         {error, Error} ->
             {error, Error}
     end.
 
 
 
-get_mek_iv() ->
-    case config:get_boolean("encryption", "enabled", false) of
-        false ->
-            {error, encryption_disabled};
+get_mek() ->
+    case erlang:function_exported(?MEK_CACHE_MODULE, get, 0) of
         true ->
-            KeyFile = config:get("encryption", "key_file"),
-            IVFile = config:get("encryption", "iv_file"),
-            get_mek_iv(KeyFile, IVFile)
+            ?MEK_CACHE_MODULE:get();
+        false ->
+            maybe_cache_mek()
     end.
 
 
-get_mek_iv(KeyFile, IVFile) ->
-    case {file:read_file(KeyFile), file:read_file(IVFile)} of
-        {{ok, MEK}, {ok, IV}}
-                when bit_size(MEK) == 512, bit_size(IV) == 256 ->
-            {ok, <<<<I:4>> || <<I>> <= MEK>>, <<<<I:4>> || <<I>> <= IV>>};
-        {{ok, _}, _} ->
-            {error, invalid_key_length};
-        {{error, Error}, _} ->
-            {error, {invalid_key_file, Error}};
-        {_, {ok, _}} ->
-            {error, invalid_iv_length};
-        {_, {error, Error}} ->
-            {error, {invalid_iv_file, Error}}
+maybe_cache_mek() ->
+    KeyProvider = config:get("encryption", "key_provider"),
+    case iolist_to_binary(os:cmd(KeyProvider)) of
+        MEK when bit_size(MEK) rem 64 == 0, bit_size(MEK) =< 256 ->
+            ModuleName = ?MEK_CACHE_MODULE,
+            Module = ?Q("-module('@ModuleName@')."),
+            Export = ?Q("-export([get/0])."),
+            Function = erl_syntax:function(merl:term(get), [
+                ?Q("() -> {ok, _@MEK@}")
+            ]),
+            merl:compile_and_load([Module, Export, Function],
+                [no_spawn_compiler_process, no_line_info]),
+            {ok, MEK};
+        _ ->
+            {error, invalid_key_length}
     end.
+
+
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+
+get_mek_failure_test_() ->
+    {
+        setup,
+        fun() ->
+            ok = meck:new([config], [passthrough]),
+            ok = meck:expect(config, get, fun("encryption", "key_provider") ->
+                "echo 0"
+            end)
+        end,
+        fun(ok) ->
+            meck:unload()
+        end,
+        fun(ok) ->
+            [
+                {"should return error when failed to acquire mek",
+                ?_assertEqual({error, invalid_key_length}, get_mek())}
+            ]
+        end
+    }.
+
+
+get_unwrap_kek_test_() ->
+    {
+        setup,
+        fun() ->
+            ok = meck:new([config], [passthrough]),
+            ok = meck:expect(config, get, fun("encryption", "key_provider") ->
+                "echo 0000000000000000000000000000000"
+            end)
+        end,
+        fun(ok) ->
+            meck:unload()
+        end,
+        fun(ok) ->
+            [
+                {"should cache acquired mek",
+                fun test_get_mek/0},
+                {"should gernerate and wrap kek",
+                fun test_get_kek/0},
+                {"should unwrap valid wrapped kek",
+                fun test_unwrap_kek/0},
+                {"should return error on invalid wrapped key",
+                ?_assertMatch({error, _}, unwrap_kek(<<0:320>>))}
+            ]
+        end
+    }.
+
+
+test_get_mek() ->
+    {ok, MEK1} = get_mek(),
+    {ok, MEK2} = get_mek(),
+    ?assertEqual(MEK2, MEK1),
+    N1 = meck:num_calls(config, get, ["encryption", "key_provider"]),
+    ?assertEqual(1, N1).
+
+
+test_get_kek() ->
+    Resp = get_kek(<<"db">>),
+    ?assertMatch({ok, _, _}, Resp),
+    {ok, KEK, WrappedKEK} = Resp,
+    ?assertEqual(256, bit_size(KEK)),
+    ?assertNotEqual(WrappedKEK, KEK).
+
+
+test_unwrap_kek() ->
+    WrappedKEK = <<16#0c714838ba4b937fdde5a2ca8a318ead3c2c49ddfc77eef90e1a954f18962848f601d18f7cf32bb9:320>>,
+    Resp = unwrap_kek(WrappedKEK),
+    ?assertMatch({ok, _, _}, Resp),
+    {ok, KEK, WrappedKEK2} = Resp,
+    ?assertEqual(256, bit_size(KEK)),
+    ?assertEqual(WrappedKEK, WrappedKEK2),
+    ?assertNotEqual(WrappedKEK2, KEK).
+
+-endif.

--- a/src/fabric/src/fabric2_encryption_provider.erl
+++ b/src/fabric/src/fabric2_encryption_provider.erl
@@ -93,6 +93,7 @@ get_mek_failure_test_() ->
     {
         setup,
         fun() ->
+            code:delete(?MEK_CACHE_MODULE),
             ok = meck:new([config], [passthrough]),
             ok = meck:expect(config, get, fun("encryption", "key_provider") ->
                 "echo 0"

--- a/src/fabric/src/fabric2_epi.erl
+++ b/src/fabric/src/fabric2_epi.erl
@@ -28,11 +28,14 @@ app() ->
     fabric.
 
 providers() ->
-    [].
+    [
+        {fabric2_encryption, fabric2_encryption_provider}
+    ].
 
 services() ->
     [
-        {fabric2_db, fabric2_db_plugin}
+        {fabric2_db, fabric2_db_plugin},
+        {fabric2_encryption, fabric2_encryption_plugin}
     ].
 
 data_subscriptions() ->

--- a/src/fabric/src/fabric2_epi.erl
+++ b/src/fabric/src/fabric2_epi.erl
@@ -28,9 +28,7 @@ app() ->
     fabric.
 
 providers() ->
-    [
-        {fabric2_encryption, fabric2_encryption_provider}
-    ].
+    [].
 
 services() ->
     [

--- a/src/fabric/src/fabric2_sup.erl
+++ b/src/fabric/src/fabric2_sup.erl
@@ -55,6 +55,14 @@ init([]) ->
             5000,
             worker,
             [fabric2_index]
+        },
+        {
+            fabric2_encryption,
+            {fabric2_encryption, start_link, []},
+            permanent,
+            5000,
+            worker,
+            [fabric2_encryption]
         }
     ],
     ChildrenWithEpi = couch_epi:register_service(fabric2_epi, Children),

--- a/src/fabric/test/fabric2_encryption_tests.erl
+++ b/src/fabric/test/fabric2_encryption_tests.erl
@@ -1,0 +1,208 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_encryption_tests).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("fabric2_test.hrl").
+
+
+-define(PLUGIN, fabric2_encryption_provider).
+-define(WK, <<0:256>>).
+-define(FIXTURE, #{
+    db => <<"db">>,
+    doc_id => <<"0001">>,
+    doc_rev => <<"1-abcdef">>,
+    val => term_to_binary({[], [], false}),
+    enc => <<16#32AA68545ACE6A71466E25089101C5BC378019F304582A9FF9BD4A6F4F:232>>
+}).
+
+
+encryption_basic_test_() ->
+    {
+        setup,
+        fun basic_setup/0,
+        fun teardown/1,
+        [
+            fun test_get_wrapped_kek/0,
+            fun test_basic_encrypt/0,
+            fun test_basic_decrypt/0
+        ]
+    }.
+
+
+basic_setup() ->
+    Ctx = test_util:start_couch([fabric]),
+    meck:new([?PLUGIN], [passthrough]),
+    ok = meck:expect(?PLUGIN, get_kek, 1, {ok, ?WK, ?WK}),
+    ok = meck:expect(?PLUGIN, unwrap_kek, 2, {ok, ?WK, ?WK}),
+    Ctx.
+
+
+teardown(Ctx) ->
+    meck:unload(),
+    test_util:stop_couch(Ctx).
+
+
+test_get_wrapped_kek() ->
+    #{
+        db := DbName
+    } = ?FIXTURE,
+
+    Result = fabric2_encryption:get_wrapped_kek(DbName),
+    ?assertMatch({ok, _}, Result),
+
+    {ok, WrappedKEK} = Result,
+    ?assertEqual(?WK, WrappedKEK).
+
+
+test_basic_encrypt() ->
+    #{
+        db := DbName,
+        doc_id := DocId,
+        doc_rev := DocRev,
+        val := Value,
+        enc := Expected
+    } = ?FIXTURE,
+
+    Result = fabric2_encryption:encrypt(?WK, DbName, DocId, DocRev, Value),
+    ?assertMatch({ok, _}, Result),
+
+    {ok, Encrypted} = Result,
+    ?assertNotEqual(Value, Encrypted),
+    ?assertEqual(Expected, Encrypted).
+
+
+test_basic_decrypt() ->
+    #{
+        db := DbName,
+        doc_id := DocId,
+        doc_rev := DocRev,
+        val := Value,
+        enc := Expected
+    } = ?FIXTURE,
+
+    Result = fabric2_encryption:decrypt(?WK, DbName, DocId, DocRev, Expected),
+    ?assertMatch({ok, _}, Result),
+
+    {ok, Decrypted} = Result,
+    ?assertNotEqual(Expected, Decrypted),
+    ?assertEqual(Value, Decrypted).
+
+
+
+encryption_cache_test_() ->
+    {
+        foreach,
+        fun cache_setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(test_cache_encrypt),
+            ?TDEF_FE(test_cache_decrypt)
+        ]
+    }.
+
+
+cache_setup() ->
+    Ctx = test_util:start_couch([fabric]),
+    meck:new([?PLUGIN], [passthrough]),
+    ok = meck:expect(?PLUGIN, unwrap_kek, 2, {ok, ?WK, ?WK}),
+    Ctx.
+
+
+test_cache_encrypt(_) ->
+    #{
+        db := DbName,
+        doc_id := DocId,
+        doc_rev := DocRev,
+        val := Value,
+        enc := Expected
+    } = ?FIXTURE,
+
+    {ok, V1} = fabric2_encryption:encrypt(?WK, DbName, DocId, DocRev, Value),
+    {ok, V2} = fabric2_encryption:encrypt(?WK, DbName, DocId, DocRev, Value),
+
+    ?assertEqual(Expected, V1),
+    ?assertEqual(Expected, V2),
+    ?assertEqual(1, meck:num_calls(?PLUGIN, unwrap_kek, 2)).
+
+
+test_cache_decrypt(_) ->
+    #{
+        db := DbName,
+        doc_id := DocId,
+        doc_rev := DocRev,
+        val := Value,
+        enc := Expected
+    } = ?FIXTURE,
+
+    {ok, V1} = fabric2_encryption:decrypt(?WK, DbName, DocId, DocRev, Expected),
+    {ok, V2} = fabric2_encryption:decrypt(?WK, DbName, DocId, DocRev, Expected),
+
+    ?assertEqual(Value, V1),
+    ?assertEqual(Value, V2),
+    ?assertEqual(1, meck:num_calls(?PLUGIN, unwrap_kek, 2)).
+
+
+
+encryption_failure_test_() ->
+    {
+        foreach,
+        fun faiure_setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(test_failure_encrypt),
+            ?TDEF_FE(test_failure_decrypt)
+        ]
+    }.
+
+
+faiure_setup() ->
+    Ctx = test_util:start_couch([fabric]),
+    meck:new([?PLUGIN], [passthrough]),
+    ok = meck:expect(?PLUGIN, unwrap_kek, 2, {error, unable_to_unwrap_kek}),
+    Ctx.
+
+
+test_failure_encrypt(_) ->
+    #{
+        db := DbName,
+        doc_id := DocId,
+        doc_rev := DocRev,
+        val := Value
+    } = ?FIXTURE,
+
+    Result1 = fabric2_encryption:encrypt(?WK, DbName, DocId, DocRev, Value),
+    Result2 = fabric2_encryption:encrypt(?WK, DbName, DocId, DocRev, Value),
+
+    %% make sure we don't overwrap error messages and don't cache the errors
+    ?assertEqual({error, unable_to_unwrap_kek}, Result1),
+    ?assertEqual({error, unable_to_unwrap_kek}, Result2),
+    ?assertEqual(2, meck:num_calls(?PLUGIN, unwrap_kek, 2)).
+
+
+test_failure_decrypt(_) ->
+    #{
+        db := DbName,
+        doc_id := DocId,
+        doc_rev := DocRev,
+        enc := Expected
+    } = ?FIXTURE,
+
+    Result1 = fabric2_encryption:decrypt(?WK, DbName, DocId, DocRev, Expected),
+    Result2 = fabric2_encryption:decrypt(?WK, DbName, DocId, DocRev, Expected),
+
+    ?assertEqual({error, unable_to_unwrap_kek}, Result1),
+    ?assertEqual({error, unable_to_unwrap_kek}, Result2),
+    ?assertEqual(2, meck:num_calls(?PLUGIN, unwrap_kek, 2)).


### PR DESCRIPTION
# Overview

This PR adds an option for enabling encryption for primary data. The encryption done with aes-256-gcm algorithm per document with document keys (Data Encryption Keys) derived from an individual database's key (Key Encryption Key). KEK supplied at time of the database creation and stored along with the rest of its configuration in encrypted "wrapped" form.

The encoding and decoding of documents handled in a dedicated module that also acts as a cache of "unwrapped" KEKs. The general management of KEKs implemented through epi plugin interface to allow a possibility for implementation of interfaces to alternative Key Management Services, e.g. Hashicorps Vault or SecretHub.

The default epi plugin generates KEK at a databae creation time and encrypts it with a Master Encryption Key specified in CouchDB configuration.

## Testing recommendations

Make target `make check-fdb` should pass
