### PR TITLE
Jwt enhancements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,9 @@ defmodule CouchDBTest.Mixfile do
       {:junit_formatter, "~> 3.0", only: [:dev, :test, :integration]},
       {:httpotion, ">= 3.1.3", only: [:dev, :test, :integration], runtime: false},
       {:excoveralls, "~> 0.12", only: :test},
+      {:b64url, path: Path.expand("src/b64url", __DIR__)},
       {:jiffy, path: Path.expand("src/jiffy", __DIR__)},
+      {:jwtf, path: Path.expand("src/jwtf", __DIR__)},
       {:ibrowse,
        path: Path.expand("src/ibrowse", __DIR__), override: true, compile: false},
       {:credo, "~> 1.3.1", only: [:dev, :test, :integration], runtime: false}

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -141,12 +141,24 @@ max_db_number_for_dbs_info_req = 100
 ; admin_only_all_dbs = true
 
 ;[jwt_auth]
-; Symmetric secret to be used when checking JWT token signatures
-; secret =
 ; List of claims to validate
 ; required_claims = exp
 ; List of algorithms to accept during checks
 ; allowed_algorithms = HS256
+;
+; [jwt_keys]
+; Configure at least one key here if using the JWT auth handler.
+; If your JWT tokens do not include a "kid" attribute, use "_default"
+; as the config key, otherwise use the kid as the config key.
+; Examples
+; _default = aGVsbG8=
+; foo = aGVsbG8=
+; The config values can represent symmetric and asymmetrics keys.
+; For symmetrics keys, the value is base64 encoded;
+; _default = aGVsbG8= # base64-encoded form of "hello"
+; For asymmetric keys, the value is the PEM encoding of the public
+; key with newlines replaced with the escape sequence \n.
+; foo = -----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDsr0lz/Dg3luarb+Kua0Wcj9WrfR23os\nwHzakglb8GhWRDn+oZT0Bt/26sX8uB4/ij9PEOLHPo+IHBtX4ELFFVr5GTzlqcJe\nyctaTDd1OOAPXYuc67EWtGZ3pDAzztRs\n-----END PUBLIC KEY-----\n\n
 
 [couch_peruser]
 ; If enabled, couch_peruser ensures that a private per-user database

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -211,7 +211,7 @@ get_configured_algorithms() ->
     re:split(config:get("jwt_auth", "allowed_algorithms", "HS256"), "\s*,\s*", [{return, binary}]).
 
 get_configured_claims() ->
-    lists:usort(re:split(config:get("jwt_auth", "required_claims", ""), "\s*,\s*", [{return, binary}])).
+    re:split(config:get("jwt_auth", "required_claims", ""), "\s*,\s*", [{return, binary}]).
 
 cookie_authentication_handler(Req) ->
     cookie_authentication_handler(Req, couch_auth_cache).

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -202,7 +202,7 @@ jwt_authentication_handler(Req) ->
                         }}
                     end;
                 {error, Reason} ->
-                    throw({unauthorized, Reason})
+                    throw(Reason)
             end;
         _ -> Req
     end.

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -193,7 +193,7 @@ jwt_authentication_handler(Req) ->
         "Bearer " ++ Jwt ->
             RequiredClaims = get_configured_claims(),
             AllowedAlgorithms = get_configured_algorithms(),
-            case jwtf:decode(?l2b(Jwt), [{alg, AllowedAlgorithms} | RequiredClaims], fun jwt_keystore/2) of
+            case jwtf:decode(?l2b(Jwt), [{alg, AllowedAlgorithms} | RequiredClaims], fun jwtf_keystore:get/2) of
                 {ok, {Claims}} ->
                     case lists:keyfind(<<"sub">>, 1, Claims) of
                         false -> throw({unauthorized, <<"Token missing sub claim.">>});
@@ -212,19 +212,6 @@ get_configured_algorithms() ->
 
 get_configured_claims() ->
     re:split(config:get("jwt_auth", "required_claims", ""), "\s*,\s*", [{return, binary}]).
-
-jwt_keystore(Alg, undefined) ->
-    jwt_keystore(Alg, "_default");
-jwt_keystore(Alg, KID) ->
-    Key = config:get("jwt_keys", KID),
-    case jwtf:verification_algorithm(Alg) of
-        {hmac, _} ->
-            Key;
-        {public_key, _} ->
-            BinKey = ?l2b(string:replace(Key, "\\n", "\n", all)),
-            [PEMEntry] = public_key:pem_decode(BinKey),
-            public_key:pem_entry_decode(PEMEntry)
-    end.
 
 cookie_authentication_handler(Req) ->
     cookie_authentication_handler(Req, couch_auth_cache).

--- a/src/jwtf/src/jwtf_app.erl
+++ b/src/jwtf/src/jwtf_app.erl
@@ -10,23 +10,19 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
-{application, jwtf, [
-    {description, "JSON Web Token Functions"},
-    {vsn, git},
-    {registered, []},
-    {applications, [
-        kernel,
-        stdlib,
-        b64url,
-        config,
-        crypto,
-        jiffy,
-        public_key
-    ]},
-    {mod, {jwtf_app, []}},
-    {env,[]},
-    {modules, []},
-    {maintainers, []},
-    {licenses, []},
-    {links, []}
-]}.
+-module(jwtf_app).
+
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+%% ===================================================================
+%% Application callbacks
+%% ===================================================================
+
+start(_StartType, _StartArgs) ->
+    jwtf_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/src/jwtf/src/jwtf_keystore.erl
+++ b/src/jwtf/src/jwtf_keystore.erl
@@ -109,7 +109,7 @@ get_from_config(Alg, KID) ->
         Key ->
             case jwtf:verification_algorithm(Alg) of
                 {hmac, _} ->
-                    list_to_binary(Key);
+                    base64:decode(Key);
                 {public_key, _} ->
                     BinKey = iolist_to_binary(string:replace(Key, "\\n", "\n", all)),
                     [PEMEntry] = public_key:pem_decode(BinKey),

--- a/src/jwtf/src/jwtf_keystore.erl
+++ b/src/jwtf/src/jwtf_keystore.erl
@@ -1,0 +1,118 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(jwtf_keystore).
+-behaviour(gen_server).
+-behaviour(config_listener).
+
+% public api.
+-export([
+    get/2,
+    start_link/0
+]).
+
+% gen_server api.
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+    code_change/3, terminate/2]).
+
+% config_listener api
+-export([handle_config_change/5, handle_config_terminate/3]).
+
+% public functions
+
+get(Alg, undefined) ->
+    get(Alg, "_default");
+
+get(Alg, KID) when is_binary(KID) ->
+    get(Alg, binary_to_list(KID));
+
+get(Alg, KID) ->
+    case ets:lookup(?MODULE, KID) of
+        [] ->
+            Key = get_from_config(Alg, KID),
+            ok = gen_server:call(?MODULE, {set, KID, Key}),
+            Key;
+        [{KID, Key}] ->
+             Key
+    end.
+
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+% gen_server functions
+
+init(_) ->
+    ok = config:listen_for_changes(?MODULE, nil),
+    ets:new(?MODULE, [public, named_table]),
+    {ok, nil}.
+
+
+handle_call({set, KID, Key}, _From, State) ->
+    true = ets:insert(?MODULE, {KID, Key}),
+    {reply, ok, State}.
+
+
+handle_cast({delete, KID}, State) ->
+    true = ets:delete(?MODULE, KID),
+    {noreply, State};
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+
+handle_info(restart_config_listener, State) ->
+    ok = config:listen_for_changes(?MODULE, nil),
+    {noreply, State};
+
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+
+terminate(_Reason, _State) ->
+    ok.
+
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+% config listener callback
+
+handle_config_change("jwt_keys", KID, _Value, _, _) ->
+    {ok, gen_server:cast(?MODULE, {delete, KID})};
+
+handle_config_change(_, _, _, _, _) ->
+    {ok, nil}.
+
+handle_config_terminate(_Server, stop, _State) ->
+    ok;
+
+handle_config_terminate(_Server, _Reason, _State) ->
+    erlang:send_after(100, whereis(?MODULE), restart_config_listener).
+
+% private functions
+
+get_from_config(Alg, KID) ->
+    case config:get("jwt_keys", KID) of
+        undefined ->
+            throw({bad_request, <<"Unknown kid">>});
+        Key ->
+            case jwtf:verification_algorithm(Alg) of
+                {hmac, _} ->
+                    list_to_binary(Key);
+                {public_key, _} ->
+                    BinKey = iolist_to_binary(string:replace(Key, "\\n", "\n", all)),
+                    [PEMEntry] = public_key:pem_decode(BinKey),
+                    public_key:pem_entry_decode(PEMEntry)
+            end
+    end.

--- a/src/jwtf/src/jwtf_sup.erl
+++ b/src/jwtf/src/jwtf_sup.erl
@@ -1,0 +1,38 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(jwtf_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% Helper macro for declaring children of supervisor
+-define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init([]) ->
+    {ok, { {one_for_one, 5, 10}, [?CHILD(jwtf_keystore, worker)]} }.

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -3,7 +3,7 @@ defmodule JwtAuthTest do
 
   @moduletag :authentication
 
-  test "jwt auth with HS256 secret", _context do
+  test "jwt auth with HMAC secret", _context do
 
     secret = "zxczxc12zxczxc12"
 
@@ -12,12 +12,17 @@ defmodule JwtAuthTest do
         :section => "jwt_auth",
         :key => "secret",
         :value => secret
+      },
+      %{
+        :section => "jwt_auth",
+        :key => "allowed_algorithms",
+        :value => "HS256, HS384, HS512"
       }
     ]
 
-    run_on_modified_server(server_config, fn ->
-      test_fun("HS256", secret)
-    end)
+    run_on_modified_server(server_config, fn -> test_fun("HS256", secret) end)
+    run_on_modified_server(server_config, fn -> test_fun("HS384", secret) end)
+    run_on_modified_server(server_config, fn -> test_fun("HS512", secret) end)
   end
 
   def test_fun(alg, key) do

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -3,7 +3,7 @@ defmodule JwtAuthTest do
 
   @moduletag :authentication
 
-  test "jwt auth with secret", _context do
+  test "jwt auth with HS256 secret", _context do
 
     secret = "zxczxc12zxczxc12"
 
@@ -16,13 +16,14 @@ defmodule JwtAuthTest do
     ]
 
     run_on_modified_server(server_config, fn ->
-      test_fun()
+      test_fun("HS256", secret)
     end)
   end
 
-  def test_fun() do
+  def test_fun(alg, key) do
+    {:ok, token} = :jwtf.encode({[{"alg", alg}, {"typ", "JWT"}]}, {[{"sub", "couch@apache.org"}]}, key)
     resp = Couch.get("/_session",
-      headers: [authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjb3VjaEBhcGFjaGUub3JnIn0.KYHmGXWj0HNHzZCjfOfsIfZWdguEBSn31jUdDUA9118"]
+      headers: [authorization: "Bearer #{token}"]
     )
 
     assert resp.body["userCtx"]["name"] == "couch@apache.org"

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -11,7 +11,7 @@ defmodule JwtAuthTest do
       %{
         :section => "jwt_keys",
         :key => "_default",
-        :value => secret
+        :value => :base64.encode(secret)
       },
       %{
         :section => "jwt_auth",


### PR DESCRIPTION
## Overview

This enhances the JWT authentication handler in the following ways;

* Multiple keys are allowed, identified by the "kid" attribute in the token.
* A default key (called "_default") is used if there is no "kid" attribute.
* Support for EC keys.
* Support for RSA keys.

## Testing recommendations

Test coverage is pretty good but real world testing is a good idea too.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
