### PR TITLE
Ignore unused string variable inside utf8 test case

### DIFF
--- a/test/elixir/test/utf8_test.exs
+++ b/test/elixir/test/utf8_test.exs
@@ -29,7 +29,7 @@ defmodule UTF8Test do
 
     texts
     |> Enum.with_index()
-    |> Enum.each(fn {string, index} ->
+    |> Enum.each(fn {_, index} ->
       resp = Couch.get("/#{db_name}/#{index}")
       %{"_id" => id, "text" => text} = resp.body
       assert resp.status_code == 200


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Just a little fix: we had an unused variable inside the utf8 test suite.

## Testing recommendations
Just issue `make elixir` or have a look at the CI

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
