### PR TITLE
Fix create db options on secondary shard creation

### DIFF
--- a/src/couch/include/couch_eunit.hrl
+++ b/src/couch/include/couch_eunit.hrl
@@ -49,6 +49,11 @@
         Suffix = couch_uuids:random(),
         iolist_to_binary(["eunit-test-db-", Suffix])
     end).
+-define(tempshard,
+    fun() ->
+        Suffix = couch_uuids:random(),
+        iolist_to_binary(["shards/80000000-ffffffff/eunit-test-db-", Suffix])
+    end).
 -define(docid,
     fun() ->
         integer_to_list(couch_util:unique_monotonic_integer())

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -439,7 +439,7 @@ get_node_seqs(Db, Nodes) ->
 
 
 get_or_create_db(DbName, Options) ->
-    couch_db:open_int(DbName, [{create_if_missing, true} | Options]).
+    mem3_util:get_or_create_db(DbName, Options).
 
 
 get_view_cb(#mrargs{extra = Options}) ->

--- a/src/fabric/test/eunit/fabric_rpc_tests.erl
+++ b/src/fabric/test/eunit/fabric_rpc_tests.erl
@@ -1,0 +1,181 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric_rpc_tests).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+-define(TDEF(A), {A, fun A/1}).
+
+
+main_test_() ->
+    {
+        setup,
+        spawn,
+        fun setup_all/0,
+        fun teardown_all/1,
+        [
+            {
+                foreach,
+                fun setup_no_db_or_config/0,
+                fun teardown_db/1,
+                lists:map(fun wrap/1, [
+                    ?TDEF(t_no_config_non_shard_db_create_succeeds)
+                ])
+            },
+            {
+                foreach,
+                fun setup_shard/0,
+                fun teardown_noop/1,
+                lists:map(fun wrap/1, [
+                    ?TDEF(t_no_db),
+                    ?TDEF(t_no_config_db_create_fails_for_shard),
+                    ?TDEF(t_no_config_db_create_fails_for_shard_rpc)
+                ])
+            },
+            {
+                foreach,
+                fun setup_shard/0,
+                fun teardown_db/1,
+                lists:map(fun wrap/1, [
+                    ?TDEF(t_db_create_with_config)
+                ])
+            }
+
+        ]
+    }.
+
+
+setup_all() ->
+    test_util:start_couch([rexi, mem3, fabric]).
+
+
+teardown_all(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+
+setup_no_db_or_config() ->
+    ?tempdb().
+
+
+setup_shard() ->
+    ?tempshard().
+
+
+teardown_noop(_DbName) ->
+    ok.
+
+teardown_db(DbName) ->
+    ok = couch_server:delete(DbName, []).
+
+
+wrap({Name, Fun}) ->
+    fun(Arg) ->
+        {timeout, 60, {atom_to_list(Name), fun() ->
+            process_flag(trap_exit, true),
+            Fun(Arg)
+        end}}
+    end.
+
+
+t_no_db(DbName) ->
+    ?assertEqual({not_found, no_db_file}, couch_db:open_int(DbName, [?ADMIN_CTX])).
+
+
+t_no_config_non_shard_db_create_succeeds(DbName) ->
+    ?assertEqual({not_found, no_db_file}, couch_db:open_int(DbName, [?ADMIN_CTX])),
+    ?assertEqual(DbName, mem3:dbname(DbName)),
+    ?assertMatch({ok, _}, mem3_util:get_or_create_db(DbName, [?ADMIN_CTX])).
+
+
+t_no_config_db_create_fails_for_shard(DbName) ->
+    ?assertEqual({not_found, no_db_file}, couch_db:open_int(DbName, [?ADMIN_CTX])),
+    ?assertException(throw, {error, missing_target}, mem3_util:get_or_create_db(DbName, [?ADMIN_CTX])).
+
+
+t_no_config_db_create_fails_for_shard_rpc(DbName) ->
+    ?assertEqual({not_found, no_db_file}, couch_db:open_int(DbName, [?ADMIN_CTX])),
+    ?assertException(throw, {error, missing_target}, mem3_util:get_or_create_db(DbName, [?ADMIN_CTX])),
+    MFA = {fabric_rpc, get_db_info, [DbName]},
+    Ref = rexi:cast(node(), self(), MFA),
+    Resp = receive
+        Resp0 -> Resp0
+    end,
+    ?assertMatch({Ref, {'rexi_EXIT', {{error, missing_target}, _}}}, Resp).
+
+
+t_db_create_with_config(DbName) ->
+    MDbName = mem3:dbname(DbName),
+    DbDoc = #doc{id = MDbName, body = test_db_doc()},
+
+    ?assertEqual({not_found, no_db_file}, couch_db:open_int(DbName, [?ADMIN_CTX])),
+
+    %% Write the dbs db config
+    couch_util:with_db(mem3_sync:shards_db(), fun(Db) ->
+        ?assertEqual({not_found, missing}, couch_db:open_doc(Db, MDbName, [ejson_body])),
+        ?assertMatch({ok, _}, couch_db:update_docs(Db, [DbDoc]))
+    end),
+
+    %% Test get_or_create_db loads the properties as expected
+    couch_util:with_db(mem3_sync:shards_db(), fun(Db) ->
+        ?assertMatch({ok, _}, couch_db:open_doc(Db, MDbName, [ejson_body])),
+        ?assertEqual({not_found, no_db_file}, couch_db:open_int(DbName, [?ADMIN_CTX])),
+        Resp = mem3_util:get_or_create_db(DbName, [?ADMIN_CTX]),
+        ?assertMatch({ok, _}, Resp),
+        {ok, LDb} = Resp,
+
+        {Body} = test_db_doc(),
+        DbProps = mem3_util:get_shard_opts(Body),
+        {Props} = case couch_db_engine:get_props(LDb) of
+            undefined -> {[]};
+            Else -> {Else}
+        end,
+        %% We don't normally store the default engine name
+        EngineProps = case couch_db_engine:get_engine(LDb) of
+            couch_bt_engine ->
+                [];
+            EngineName ->
+                [{engine, EngineName}]
+        end,
+        ?assertEqual([{props, Props} | EngineProps], DbProps)
+    end).
+
+
+test_db_doc() ->
+    {[
+        {<<"shard_suffix">>, ".1584997648"},
+        {<<"changelog">>, [
+            [<<"add">>, <<"00000000-7fffffff">>, <<"node1@127.0.0.1">>],
+            [<<"add">>, <<"00000000-7fffffff">>, <<"node2@127.0.0.1">>],
+            [<<"add">>, <<"00000000-7fffffff">>, <<"node3@127.0.0.1">>],
+            [<<"add">>, <<"80000000-ffffffff">>, <<"node1@127.0.0.1">>],
+            [<<"add">>, <<"80000000-ffffffff">>, <<"node2@127.0.0.1">>],
+            [<<"add">>, <<"80000000-ffffffff">>, <<"node3@127.0.0.1">>]
+        ]},
+        {<<"by_node">>, {[
+            {<<"node1@127.0.0.1">>, [<<"00000000-7fffffff">>, <<"80000000-ffffffff">>]},
+            {<<"node2@127.0.0.1">>, [<<"00000000-7fffffff">>, <<"80000000-ffffffff">>]},
+            {<<"node3@127.0.0.1">>, [<<"00000000-7fffffff">>, <<"80000000-ffffffff">>]}
+        ]}},
+        {<<"by_range">>, {[
+            {<<"00000000-7fffffff">>, [<<"node1@127.0.0.1">>, <<"node2@127.0.0.1">>, <<"node3@127.0.0.1">>]},
+            {<<"80000000-ffffffff">>, [<<"node1@127.0.0.1">>, <<"node2@127.0.0.1">>, <<"node3@127.0.0.1">>]}
+        ]}},
+        {<<"props">>, {[
+            {partitioned, true},
+            {hash, [couch_partition, hash, []]}
+        ]}}
+    ]}.
+

--- a/src/mem3/src/mem3_reshard_dbdoc.erl
+++ b/src/mem3/src/mem3_reshard_dbdoc.erl
@@ -146,9 +146,8 @@ replicate_to_all_nodes(TimeoutMSec) ->
 
 
 write_shard_doc(#doc{id = Id} = Doc, Body) ->
-    DbName = ?l2b(config:get("mem3", "shards_db", "_dbs")),
     UpdatedDoc = Doc#doc{body = Body},
-    couch_util:with_db(DbName, fun(Db) ->
+    couch_util:with_db(mem3_sync:shards_db(), fun(Db) ->
         try
             {ok, _} = couch_db:update_doc(Db, UpdatedDoc, [])
         catch

--- a/src/mem3/src/mem3_rpc.erl
+++ b/src/mem3/src/mem3_rpc.erl
@@ -401,7 +401,7 @@ rexi_call(Node, MFA, Timeout) ->
 
 
 get_or_create_db(DbName, Options) ->
-    couch_db:open_int(DbName, [{create_if_missing, true} | Options]).
+    mem3_util:get_or_create_db(DbName, Options).
 
 
 -ifdef(TEST).

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -144,8 +144,7 @@ local(DbName) ->
     lists:filter(Pred, for_db(DbName)).
 
 fold(Fun, Acc) ->
-    DbName = config:get("mem3", "shards_db", "_dbs"),
-    {ok, Db} = mem3_util:ensure_exists(DbName),
+    {ok, Db} = mem3_util:ensure_exists(mem3_sync:shards_db()),
     FAcc = {Db, Fun, Acc},
     try
         {ok, LastAcc} = couch_db:fold_docs(Db, fun fold_fun/2, FAcc),
@@ -309,15 +308,13 @@ fold_fun(#doc_info{}=DI, {Db, UFun, UAcc}) ->
     end.
 
 get_update_seq() ->
-    DbName = config:get("mem3", "shards_db", "_dbs"),
-    {ok, Db} = mem3_util:ensure_exists(DbName),
+    {ok, Db} = mem3_util:ensure_exists(mem3_sync:shards_db()),
     Seq = couch_db:get_update_seq(Db),
     couch_db:close(Db),
     Seq.
 
 listen_for_changes(Since) ->
-    DbName = config:get("mem3", "shards_db", "_dbs"),
-    {ok, Db} = mem3_util:ensure_exists(DbName),
+    {ok, Db} = mem3_util:ensure_exists(mem3_sync:shards_db()),
     Args = #changes_args{
         feed = "continuous",
         since = Since,
@@ -362,8 +359,7 @@ changes_callback(timeout, _) ->
 
 load_shards_from_disk(DbName) when is_binary(DbName) ->
     couch_stats:increment_counter([mem3, shard_cache, miss]),
-    X = ?l2b(config:get("mem3", "shards_db", "_dbs")),
-    {ok, Db} = mem3_util:ensure_exists(X),
+    {ok, Db} = mem3_util:ensure_exists(mem3_sync:shards_db()),
     try
         load_shards_from_db(Db, DbName)
     after

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -20,6 +20,7 @@
 -export([handle_config_change/5, handle_config_terminate/3]).
 
 -export([start_link/0]).
+-export([opts_for_db/1]).
 -export([for_db/1, for_db/2, for_docid/2, for_docid/3, get/3, local/1, fold/2]).
 -export([for_shard_range/1]).
 -export([set_max_size/1]).
@@ -44,6 +45,15 @@
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+opts_for_db(DbName) ->
+    {ok, Db} = mem3_util:ensure_exists(mem3_sync:shards_db()),
+    case couch_db:open_doc(Db, DbName, [ejson_body]) of
+        {ok, #doc{body = {Props}}} ->
+            mem3_util:get_shard_opts(Props);
+        {not_found, _} ->
+            erlang:error(database_does_not_exist, ?b2l(DbName))
+    end.
 
 for_db(DbName) ->
     for_db(DbName, []).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This is a continuation of the work in https://github.com/apache/couchdb/pull/2672 to fix issues around secondary shard creation when nodes re-enter a cluster after a database was created while the node was down (or potentially in maintenance mode).

This PR introduces logic to handle the following four scenarios while opening a db in context of `fabric_rpc` and `mem3_rpc`:

  1) the db already exists
    - just return the db as normal
  2) the db does not exist locally, but the dbs db doc with db create options is present
    - load the db create options and create the local shard
  3) the db does not exist locally but it's not a sharded database
    - just create the local db as expected
  4) the db does not exist locally, it's a sharded database, and the dbs db doc is not present
    - throw an error and prevent creating the db with incomplete settings

This PR changes the behavior of scenario 2) by loading the appropriate config and creating the db with the desired parameters, and of scenario 4) by no longer allowing the db to be created inappropriately.

For scenario three, I've taken the approach of not loading config as a non sharded db won't have a dbs db doc. In particular here, we want to properly handle updates to internal dbs like `_dbs` and also `sys_dbs` like `_users`.

Another open item here is the merging of the db create options and the provided options. Right now, I'm just doing `DbOpts ++ Opts` basically, but I wrote a functions `opts_merge/{2,3}` that will merge two proplists, prioritizing the first list of items, and supports atoms. It's... a bit gnarly, and I'm not convinced we should use it. So we need to figure out what to do with the options lists here, but I _think_ we might be ok just combining the two.

While in the general neighborhood, I took the opportunity to de-duplicate some of the shards_db config lookups as well. I've isolated those changes to a dedicated commit.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

This needs more testing. I've got a WIP commit for adding a test suite here that is not yet complete. I figured it was worthwhile to get this PR out for feedback while continuing to work on the tests.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/2672

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
