### PR TITLE
Fix database re-creation

### DIFF
--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -178,7 +178,8 @@ create(DbName, Options) ->
 
 
 open(DbName, Options) ->
-    case fabric2_server:fetch(DbName) of
+    UUID = fabric2_util:get_value(uuid, Options),
+    case fabric2_server:fetch(DbName, UUID) of
         #{} = Db ->
             Db1 = maybe_set_user_ctx(Db, Options),
             {ok, require_member_check(Db1)};

--- a/src/fabric/src/fabric2_server.erl
+++ b/src/fabric/src/fabric2_server.erl
@@ -17,7 +17,7 @@
 
 -export([
     start_link/0,
-    fetch/1,
+    fetch/2,
     store/1,
     remove/1,
     fdb_directory/0,
@@ -48,10 +48,12 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 
-fetch(DbName) when is_binary(DbName) ->
-    case ets:lookup(?MODULE, DbName) of
-        [{DbName, #{} = Db}] -> Db;
-        [] -> undefined
+fetch(DbName, UUID) when is_binary(DbName) ->
+    case {UUID, ets:lookup(?MODULE, DbName)} of
+        {_, []} -> undefined;
+        {undefined, [{DbName, #{} = Db}]} -> Db;
+        {<<_/binary>>, [{DbName, #{uuid := UUID} = Db}]} -> Db;
+        {<<_/binary>>, [{DbName, #{} = _Db}]} -> undefined
     end.
 
 

--- a/src/fabric/test/fabric2_db_misc_tests.erl
+++ b/src/fabric/test/fabric2_db_misc_tests.erl
@@ -302,7 +302,8 @@ metadata_bump({DbName, _, _}) ->
     {ok, _} = fabric2_db:get_db_info(Db),
 
     % Check that db handle in the cache got the new metadata version
-    ?assertMatch(#{md_version := NewMDVersion}, fabric2_server:fetch(DbName)).
+    CachedDb = fabric2_server:fetch(DbName, undefined),
+    ?assertMatch(#{md_version := NewMDVersion}, CachedDb).
 
 
 db_version_bump({DbName, _, _}) ->
@@ -326,7 +327,7 @@ db_version_bump({DbName, _, _}) ->
     {ok, _} = fabric2_db:get_db_info(Db),
 
     % After previous operation, the cache should have been cleared
-    ?assertMatch(undefined, fabric2_server:fetch(DbName)),
+    ?assertMatch(undefined, fabric2_server:fetch(DbName, undefined)),
 
     % Call open again and check that we have the latest db version
     {ok, Db2} = fabric2_db:open(DbName, [{user_ctx, ?ADMIN_USER}]),


### PR DESCRIPTION
Previously it was possible for a database to be re-created while a `Db` handle was open and the `Db` handle would continue operating on the new db without any error.

To avoid that situation ensure instance UUID is explicitly checked during open and reopen calls. This includes checking it after the metadata is loaded in `fabric2_fdb:open/2` and when fetching the handle from the cache.

Also, create a `{uuid, UUID}` option to allow specifying a particular instance UUID when opening a database. If that instance doesn't exist raise a `database_does_not_exist` error.
