### PR TITLE
Port http, method_override and jsonp tests into elixir test suite - 3.0.x

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -50,15 +50,15 @@ X means done, - means partially
   - [X] Port etags_head.js
   - [ ] ~~Port etags_views.js~~ (skipped in js test suite)
   - [X] Port form_submit.js
-  - [ ] Port http.js
+  - [X] Port http.js
   - [X] Port invalid_docids.js
-  - [ ] Port jsonp.js
+  - [X] Port jsonp.js
   - [X] Port large_docs.js
   - [ ] Port list_views.js
   - [X] Port lorem_b64.txt
   - [X] Port lorem.txt
   - [X] Port lots_of_docs.js
-  - [ ] Port method_override.js
+  - [X] Port method_override.js
   - [X] Port multiple_rows.js
   - [X] Port proxyauth.js
   - [ ] Port purge.js

--- a/test/elixir/lib/couch/db_test.ex
+++ b/test/elixir/lib/couch/db_test.ex
@@ -399,8 +399,8 @@ defmodule Couch.DBTest do
         Enum.each(setting.nodes, fn node_value ->
           node = elem(node_value, 0)
           value = elem(node_value, 1)
-
-          if value == ~s(""\\n) do
+          
+          if value == ~s(""\\n) or value == "" or value == nil do
             resp =
               Couch.delete(
                 "/_node/#{node}/_config/#{setting.section}/#{setting.key}",

--- a/test/elixir/test/http_test.exs
+++ b/test/elixir/test/http_test.exs
@@ -1,0 +1,81 @@
+defmodule HttpTest do
+  use CouchTestCase
+
+  @moduletag :http
+
+  @tag :with_db
+  test "location header", context do
+    db_name = context[:db_name]
+    resp = Couch.put("/#{db_name}/test", body: %{})
+    db_url = Couch.process_url("/" <> db_name)
+    assert resp.headers.hdrs["location"] == db_url <> "/test"
+  end
+
+  @tag :with_db
+  test "location header should include X-Forwarded-Host", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.put("/#{db_name}/test2",
+        body: %{},
+        headers: ["X-Forwarded-Host": "mysite.com"]
+      )
+
+    assert resp.headers.hdrs["location"] == "http://mysite.com/#{db_name}/test2"
+  end
+
+  @tag :with_db
+  test "location header should include custom header", context do
+    db_name = context[:db_name]
+
+    server_config = [
+      %{
+        :section => "httpd",
+        :key => "x_forwarded_host",
+        :value => "X-Host"
+      }
+    ]
+
+    run_on_modified_server(server_config, fn ->
+      resp =
+        Couch.put("/#{db_name}/test3",
+          body: %{},
+          headers: ["X-Host": "mysite2.com"]
+        )
+
+      assert resp.headers.hdrs["location"] == "http://mysite2.com/#{db_name}/test3"
+    end)
+  end
+
+  @tag :with_db
+  test "COUCHDB-708: newlines document names", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.put("/#{db_name}/docid%0A/attachment.txt",
+        body: %{},
+        headers: ["Content-Type": "text/plain;charset=utf-8"]
+      )
+
+    db_url = Couch.process_url("/" <> db_name)
+    assert resp.headers.hdrs["location"] == db_url <> "/docid%0A/attachment.txt"
+
+    resp =
+      Couch.put("/#{db_name}/docidtest%0A",
+        body: %{},
+        headers: ["Content-Type": "text/plain;charset=utf-8"]
+      )
+
+    db_url = Couch.process_url("/" <> db_name)
+    assert resp.headers.hdrs["location"] == db_url <> "/docidtest%0A"
+
+    resp =
+      Couch.post("/#{db_name}/",
+        body: %{_id: "docidtestpost%0A"},
+        headers: ["Content-Type": "application/json"]
+      )
+
+    db_url = Couch.process_url("/" <> db_name)
+    assert resp.headers.hdrs["location"] == db_url <> "/docidtestpost%250A"
+  end
+end

--- a/test/elixir/test/jsonp_test.exs
+++ b/test/elixir/test/jsonp_test.exs
@@ -1,0 +1,116 @@
+defmodule JsonpTest do
+  use CouchTestCase
+
+  @moduletag :jsonp
+
+  @tag :with_db
+  test "jsonp not configured callbacks", context do
+    db_name = context[:db_name]
+    {:ok, _} = create_doc(db_name, %{_id: "0", a: 0, b: 0})
+
+    resp = Couch.get("/#{db_name}/0?callback=jsonp_no_chunk")
+    assert resp.status_code == 200
+    assert resp.headers.hdrs["content-type"] == "application/json"
+  end
+
+  @tag :with_db
+  test "jsonp unchunked callbacks", context do
+    db_name = context[:db_name]
+
+    server_config = [
+      %{
+        :section => "httpd",
+        :key => "allow_jsonp",
+        :value => "true"
+      }
+    ]
+
+    {:ok, create_resp} = create_doc(db_name, %{_id: "0", a: 0, b: 0})
+
+    run_on_modified_server(server_config, fn ->
+      resp = Couch.get("/#{db_name}/0?callback=jsonp_no_chunk")
+
+      assert resp.status_code == 200
+      assert resp.headers.hdrs["content-type"] == "application/javascript"
+
+      {callback_fun, callback_param} = parse_callback(resp.body)
+
+      assert callback_fun == "jsonp_no_chunk"
+      assert create_resp.body["id"] == callback_param["_id"]
+      assert create_resp.body["rev"] == callback_param["_rev"]
+
+      resp = Couch.get("/#{db_name}/0?callback=jsonp_no_chunk\"")
+      assert resp.status_code == 400
+    end)
+  end
+
+  @tag :with_db
+  test "jsonp chunked callbacks", context do
+    db_name = context[:db_name]
+
+    server_config = [
+      %{
+        :section => "httpd",
+        :key => "allow_jsonp",
+        :value => "true"
+      }
+    ]
+
+    design_doc = %{
+      _id: "_design/test",
+      language: "javascript",
+      views: %{
+        all_docs: %{map: "function(doc) {if(doc.a) emit(null, doc.a);}"}
+      }
+    }
+
+    {:ok, _} = create_doc(db_name, design_doc)
+    {:ok, _} = create_doc(db_name, %{_id: "0", a: 0, b: 0})
+    {:ok, _} = create_doc(db_name, %{_id: "1", a: 1, b: 1})
+
+    run_on_modified_server(server_config, fn ->
+      resp = Couch.get("/#{db_name}/_design/test/_view/all_docs?callback=jsonp_chunk")
+      assert resp.status_code == 200
+      assert resp.headers.hdrs["content-type"] == "application/javascript"
+
+      {callback_fun, callback_param} = parse_callback(resp.body)
+
+      assert callback_fun == "jsonp_chunk"
+      assert callback_param["total_rows"] == 1
+
+      resp = Couch.get("/#{db_name}/_design/test/_view/all_docs?callback=jsonp_chunk'")
+      assert resp.status_code == 400
+
+      resp = Couch.get("/#{db_name}/_changes?callback=jsonp_chunk")
+      assert resp.status_code == 200
+      assert resp.headers.hdrs["content-type"] == "application/javascript"
+
+      {callback_fun, callback_param} = parse_callback(resp.body)
+      assert callback_fun == "jsonp_chunk"
+      assert length(callback_param["results"]) == 3
+
+    end)
+  end
+
+  defp parse_callback(msg) do
+    captures = Regex.scan(~r/\/\* CouchDB \*\/(\w+)\((.*)\)/s, msg)
+
+    callback_fun =
+      captures
+      |> Enum.map(fn p -> Enum.at(p, 1) end)
+      |> Enum.at(0)
+
+    param =
+      captures
+      |> Enum.map(fn p -> Enum.at(p, 2) end)
+      |> Enum.filter(fn p -> String.trim(p) != "" end)
+      |> Enum.map(fn p ->
+        p
+        |> IO.iodata_to_binary()
+        |> :jiffy.decode([:return_maps])
+      end)
+      |> Enum.at(0)
+
+    {callback_fun, param}
+  end
+end

--- a/test/elixir/test/method_override_test.exs
+++ b/test/elixir/test/method_override_test.exs
@@ -1,0 +1,55 @@
+defmodule MethodOverrideTest do
+  use CouchTestCase
+
+  @moduletag :http
+
+  @moduledoc """
+   Allow broken HTTP clients to fake a full method vocabulary with an
+   X-HTTP-METHOD-OVERRIDE header
+  """
+
+  @tag :with_db
+  test "method override PUT", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.post("/#{db_name}/fnord",
+        body: %{bob: "connie"},
+        headers: ["X-HTTP-Method-Override": "PUT"]
+      )
+
+    assert resp.status_code == 201
+
+    resp = Couch.get("/#{db_name}/fnord")
+    assert resp.body["bob"] == "connie"
+  end
+
+  @tag :with_db
+  test "method override DELETE", context do
+    db_name = context[:db_name]
+    {:ok, resp} = create_doc(db_name, %{_id: "fnord", bob: "connie"})
+
+    resp =
+      Couch.post("/#{db_name}/fnord?rev=#{resp.body["rev"]}",
+        headers: ["X-HTTP-Method-Override": "DELETE"]
+      )
+
+    assert resp.status_code == 200
+
+    resp = Couch.get("/#{db_name}/fnord")
+    assert resp.status_code == 404
+  end
+
+  @tag :with_db
+  test "Method Override is ignored when original Method isn't POST", context do
+    db_name = context[:db_name]
+
+    resp =
+      Couch.get("/#{db_name}/fnord2",
+        body: %{bob: "connie"},
+        headers: ["X-HTTP-Method-Override": "PUT"]
+      )
+
+    assert resp.status_code == 404
+  end
+end

--- a/test/javascript/tests/changes.js
+++ b/test/javascript/tests/changes.js
@@ -9,15 +9,17 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
+couchTests.elixir = true;
+ 
 function jsonp(obj) {
-  return console.log('done in test/elixir/test/changes_test.exs and changes_async_test.exs');
   T(jsonp_flag == 0);
   T(obj.results.length == 1 && obj.last_seq == 1, "jsonp");
   jsonp_flag = 1;
 }
 
 couchTests.changes = function(debug) {
+  return console.log('done in test/elixir/test/changes_test.exs and changes_async_test.exs');
+  
   var db;
   if (debug) debugger;
 

--- a/test/javascript/tests/http.js
+++ b/test/javascript/tests/http.js
@@ -9,8 +9,9 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
+couchTests.elixir = true;
 couchTests.http = function(debug) {
+  return console.log('done in test/elixir/test/http_test.exs');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
 

--- a/test/javascript/tests/jsonp.js
+++ b/test/javascript/tests/jsonp.js
@@ -9,6 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+couchTests.elixir = true;
 
 // Verify callbacks ran
 var jsonp_flag = 0;
@@ -28,6 +29,7 @@ function jsonp_chunk(doc) {
 
 // Do some jsonp tests.
 couchTests.jsonp = function(debug) {
+  return console.log('done in test/elixir/test/jsonp_test.exs');
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});
   db.createDb();

--- a/test/javascript/tests/method_override.js
+++ b/test/javascript/tests/method_override.js
@@ -11,7 +11,9 @@
 // the License.
 
 // Allow broken HTTP clients to fake a full method vocabulary with an X-HTTP-METHOD-OVERRIDE header
+couchTests.elixir = true;
 couchTests.method_override = function(debug) {
+  return console.log('done in test/elixir/test/method_override_test.exs');
   var result = JSON.parse(CouchDB.request("GET", "/").responseText);
   T(result.couchdb == "Welcome");
 


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Port http, method_override and jsonp tests into elixir test suite 
Merging #2646  into 3.0.x
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
