### PR TITLE
Add support for roles to be obtained from JWTs.

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -198,7 +198,13 @@ jwt_authentication_handler(Req) ->
                     case lists:keyfind(<<"sub">>, 1, Claims) of
                         false -> throw({unauthorized, <<"Token missing sub claim.">>});
                         {_, User} -> Req#httpd{user_ctx=#user_ctx{
-                            name=User
+                            name=User,
+                            roles=case lists:keyfind(<<"roles">>, 1, Claims) of
+                                false -> [];
+                                {_, Roles} -> 
+                                    erlang:display(Roles),
+                                    re:split(Roles, "\s*,\s*", [{return, binary}])
+                            end
                         }}
                     end;
                 {error, Reason} ->

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -201,9 +201,7 @@ jwt_authentication_handler(Req) ->
                             name=User,
                             roles=case lists:keyfind(<<"roles">>, 1, Claims) of
                                 false -> [];
-                                {_, Roles} -> 
-                                    erlang:display(Roles),
-                                    re:split(Roles, "\s*,\s*", [{return, binary}])
+                                {_, Roles} -> Roles
                             end
                         }}
                     end;

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -198,11 +198,8 @@ jwt_authentication_handler(Req) ->
                     case lists:keyfind(<<"sub">>, 1, Claims) of
                         false -> throw({unauthorized, <<"Token missing sub claim.">>});
                         {_, User} -> Req#httpd{user_ctx=#user_ctx{
-                            name=User,
-                            roles=case lists:keyfind(<<"roles">>, 1, Claims) of
-                                false -> [];
-                                {_, Roles} -> Roles
-                            end
+                            name = User,
+                            roles = couch_util:get_value(<<"roles">>, Claims, [])
                         }}
                     end;
                 {error, Reason} ->

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -108,10 +108,6 @@ defmodule JwtAuthTest do
     resp = Couch.get("/_session",
       headers: [authorization: "Bearer #{token}"]
     )
-
-    assert resp.body["userCtx"]["name"] == "couch@apache.org"
-    assert resp.body["userCtx"]["roles"] == [<<"_admin">>]
-    assert resp.body["info"]["authenticated"] == "jwt"
   end
 
   test "jwt auth without secret", _context do

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -110,6 +110,7 @@ defmodule JwtAuthTest do
     )
 
     assert resp.body["userCtx"]["name"] == "couch@apache.org"
+    assert resp.body["userCtx"]["roles"] == [<<"_admin">>]
     assert resp.body["info"]["authenticated"] == "jwt"
   end
 

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -116,6 +116,10 @@ defmodule JwtAuthTest do
     resp = Couch.get("/_session",
       headers: [authorization: "Bearer #{token}"]
     )
+
+    assert resp.body["userCtx"]["name"] == "couch@apache.org"
+    assert resp.body["userCtx"]["roles"] == ["testing"]
+    assert resp.body["info"]["authenticated"] == "jwt"
   end
 
   test "jwt auth without secret", _context do

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -93,13 +93,21 @@ defmodule JwtAuthTest do
       %{
         :section => "jwt_auth",
         :key => "allowed_algorithms",
-        :value => "ES256, ES384, ES512"
+        :value => "RS256, RS384, RS512"
       }
     ]
 
-    run_on_modified_server(server_config, fn -> test_fun("ES256", private_key) end)
-    run_on_modified_server(server_config, fn -> test_fun("ES384", private_key) end)
-    run_on_modified_server(server_config, fn -> test_fun("ES512", private_key) end)
+    run_on_modified_server(server_config, fn -> test_fun("RS256", private_key) end)
+    run_on_modified_server(server_config, fn -> test_fun("RS384", private_key) end)
+    run_on_modified_server(server_config, fn -> test_fun("RS512", private_key) end)
+  end
+
+  defmodule EC do
+    require Record
+    Record.defrecord :point, :ECPoint,
+      Record.extract(:ECPoint, from_lib: "public_key/include/public_key.hrl")
+    Record.defrecord :private, :ECPrivateKey,
+      Record.extract(:ECPrivateKey, from_lib: "public_key/include/public_key.hrl")
   end
 
   def test_fun(alg, key) do

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -93,21 +93,13 @@ defmodule JwtAuthTest do
       %{
         :section => "jwt_auth",
         :key => "allowed_algorithms",
-        :value => "RS256, RS384, RS512"
+        :value => "ES256, ES384, ES512"
       }
     ]
 
-    run_on_modified_server(server_config, fn -> test_fun("RS256", private_key) end)
-    run_on_modified_server(server_config, fn -> test_fun("RS384", private_key) end)
-    run_on_modified_server(server_config, fn -> test_fun("RS512", private_key) end)
-  end
-
-  defmodule EC do
-    require Record
-    Record.defrecord :point, :ECPoint,
-      Record.extract(:ECPoint, from_lib: "public_key/include/public_key.hrl")
-    Record.defrecord :private, :ECPrivateKey,
-      Record.extract(:ECPrivateKey, from_lib: "public_key/include/public_key.hrl")
+    run_on_modified_server(server_config, fn -> test_fun("ES256", private_key) end)
+    run_on_modified_server(server_config, fn -> test_fun("ES384", private_key) end)
+    run_on_modified_server(server_config, fn -> test_fun("ES512", private_key) end)
   end
 
   def test_fun(alg, key) do


### PR DESCRIPTION
As a followon to https://github.com/apache/couchdb/pull/2648, I'd like to include support for roles in JWTs.

Chalk this up to my newness with couchdb, I thought simply being an admin user would inherit roles 😉 

Basically I need a way to allow my servers to generate short lived `_admin` tokens to perform admin commands from my main application logic.  Example: Ensuring per-user databases are provisioned.