### PR TITLE
Fix ported to elixir tag

### DIFF
--- a/test/javascript/tests/design_docs_query.js
+++ b/test/javascript/tests/design_docs_query.js
@@ -9,7 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
+couchTests.elixir = true;
 couchTests.design_docs_query = function(debug) {
   return console.log('done in test/elixir/test/design_docs_query_test.exs');
 

--- a/test/javascript/tests/design_options.js
+++ b/test/javascript/tests/design_options.js
@@ -9,7 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
+couchTests.elixir = true;
 couchTests.design_options = function(debug) {
   return console.log('done in test/elixir/test/design_options.exs');
   var db_name = get_random_db_name();

--- a/test/javascript/tests/design_paths.js
+++ b/test/javascript/tests/design_paths.js
@@ -9,7 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
+couchTests.elixir = true;
 couchTests.design_paths = function(debug) {
   return console.log('done in test/elixir/test/design_paths.exs');
   if (debug) debugger;

--- a/test/javascript/tests/erlang_views.js
+++ b/test/javascript/tests/erlang_views.js
@@ -9,7 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
+couchTests.elixir = true;
 couchTests.erlang_views = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/form_submit.js
+++ b/test/javascript/tests/form_submit.js
@@ -11,6 +11,7 @@
 // the License.
 
 // Do some basic tests.
+couchTests.elixir = true;
 couchTests.form_submit = function(debug) {
     return console.log('done in test/elixir/test/form_summit_test.exs');
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR adds 'couchTests.elixir = true;'  to js tests that were already ported. 
The ported tests that were incorrectly tagged are:
- design_docs_query.js
- design_options.js
- design_paths.js
- erlang_views.js
- form_submit.js

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
 make couch
 make javascript
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

the result should be ...
```
...
test/javascript/tests/design_docs.js                           ported to elixir
test/javascript/tests/design_options.js                        ported to elixir
test/javascript/tests/design_paths.js                          ported to elixir
test/javascript/tests/erlang_views.js                          ported to elixir
...
test/javascript/tests/form_submit.js                           ported to elixir
...
```
## Related Issues or Pull Requests
N/A
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
