### PR TITLE
Fix couch_jobs after recent db re-creation commit

### DIFF
--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -288,9 +288,10 @@ open(#{} = Db0, Options) ->
     load_validate_doc_funs(Db3).
 
 
-refresh(#{tx := undefined} = Db) ->
+% Match on `name` in the function head since some non-fabric2 db
+% objects might not have names and so they don't get cached
+refresh(#{tx := undefined, name := DbName} = Db) ->
     #{
-        name := DbName,
         uuid := UUID,
         md_version := OldVer
     } = Db,


### PR DESCRIPTION
The e520294c7ee3f55c3e8cc7d528ff37a5a93c800f commit inadvertently changed the `fabric2_fdb:refresh/1` head matching to accept db instances with no names. `couch_jobs` uses those but they are not cached in `fabric2_server`. So here we return to the previous matching rule where contexts without names don't get refreshed from the cache.

