### PR TITLE
add info endpoint for fdb stored views

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -368,7 +368,7 @@ bad_action_req(#httpd{path_parts=[_, _, Name|FileNameParts]}=Req, Db, _DDoc) ->
 
 handle_design_info_req(#httpd{method='GET'}=Req, Db, #doc{} = DDoc) ->
     [_, _, Name, _] = Req#httpd.path_parts,
-    {ok, GroupInfoList} = fabric:get_view_group_info(Db, DDoc),
+    {ok, GroupInfoList} = couch_views:get_views_info(Db, DDoc),
     send_json(Req, 200, {[
         {name,  Name},
         {view_index, {GroupInfoList}}

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -368,7 +368,7 @@ bad_action_req(#httpd{path_parts=[_, _, Name|FileNameParts]}=Req, Db, _DDoc) ->
 
 handle_design_info_req(#httpd{method='GET'}=Req, Db, #doc{} = DDoc) ->
     [_, _, Name, _] = Req#httpd.path_parts,
-    {ok, GroupInfoList} = couch_views:get_views_info(Db, DDoc),
+    {ok, GroupInfoList} = couch_views:get_info(Db, DDoc),
     send_json(Req, 200, {[
         {name,  Name},
         {view_index, {GroupInfoList}}

--- a/src/couch_views/src/couch_views.erl
+++ b/src/couch_views/src/couch_views.erl
@@ -205,6 +205,7 @@ view_cmp(SK, SKD, EK, EKD) ->
     PackedEK = erlfdb_tuple:pack({BinEK, EKD}),
     PackedSK =< PackedEK.
 
+
 get_update_options(#mrst{design_opts = Opts}) ->
     IncDesign = couch_util:get_value(<<"include_design">>, Opts, false),
     LocalSeq = couch_util:get_value(<<"local_seq">>, Opts, false),

--- a/src/couch_views/src/couch_views.erl
+++ b/src/couch_views/src/couch_views.erl
@@ -21,7 +21,7 @@
 
     % fabric2_index behavior
     build_indices/2,
-    get_views_info/2
+    get_info/2
 ]).
 
 -include("couch_views.hrl").
@@ -74,7 +74,7 @@ build_indices(#{} = Db, DDocs) when is_list(DDocs) ->
         end
     end, DDocs).
 
-get_views_info(Db, DDoc) ->
+get_info(Db, DDoc) ->
     DbName = fabric2_db:name(Db),
     {ok, Mrst} = couch_views_util:ddoc_to_mrst(DbName, DDoc),
     Sig = fabric2_util:to_hex(Mrst#mrst.sig),

--- a/src/couch_views/src/couch_views.erl
+++ b/src/couch_views/src/couch_views.erl
@@ -93,8 +93,7 @@ get_info(Db, DDoc) ->
         running -> true;
         _ -> false
     end,
-    UpdateOptions0 = couch_mrview_index:get(update_options, Mrst),
-    UpdateOptions = [atom_to_binary(O, latin1) || O <- UpdateOptions0],
+    UpdateOptions = get_update_options(Mrst),
     {ok, [
         {language, Mrst#mrst.language},
         {signature, Sig},
@@ -202,3 +201,10 @@ view_cmp(SK, SKD, EK, EKD) ->
     PackedSK = erlfdb_tuple:pack({BinSK, SKD}),
     PackedEK = erlfdb_tuple:pack({BinEK, EKD}),
     PackedSK =< PackedEK.
+
+get_update_options(#mrst{design_opts = Opts}) ->
+    IncDesign = couch_util:get_value(<<"include_design">>, Opts, false),
+    LocalSeq = couch_util:get_value(<<"local_seq">>, Opts, false),
+    UpdateOptions = if IncDesign -> [include_design]; true -> [] end
+        ++ if LocalSeq -> [local_seq]; true -> [] end,
+    [atom_to_binary(O, latin1) || O <- UpdateOptions].

--- a/src/couch_views/src/couch_views.erl
+++ b/src/couch_views/src/couch_views.erl
@@ -103,7 +103,6 @@ get_info(Db, DDoc) ->
         ]}},
         {update_seq, UpdateSeq},
         {updater_running, Status1},
-        {data_size, DataSize},
         {update_options, UpdateOptions}
     ]}.
 

--- a/src/couch_views/src/couch_views.erl
+++ b/src/couch_views/src/couch_views.erl
@@ -74,6 +74,7 @@ build_indices(#{} = Db, DDocs) when is_list(DDocs) ->
         end
     end, DDocs).
 
+
 get_info(Db, DDoc) ->
     DbName = fabric2_db:name(Db),
     {ok, Mrst} = couch_views_util:ddoc_to_mrst(DbName, DDoc),
@@ -106,11 +107,13 @@ get_info(Db, DDoc) ->
         {update_options, UpdateOptions}
     ]}.
 
+
 get_total_view_size(TxDb, Mrst) ->
     ViewIds = [View#mrview.id_num || View <- Mrst#mrst.views],
     lists:foldl(fun (ViewId, Total) ->
         Total + couch_views_fdb:get_kv_size(TxDb, Mrst, ViewId)
     end, 0, ViewIds).
+
 
 read_view(Db, Mrst, ViewName, Callback, Acc0, Args) ->
     fabric2_fdb:transactional(Db, fun(TxDb) ->

--- a/src/couch_views/src/couch_views.erl
+++ b/src/couch_views/src/couch_views.erl
@@ -93,12 +93,18 @@ get_info(Db, DDoc) ->
         running -> true;
         _ -> false
     end,
+    UpdateOptions0 = couch_mrview_index:get(update_options, Mrst),
+    UpdateOptions = [atom_to_binary(O, latin1) || O <- UpdateOptions0],
     {ok, [
         {language, Mrst#mrst.language},
         {signature, Sig},
+        {sizes, {[
+            {active, DataSize}
+        ]}},
         {update_seq, UpdateSeq},
         {updater_running, Status1},
-        {data_size, DataSize}
+        {data_size, DataSize},
+        {update_options, UpdateOptions}
     ]}.
 
 get_total_view_size(TxDb, Mrst) ->

--- a/src/couch_views/test/couch_views_info_test.erl
+++ b/src/couch_views/test/couch_views_info_test.erl
@@ -62,6 +62,7 @@ views_info_test_() ->
                     fun sig_is_binary/1,
                     fun language_is_js/1,
                     fun update_seq_is_binary/1,
+                    fun updater_running_is_boolean/1,
                     fun data_size_is_non_neg_int/1
                 ]
             }
@@ -76,6 +77,9 @@ language_is_js({_, Info}) ->
 
 data_size_is_non_neg_int({_, Info}) ->
     ?_assert(check_non_neg_int(data_size, Info)).
+
+updater_running_is_boolean({_, Info}) ->
+    ?_assert(is_boolean(prop(updater_running, Info))).
 
 update_seq_is_binary({_, Info}) ->
     ?_assert(is_binary(prop(update_seq, Info))).

--- a/src/couch_views/test/couch_views_info_test.erl
+++ b/src/couch_views/test/couch_views_info_test.erl
@@ -40,7 +40,7 @@ foreach_setup() ->
     {ok, _} = fabric2_db:update_doc(Db, Doc1, []),
 
     run_query(Db, DDoc, ?MAP_FUN1),
-    {ok, Info} = couch_views:get_views_info(Db, DDoc),
+    {ok, Info} = couch_views:get_info(Db, DDoc),
     {Db, Info}.
 
 foreach_teardown({Db, _}) ->

--- a/src/couch_views/test/couch_views_info_test.erl
+++ b/src/couch_views/test/couch_views_info_test.erl
@@ -70,7 +70,6 @@ views_info_test_() ->
                     fun language_is_js/1,
                     fun update_seq_is_binary/1,
                     fun updater_running_is_boolean/1,
-                    fun data_size_is_non_neg_int/1,
                     fun active_size_is_non_neg_int/1,
                     fun update_opts_is_bin_list/1
                 ]
@@ -85,10 +84,6 @@ sig_is_binary({_, Info}) ->
 
 language_is_js({_, Info}) ->
     ?_assertEqual(<<"javascript">>, prop(language, Info)).
-
-
-data_size_is_non_neg_int({_, Info}) ->
-    ?_assert(check_non_neg_int(data_size, Info)).
 
 
 active_size_is_non_neg_int({_, Info}) ->

--- a/src/couch_views/test/couch_views_info_test.erl
+++ b/src/couch_views/test/couch_views_info_test.erl
@@ -63,7 +63,9 @@ views_info_test_() ->
                     fun language_is_js/1,
                     fun update_seq_is_binary/1,
                     fun updater_running_is_boolean/1,
-                    fun data_size_is_non_neg_int/1
+                    fun data_size_is_non_neg_int/1,
+                    fun active_size_is_non_neg_int/1,
+                    fun update_opts_is_bin_list/1
                 ]
             }
         }
@@ -78,11 +80,19 @@ language_is_js({_, Info}) ->
 data_size_is_non_neg_int({_, Info}) ->
     ?_assert(check_non_neg_int(data_size, Info)).
 
+active_size_is_non_neg_int({_, Info}) ->
+    ?_assert(check_non_neg_int([sizes, active], Info)).
+
 updater_running_is_boolean({_, Info}) ->
     ?_assert(is_boolean(prop(updater_running, Info))).
 
 update_seq_is_binary({_, Info}) ->
     ?_assert(is_binary(prop(update_seq, Info))).
+
+update_opts_is_bin_list({_, Info}) ->
+    Opts = prop(update_options, Info),
+    ?_assert(is_list(Opts) andalso
+            (Opts == [] orelse lists:all([is_binary(B) || B <- Opts]))).
 
 check_non_neg_int(Key, Info) ->
     Size = prop(Key, Info),

--- a/src/couch_views/test/couch_views_info_test.erl
+++ b/src/couch_views/test/couch_views_info_test.erl
@@ -12,12 +12,15 @@
 
 -module(couch_views_info_test).
 
+
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch_mrview/include/couch_mrview.hrl").
 -include_lib("fabric/test/fabric2_test.hrl").
 
+
 -define(MAP_FUN1, <<"map_fun1">>).
+
 
 setup() ->
     Ctx = test_util:start_couch([
@@ -28,8 +31,10 @@ setup() ->
         ]),
     Ctx.
 
+
 cleanup(Ctx) ->
     test_util:stop_couch(Ctx).
+
 
 foreach_setup() ->
     {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),
@@ -43,9 +48,11 @@ foreach_setup() ->
     {ok, Info} = couch_views:get_info(Db, DDoc),
     {Db, Info}.
 
+
 foreach_teardown({Db, _}) ->
     meck:unload(),
     ok = fabric2_db:delete(fabric2_db:name(Db), []).
+
 
 views_info_test_() ->
     {
@@ -71,41 +78,54 @@ views_info_test_() ->
         }
     }.
 
+
 sig_is_binary({_, Info}) ->
     ?_assert(is_binary(prop(signature, Info))).
+
 
 language_is_js({_, Info}) ->
     ?_assertEqual(<<"javascript">>, prop(language, Info)).
 
+
 data_size_is_non_neg_int({_, Info}) ->
     ?_assert(check_non_neg_int(data_size, Info)).
+
 
 active_size_is_non_neg_int({_, Info}) ->
     ?_assert(check_non_neg_int([sizes, active], Info)).
 
+
 updater_running_is_boolean({_, Info}) ->
     ?_assert(is_boolean(prop(updater_running, Info))).
 
+
 update_seq_is_binary({_, Info}) ->
     ?_assert(is_binary(prop(update_seq, Info))).
+
 
 update_opts_is_bin_list({_, Info}) ->
     Opts = prop(update_options, Info),
     ?_assert(is_list(Opts) andalso
             (Opts == [] orelse lists:all([is_binary(B) || B <- Opts]))).
 
+
 check_non_neg_int(Key, Info) ->
     Size = prop(Key, Info),
     is_integer(Size) andalso Size >= 0.
 
+
 prop(Key, {Props}) when is_list(Props) ->
     prop(Key, Props);
+
 prop([Key], Info) ->
     prop(Key, Info);
+
 prop([Key | Rest], Info) ->
     prop(Rest, prop(Key, Info));
+
 prop(Key, Info) when is_atom(Key), is_list(Info) ->
     couch_util:get_value(Key, Info).
+
 
 create_ddoc() ->
     couch_doc:from_json_obj({[
@@ -117,18 +137,23 @@ create_ddoc() ->
         ]}}
     ]}).
 
+
 doc(Id, Val) ->
     couch_doc:from_json_obj({[
         {<<"_id">>, list_to_binary(integer_to_list(Id))},
         {<<"val">>, Val}
     ]}).
 
+
 fold_fun({meta, _Meta}, Acc) ->
     {ok, Acc};
+
 fold_fun({row, _} = Row, Acc) ->
     {ok, [Row | Acc]};
+
 fold_fun(complete, Acc) ->
     {ok, lists:reverse(Acc)}.
+
 
 run_query(#{} = Db, DDoc, <<_/binary>> = View) ->
     couch_views:query(Db, DDoc, View, fun fold_fun/2, [], #mrargs{}).

--- a/src/couch_views/test/couch_views_info_test.erl
+++ b/src/couch_views/test/couch_views_info_test.erl
@@ -1,0 +1,120 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_views_info_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl").
+-include_lib("fabric/test/fabric2_test.hrl").
+
+-define(MAP_FUN1, <<"map_fun1">>).
+
+setup() ->
+    Ctx = test_util:start_couch([
+            fabric,
+            couch_jobs,
+            couch_js,
+            couch_views
+        ]),
+    Ctx.
+
+cleanup(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+foreach_setup() ->
+    {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),
+    DDoc = create_ddoc(),
+    Doc1 = doc(0, 1),
+
+    {ok, _} = fabric2_db:update_doc(Db, DDoc, []),
+    {ok, _} = fabric2_db:update_doc(Db, Doc1, []),
+
+    run_query(Db, DDoc, ?MAP_FUN1),
+    {ok, Info} = couch_views:get_views_info(Db, DDoc),
+    {Db, Info}.
+
+foreach_teardown({Db, _}) ->
+    meck:unload(),
+    ok = fabric2_db:delete(fabric2_db:name(Db), []).
+
+views_info_test_() ->
+    {
+        "Views index info test",
+        {
+            setup,
+            fun setup/0,
+            fun cleanup/1,
+            {
+                foreach,
+                fun foreach_setup/0,
+                fun foreach_teardown/1,
+                [
+                    fun sig_is_binary/1,
+                    fun language_is_js/1,
+                    fun update_seq_is_binary/1,
+                    fun data_size_is_non_neg_int/1
+                ]
+            }
+        }
+    }.
+
+sig_is_binary({_, Info}) ->
+    ?_assert(is_binary(prop(signature, Info))).
+
+language_is_js({_, Info}) ->
+    ?_assertEqual(<<"javascript">>, prop(language, Info)).
+
+data_size_is_non_neg_int({_, Info}) ->
+    ?_assert(check_non_neg_int(data_size, Info)).
+
+update_seq_is_binary({_, Info}) ->
+    ?_assert(is_binary(prop(update_seq, Info))).
+
+check_non_neg_int(Key, Info) ->
+    Size = prop(Key, Info),
+    is_integer(Size) andalso Size >= 0.
+
+prop(Key, {Props}) when is_list(Props) ->
+    prop(Key, Props);
+prop([Key], Info) ->
+    prop(Key, Info);
+prop([Key | Rest], Info) ->
+    prop(Rest, prop(Key, Info));
+prop(Key, Info) when is_atom(Key), is_list(Info) ->
+    couch_util:get_value(Key, Info).
+
+create_ddoc() ->
+    couch_doc:from_json_obj({[
+        {<<"_id">>, <<"_design/bar">>},
+        {<<"views">>, {[
+            {?MAP_FUN1, {[
+                {<<"map">>, <<"function(doc) {emit(doc.val, doc.val);}">>}
+            ]}}
+        ]}}
+    ]}).
+
+doc(Id, Val) ->
+    couch_doc:from_json_obj({[
+        {<<"_id">>, list_to_binary(integer_to_list(Id))},
+        {<<"val">>, Val}
+    ]}).
+
+fold_fun({meta, _Meta}, Acc) ->
+    {ok, Acc};
+fold_fun({row, _} = Row, Acc) ->
+    {ok, [Row | Acc]};
+fold_fun(complete, Acc) ->
+    {ok, lists:reverse(Acc)}.
+
+run_query(#{} = Db, DDoc, <<_/binary>> = View) ->
+    couch_views:query(Db, DDoc, View, fun fold_fun/2, [], #mrargs{}).


### PR DESCRIPTION
## Overview

This is a WIP to add the `_info` endpoint for views stored in fdb. Currently, I am unsure of the backwards compatibility for some of the fields returned by traditional couchdb views.

Info can be divided into 3 categories: 

1) Status of the build - In traditional views, we looked at
    **a) the update seq of the view**
    b) committed seq
    c) number of clients waiting to commit
    d) number of clients waiting
    e) if the indexer is still running

We can determine **a)** by calling `couch_views_fdb:get_update_seq/2` (note it's a binary instead of couch_mrview's `update_seq` values which are integers).  In traditional views, **b)-d)** refers the number of workers in a queue that are waiting to start indexing and then committing. I'm not sure how this transfers over to fdb as workers are part of the couch_jobs framework and commits occur for very transaction. For e), I looked at `couch_jobs` to see if crafting the `job_id` can give us the state of the job (confirmed with @nickva )

2) Size of the Index - Disk size does not seem applicable. For data size, `couch_view` has a `couch_views_fdb:get_kv_size/2` function for each view built. I don't think the subcategories of size are applicable either: `file`, `external`, `active`. 

Compaction - Not Applicable.

## Testing recommendations

Added a new `_info` endpoint test.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
