### PR TITLE
Ensure clean PATH for Windows couchdb.cmd

### DIFF
--- a/rel/files/couchdb.cmd.in
+++ b/rel/files/couchdb.cmd.in
@@ -23,7 +23,7 @@ FOR /F "tokens=2" %%G IN ("%START_ERL%") DO SET APP_VSN=%%G
 set BINDIR=%ROOTDIR%/erts-%ERTS_VSN%/bin
 set EMU=beam
 set PROGNAME=%~n0
-set PATH=%PATH%;%COUCHDB_BIN_DIR%
+set PATH=%COUCHDB_BIN_DIR%;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\
 
 IF NOT DEFINED COUCHDB_QUERY_SERVER_JAVASCRIPT SET COUCHDB_QUERY_SERVER_JAVASCRIPT={{prefix}}/bin/couchjs {{prefix}}/share/server/main.js
 IF NOT DEFINED COUCHDB_QUERY_SERVER_COFFEESCRIPT SET COUCHDB_QUERY_SERVER_COFFEESCRIPT={{prefix}}/bin/couchjs {{prefix}}/share/server/main-coffee.js


### PR DESCRIPTION
## Overview

On Windows, our PATH could inadvertently bring in DLLs that conflict with those we ship ourselves, such as OpenSSL. This would lead to startup errors.

This patch forces our PATH variable to just the bare minimum: our own binary path first, followed by the bare minimum Windows path.

## Testing recommendations

```
make -f Makefile.win release
rel\couchdb\bin\couchdb.cmd
```

## Related Issues or Pull Requests

Closes #2680 

## Checklist

- [X] Code is written and works correctly