### PR TITLE
Handle db re-creation in view indexing

### DIFF
--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -1715,6 +1715,7 @@ get_previous_transaction_result() ->
 
 
 execute_transaction(Tx, Fun, LayerPrefix) ->
+    put(?PDICT_CHECKED_MD_IS_CURRENT, false),
     put(?PDICT_CHECKED_DB_IS_CURRENT, false),
     Result = Fun(Tx),
     case erlfdb:is_read_only(Tx) of


### PR DESCRIPTION
Add the db instance id to indexing job data. During indexing ensure the
database is opened with the `{uuid, DbUUID}` option. After that any stale db
reads in `update/3` will throw the `database_does_not_exist` error.

In addition, when the indexing job is re-submitted in `build_view_async/2`,
check if it contains a reference to an old db instance id and replace the job.
That has to happen since couch_jobs doesn't overwrite job data for running
jobs.
