### PR TITLE
Make the JWT roles claim more CouchDB specific

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -199,7 +199,7 @@ jwt_authentication_handler(Req) ->
                         false -> throw({unauthorized, <<"Token missing sub claim.">>});
                         {_, User} -> Req#httpd{user_ctx=#user_ctx{
                             name = User,
-                            roles = couch_util:get_value(<<"roles">>, Claims, [])
+                            roles = couch_util:get_value(<<"_couchdb.roles">>, Claims, [])
                         }}
                     end;
                 {error, Reason} ->

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -103,7 +103,7 @@ defmodule JwtAuthTest do
   end
 
   def test_fun(alg, key) do
-    {:ok, token} = :jwtf.encode({[{"alg", alg}, {"typ", "JWT"}]}, {[{"sub", "couch@apache.org"}, {"roles", ["testing"]}]}, key)
+    {:ok, token} = :jwtf.encode({[{"alg", alg}, {"typ", "JWT"}]}, {[{"sub", "couch@apache.org"}, {"_couchdb.roles", ["testing"]}]}, key)
 
     resp = Couch.get("/_session",
       headers: [authorization: "Bearer #{token}"]


### PR DESCRIPTION
Following some discussion about naming for the claim, it's been determined that it would be better to make it clear that this value is CouchDB specific.

Constraining the token name this way also reduces the likelihood of an accidental collision with other schemas participating in the same token.