### PR TITLE
Port purge.js into elixir test suite - 3.0.x

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -61,7 +61,7 @@ X means done, - means partially
   - [X] Port method_override.js
   - [X] Port multiple_rows.js
   - [X] Port proxyauth.js
-  - [ ] Port purge.js
+  - [X] Port purge.js
   - [ ] Port reader_acl.js
   - [ ] Port recreate_doc.js
   - [ ] Port reduce_builtin.js

--- a/test/elixir/test/purge_test.exs
+++ b/test/elixir/test/purge_test.exs
@@ -1,0 +1,168 @@
+defmodule PurgeTest do
+  use CouchTestCase
+
+  @moduletag :purge
+
+  @tag :with_db
+  test "purge documents", context do
+    db_name = context[:db_name]
+
+    design_doc = %{
+      _id: "_design/test",
+      language: "javascript",
+      views: %{
+        all_docs_twice: %{
+          map: "function(doc) { emit(doc.integer, null); emit(doc.integer, null) }"
+        },
+        single_doc: %{
+          map: "function(doc) { if (doc._id == \"1\") { emit(1, null) }}"
+        }
+      }
+    }
+
+    {:ok, _} = create_doc(db_name, design_doc)
+
+    num_docs = 10
+    bulk_save(db_name, make_docs(1..(num_docs + 1)))
+
+    test_all_docs_twice(db_name, num_docs, 1)
+
+    info = info(db_name)
+
+    doc1 = open_doc(db_name, 1)
+    doc2 = open_doc(db_name, 2)
+
+    resp =
+      Couch.post("/#{db_name}/_purge",
+        body: %{"1": [doc1["_rev"]], "2": [doc2["_rev"]]}
+      )
+
+    assert resp.status_code == 201
+    result = resp.body
+
+    assert Enum.at(result["purged"]["1"], 0) == doc1["_rev"]
+    assert Enum.at(result["purged"]["2"], 0) == doc2["_rev"]
+
+    open_doc(db_name, 1, 404)
+    open_doc(db_name, 2, 404)
+
+    purged_info = info(db_name)
+
+    assert purged_info["purge_seq"] != info["purge_seq"]
+
+    test_all_docs_twice(db_name, num_docs, 0, 2)
+
+    # purge sequences are preserved after compaction (COUCHDB-1021)
+    resp = Couch.post("/#{db_name}/_compact")
+    assert resp.status_code == 202
+
+    retry_until(fn ->
+      info(db_name)["compact_running"] == false
+    end)
+
+    compacted_info = info(db_name)
+    assert compacted_info["purge_seq"] == purged_info["purge_seq"]
+
+    # purge documents twice in a row without loading views
+    # (causes full view rebuilds)
+
+    doc3 = open_doc(db_name, 3)
+    doc4 = open_doc(db_name, 4)
+
+    resp =
+      Couch.post("/#{db_name}/_purge",
+        body: %{"3": [doc3["_rev"]]}
+      )
+
+    assert resp.status_code == 201
+
+    resp =
+      Couch.post("/#{db_name}/_purge",
+        body: %{"4": [doc4["_rev"]]}
+      )
+
+    assert resp.status_code == 201
+
+    test_all_docs_twice(db_name, num_docs, 0, 4)
+  end
+
+  @tag :with_db
+  test "COUCHDB-1065", context do
+    db_name_a = context[:db_name]
+    db_name_b = random_db_name()
+    {:ok, _} = create_db(db_name_b)
+
+    {:ok, doc_a_resp} = create_doc(db_name_a, %{_id: "test", a: 1})
+    {:ok, doc_b_resp} = create_doc(db_name_b, %{_id: "test", a: 2})
+    replicate(db_name_a, db_name_b)
+
+    open_rev(db_name_b, "test", doc_a_resp.body["rev"], 200)
+    open_rev(db_name_b, "test", doc_b_resp.body["rev"], 200)
+
+    resp =
+      Couch.post("/#{db_name_b}/_purge",
+        body: %{test: [doc_a_resp.body["rev"]]}
+      )
+
+    assert resp.status_code == 201
+
+    open_rev(db_name_b, "test", doc_a_resp.body["rev"], 404)
+
+    resp =
+      Couch.post("/#{db_name_b}/_purge",
+        body: %{test: [doc_b_resp.body["rev"]]}
+      )
+
+    assert resp.status_code == 201
+
+    open_rev(db_name_b, "test", doc_b_resp.body["rev"], 404)
+
+    resp =
+      Couch.post("/#{db_name_b}/_purge",
+        body: %{test: [doc_a_resp.body["rev"], doc_b_resp.body["rev"]]}
+      )
+
+    assert resp.status_code == 201
+
+    delete_db(db_name_b)
+  end
+
+  def replicate(src, tgt, options \\ []) do
+    defaults = [headers: [], body: %{}, timeout: 30_000]
+    options = defaults |> Keyword.merge(options) |> Enum.into(%{})
+
+    %{body: body} = options
+    body = [source: src, target: tgt] |> Enum.into(body)
+    options = Map.put(options, :body, body)
+
+    resp = Couch.post("/_replicate", Enum.to_list(options))
+    assert HTTPotion.Response.success?(resp), "#{inspect(resp)}"
+    resp.body
+  end
+
+  defp open_doc(db_name, id, expect \\ 200) do
+    resp = Couch.get("/#{db_name}/#{id}")
+    assert resp.status_code == expect
+    resp.body
+  end
+
+  defp open_rev(db_name, id, rev, expect) do
+    resp = Couch.get("/#{db_name}/#{id}?rev=#{rev}")
+    assert resp.status_code == expect
+    resp.body
+  end
+
+  defp test_all_docs_twice(db_name, num_docs, sigle_doc_expect, offset \\ 0) do
+    resp = Couch.get("/#{db_name}/_design/test/_view/all_docs_twice")
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+
+    for x <- 0..(num_docs - offset) do
+      assert Map.get(Enum.at(rows, 2 * x), "key") == x + offset + 1
+      assert Map.get(Enum.at(rows, 2 * x + 1), "key") == x + offset + 1
+    end
+
+    resp = Couch.get("/#{db_name}/_design/test/_view/single_doc")
+    assert resp.body["total_rows"] == sigle_doc_expect
+  end
+end

--- a/test/javascript/tests/purge.js
+++ b/test/javascript/tests/purge.js
@@ -9,7 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
+couchTests.elixir = true; 
 couchTests.purge = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Port purge.js into elixir test suite
Merging #2704 into 3.0.x

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
