### PR TITLE
Improve cookie_auth_test.exs initialization

### DIFF
--- a/test/elixir/test/cookie_auth_test.exs
+++ b/test/elixir/test/cookie_auth_test.exs
@@ -34,13 +34,14 @@ defmodule CookieAuthTest do
     # Create db if not exists
     Couch.put("/#{@users_db}")
 
-    resp =
-      Couch.get(
-        "/#{@users_db}/_changes",
-        query: [feed: "longpoll", timeout: 5000, filter: "_design"]
-      )
-
-    assert resp.body
+    retry_until(fn ->
+      resp =
+        Couch.get(
+          "/#{@users_db}/_changes",
+          query: [feed: "longpoll", timeout: 5000, filter: "_design"]
+        )
+        length(resp.body["results"]) > 0
+    end)
 
     on_exit(&tear_down/0)
 


### PR DESCRIPTION

## Overview
Some times jenkins is failling during cookie_auth_test.exs initialization. 
```
[2020-03-22T16:10:58.479Z] CookieAuthTest
[2020-03-22T16:11:04.587Z]   * test cookie auth
								* test cookie auth (5022.9ms)
[2020-03-22T16:11:04.587Z] 
[2020-03-22T16:11:04.587Z]   1) test cookie auth (CookieAuthTest)
[2020-03-22T16:11:04.588Z]      test/elixir/test/cookie_auth_test.exs:206
[2020-03-22T16:11:04.588Z]      Assertion with == failed
[2020-03-22T16:11:04.588Z]      code:  assert resp.status_code() == expect_response
[2020-03-22T16:11:04.588Z]      left:  404
[2020-03-22T16:11:04.588Z]      right: 200
[2020-03-22T16:11:04.588Z]      stacktrace:
[2020-03-22T16:11:04.588Z]        test/elixir/test/cookie_auth_test.exs:107: CookieAuthTest.open_as/3
[2020-03-22T16:11:04.588Z]        test/elixir/test/cookie_auth_test.exs:208: (test)
```

The problem arises in the following line that respond after longpoll timeout without the expected response. 

```
resp =
      Couch.get(
        "/#{@users_db}/_changes",
        query: [feed: "longpoll", timeout: 5000, filter: "_design"]
      )

[notice] 2020-03-22T16:11:03.403004Z node1@127.0.0.1 <0.4111.1> f5456adb0c 127.0.0.1:15984 127.0.0.1 adm GET /_users/_changes?feed=longpoll&timeout=5000&filter=_design 200 ok 5002
```

This PR adds a retry during this initialization giving more chances to success.

## Testing recommendations
```
 make elixir
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
N/A

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
