### PR TITLE
Port view_offset.js to elixir test suite

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -107,7 +107,7 @@ X means done, - means partially
   - [ ] Port view_multi_key_all_docs.js
   - [ ] Port view_multi_key_design.js
   - [ ] Port view_multi_key_temp.js
-  - [ ] Port view_offsets.js
+  - [X] Port view_offsets.js
   - [X] Port view_pagination.js
   - [ ] Port view_sandboxing.js
   - [ ] Port view_update_seq.js

--- a/test/elixir/test/view_offsets_test.exs
+++ b/test/elixir/test/view_offsets_test.exs
@@ -1,0 +1,100 @@
+defmodule ViewOffsetTest do
+  use CouchTestCase
+
+  @moduletag :view_offsets
+
+  @moduledoc """
+  Tests about view offsets.
+  This is a port of the view_offsets.js javascript test suite.
+  """
+
+  @docs [
+    %{"_id" => "a1", "letter" => "a", "number" => 1, "foo" => "bar"},
+    %{"_id" => "a2", "letter" => "a", "number" => 2, "foo" => "bar"},
+    %{"_id" => "a3", "letter" => "a", "number" => 3, "foo" => "bar"},
+    %{"_id" => "b1", "letter" => "b", "number" => 1, "foo" => "bar"},
+    %{"_id" => "b2", "letter" => "b", "number" => 2, "foo" => "bar"},
+    %{"_id" => "b3", "letter" => "b", "number" => 3, "foo" => "bar"},
+    %{"_id" => "b4", "letter" => "b", "number" => 4, "foo" => "bar"},
+    %{"_id" => "b5", "letter" => "b", "number" => 5, "foo" => "bar"},
+    %{"_id" => "c1", "letter" => "c", "number" => 1, "foo" => "bar"},
+    %{"_id" => "c2", "letter" => "c", "number" => 2, "foo" => "bar"}
+  ]
+
+  @design_doc %{
+    "_id" => "_design/test",
+    "views" => %{
+      "offset" => %{
+        "map" => "function(doc) { emit([doc.letter, doc.number], doc); }"
+      }
+    }
+  }
+
+  @tag :with_db
+  test "basic view offsets", context do
+    db_name = context[:db_name]
+    save(db_name, @design_doc)
+    bulk_save(db_name, @docs)
+
+    [
+      [["c", 2], 0],
+      [["c", 1], 1],
+      [["b", 5], 2],
+      [["b", 4], 3],
+      [["b", 3], 4],
+      [["b", 2], 5],
+      [["b", 1], 6],
+      [["a", 3], 7],
+      [["a", 2], 8],
+      [["a", 1], 9]
+    ]
+    |> Enum.each(fn [start_key, offset] ->
+      result =
+        view(db_name, "test/offset", %{
+          "startkey" => :jiffy.encode(start_key),
+          "descending" => true
+        })
+
+      assert result.body["offset"] === offset
+    end)
+  end
+
+  test "repeated view offsets" do
+    0..14 |> Enum.each(fn _ -> repeated_view_offset_test_fun end)
+  end
+
+  def repeated_view_offset_test_fun do
+    db_name = random_db_name()
+    create_db(db_name)
+
+    save(db_name, @design_doc)
+    bulk_save(db_name, @docs)
+
+    first_response =
+      view(db_name, "test/offset", %{
+        "startkey" => :jiffy.encode(["b", 4]),
+        "startkey_docid" => "b4",
+        "endkey" => :jiffy.encode(["b"]),
+        "descending" => true,
+        "limit" => 2,
+        "skip" => 1
+      })
+
+    second_response =
+      view(db_name, "test/offset", %{
+        "startkey" => :jiffy.encode(["c", 3])
+      })
+
+    third_response =
+      view(db_name, "test/offset", %{
+        "startkey" => :jiffy.encode(["b", 6]),
+        "endkey" => :jiffy.encode(["b", 7])
+      })
+
+    assert first_response.body["offset"] === 4
+    assert second_response.body["offset"] === length(@docs)
+    assert third_response.body["offset"] === 8
+
+    delete_db(db_name)
+  end
+end

--- a/test/javascript/tests/view_offsets.js
+++ b/test/javascript/tests/view_offsets.js
@@ -10,6 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
+
 couchTests.view_offsets = function(debug) {
   if (debug) debugger;
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Just ported `view_offsets.js` to Elixir test suite.

## Testing recommendations

Run `make elixir tests=test/elixir/test/view_offsets_test.exs`

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
