### PR TITLE
Return a 400 error code for an invalid update sequence

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -943,6 +943,8 @@ error_info({error, {database_name_too_long, DbName}}) ->
         <<"At least one path segment of `", DbName/binary, "` is too long.">>};
 error_info({doc_validation, Reason}) ->
     {400, <<"doc_validation">>, Reason};
+error_info({invalid_since_seq, Reason}) ->
+    {400, <<"invalid_since_seq">>, Reason};
 error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
 error_info(request_entity_too_large) ->


### PR DESCRIPTION
Currently we return a 500 but a 400 return code makes more sense

```
$ http  $DB1/db1/_changes?since=0-1345

HTTP/1.1 400 Bad Request

{
    "error": "invalid_since_seq",
    "reason": "0-1345",
    "ref": 442671026
}
```


