### PR TITLE
Enhance JWT controls (again)

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -143,8 +143,6 @@ max_db_number_for_dbs_info_req = 100
 ;[jwt_auth]
 ; List of claims to validate
 ; required_claims = exp
-; List of algorithms to accept during checks
-; allowed_algorithms = HS256
 ;
 ; [jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -142,7 +142,7 @@ max_db_number_for_dbs_info_req = 100
 
 ;[jwt_auth]
 ; List of claims to validate
-; required_claims = exp
+; required_claims =
 ;
 ; [jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -192,8 +192,7 @@ jwt_authentication_handler(Req) ->
     case header_value(Req, "Authorization") of
         "Bearer " ++ Jwt ->
             RequiredClaims = get_configured_claims(),
-            AllowedAlgorithms = get_configured_algorithms(),
-            case jwtf:decode(?l2b(Jwt), [{alg, AllowedAlgorithms} | RequiredClaims], fun jwtf_keystore:get/2) of
+            case jwtf:decode(?l2b(Jwt), [alg | RequiredClaims], fun jwtf_keystore:get/2) of
                 {ok, {Claims}} ->
                     case lists:keyfind(<<"sub">>, 1, Claims) of
                         false -> throw({unauthorized, <<"Token missing sub claim.">>});
@@ -207,9 +206,6 @@ jwt_authentication_handler(Req) ->
             end;
         _ -> Req
     end.
-
-get_configured_algorithms() ->
-    re:split(config:get("jwt_auth", "allowed_algorithms", "HS256"), "\s*,\s*", [{return, binary}]).
 
 get_configured_claims() ->
     re:split(config:get("jwt_auth", "required_claims", ""), "\s*,\s*", [{return, binary}]).

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -208,7 +208,13 @@ jwt_authentication_handler(Req) ->
     end.
 
 get_configured_claims() ->
-    re:split(config:get("jwt_auth", "required_claims", ""), "\s*,\s*", [{return, binary}]).
+    Claims = config:get("jwt_auth", "required_claims", ""),
+    case re:split(Claims, "\s*,\s*", [{return, list}]) of
+        [[]] ->
+            []; %% if required_claims is the empty string.
+        List ->
+            [list_to_existing_atom(C) || C <- List]
+    end.
 
 cookie_authentication_handler(Req) ->
     cookie_authentication_handler(Req, couch_auth_cache).

--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -159,11 +159,11 @@ validate_typ(Props, Checks) ->
     Required = prop(typ, Checks),
     TYP = prop(<<"typ">>, Props),
     case {Required, TYP} of
-        {undefined, _} ->
+        {undefined, undefined} ->
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing typ header parameter">>});
-        {true, <<"JWT">>} ->
+        {_, <<"JWT">>} ->
             ok;
         {true, _} ->
             throw({bad_request, <<"Invalid typ header parameter">>})
@@ -174,11 +174,11 @@ validate_alg(Props, Checks) ->
     Required = prop(alg, Checks),
     Alg = prop(<<"alg">>, Props),
     case {Required, Alg} of
-        {undefined, _} ->
+        {undefined, undefined} ->
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing alg header parameter">>});
-        {true, Alg} ->
+        {_, Alg} ->
             case lists:member(Alg, valid_algorithms()) of
                 true ->
                     ok;
@@ -202,9 +202,9 @@ validate_iss(Props, Checks) ->
     ActualISS = prop(<<"iss">>, Props),
 
     case {ExpectedISS, ActualISS} of
-        {undefined, _} ->
+        {undefined, undefined} ->
             ok;
-        {_ISS, undefined} ->
+        {ISS, undefined} when ISS /= undefined ->
             throw({bad_request, <<"Missing iss claim">>});
         {ISS, ISS} ->
             ok;
@@ -218,11 +218,11 @@ validate_iat(Props, Checks) ->
     IAT = prop(<<"iat">>, Props),
 
     case {Required, IAT} of
-        {undefined, _} ->
+        {undefined, undefined} ->
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing iat claim">>});
-        {true, IAT} when is_integer(IAT) ->
+        {_, IAT} when is_integer(IAT) ->
             ok;
         {true, _} ->
             throw({bad_request, <<"Invalid iat claim">>})
@@ -234,11 +234,11 @@ validate_nbf(Props, Checks) ->
     NBF = prop(<<"nbf">>, Props),
 
     case {Required, NBF} of
-        {undefined, _} ->
+        {undefined, undefined} ->
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing nbf claim">>});
-        {true, IAT} ->
+        {_, IAT} ->
             assert_past(<<"nbf">>, IAT)
     end.
 
@@ -248,11 +248,11 @@ validate_exp(Props, Checks) ->
     EXP = prop(<<"exp">>, Props),
 
     case {Required, EXP} of
-        {undefined, _} ->
+        {undefined, undefined} ->
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing exp claim">>});
-        {true, EXP} ->
+        {_, EXP} ->
             assert_future(<<"exp">>, EXP)
     end.
 

--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -123,14 +123,32 @@ validate(Header0, Payload0, Signature, Checks, KS) ->
     Key = key(Header1, Checks, KS),
     verify(Alg, Header0, Payload0, Signature, Key).
 
+
 validate_checks(Checks) when is_list(Checks) ->
-    UnknownChecks = proplists:get_keys(Checks) -- ?CHECKS,
+    case {lists:usort(Checks), lists:sort(Checks)} of
+        {L, L} ->
+            ok;
+        {L1, L2} ->
+            error({duplicate_checks, L2 -- L1})
+    end,
+    {_, UnknownChecks} = lists:partition(fun valid_check/1, Checks),
     case UnknownChecks of
         [] ->
             ok;
         UnknownChecks ->
             error({unknown_checks, UnknownChecks})
     end.
+
+
+valid_check(Check) when is_atom(Check) ->
+    lists:member(Check, ?CHECKS);
+
+valid_check({Check, _}) when is_atom(Check) ->
+    lists:member(Check, ?CHECKS);
+
+valid_check(_) ->
+    false.
+
 
 validate_header(Props, Checks) ->
     validate_typ(Props, Checks),

--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -158,11 +158,10 @@ validate_alg(Props, Checks) ->
     case {Required, Alg} of
         {undefined, _} ->
             ok;
-        {Required, undefined} when Required /= undefined ->
+        {true, undefined} ->
             throw({bad_request, <<"Missing alg header parameter">>});
-        {Required, Alg} when Required == true; is_list(Required) ->
-            AllowedAlg = if Required == true -> true; true -> lists:member(Alg, Required) end,
-            case AllowedAlg andalso lists:member(Alg, valid_algorithms()) of
+        {true, Alg} ->
+            case lists:member(Alg, valid_algorithms()) of
                 true ->
                     ok;
                 false ->

--- a/src/jwtf/test/jwtf_tests.erl
+++ b/src/jwtf/test/jwtf_tests.erl
@@ -82,16 +82,6 @@ invalid_alg_test() ->
     ?assertEqual({error, {bad_request,<<"Invalid alg header parameter">>}},
         jwtf:decode(Encoded, [alg], nil)).
 
-not_allowed_alg_test() ->
-    Encoded = encode({[{<<"alg">>, <<"HS256">>}]}, []),
-    ?assertEqual({error, {bad_request,<<"Invalid alg header parameter">>}},
-        jwtf:decode(Encoded, [{alg, [<<"RS256">>]}], nil)).
-
-reject_unknown_alg_test() ->
-    Encoded = encode({[{<<"alg">>, <<"NOPE">>}]}, []),
-    ?assertEqual({error, {bad_request,<<"Invalid alg header parameter">>}},
-        jwtf:decode(Encoded, [{alg, [<<"NOPE">>]}], nil)).
-
 
 missing_iss_test() ->
     Encoded = encode(valid_header(), {[]}),
@@ -190,7 +180,7 @@ hs256_test() ->
                      "6MTAwMDAwMDAwMDAwMDAsImtpZCI6ImJhciJ9.iS8AH11QHHlczkBn"
                      "Hl9X119BYLOZyZPllOVhSBZ4RZs">>,
     KS = fun(<<"HS256">>, <<"123456">>) -> <<"secret">> end,
-    Checks = [{iss, <<"https://foo.com">>}, iat, exp, typ, {alg, [<<"HS256">>]}, kid],
+    Checks = [{iss, <<"https://foo.com">>}, iat, exp, typ, alg, kid],
     ?assertMatch({ok, _}, catch jwtf:decode(EncodedToken, Checks, KS)).
 
 

--- a/src/jwtf/test/jwtf_tests.erl
+++ b/src/jwtf/test/jwtf_tests.erl
@@ -168,9 +168,17 @@ malformed_token_test() ->
     ?assertEqual({error, {bad_request, <<"Malformed token">>}},
         jwtf:decode(<<"a.b.c.d">>, [], nil)).
 
-unknown_check_test() ->
-    ?assertError({unknown_checks, [bar, foo]},
-        jwtf:decode(<<"a.b.c">>, [exp, foo, iss, bar, exp], nil)).
+unknown_atom_check_test() ->
+    ?assertError({unknown_checks, [foo, bar]},
+        jwtf:decode(<<"a.b.c">>, [exp, foo, iss, bar], nil)).
+
+unknown_binary_check_test() ->
+    ?assertError({unknown_checks, [<<"bar">>]},
+        jwtf:decode(<<"a.b.c">>, [exp, iss, <<"bar">>], nil)).
+
+duplicate_check_test() ->
+    ?assertError({duplicate_checks, [exp]},
+        jwtf:decode(<<"a.b.c">>, [exp, exp], nil)).
 
 
 %% jwt.io generated

--- a/src/jwtf/test/jwtf_tests.erl
+++ b/src/jwtf/test/jwtf_tests.erl
@@ -275,7 +275,7 @@ header(Alg) ->
 
 
 claims() ->
-    EpochSeconds = 1496205841,
+    EpochSeconds = os:system_time(second),
     {[
         {<<"iat">>, EpochSeconds},
         {<<"exp">>, EpochSeconds + 3600}

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -103,7 +103,23 @@ defmodule JwtAuthTest do
   end
 
   def test_fun(alg, key) do
-    {:ok, token} = :jwtf.encode({[{"alg", alg}, {"typ", "JWT"}]}, {[{"sub", "couch@apache.org"}, {"_couchdb.roles", ["testing"]}]}, key)
+    now = DateTime.to_unix(DateTime.utc_now())
+    {:ok, token} = :jwtf.encode(
+      {
+        [
+          {"alg", alg},
+          {"typ", "JWT"}
+        ]
+      },
+      {
+        [
+          {"nbf", now - 60},
+          {"exp", now + 60},
+          {"sub", "couch@apache.org"},
+          {"_couchdb.roles", ["testing"]
+          }
+        ]
+      }, key)
 
     resp = Couch.get("/_session",
       headers: [authorization: "Bearer #{token}"]


### PR DESCRIPTION
## Overview

This PR;

* fixes the broken required_claims property (due to my misunderstanding of `proplists:get_keys`).
* Removes the enhancement to the `alg` check as it is superceded by the binding of algorithm type and key value in jwtf_keystore.
* Changes the default required_claims to include nbf and exp. Administrators can remove either or both restriction if they choose.

## Testing recommendations

All changes covered by unit and/or integration tests in this PR.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
