### PR TITLE
Do not copy the #server.lru field to async openers

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -381,10 +381,13 @@ maybe_close_lru_db(#server{lru=Lru}=Server) ->
     end.
 
 open_async(Server, From, DbName, Options) ->
+    NoLRUServer = Server#server{
+        lru = redacted
+    },
     Parent = self(),
     T0 = os:timestamp(),
     Opener = spawn_link(fun() ->
-        Res = open_async_int(Server, DbName, Options),
+        Res = open_async_int(NoLRUServer, DbName, Options),
         IsSuccess = case Res of
             {ok, _} -> true;
             _ -> false


### PR DESCRIPTION
This copy slowed down the `erlang:spawn_link/3` call considerably.
Measurements in the wild showed the cost of that `spawn_link/3` going
from roughly 8 uS to 800 uS.

This the 3.x PR. Original (master) PR is https://github.com/apache/couchdb/pull/2739