### PR TITLE
Compress doc bodies and attachments

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -54,6 +54,10 @@
 
 -define(CURR_LDOC_FORMAT, 0).
 
+% 0 - Attachment storage version
+
+-define(CURR_ATT_STORAGE_VER, 0).
+
 % Misc constants
 
 -define(PDICT_DB_KEY, '$fabric_db_handle').

--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -809,7 +809,8 @@ read_attachment(Db, DocId, AttId) ->
 
 write_attachment(Db, DocId, Att) ->
     Data = couch_att:fetch(data, Att),
-    {ok, AttId} = fabric2_fdb:write_attachment(Db, DocId, Data),
+    Encoding = couch_att:fetch(encoding, Att),
+    {ok, AttId} = fabric2_fdb:write_attachment(Db, DocId, Data, Encoding),
     couch_att:store(data, {loc, Db, DocId, AttId}, Att).
 
 


### PR DESCRIPTION
In CouchDB < 4.x we compressed document bodies by default, so enable it
for 4.x as well.

Use the basic term_to_binary compression mechanism for:

 - Document bodies

 - Local document bodies

 - Attachments, but only if they have not already been compressed.
