### PR TITLE
Port recreate doc test into elixir 

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -63,7 +63,7 @@ X means done, - means partially
   - [X] Port proxyauth.js
   - [X] Port purge.js
   - [ ] Port reader_acl.js
-  - [ ] Port recreate_doc.js
+  - [X] Port recreate_doc.js
   - [X] Port reduce_builtin.js
   - [X] Port reduce_false.js
   - [ ] Port reduce_false_temp.js

--- a/test/elixir/test/recreate_doc_test.exs
+++ b/test/elixir/test/recreate_doc_test.exs
@@ -1,0 +1,165 @@
+defmodule RecreateDocTest do
+  use CouchTestCase
+
+  @moduletag :recreate_doc
+
+  @moduledoc """
+  Test CouchDB document recreation
+  This is a port of the recreate_doc.js suite
+  """
+
+  @tag :with_db
+  test "recreate document", context do
+    db_name = context[:db_name]
+
+    # First create a new document with the ID "foo", and delete it again
+    doc = %{_id: "foo", a: "bar", b: 42}
+    {:ok, resp} = create_doc(db_name, doc)
+    first_rev = resp.body["rev"]
+
+    resp = Couch.delete("/#{db_name}/foo?rev=#{first_rev}")
+    assert resp.status_code == 200
+
+    # Now create a new document with the same ID, save it, and then modify it
+    doc = %{_id: "foo"}
+
+    for _i <- 0..9 do
+      {:ok, _} = create_doc(db_name, doc)
+      resp = Couch.get("/#{db_name}/foo")
+
+      updated_doc =
+        resp.body
+        |> Map.put("a", "baz")
+
+      resp = Couch.put("/#{db_name}/foo", body: updated_doc)
+      assert resp.status_code == 201
+      rev = resp.body["rev"]
+      resp = Couch.delete("/#{db_name}/foo?rev=#{rev}")
+      assert resp.status_code == 200
+    end
+  end
+
+  @tag :with_db
+  test "COUCHDB-292 - recreate a deleted document", context do
+    db_name = context[:db_name]
+    # First create a new document with the ID "foo", and delete it again
+    doc = %{_id: "foo", a: "bar", b: 42}
+    {:ok, resp} = create_doc(db_name, doc)
+    first_rev = resp.body["rev"]
+
+    resp = Couch.delete("/#{db_name}/foo?rev=#{first_rev}")
+    assert resp.status_code == 200
+
+    # COUCHDB-292 now attempt to save the document with a prev that's since
+    # been deleted and this should generate a conflict exception
+    updated_doc =
+      doc
+      |> Map.put(:_rev, first_rev)
+
+    resp = Couch.put("/#{db_name}/foo", body: updated_doc)
+    assert resp.status_code == 409
+
+    # same as before, but with binary
+    bin_att_doc = %{
+      _id: "foo",
+      _rev: first_rev,
+      _attachments: %{
+        "foo.txt": %{
+          content_type: "text/plain",
+          data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        }
+      }
+    }
+
+    resp = Couch.put("/#{db_name}/foo", body: bin_att_doc)
+    assert resp.status_code == 409
+  end
+
+  @tag :with_db
+  test "Recreate a deleted document with non-exsistant rev", context do
+    db_name = context[:db_name]
+
+    doc = %{_id: "foo", a: "bar", b: 42}
+    {:ok, resp} = create_doc(db_name, doc)
+    first_rev = resp.body["rev"]
+
+    resp = Couch.delete("/#{db_name}/foo?rev=#{first_rev}")
+    assert resp.status_code == 200
+
+    # random non-existant prev rev
+    updated_doc =
+      doc
+      |> Map.put(:_rev, "1-asfafasdf")
+
+    resp = Couch.put("/#{db_name}/foo", body: updated_doc)
+    assert resp.status_code == 409
+
+    # random non-existant prev rev with bin
+    bin_att_doc = %{
+      _id: "foo",
+      _rev: "1-aasasfasdf",
+      _attachments: %{
+        "foo.txt": %{
+          content_type: "text/plain",
+          data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        }
+      }
+    }
+
+    resp = Couch.put("/#{db_name}/foo", body: bin_att_doc)
+    assert resp.status_code == 409
+  end
+
+  @tag :with_db
+  test "COUCHDB-1265 - changes feed after we try and break the update_seq tree",
+       context do
+    db_name = context[:db_name]
+
+    # Test COUCHDB-1265 - Reinserting an old revision into the revision tree causes
+    # duplicates in the update_seq tree.
+    revs = create_rev_doc(db_name, "a", 3)
+
+    resp =
+      Couch.put("/#{db_name}/a",
+        body: Enum.at(revs, 0),
+        query: [new_edits: false]
+      )
+
+    assert resp.status_code == 201
+
+    resp =
+      Couch.put("/#{db_name}/a",
+        body: Enum.at(revs, -1)
+      )
+
+    assert resp.status_code == 201
+
+    resp = Couch.get("/#{db_name}/_changes")
+    assert resp.status_code == 200
+
+    assert length(resp.body["results"]) == 1
+  end
+
+  # function to create a doc with multiple revisions
+  defp create_rev_doc(db_name, id, num_revs) do
+    doc = %{_id: id, count: 0}
+    {:ok, resp} = create_doc(db_name, doc)
+    create_rev_doc(db_name, id, num_revs, [Map.put(doc, :_rev, resp.body["rev"])])
+  end
+
+  defp create_rev_doc(db_name, id, num_revs, revs) do
+    if length(revs) < num_revs do
+      doc = %{_id: id, _rev: Enum.at(revs, -1)[:_rev], count: length(revs)}
+      {:ok, resp} = create_doc(db_name, doc)
+
+      create_rev_doc(
+        db_name,
+        id,
+        num_revs,
+        revs ++ [Map.put(doc, :_rev, resp.body["rev"])]
+      )
+    else
+      revs
+    end
+  end
+end

--- a/test/javascript/tests/recreate_doc.js
+++ b/test/javascript/tests/recreate_doc.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.recreate_doc = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"}, {"w": 3});


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR ports the recreate_doc.js test into the elixir test suite

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
 make elixir tests=test/elixir/test/recreate_doc_test.exs
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
