### PR TITLE
Prototype/fdb layer mango plugin

### DIFF
--- a/src/mango/src/mango_epi.erl
+++ b/src/mango/src/mango_epi.erl
@@ -33,7 +33,9 @@ providers() ->
     ].
 
 services() ->
-    [].
+    [
+        {mango, mango_plugin}
+    ].
 
 data_subscriptions() ->
     [].

--- a/src/mango/src/mango_plugin.erl
+++ b/src/mango/src/mango_plugin.erl
@@ -1,0 +1,43 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mango_plugin).
+
+-export([
+    before_find/1,
+    after_find/3
+]).
+
+-define(SERVICE_ID, mango).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+before_find(HttpReq0) ->
+    with_pipe(before_find, [HttpReq0]).
+
+
+after_find(HttpReq, HttpResp, Arg0) ->
+    with_pipe(after_find, [HttpReq, HttpResp, Arg0]).
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+with_pipe(Func, Args) ->
+    do_apply(Func, Args, [pipe]).
+
+
+do_apply(Func, Args, Opts) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    couch_epi:apply(Handle, ?SERVICE_ID, Func, Args, Opts).


### PR DESCRIPTION
## Overview

We have a number of EPI extention points in CouchDB already. This PR adds EPI extension points for mango `_find`. This would allow integrator to override some aspects of mango behaviour without forking CouchDB. 

## Testing recommendations

```
make couch && make eunit apps=couch_views
```

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
