### PR TITLE
Clean up existing expiry key on update

### DIFF
--- a/src/couch_expiring_cache/src/couch_expiring_cache_server.erl
+++ b/src/couch_expiring_cache/src/couch_expiring_cache_server.erl
@@ -82,7 +82,7 @@ handle_info(remove_expired, St) ->
 
     NowTS = erlang:system_time(?TIME_UNIT),
     OldestTS = max(OldestTS0,
-        couch_expiring_cache_fdb:clear_expired_range(Name, NowTS, BatchSize)),
+        couch_expiring_cache_fdb:clear_range_to(Name, NowTS, BatchSize)),
     Elapsed = erlang:system_time(?TIME_UNIT) - NowTS,
 
     {noreply, St#{

--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -24,6 +24,7 @@
 -define(DB_HCA, 2).
 -define(DELETED_DBS, 3).
 -define(DBS, 15).
+-define(EXPIRING_CACHE, 53).
 -define(TX_IDS, 255).
 
 % Database Level: (LayerPrefix, ?DBS, DbPrefix, X, ...)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

When an existing key is inserted with different timestamps, the primary
key is the same but the primary value is different from the existing one.
Currently, this results in a new expiry key being inserted, but the old
one is not deleted, and lingers until it is removed by the inexorable
advance of time via the `remove_expired` server messages.

This checks whether there's already primary key for the inserted key,
and if so, cleans up the existing expiry key before proceeding with the
insert.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
```
make eunit apps=couch_expiring_cache
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
