### PR TITLE
Fix job removal notifications

### DIFF
--- a/src/couch_jobs/src/couch_jobs_fdb.erl
+++ b/src/couch_jobs/src/couch_jobs_fdb.erl
@@ -122,6 +122,7 @@ remove(#{jtx := true} = JTx0, #{job := true} = Job) ->
         #jv{stime = STime} ->
             couch_jobs_pending:remove(JTx, Type, JobId, STime),
             erlfdb:clear(Tx, Key),
+            update_watch(JTx, Type),
             ok;
         not_found ->
             {error, not_found}
@@ -421,6 +422,9 @@ encode_data(#{} = JobData) ->
             error({json_encoding_error, Error})
     end.
 
+
+decode_data(not_found) ->
+    not_found;
 
 decode_data(#{} = JobData) ->
     JobData;


### PR DESCRIPTION
Fix the case when a job is removed while there are subscribers waiting for it.
Most of the logic was already there except:

 * Handle the case when when data decoded from subscription results could be
   `not_found`, in that case we just pass that atom back as is.

 * Need to notify the watch when jobs are removed or couch_jobs_notifiers would
   wake up and send notification messages.
