### PR TITLE
Fix incorrect usage of couch_epi in mango plugin

### DIFF
--- a/src/mango/src/mango_plugin.erl
+++ b/src/mango/src/mango_plugin.erl
@@ -24,11 +24,14 @@
 %% ------------------------------------------------------------------
 
 before_find(HttpReq0) ->
-    with_pipe(before_find, [HttpReq0]).
+    [HttpReq1] = with_pipe(before_find, [HttpReq0]),
+    {ok, HttpReq1}.
 
 
 after_find(HttpReq, HttpResp, Arg0) ->
-    with_pipe(after_find, [HttpReq, HttpResp, Arg0]).
+    [_HttpReq, _HttpResp, Arg1] = with_pipe(after_find, [HttpReq, HttpResp, Arg0]),
+    {ok, Arg1}.
+
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions


### PR DESCRIPTION
# Overview

Previously we used the value returned from couch_epi apply as is.
However it returns a list of arguments passed in the same order.

## Testing recommendations

```
./configure --dev && make && make mango-test
```

## Related Issues or Pull Requests

* Fixes https://github.com/apache/couchdb/pull/2767 

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
