### PR TITLE
report changes stats intermittently

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -269,8 +269,9 @@ handle_request_int(MochiReq) ->
 before_request(HttpReq) ->
     ctrace:is_enabled() andalso start_span(HttpReq),
     try
-        chttpd_stats:init(),
-        chttpd_plugin:before_request(HttpReq)
+        {ok, HttpReq1} = chttpd_plugin:before_request(HttpReq),
+        chttpd_stats:init(HttpReq1),
+        {ok, HttpReq1}
     catch Tag:Error ->
         {error, catch_error(HttpReq, Tag, Error)}
     end.
@@ -285,7 +286,7 @@ after_request(HttpReq, HttpResp0) ->
             {ok, HttpResp0#httpd_resp{status = aborted}}
         end,
     HttpResp2 = update_stats(HttpReq, HttpResp1),
-    chttpd_stats:report(HttpReq, HttpResp2),
+    chttpd_stats:report(HttpResp2),
     maybe_log(HttpReq, HttpResp2),
     HttpResp2.
 

--- a/src/chttpd/src/chttpd_stats.erl
+++ b/src/chttpd/src/chttpd_stats.erl
@@ -68,20 +68,18 @@ report(HttpResp) ->
     end.
 
 
+report(HttpResp, #st{reporter = undefined}) ->
+    ok;
+
 report(HttpResp, #st{reporter = Reporter} = St) ->
-    case Reporter of
-        undefined ->
-            ok;
-        ModStr ->
-            Mod = list_to_existing_atom(ModStr),
-            #st{
-                reads = Reads,
-                writes = Writes,
-                rows = Rows,
-                request = HttpReq
-            } = St,
-            Mod:report(HttpReq, HttpResp, Reads, Writes, Rows)
-    end.
+    Mod = list_to_existing_atom(Reporter),
+    #st{
+        reads = Reads,
+        writes = Writes,
+        rows = Rows,
+        request = HttpReq
+    } = St,
+    Mod:report(HttpReq, HttpResp, Reads, Writes, Rows).
 
 
 incr_reads() ->
@@ -130,7 +128,7 @@ maybe_report_intermittent(State) ->
             % Mod:report(HttpReq, HttpResp, Reads, Writes, Rows) should
             % be aware of this. Mod:report should also return a boolean
             % to indicate if reset should occur
-            case report(undefined) of
+            case ?MODULE:report(undefined) of
                 true ->
                     reset_stats(State, CurrentTime);
                 _ ->

--- a/src/chttpd/test/eunit/chttpd_stats_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_stats_tests.erl
@@ -1,0 +1,48 @@
+-module(chttpd_stats_tests).
+
+-define(NODEBUG, ok).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+setup() ->
+    ok = meck:new(chttpd_stats, [unstick, passthrough]),
+    ok = meck:expect(chttpd_stats, report, fun(_) -> ok end).
+
+teardown(_) ->
+    meck:unload(),
+    ok.
+
+
+chttpd_stats_test_() ->
+    {
+        "chttpd_stats tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun test_reset/1
+                ]
+            }
+        }
+    }.
+
+
+test_reset(_) ->
+   config:set_integer("chttpd", "stats_reset_interval", 60),
+   chttpd_stats:init(undefined),
+   chttpd_stats:incr_rows(),
+   State = get(chttpd_stats),
+   ?assertEqual(1, element(4, State)),
+   % force a reset with 0 interval
+   chttpd_stats:update_interval(0),
+   % after this is called, the report should happen and rows should
+   % reset to 0
+   chttpd_stats:incr_rows(),
+   ResetState = get(chttpd_stats),
+   ?_assertEqual(0, element(4, ResetState)).

--- a/src/chttpd/test/eunit/chttpd_stats_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_stats_tests.erl
@@ -14,7 +14,6 @@ stop(_) ->
     ok = application:stop(couch_log).
 
 
-
 setup() ->
     ok = meck:new(chttpd_stats, [passthrough]).
 

--- a/src/chttpd/test/eunit/chttpd_stats_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_stats_tests.erl
@@ -1,14 +1,11 @@
 -module(chttpd_stats_tests).
 
--define(NODEBUG, ok).
-
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
 
 setup() ->
-    ok = meck:new(chttpd_stats, [unstick, passthrough]),
-    ok = meck:expect(chttpd_stats, report, fun(_) -> ok end).
+    ok = meck:new(chttpd_stats, [passthrough]).
 
 teardown(_) ->
     meck:unload(),
@@ -34,15 +31,18 @@ chttpd_stats_test_() ->
 
 
 test_reset(_) ->
-   config:set_integer("chttpd", "stats_reset_interval", 60),
-   chttpd_stats:init(undefined),
-   chttpd_stats:incr_rows(),
-   State = get(chttpd_stats),
-   ?assertEqual(1, element(4, State)),
-   % force a reset with 0 interval
-   chttpd_stats:update_interval(0),
-   % after this is called, the report should happen and rows should
-   % reset to 0
-   chttpd_stats:incr_rows(),
-   ResetState = get(chttpd_stats),
-   ?_assertEqual(0, element(4, ResetState)).
+    ?_test(begin
+        config:set_integer("chttpd", "stats_reporting_interval", 60),
+        ok = meck:expect(chttpd_stats, report, fun(_) -> true end),
+        chttpd_stats:init(undefined),
+        chttpd_stats:incr_rows(),
+        State = get(chttpd_stats),
+        ?assertEqual(1, element(4, State)),
+        % force a reset with 0 interval
+        chttpd_stats:update_interval(0),
+        % after this is called, the report should happen and rows should
+        % reset to 0
+        chttpd_stats:incr_rows(),
+        ResetState = get(chttpd_stats),
+        ?assertEqual(0, element(4, ResetState))
+    end).


### PR DESCRIPTION
## Overview

Stats are reported at the end of a request. With changes feeds,
sometimes this can take a long or never end at all. This allows
stats to be reported when changes are flushed and sent to user.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
