### PR TITLE
Fetch doc in same transaction as _all_doc row

### DIFF
--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -954,7 +954,7 @@ fold_docs(Db, UserFun, UserAcc0, Options) ->
 
                 Row1 = case lists:keyfind(include_docs, 1, Options) of
                     {include_docs, true} ->
-                        Row0 ++ open_json_doc(Db, DocId, OpenOpts, DocOpts);
+                        Row0 ++ open_json_doc(TxDb, DocId, OpenOpts, DocOpts);
                     _ ->
                         Row0
                 end,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Small optimisation: Fetch doc in same transaction as _all_doc row

## Testing recommendations

make check should pass

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
