### PR TITLE
Add fold_docs for DocId list

### DIFF
--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -384,7 +384,7 @@ fetch_docs(Db, Changes) ->
     RevFutures = maps:keys(RevState),
     BodyState = lists:foldl(fun(RevFuture, Acc) ->
         {Id, Change} = maps:get(RevFuture, RevState),
-        Revs = fabric2_fdb:get_winning_revs_wait(Db, RevFuture),
+        Revs = fabric2_fdb:get_revs_wait(Db, RevFuture),
 
         % I'm assuming that in this changes transaction that the winning
         % doc body exists since it is listed in the changes feed as not deleted

--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -1534,7 +1534,7 @@ update_doc_interactive(Db, Doc0, Options) ->
 
 
 update_doc_interactive(Db, Doc0, Future, _Options) ->
-    RevInfos = fabric2_fdb:get_winning_revs_wait(Db, Future),
+    RevInfos = fabric2_fdb:get_revs_wait(Db, Future),
     {Winner, SecondPlace} = case RevInfos of
         [] -> {not_found, not_found};
         [WRI] -> {WRI, not_found};


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Adds a fold_docs function that will fetch the docs for a list of
Doc Id's in parallel. This is used for _all_docs?keys=["id1", "id2"].

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
All existing tests should pass


## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
