### PR TITLE
fix operator issue with empty arrays

### DIFF
--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -406,7 +406,7 @@ negate({[{Field, Cond}]}) ->
 % We need to treat an empty array as always true. This will be applied
 % for $or, $in, $all, $nin as well.
 match({[{<<"$and">>, []}]}, _, _) ->
-    true;
+    false;
 match({[{<<"$and">>, Args}]}, Value, Cmp) ->
     Pred = fun(SubSel) -> match(SubSel, Value, Cmp) end,
     lists:all(Pred, Args);
@@ -421,7 +421,7 @@ match({[{<<"$not">>, Arg}]}, Value, Cmp) ->
     not match(Arg, Value, Cmp);
 
 match({[{<<"$all">>, []}]}, _, _) ->
-    true;
+    false;
 % All of the values in Args must exist in Values or
 % Values == hd(Args) if Args is a single element list
 % that contains a list.

--- a/src/mango/test/21-empty-selector-tests.py
+++ b/src/mango/test/21-empty-selector-tests.py
@@ -35,13 +35,35 @@ def make_empty_selector_suite(klass):
             docs = self.db.find({"age": 22, "$or": []})
             assert len(docs) == 1
 
+        def test_empty_array_in_with_age(self):
+            resp = self.db.find({"age": 22, "company": {"$in": []}}, explain=True)
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find({"age": 22, "company": {"$in": []}})
+            assert len(docs) == 0
+
         def test_empty_array_and_with_age(self):
             resp = self.db.find(
-                {"age": 22, "$and": [{"b": {"$all": []}}]}, explain=True
+                {"age": 22, "$and": []}, explain=True
             )
             self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
             docs = self.db.find({"age": 22, "$and": []})
             assert len(docs) == 1
+
+        def test_empty_array_all_age(self):
+            resp = self.db.find(
+                {"age": 22, "company": {"$all": []}}, explain=True
+            )
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find({"age": 22, "company": {"$all": []}})
+            assert len(docs) == 0
+
+        def test_empty_array_nested_all_with_age(self):
+            resp = self.db.find(
+                {"age": 22, "$and": [{"company": {"$all": []}}]}, explain=True
+            )
+            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
+            docs = self.db.find( {"age": 22, "$and": [{"company": {"$all": []}}]})
+            assert len(docs) == 0
 
         def test_empty_arrays_complex(self):
             resp = self.db.find({"$or": [], "a": {"$in": []}}, explain=True)


### PR DESCRIPTION
Previously, in https://github.com/apache/couchdb/pull/1783, the logic
was wrong in relation to how certain operators interacted with empty
arrays. We modify this logic to make it such that:
```
{"foo":"bar", "bar":{"$in":[]}}
and
{"foo":"bar", "bar":{"$all":[]}}
```
should return 0 results.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
