### PR TITLE
fix: use correct logging module name, fixes #2797 (#2798)

### DIFF
--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -262,7 +262,7 @@ sync_config(Section, Key, Value) ->
         ok ->
             ok;
         error ->
-            log:error("~p sync_admin results ~p errors ~p",
+            couch_log:error("~p sync_admin results ~p errors ~p",
                 [?MODULE, Results, Errors]),
             Reason = "Cluster setup unable to sync admin passwords",
             throw({setup_error, Reason})


### PR DESCRIPTION
Co-authored-by: Joan Touzet <wohali@users.noreply.github.com>