### PR TITLE
Add after_interactive_write plugin to couch_views_updater

### DIFF
--- a/src/couch_views/src/couch_views_epi.erl
+++ b/src/couch_views/src/couch_views_epi.erl
@@ -39,7 +39,9 @@ providers() ->
 
 
 services() ->
-    [].
+    [
+        {couch_views, couch_views_plugin}
+    ].
 
 
 data_subscriptions() ->

--- a/src/couch_views/src/couch_views_plugin.erl
+++ b/src/couch_views/src/couch_views_plugin.erl
@@ -1,0 +1,40 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+
+-module(couch_views_plugin).
+
+
+-export([
+    after_interactive_write/4
+]).
+
+
+-define(SERVICE_ID, couch_views).
+
+
+after_interactive_write(Db, Mrst, Result, DocNumber) ->
+    with_pipe(after_interactive_write, [Db, Mrst, Result, DocNumber]),
+    ok.
+
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+with_pipe(Func, Args) ->
+    do_apply(Func, Args, [pipe]).
+
+
+do_apply(Func, Args, Opts) ->
+    Handle = couch_epi:get_handle(?SERVICE_ID),
+    couch_epi:apply(Handle, ?SERVICE_ID, Func, Args, Opts).

--- a/src/couch_views/src/couch_views_updater.erl
+++ b/src/couch_views/src/couch_views_updater.erl
@@ -86,7 +86,10 @@ write_doc(Db, #doc{deleted = Deleted} = Doc) ->
         case should_index_doc(Doc, Mrst) of
             true ->
                 {Mrst1, Result1} = couch_views_indexer:map_docs(Mrst, Result0),
-                couch_views_indexer:write_docs(Db, Mrst1, Result1, State),
+                DocNumber = couch_views_indexer:write_docs(Db, Mrst1,
+                    Result1, State),
+                couch_views_plugin:after_interactive_write(Db, Mrst1,
+                    Result1, DocNumber),
                 couch_eval:release_map_context(Mrst1#mrst.qserver);
             false ->
                 ok


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Adds an epi plugin to couch_views_updater

## Testing recommendations

all tests should still pass

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
