### PR TITLE
safer binary_to_term in mango_json_bookmark

### DIFF
--- a/src/mango/src/mango_json_bookmark.erl
+++ b/src/mango/src/mango_json_bookmark.erl
@@ -54,7 +54,7 @@ unpack(nil) ->
     nil;
 unpack(Packed) ->
     try
-        Bookmark = binary_to_term(couch_util:decodeBase64Url(Packed)),
+        Bookmark = binary_to_term(couch_util:decodeBase64Url(Packed), [safe]),
         verify(Bookmark)
     catch _:_ ->
         ?MANGO_ERROR({invalid_bookmark, Packed})


### PR DESCRIPTION
## Overview

The safe property prevents creation of new atoms among other things, prudent to have it here.

## Testing recommendations

craft a weird bookmark I guess

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
