### PR TITLE
Report the chttpd_auth authentication db in session info

### DIFF
--- a/src/chttpd/test/eunit/chttpd_session_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_session_tests.erl
@@ -1,0 +1,74 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_session_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include("chttpd_test.hrl").
+
+-define(USER, "chttpd_test_admin").
+-define(PASS, "pass").
+
+
+setup() ->
+    ok = config:delete("chttpd_auth", "authentication_db", _Persist=false),
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, binary_to_list(Hashed), _Persist=false),
+    root_url() ++ "/_session".
+
+
+cleanup(_) ->
+    ok = config:delete("chttpd_auth", "authentication_db", _Persist=false),
+    ok = config:delete("admins", ?USER, _Persist=false).
+
+
+session_test_() ->
+    {
+        "Session tests",
+        {
+            setup,
+            fun() -> test_util:start_couch([fabric, chttpd]) end,
+            fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0,
+                fun cleanup/1,
+                [
+                    ?TDEF_FE(session_authentication_db_absent),
+                    ?TDEF_FE(session_authentication_db_present)
+                ]
+            }
+        }
+    }.
+
+
+session_authentication_db_absent(Url) ->
+    ok = config:delete("chttpd_auth", "authentication_db", _Persist=false),
+    ?assertThrow({not_found, _}, session_authentication_db(Url)).
+
+
+session_authentication_db_present(Url) ->
+    Name = "_users",
+    ok = config:set("chttpd_auth", "authentication_db", Name, false),
+    ?assertEqual(list_to_binary(Name), session_authentication_db(Url)).
+
+
+session_authentication_db(Url) ->
+    {ok, 200, _, Body} = test_request:get(Url, [{basic_auth, {?USER, ?PASS}}]),
+    couch_util:get_nested_json_value(
+        jiffy:decode(Body), [<<"info">>, <<"authentication_db">>]).
+
+
+root_url() ->
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    lists:concat(["http://", Addr, ":", Port]).

--- a/src/chttpd/test/eunit/chttpd_test.hrl
+++ b/src/chttpd/test/eunit/chttpd_test.hrl
@@ -1,0 +1,35 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+
+% Borrowed from fabric2_test.hrl
+
+% Some test modules do not use with, so squash the unused fun compiler warning
+-compile([{nowarn_unused_function, [{with, 1}]}]).
+
+
+-define(TDEF(Name), {atom_to_list(Name), fun Name/1}).
+-define(TDEF(Name, Timeout), {atom_to_list(Name), Timeout, fun Name/1}).
+
+-define(TDEF_FE(Name), fun(Arg) -> {atom_to_list(Name), ?_test(Name(Arg))} end).
+-define(TDEF_FE(Name, Timeout), fun(Arg) -> {atom_to_list(Name), {timeout, Timeout, ?_test(Name(Arg))}} end).
+
+
+with(Tests) ->
+    fun(ArgsTuple) ->
+        lists:map(fun
+            ({Name, Fun}) ->
+                {Name, ?_test(Fun(ArgsTuple))};
+            ({Name, Timeout, Fun}) ->
+                {Name, {timeout, Timeout, ?_test(Fun(ArgsTuple))}}
+        end, Tests)
+    end.

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -355,11 +355,12 @@ handle_session_req(#httpd{method='GET', user_ctx=UserCtx}=Req, _AuthModule) ->
                     {roles, UserCtx#user_ctx.roles}
                 ]}},
                 {info, {[
-                    {authentication_db, ?l2b(config:get("couch_httpd_auth", "authentication_db"))},
                     {authentication_handlers, [
                        N || {N, _Fun} <- Req#httpd.authentication_handlers]}
                 ] ++ maybe_value(authenticated, UserCtx#user_ctx.handler, fun(Handler) ->
                         Handler
+                    end) ++ maybe_value(authentication_db, config:get("chttpd_auth", "authentication_db"), fun(Val) ->
+                        ?l2b(Val)
                     end)}}
             ]})
     end;


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove i.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Currently, result of GET `/_session` reports the `authentication_db` of
the obsolete admin port 5986. This updates it to report the actual db
used for authentication, provided it is configured. Otherwise, it omits
`authentication_db` entirely from the session info.

Backport of https://github.com/apache/couchdb/pull/2813

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make check
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
