### PR TITLE
View is partitioned if db and view are partitioned

### DIFF
--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -252,16 +252,7 @@ set_partitioned(Db, State) ->
     DbPartitioned = couch_db:is_partitioned(Db),
     ViewPartitioned = couch_util:get_value(
             <<"partitioned">>, DesignOpts, DbPartitioned),
-    IsPartitioned = case {DbPartitioned, ViewPartitioned} of
-        {true, true} ->
-            true;
-        {true, false} ->
-            false;
-        {false, false} ->
-            false;
-        _ ->
-            throw({bad_request, <<"invalid partition option">>})
-    end,
+    IsPartitioned = DbPartitioned andalso ViewPartitioned,
     State#mrst{partitioned = IsPartitioned}.
 
 


### PR DESCRIPTION
We've seen a crash if DbPartitioned is false and ViewPartitioned is
true, which is obviously nonsense. The effect of the `nocase` is the
termination of the couch_index_server gen_server, which is a serious
amplification of a small (user-initiated) oddity.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
