### PR TITLE
Remove etag from changes and _list_dbs

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -130,20 +130,11 @@ handle_all_dbs_req(#httpd{method='GET'}=Req) ->
         {skip, Skip}
     ],
 
-    % Eventually the Etag for this request will be derived
-    % from the \xFFmetadataVersion key in fdb
-    Etag = <<"foo">>,
-
-    {ok, Resp} = chttpd:etag_respond(Req, Etag, fun() ->
-        {ok, Resp} = chttpd:start_delayed_json_response(Req, 200, [{"ETag",Etag}]),
-        Callback = fun all_dbs_callback/2,
-        Acc = #vacc{req=Req,resp=Resp},
-        fabric2_db:list_dbs(Callback, Acc, Options)
-    end),
-    case is_record(Resp, vacc) of
-        true -> {ok, Resp#vacc.resp};
-        _ -> {ok, Resp}
-    end;
+    {ok, Resp} = chttpd:start_delayed_json_response(Req, 200, []),
+    Callback = fun all_dbs_callback/2,
+    Acc = #vacc{req=Req,resp=Resp},
+    {ok, Acc1} = fabric2_db:list_dbs(Callback, Acc, Options),
+    {ok, Acc1#vacc.resp};
 handle_all_dbs_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The etag values were hardcoded. Remove them for now until we decide on a way to set the etag's correctly.

## Testing recommendations

All existing tests should pass.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
