### PR TITLE
Change tx timeout and tx retry_limit to be integers

### DIFF
--- a/src/fabric/src/fabric2_server.erl
+++ b/src/fabric/src/fabric2_server.erl
@@ -45,8 +45,8 @@
 -define(TX_OPTIONS_SECTION, "fdb_tx_options").
 -define(RELISTEN_DELAY, 1000).
 
--define(DEFAULT_TIMEOUT_MSEC, "60000").
--define(DEFAULT_RETRY_LIMIT, "100").
+-define(DEFAULT_TIMEOUT_MSEC, 60000).
+-define(DEFAULT_RETRY_LIMIT, 100).
 
 -define(TX_OPTIONS, #{
     machine_id                           => {binary,  undefined},


### PR DESCRIPTION
## Overview

Fix type for tx `timeout` and tx `retry_limit` in `fabric2_server`. Currently the parameters raise invalid errors.

```
[error] 2020-04-28T12:22:11.553416Z node1@127.0.0.1 <0.453.0> -------- fabric2_server : Invalid integer tx option retry_limit = "100"
[error] 2020-04-28T12:22:11.553457Z node1@127.0.0.1 <0.453.0> -------- fabric2_server : Invalid integer tx option timeout = "60000"
```
