### PR TITLE
Suppress offsetof gcc warnings for SM60

### DIFF
--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -122,7 +122,7 @@ end.
         };
     {unix, _} when SMVsn == "60" ->
         {
-            "-DXP_UNIX -I/usr/include/mozjs-60 -I/usr/local/include/mozjs-60 -std=c++14",
+            "-DXP_UNIX -I/usr/include/mozjs-60 -I/usr/local/include/mozjs-60 -std=c++14 -Wno-invalid-offsetof",
             "-L/usr/local/lib -std=c++14 -lmozjs-60 -lm"
         };
     {unix, _} when SMVsn == "68" ->


### PR DESCRIPTION
Mozilla did this years ago:

https://hg.mozilla.org/mozilla-central/rev/41d9d32ab5a7

