### PR TITLE
Re-enable the tx options tests

### DIFF
--- a/src/fabric/test/fabric2_tx_options_tests.erl
+++ b/src/fabric/test/fabric2_tx_options_tests.erl
@@ -20,7 +20,7 @@
 -include("fabric2.hrl").
 
 
-fdb_tx_options_test_DISABLE() ->
+fdb_tx_options_test_() ->
     {
         "Test setting default transaction options",
         setup,


### PR DESCRIPTION
And an extra level of error checking to erlfdb:set_option since it could fail
if we forget to update erlfdb dependency or fdb server version is too old. That
operation can fail with an error:badarg which is exactly how list_to_integer
fails and result in a confusing log message.

