### PR TITLE
Add Ubuntu Focal (20.04) + SM68 to Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .eunit/
 cover/
 core
+debian/
 log
 apache-couchdb-*/
 bin/

--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -33,7 +33,7 @@ mkdir couchdb
 cp ${WORKSPACE}/apache-couchdb-*.tar.gz couchdb
 tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz -C couchdb
 cd couchdb-pkg
-make ${platform} PLATFORM=${platform}
+make
 '''
 
 cleanup_and_save = '''
@@ -417,6 +417,50 @@ pipeline {
           } // post
         } // stage
 
+        stage('Ubuntu Focal') {
+          agent {
+            docker {
+              image 'couchdbdev/ubuntu-focal-erlang-20.3.8.25-1:latest'
+              label 'docker'
+              alwaysPull true
+              args "${DOCKER_ARGS}"
+            }
+          }
+          environment {
+            platform = 'focal'
+            sm_ver = '68'
+          }
+          stages {
+            stage('Build from tarball & test') {
+              steps {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
+              post {
+                always {
+                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
+                }
+              }
+            }
+            stage('Build CouchDB packages') {
+              steps {
+                sh( script: make_packages )
+                sh( script: cleanup_and_save )
+              }
+              post {
+                success {
+                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+                }
+              }
+            }
+          } // stages
+          post {
+            cleanup {
+              sh 'rm -rf ${WORKSPACE}/*'
+            }
+          } // post
+        } // stage
+
         stage('Debian Stretch') {
           agent {
             docker {
@@ -697,11 +741,12 @@ pipeline {
             cp js/debian-stretch/*.deb pkgs/stretch
             reprepro -b couchdb-pkg/repo includedeb stretch pkgs/stretch/*.deb
             cp js/debian-buster/*.deb pkgs/stretch
-            reprepro -b couchdb-pkg/repo includedeb stretch pkgs/buster/*.deb
+            reprepro -b couchdb-pkg/repo includedeb buster pkgs/buster/*.deb
             cp js/ubuntu-xenial/*.deb pkgs/xenial
             reprepro -b couchdb-pkg/repo includedeb xenial pkgs/xenial/*.deb
             cp js/ubuntu-bionic/*.deb pkgs/bionic
             reprepro -b couchdb-pkg/repo includedeb bionic pkgs/bionic/*.deb
+            reprepro -b couchdb-pkg/repo includedeb focal pkgs/focal/*.deb
           '''
 
           echo 'Building CentOS repos...'


### PR DESCRIPTION
## Overview

This PR adds Ubuntu Focal Fossa to our CI build matrix.

Coupled with a [small change to the `couchdb-pkg` repo that's already landed](https://github.com/apache/couchdb-pkg/commit/734ed6467a1f1c0555fd2261abbc24f856f4a8ca), it also simplifies the arguments required for package build down to `make`. Nice!

## Testing recommendations

https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FFullPlatformMatrix/detail/jenkins-fossa-sm68/5/pipeline/275/