### PR TITLE
3.0.x backports verbump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,9 @@ elixir-credo: elixir-init
 .PHONY: javascript
 # target: javascript - Run JavaScript test suites or specific ones defined by suites option
 javascript: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
-javascript: devclean
+javascript: 
+
+	@$(MAKE) devclean
 	@mkdir -p share/www/script/test
 ifeq ($(IN_RELEASE), true)
 	@cp test/javascript/tests/lorem*.txt share/www/script/test/

--- a/Makefile.win
+++ b/Makefile.win
@@ -186,7 +186,7 @@ python-black: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe --check \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
-		build-aux\*.py dev\run test\javascript\run src\mango\test\*.py src\docs\src\conf.py src\docs\ext\*.py .
+		build-aux dev\run test\javascript\run src\mango\test src\docs\src\conf.py src\docs\ext .
 
 python-black-update: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
@@ -194,7 +194,7 @@ python-black-update: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
-		build-aux\*.py dev\run test\javascript\run src\mango\test\*.py src\docs\src\conf.py src\docs\ext\*.py .
+		build-aux dev\run test\javascript\run src\mango\test src\docs\src\conf.py src\docs\ext .
 
 .PHONY: elixir
 elixir: export MIX_ENV=integration

--- a/Makefile.win
+++ b/Makefile.win
@@ -235,7 +235,8 @@ elixir-credo: elixir-init
 .PHONY: javascript
 # target: javascript - Run JavaScript test suites or specific ones defined by suites option
 javascript: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
-javascript: devclean
+javascript:
+	@$(MAKE) devclean
 	-@mkdir share\www\script\test
 ifeq ($(IN_RELEASE), true)
 	@copy test\javascript\tests\lorem*.txt share\www\script\test

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -12,7 +12,7 @@
 
 {sys, [
     {lib_dirs, ["../src"]},
-    {rel, "couchdb", "3.0.0", [
+    {rel, "couchdb", "3.0.1", [
         %% stdlib
         asn1,
         compiler,

--- a/version.mk
+++ b/version.mk
@@ -1,3 +1,3 @@
 vsn_major=3
 vsn_minor=0
-vsn_patch=0
+vsn_patch=1


### PR DESCRIPTION
* Backport of fix for #2852
* Version number bump
* Fix for Windows `python-black*` Makefile targets