### PR TITLE
Fix python-black target for Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -190,7 +190,7 @@ python-black: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe --check \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
-		build-aux\*.py dev\run test\javascript\run src\mango\test\*.py src\docs\src\conf.py src\docs\ext\*.py .
+		build-aux dev\run test\javascript\run src\mango\test src\docs\src\conf.py src\docs\ext .
 
 python-black-update: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
@@ -198,7 +198,7 @@ python-black-update: .venv/bin/black
 	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
-		build-aux\*.py dev\run test\javascript\run src\mango\test\*.py src\docs\src\conf.py src\docs\ext\*.py .
+		build-aux dev\run test\javascript\run src\mango\test src\docs\src\conf.py src\docs\ext .
 
 .PHONY: elixir
 elixir: export MIX_ENV=integration


### PR DESCRIPTION
I really need to get a Windows machine into the CI matrix.

Perhaps we can have it run builds on any branch named `windows-*`. We certainly won't want it to run on every branch.