### PR TITLE
Background database deletion

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -13,6 +13,7 @@
 
 -define(uint2bin(I), binary:encode_unsigned(I, little)).
 -define(bin2uint(I), binary:decode_unsigned(I, little)).
+-define(bin2int(V), binary_to_integer(V)).
 -define(METADATA_VERSION_KEY, <<16#FF, "/metadataVersion">>).
 
 % Prefix Definitions

--- a/src/fabric/src/fabric2_db_expiration.erl
+++ b/src/fabric/src/fabric2_db_expiration.erl
@@ -1,0 +1,246 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_db_expiration).
+
+
+-behaviour(gen_server).
+
+
+-export([
+    start_link/0,
+    cleanup/1,
+    process_expirations/2
+]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("fabric/include/fabric2.hrl").
+
+-define(JOB_TYPE, <<"db_expiration">>).
+-define(JOB_ID, <<"db_expiration_job">>).
+-define(DEFAULT_JOB_Version, 1).
+-define(DEFAULT_RETENTION_SEC, 172800). % 48 hours
+-define(DEFAULT_SCHEDULE_SEC, 3600). % 1 hour
+-define(ERROR_RESCHEDULE_SEC, 5).
+-define(CHECK_ENABLED_SEC, 2).
+-define(JOB_TIMEOUT_SEC, 30).
+
+
+-record(st, {
+    job
+}).
+
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+
+init(_) ->
+    process_flag(trap_exit, true),
+    {ok, #st{job = undefined}, 0}.
+
+
+terminate(_M, _St) ->
+    ok.
+
+
+handle_call(Msg, _From, St) ->
+    {stop, {bad_call, Msg}, {bad_call, Msg}, St}.
+
+
+handle_cast(Msg, St) ->
+    {stop, {bad_cast, Msg}, St}.
+
+
+handle_info(timeout, #st{job = undefined} = St) ->
+    ok = wait_for_couch_jobs_app(),
+    ok = couch_jobs:set_type_timeout(?JOB_TYPE, ?JOB_TIMEOUT_SEC),
+    ok = maybe_add_job(),
+    Pid = spawn_link(?MODULE, cleanup, [is_enabled()]),
+    {noreply, St#st{job = Pid}};
+
+handle_info({'EXIT', Pid, Exit}, #st{job = Pid} = St) ->
+    case Exit of
+        normal -> ok;
+        Error -> couch_log:error("~p : job error ~p", [?MODULE, Error])
+    end,
+    NewPid = spawn_link(?MODULE, cleanup, [is_enabled()]),
+    {noreply, St#st{job = NewPid}};
+
+handle_info(Msg, St) ->
+    {stop, {bad_info, Msg}, St}.
+
+
+code_change(_OldVsn, St, _Extra) ->
+    {ok, St}.
+
+
+wait_for_couch_jobs_app() ->
+    % Because of a circular dependency between couch_jobs and fabric apps, wait
+    % for couch_jobs to initialize before continuing. If we refactor the
+    % commits FDB utilities out we can remove this bit of code.
+    case lists:keysearch(couch_jobs, 1, application:which_applications()) of
+        {value, {couch_jobs, _, _}} ->
+            ok;
+        false ->
+            timer:sleep(100),
+            wait_for_couch_jobs_app()
+    end.
+
+
+maybe_add_job() ->
+    case couch_jobs:get_job_data(undefined, ?JOB_TYPE, job_id()) of
+        {error, not_found} ->
+            Now = erlang:system_time(second),
+            ok = couch_jobs:add(undefined, ?JOB_TYPE, job_id(), #{}, Now);
+        {ok, _JobData} ->
+            ok
+    end.
+
+
+cleanup(false) ->
+    timer:sleep(?CHECK_ENABLED_SEC * 1000),
+    exit(normal);
+
+cleanup(true) ->
+    Now = erlang:system_time(second),
+    ScheduleSec = schedule_sec(),
+    Opts = #{max_sched_time => Now + min(ScheduleSec div 3, 15)},
+    case couch_jobs:accept(?JOB_TYPE, Opts) of
+        {ok, Job, Data} ->
+            try
+                {ok, Job1, Data1} = ?MODULE:process_expirations(Job, Data),
+                ok = resubmit_job(Job1, Data1, schedule_sec())
+            catch
+                _Tag:Error ->
+                    Stack = erlang:get_stacktrace(),
+                    couch_log:error("~p : processing error ~p ~p ~p",
+                        [?MODULE, Job, Error, Stack]),
+                    ok = resubmit_job(Job, Data, ?ERROR_RESCHEDULE_SEC),
+                    exit({job_error, Error, Stack})
+            end;
+        {error, not_found} ->
+            timer:sleep(?CHECK_ENABLED_SEC * 1000),
+            ?MODULE:cleanup(is_enabled())
+    end.
+
+
+resubmit_job(Job, Data, After) ->
+    Now = erlang:system_time(second),
+    SchedTime = Now + After,
+    couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(), fun(JTx) ->
+         {ok, Job1} = couch_jobs:resubmit(JTx, Job, SchedTime),
+         ok = couch_jobs:finish(JTx, Job1, Data)
+    end),
+    ok.
+
+
+process_expirations(#{} = Job, #{} = Data) ->
+    Start = now_sec(),
+    Callback = fun(Value, LastUpdateAt) ->
+        case Value of
+            {meta, _} -> ok;
+            {row, DbInfo} -> process_row(DbInfo);
+            complete -> ok
+        end,
+        {ok, maybe_report_progress(Job, LastUpdateAt)}
+    end,
+    {ok, _Infos} = fabric2_db:list_deleted_dbs_info(
+        Callback,
+        Start,
+        [{restart_tx, true}]
+    ),
+    {ok, Job, Data}.
+
+
+process_row(DbInfo) ->
+    DbName = proplists:get_value(db_name, DbInfo),
+    TimeStamp = proplists:get_value(timestamp, DbInfo),
+    Now = now_sec(),
+    Retention = retention_sec(),
+    Since = Now - Retention,
+    case Since >= timestamp_to_sec(TimeStamp)  of
+        true ->
+            couch_log:notice("Permanently deleting ~p database with"
+                "  timestamp ~p", [DbName, TimeStamp]),
+            ok = fabric2_db:delete(DbName, [{deleted_at, TimeStamp}]);
+        false ->
+            ok
+    end.
+
+
+maybe_report_progress(Job, LastUpdateAt) ->
+    % Update periodically the job so it doesn't expire
+    Now = now_sec(),
+    Progress = #{
+        <<"processed_at">> => Now
+
+    },
+    case (Now - LastUpdateAt) > (?JOB_TIMEOUT_SEC div 2) of
+        true ->
+            couch_jobs:update(undefined, Job, Progress),
+            Now;
+        false ->
+            LastUpdateAt
+    end.
+
+
+job_id() ->
+    JobVersion = job_version(),
+    <<?JOB_ID/binary, "-", JobVersion:16/integer>>.
+
+
+now_sec() ->
+    Now = os:timestamp(),
+    Nowish = calendar:now_to_universal_time(Now),
+    calendar:datetime_to_gregorian_seconds(Nowish).
+
+
+timestamp_to_sec(TimeStamp) ->
+    <<Year:4/binary, "-", Month:2/binary, "-", Day:2/binary,
+        "T",
+        Hour:2/binary, ":", Minutes:2/binary, ":", Second:2/binary,
+        "Z">> = TimeStamp,
+
+    calendar:datetime_to_gregorian_seconds(
+        {{?bin2int(Year), ?bin2int(Month), ?bin2int(Day)},
+            {?bin2int(Hour), ?bin2int(Minutes), ?bin2int(Second)}}
+    ).
+
+
+is_enabled() ->
+    config:get_boolean("couchdb", "db_expiration_enabled", false).
+
+
+job_version() ->
+    config:get_integer("couchdb", "db_expiration_job_version",
+        ?DEFAULT_JOB_Version).
+
+
+retention_sec() ->
+    config:get_integer("couchdb", "db_expiration_retention_sec",
+        ?DEFAULT_RETENTION_SEC).
+
+
+schedule_sec() ->
+    config:get_integer("couchdb", "db_expiration_schedule_sec",
+        ?DEFAULT_SCHEDULE_SEC).

--- a/src/fabric/src/fabric2_sup.erl
+++ b/src/fabric/src/fabric2_sup.erl
@@ -30,7 +30,7 @@ start_link(Args) ->
 
 init([]) ->
     config:enable_feature(fdb),
-    Flags = {one_for_one, 1, 5},
+    Flags = {rest_for_one, 1, 5},
     Children = [
         {
             fabric2_server,
@@ -55,6 +55,14 @@ init([]) ->
             5000,
             worker,
             [fabric2_index]
+        },
+        {
+            fabric2_db_expiration,
+            {fabric2_db_expiration, start_link, []},
+            permanent,
+            5000,
+            worker,
+            [fabric2_db_expiration]
         }
     ],
     ChildrenWithEpi = couch_epi:register_service(fabric2_epi, Children),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Allow to permanently delete those soft-deleted databases under background. In general, the soft-deleted database can be kept from several hours to several days. Later, they need to be deleted to reclaim disk space. So one criteria can be specified to decide how to select which soft-deleted databases to be deleted.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check apps=fabric tests=crud_test_,scheduled_db_remove_error_test_
```
INFO:  Cover compiling /Users/jiangph/fdb/fdb-dbcore-0413/fdb-dbcore/src/couchdb/src/fabric
======================== EUnit ========================
Test scheduled database remove operations
  fabric2_db_crud_tests:77: scheduled_db_remove_error_test_ (scheduled_remove_deleted_dbs_with_error)...[0.026 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 0.082 s]
Test database CRUD operations
  fabric2_db_crud_tests:37: crud_test_ (create_db)...[0.031 s] ok
  fabric2_db_crud_tests:38: crud_test_ (open_db)...[0.015 s] ok
  fabric2_db_crud_tests:39: crud_test_ (delete_db)...[0.023 s] ok
  fabric2_db_crud_tests:40: crud_test_ (recreate_db)...[0.058 s] ok
  fabric2_db_crud_tests:41: crud_test_ (undelete_db)...[0.039 s] ok
  fabric2_db_crud_tests:42: crud_test_ (remove_deleted_db)...[0.044 s] ok
  fabric2_db_crud_tests:43: crud_test_ (scheduled_remove_deleted_db)...[1.312 s] ok
  fabric2_db_crud_tests:44: crud_test_ (scheduled_remove_deleted_dbs)...[2.016 s] ok
  fabric2_db_crud_tests:45: crud_test_ (old_db_handle)...[0.163 s] ok
  fabric2_db_crud_tests:46: crud_test_ (list_dbs)...[0.024 s] ok
  fabric2_db_crud_tests:47: crud_test_ (list_dbs_user_fun)...[0.014 s] ok
  fabric2_db_crud_tests:48: crud_test_ (list_dbs_user_fun_partial)...ok
  fabric2_db_crud_tests:49: crud_test_ (list_dbs_info)...[0.036 s] ok
  fabric2_db_crud_tests:50: crud_test_ (list_dbs_info_partial)...ok
  fabric2_db_crud_tests:51: crud_test_ (list_dbs_tx_too_old)...[0.076 s] ok
  fabric2_db_crud_tests:52: crud_test_ (list_dbs_info_tx_too_old)...[0.772 s] ok
  fabric2_db_crud_tests:53: crud_test_ (list_deleted_dbs_info)...[0.038 s] ok
  fabric2_db_crud_tests:54: crud_test_ (list_deleted_dbs_info_user_fun)...[0.026 s] ok
  fabric2_db_crud_tests:55: crud_test_ (list_deleted_dbs_info_user_fun_partial)...ok
  fabric2_db_crud_tests:56: crud_test_ (list_deleted_dbs_info_with_timestamps)...[2.284 s] ok
  fabric2_db_crud_tests:57: crud_test_ (get_info_wait_retry_on_tx_too_old)...[0.081 s] ok
  fabric2_db_crud_tests:58: crud_test_ (get_info_wait_retry_on_tx_abort)...[0.080 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 8.509 s]
=======================================================
  All 23 tests passed.
Cover analysis: /Users/jiangph/fdb/fdb-dbcore-0413/fdb-dbcore/src/couchdb/src/fabric/.eunit/index.html
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
