### PR TITLE
add test to make sure type <<"text">> design docs are ignored

### DIFF
--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -246,6 +246,14 @@ class IndexSelectorJson(mango.DbPerClass):
         docs = self.db.find(selector, use_index="oldschooltext")
         self.assertEqual(len(docs), 3)
 
+    def test_text_old_index_not_used(self):
+        selector = {"location": {"$gte": "FRA"}}
+        self.db.save_doc(oldschoolddoctext)
+        resp = self.db.find(selector, explain=True)
+        self.assertEqual(resp["index"]["name"], "_all_docs")
+        docs = self.db.find(selector)
+        self.assertEqual(len(docs), 3)
+
     @unittest.skipUnless(mango.has_text_service(), "requires text service")
     def test_text_old_selector_still_supported_via_api(self):
         selector = {"location": {"$gte": "FRA"}}


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Design docs using type <<"text">> (either via replication or traditional POST)should be ignored.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
