### PR TITLE
Convert aegis key cach to LRU with hard expiration time

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -764,3 +764,16 @@ opts = #{budget => 100, target => 2500, window => 60000, sensitivity => 1000}
 ; performance. This value must be at least 10000 and cannot be set to higher than
 ; 10000000, the default transaction size limit.
 ;size_limit = 10000000
+
+[aegis]
+; The maximum number of entries in the key cache.
+; Once the limit reached the least recently used entries are eviceted.
+;cache_limit = 100000
+
+; The period in seconds for how long each entry kept in cache.
+; This is not affected by access time, i.e. the keys are always removed
+; once expired and re-fetched on a next encrypt/decrypt operation.
+;cache_max_age_sec = 1800
+
+; The interval in seconds of how often the expiration check runs.
+;cache_expiration_check_sec = 10

--- a/src/fabric/src/fabric2_util.erl
+++ b/src/fabric/src/fabric2_util.erl
@@ -41,6 +41,7 @@
     all_docs_view_opts/1,
 
     iso8601_timestamp/0,
+    now/1,
     do_recovery/0,
 
     pmap/2,
@@ -346,6 +347,13 @@ iso8601_timestamp() ->
         calendar:now_to_datetime(Now),
     Format = "~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0BZ",
     io_lib:format(Format, [Year, Month, Date, Hour, Minute, Second]).
+
+
+now(ms) ->
+    {Mega, Sec, Micro} = os:timestamp(),
+    (Mega * 1000000 + Sec) * 1000 + round(Micro / 1000);
+now(sec) ->
+    now(ms) div 1000.
 
 
 do_recovery() ->


### PR DESCRIPTION
## Overview

This converts aegis's key cache into LRU with hard expiration time.

The cache evicts the least recently used entries when number of entries in the cache exceeds "cache_limit" parameter with default set to 100000.

Additionally keys removed once their lifetime exceeds "cache_max_age_sec" parameter with default set to 30 minutes.

## Testing recommendations

` make eunit apps=aegis suites=aegis_server_test tests=lru_cache_with_expiration_test_`

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
