### PR TITLE
Fix couch_views updater_running info result

### DIFF
--- a/src/couch_views/src/couch_views_jobs.erl
+++ b/src/couch_views/src/couch_views_jobs.erl
@@ -16,7 +16,8 @@
     set_timeout/0,
     build_view/3,
     build_view_async/2,
-    remove/2
+    remove/2,
+    job_state/2
 ]).
 
 -ifdef(TEST).
@@ -65,6 +66,11 @@ remove(TxDb, Sig) ->
     DbName = fabric2_db:name(TxDb),
     JobId = job_id(DbName, Sig),
     couch_jobs:remove(TxDb, ?INDEX_JOB_TYPE, JobId).
+
+
+job_state(#{} = TxDb, #mrst{} = Mrst) ->
+    JobId = job_id(TxDb, Mrst),
+    couch_jobs:get_job_state(TxDb, ?INDEX_JOB_TYPE, JobId).
 
 
 ensure_correct_tx(#{tx := undefined} = TxDb) ->


### PR DESCRIPTION
Previously we always returned `false` because the result from `couch_jobs:get_job_state` was expected to be just `Status`, but it is `{ok, Status}`. That part is now explicit so we account for every possible job state and would fail on a clause match if we get something else there.

Moved `job_state/2` function to `couch_view_jobs` to avoid duplicating the logic on how to calculate job_id and keep it all in one module.

Tests were updated to explicitly check for each state job state.