### PR TITLE
Add aegis info to db_info

### DIFF
--- a/src/aegis/src/aegis.erl
+++ b/src/aegis/src/aegis.erl
@@ -20,6 +20,7 @@
 -export([
     init_db/2,
     open_db/1,
+    get_db_info/1,
 
     decrypt/2,
     decrypt/3,
@@ -37,6 +38,10 @@ open_db(#{} = Db) ->
     Db#{
         is_encrypted => aegis_server:open_db(Db)
     }.
+
+
+get_db_info(#{} = Db) ->
+    ?AEGIS_KEY_MANAGER:get_db_info(Db).
 
 
 encrypt(#{} = _Db, _Key, <<>>) ->

--- a/src/aegis/src/aegis_key_manager.erl
+++ b/src/aegis/src/aegis_key_manager.erl
@@ -20,3 +20,6 @@
 
 
 -callback open_db(Db :: #{}) -> {ok, binary()} | false.
+
+
+-callback get_db_info(Db :: #{}) -> list().

--- a/src/aegis/src/aegis_noop_key_manager.erl
+++ b/src/aegis/src/aegis_noop_key_manager.erl
@@ -18,7 +18,8 @@
 
 -export([
     init_db/2,
-    open_db/1
+    open_db/1,
+    get_db_info/1
 ]).
 
 
@@ -29,3 +30,7 @@ init_db(#{} = _Db, _Options) ->
 
 open_db(#{} = _Db) ->
     false.
+
+
+get_db_info(#{} = _Db) ->
+    [{encrypted, false}].

--- a/src/fabric/test/fabric2_db_crud_tests.erl
+++ b/src/fabric/test/fabric2_db_crud_tests.erl
@@ -631,7 +631,7 @@ get_info_wait_retry_on_tx_too_old(_) ->
         ok = erlfdb:set_option(Tx, disallow_writes),
 
         InfoF = fabric2_fdb:get_info_future(Tx, DbPrefix),
-        {info_future, _, _, ChangesF, _, _} = InfoF,
+        {info_future, _, _, ChangesF, _, _, _} = InfoF,
 
         raise_in_erlfdb_wait(ChangesF, {erlfdb_error, 1007}, 3),
         ?assertError({erlfdb_error, 1007}, fabric2_fdb:get_info_wait(InfoF)),
@@ -659,7 +659,7 @@ get_info_wait_retry_on_tx_abort(_)->
         ok = erlfdb:set_option(Tx, disallow_writes),
 
         InfoF = fabric2_fdb:get_info_future(Tx, DbPrefix),
-        {info_future, _, _, ChangesF, _, _} = InfoF,
+        {info_future, _, _, ChangesF, _, _, _} = InfoF,
 
         raise_in_erlfdb_wait(ChangesF, {erlfdb_error, 1025}, 3),
         ?assertError({erlfdb_error, 1025}, fabric2_fdb:get_info_wait(InfoF)),


### PR DESCRIPTION
## Overview

This adds a function `get_db_info/1` to aegis key manager behaviour that allows to supply db_info with aegis specific information
