### PR TITLE
allow configurability of JWT claims that require a value

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -142,7 +142,9 @@ max_db_number_for_dbs_info_req = 100
 
 ;[jwt_auth]
 ; List of claims to validate
-; required_claims =
+; can be the name of a claim like "exp" or a tuple if the claim requires
+; a parameter
+; required_claims = exp, {iss, "IssuerNameHere"}
 ;
 ; [jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -931,6 +931,8 @@ error_info({error, {illegal_database_name, Name}}) ->
     {400, <<"illegal_database_name">>, Message};
 error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
+error_info({misconfigured_server, Reason}) ->
+    {500, <<"misconfigured_server">>, couch_util:to_binary(Reason)};
 error_info({Error, Reason}) ->
     {500, couch_util:to_binary(Error), couch_util:to_binary(Reason)};
 error_info(Error) ->

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -209,12 +209,21 @@ jwt_authentication_handler(Req) ->
 
 get_configured_claims() ->
     Claims = config:get("jwt_auth", "required_claims", ""),
-    case re:split(Claims, "\s*,\s*", [{return, list}]) of
-        [[]] ->
-            []; %% if required_claims is the empty string.
-        List ->
-            [list_to_existing_atom(C) || C <- List]
+    Re = "((?<key1>[a-z]+)|{(?<key2>[a-z]+)\s*,\s*\"(?<val>[^\"]+)\"})",
+    case re:run(Claims, Re, [global, {capture,  [key1, key2, val], binary}]) of
+        nomatch when Claims /= "" ->
+            couch_log:error("[jwt_auth] required_claims is set to an invalid value.", []),
+            throw({misconfigured_server, <<"JWT is not configured correctly">>});
+        nomatch ->
+            [];
+        {match, Matches} ->
+            lists:map(fun to_claim/1, Matches)
     end.
+
+to_claim([Key, <<>>, <<>>]) ->
+    binary_to_atom(Key, latin1);
+to_claim([<<>>, Key, Value]) ->
+    {binary_to_atom(Key, latin1), Value}.
 
 cookie_authentication_handler(Req) ->
     cookie_authentication_handler(Req, couch_auth_cache).


### PR DESCRIPTION
e.g;

[jwt]
required_claims = {iss, "hello"}

fixes https://github.com/apache/couchdb/issues/2886