### PR TITLE
Add batching for _bulk_docs

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -152,7 +152,7 @@ DepDescs = [
 %% Independent Apps
 {config,           "config",           {tag, "2.1.7"}},
 {b64url,           "b64url",           {tag, "1.0.2"}},
-{erlfdb,           "erlfdb",           {tag, "v1.2.0"}},
+{erlfdb,           "erlfdb",           {tag, "v1.2.1"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.4"}},

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -242,6 +242,9 @@ port = 6984
 ;
 ; Byte size of binary chunks written to FDB values. Defaults to FDB max limit.
 ;binary_chunk_size = 100000
+;
+; Bulk docs transaction batch size in bytes
+;update_docs_batch_size = 5000000
 
 ; [rexi]
 ; buffer_count = 2000

--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -75,6 +75,8 @@
 
     new_versionstamp/1,
 
+    get_approximate_tx_size/1,
+
     debug_cluster/0,
     debug_cluster/2
 ]).
@@ -1157,6 +1159,12 @@ next_vs({versionstamp, VS, Batch, TxId}) ->
 new_versionstamp(Tx) ->
     TxId = erlfdb:get_next_tx_id(Tx),
     {versionstamp, 16#FFFFFFFFFFFFFFFF, 16#FFFF, TxId}.
+
+
+get_approximate_tx_size(#{} = TxDb) ->
+    require_transaction(TxDb),
+    #{tx := Tx} = TxDb,
+    erlfdb:wait(erlfdb:get_approximate_size(Tx)).
 
 
 debug_cluster() ->

--- a/src/fabric/test/fabric2_update_docs_tests.erl
+++ b/src/fabric/test/fabric2_update_docs_tests.erl
@@ -1,0 +1,222 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_update_docs_tests).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("fabric2_test.hrl").
+
+
+update_docs_test_() ->
+    {
+        "Test update_docs",
+        {
+            setup,
+            fun setup_all/0,
+            fun teardown_all/1,
+            {
+                foreach,
+                fun setup/0,
+                fun cleanup/1,
+                [
+                    ?TDEF_FE(update_docs),
+                    ?TDEF_FE(update_docs_replicated),
+                    ?TDEF_FE(update_docs_batches),
+                    ?TDEF_FE(update_docs_replicated_batches),
+                    ?TDEF_FE(update_docs_duplicate_ids_conflict),
+                    ?TDEF_FE(update_docs_duplicate_ids_with_batches),
+                    ?TDEF_FE(update_docs_replicate_batches_duplicate_id)
+                ]
+            }
+        }
+    }.
+
+
+setup_all() ->
+    test_util:start_couch([fabric]).
+
+
+teardown_all(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+
+setup() ->
+    {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),
+    meck:new(erlfdb, [passthrough]),
+    Db.
+
+
+cleanup(#{} = Db) ->
+    meck:unload(),
+    ok = fabric2_db:delete(fabric2_db:name(Db), []).
+
+
+update_docs(Db) ->
+    ?assertEqual({ok, []}, fabric2_db:update_docs(Db, [])),
+
+    Doc1 = doc(),
+    Res1 = fabric2_db:update_docs(Db, [Doc1]),
+    ?assertMatch({ok, [_]}, Res1),
+    {ok, [Doc1Res]} = Res1,
+    ?assertMatch({ok, {1, <<_/binary>>}}, Doc1Res),
+    {ok, {1, Rev1}} = Doc1Res,
+    {ok, Doc1Open} = fabric2_db:open_doc(Db, Doc1#doc.id),
+    ?assertEqual(Doc1#doc{revs = {1, [Rev1]}}, Doc1Open),
+
+    Doc2 = doc(),
+    Doc3 = doc(),
+    Res2 = fabric2_db:update_docs(Db, [Doc2, Doc3]),
+    ?assertMatch({ok, [_, _]}, Res2),
+    {ok, [Doc2Res, Doc3Res]} = Res2,
+    ?assertMatch({ok, {1, <<_/binary>>}}, Doc2Res),
+    ?assertMatch({ok, {1, <<_/binary>>}}, Doc3Res).
+
+
+update_docs_replicated(Db) ->
+    Opts = [replicated_changes],
+
+    ?assertEqual({ok, []}, fabric2_db:update_docs(Db, [], Opts)),
+
+    Doc1 = doc(10, {1, [rev()]}),
+    ?assertMatch({ok, []}, fabric2_db:update_docs(Db, [Doc1], Opts)),
+    {ok, Doc1Open} = fabric2_db:open_doc(Db, Doc1#doc.id),
+    ?assertEqual(Doc1, Doc1Open),
+
+    Doc2 = doc(10, {1, [rev()]}),
+    Doc3 = doc(10, {1, [rev()]}),
+    ?assertMatch({ok, []}, fabric2_db:update_docs(Db, [Doc2, Doc3], Opts)),
+    {ok, Doc2Open} = fabric2_db:open_doc(Db, Doc2#doc.id),
+    ?assertEqual(Doc2, Doc2Open),
+    {ok, Doc3Open} = fabric2_db:open_doc(Db, Doc3#doc.id),
+    ?assertEqual(Doc3, Doc3Open).
+
+
+update_docs_batches(Db) ->
+    Opts = [{batch_size, 5000}],
+
+    Docs1 = [doc(9000), doc(9000)],
+
+    meck:reset(erlfdb),
+    ?assertMatch({ok, [_ | _]}, fabric2_db:update_docs(Db, Docs1, Opts)),
+    ?assertEqual(2, meck:num_calls(erlfdb, transactional, 2)),
+
+    lists:foreach(fun(#doc{} = Doc) ->
+        ?assertMatch({ok, #doc{}}, fabric2_db:open_doc(Db, Doc#doc.id))
+    end, Docs1),
+
+    Docs2 = [doc(10), doc(10), doc(9000), doc(10)],
+
+    meck:reset(erlfdb),
+    ?assertMatch({ok, [_ | _]}, fabric2_db:update_docs(Db, Docs2, Opts)),
+    ?assertEqual(2, meck:num_calls(erlfdb, transactional, 2)),
+
+    lists:foreach(fun(#doc{} = Doc) ->
+        ?assertMatch({ok, #doc{}}, fabric2_db:open_doc(Db, Doc#doc.id))
+    end, Docs2).
+
+
+update_docs_replicated_batches(Db) ->
+    Opts = [{batch_size, 5000}, replicated_changes],
+
+    Docs1 = [doc(Size, {1, [rev()]}) || Size <- [9000, 9000]],
+
+    meck:reset(erlfdb),
+    ?assertMatch({ok, []}, fabric2_db:update_docs(Db, Docs1, Opts)),
+    ?assertEqual(2, meck:num_calls(erlfdb, transactional, 2)),
+
+    lists:foreach(fun(#doc{} = Doc) ->
+        ?assertEqual({ok, Doc}, fabric2_db:open_doc(Db, Doc#doc.id))
+    end, Docs1),
+
+    Docs2 = [doc(Size, {1, [rev()]}) || Size <- [10, 10, 9000, 10]],
+
+    meck:reset(erlfdb),
+    ?assertMatch({ok, []}, fabric2_db:update_docs(Db, Docs2, Opts)),
+    ?assertEqual(2, meck:num_calls(erlfdb, transactional, 2)),
+
+    lists:foreach(fun(#doc{} = Doc) ->
+        ?assertEqual({ok, Doc}, fabric2_db:open_doc(Db, Doc#doc.id))
+    end, Docs2).
+
+
+update_docs_duplicate_ids_conflict(Db) ->
+    Doc = doc(),
+
+    Res = fabric2_db:update_docs(Db, [Doc, doc(), Doc]),
+    ?assertMatch({ok, [_, _, _]}, Res),
+
+    {ok, [Doc1Res, Doc2Res, Doc3Res]} = Res,
+    ?assertMatch({ok, {1, <<_/binary>>}}, Doc1Res),
+    ?assertMatch({ok, {1, <<_/binary>>}}, Doc2Res),
+    ?assertMatch(conflict, Doc3Res).
+
+
+update_docs_duplicate_ids_with_batches(Db) ->
+    Opts = [{batch_size, 5000}],
+
+    Doc = doc(9000),
+
+    meck:reset(erlfdb),
+    Res = fabric2_db:update_docs(Db, [Doc, doc(9000), Doc], Opts),
+    ?assertMatch({ok, [_, _, _]}, Res),
+    ?assertEqual(3, meck:num_calls(erlfdb, transactional, 2)),
+
+    {ok, [Doc1Res, Doc2Res, Doc3Res]} = Res,
+    ?assertMatch({ok, {1, <<_/binary>>}}, Doc1Res),
+    ?assertMatch({ok, {1, <<_/binary>>}}, Doc2Res),
+    ?assertMatch(conflict, Doc3Res).
+
+
+update_docs_replicate_batches_duplicate_id(Db) ->
+    Opts = [replicated_changes],
+
+    Doc = doc(10, {1, [rev()]}),
+    Docs = [Doc, Doc],
+
+    meck:reset(erlfdb),
+    ?assertMatch({ok, []}, fabric2_db:update_docs(Db, Docs, Opts)),
+    ?assertEqual(2, meck:num_calls(erlfdb, transactional, 2)),
+
+    ?assertEqual({ok, Doc}, fabric2_db:open_doc(Db, Doc#doc.id)).
+
+
+% Utility functions
+
+doc() ->
+    doc(2).
+
+
+doc(Size) ->
+    doc(Size, undefined).
+
+
+doc(Size, Revs) ->
+    Doc = #doc{
+        id = fabric2_util:uuid(),
+        body = doc_body(Size)
+    },
+    case Revs of
+        undefined -> Doc;
+        _ -> Doc#doc{revs = Revs}
+    end.
+
+
+rev() ->
+    fabric2_util:to_hex(crypto:strong_rand_bytes(16)).
+
+
+doc_body(Size) when is_integer(Size), Size >= 2 ->
+    Val = fabric2_util:to_hex(crypto:strong_rand_bytes(Size div 2)),
+    {[{<<"x">>, Val}]}.


### PR DESCRIPTION
Bulk docs transaction batching

 * Interactive (regular) requests are split into smaller transactions, so
   larger updates won't fail with either timeout so or transaction too large
   FDB errors.

 * Non-interactive (replicated) requests can now batch their updates in a few
   transaction and gain extra performance.

Batch size is configurable:
```
[fabric]
update_docs_batch_size = 5000000
```