### PR TITLE
Fix handling of limit query parameter

### DIFF
--- a/src/chttpd/test/exunit/pagination_test.exs
+++ b/src/chttpd/test/exunit/pagination_test.exs
@@ -384,6 +384,55 @@ defmodule Couch.Test.Pagination do
       assert resp.status_code == 200, "got error #{inspect(resp.body)}"
     end
 
+    test ": _all_docs?page_size=4 should respect limit", ctx do
+      %{session: session, db_name: db_name} = ctx
+
+      resp =
+        Couch.Session.get(session, "/#{db_name}/_all_docs",
+          query: %{page_size: ctx.page_size, limit: ctx.page_size - 2}
+        )
+
+      assert resp.status_code == 200, "got error #{inspect(resp.body)}"
+      assert length(resp.body["rows"]) == ctx.page_size - 2
+      assert not Map.has_key?(resp.body, "next")
+
+      resp =
+        Couch.Session.get(session, "/#{db_name}/_all_docs",
+          query: %{page_size: ctx.page_size, limit: ctx.page_size - 1}
+        )
+
+      assert resp.status_code == 200, "got error #{inspect(resp.body)}"
+      assert length(resp.body["rows"]) == ctx.page_size - 1
+      assert not Map.has_key?(resp.body, "next")
+
+      resp =
+        Couch.Session.get(session, "/#{db_name}/_all_docs",
+          query: %{page_size: ctx.page_size, limit: ctx.page_size}
+        )
+
+      assert resp.status_code == 200, "got error #{inspect(resp.body)}"
+      assert length(resp.body["rows"]) == ctx.page_size
+      assert not Map.has_key?(resp.body, "next")
+
+      resp =
+        Couch.Session.get(session, "/#{db_name}/_all_docs",
+          query: %{page_size: ctx.page_size, limit: ctx.page_size + 1}
+        )
+
+      assert resp.status_code == 200, "got error #{inspect(resp.body)}"
+      assert length(resp.body["rows"]) == ctx.page_size
+      assert Map.has_key?(resp.body, "next")
+
+      resp =
+        Couch.Session.get(session, "/#{db_name}/_all_docs",
+          query: %{page_size: ctx.page_size, limit: ctx.page_size + 2}
+        )
+
+      assert resp.status_code == 200, "got error #{inspect(resp.body)}"
+      assert length(resp.body["rows"]) == ctx.page_size
+      assert Map.has_key?(resp.body, "next")
+    end
+
     test ": _all_docs/queries should limit number of queries", ctx do
       queries = %{
         queries: [%{}, %{}, %{}, %{}, %{}]


### PR DESCRIPTION
## Overview

This PR fixes a one off problem when limit is given in query parameter and it's value is less than page_size.

## Testing recommendations

```
make eunit apps=couch_views tests=check_completion_test
make exunit tests=src/chttpd/test/exunit/pagination_test.exs
```

## Related Issues or Pull Requests

* fixes https://github.com/apache/couchdb/pull/2870

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
