### PR TITLE
Improve log of permanently deleting databases

### DIFF
--- a/src/fabric/src/fabric2_db_expiration.erl
+++ b/src/fabric/src/fabric2_db_expiration.erl
@@ -180,8 +180,8 @@ process_row(DbInfo) ->
     Since = Now - Retention,
     case Since >= timestamp_to_sec(TimeStamp)  of
         true ->
-            couch_log:notice("Permanently deleting ~p database with"
-                "  timestamp ~p", [DbName, TimeStamp]),
+            couch_log:notice("Permanently deleting ~s database with"
+                " timestamp ~s", [DbName, TimeStamp]),
             ok = fabric2_db:delete(DbName, [{deleted_at, TimeStamp}]);
         false ->
             ok


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Improve log of permanently deleting databases. The log will be changed to `[notice] 2020-05-21T02:52:44.925392Z nonode@nohost <0.1820.0> -------- Permanently deleting eunit-test-db-1003fd212922d7dec0d25876feacf194 database with timestamp 2020-05-21T02:52:43Z`

## Testing recommendations
make check apps=fabric tests=crud_test_,scheduled_db_remove_error_test_

```
Test scheduled database remove operations
  fabric2_db_crud_tests:77: scheduled_db_remove_error_test_ (scheduled_remove_deleted_dbs_with_error)...[0.049 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 0.109 s]
Test database CRUD operations
  fabric2_db_crud_tests:37: crud_test_ (create_db)...[0.027 s] ok
  fabric2_db_crud_tests:38: crud_test_ (open_db)...[0.015 s] ok
  fabric2_db_crud_tests:39: crud_test_ (delete_db)...[0.021 s] ok
  fabric2_db_crud_tests:40: crud_test_ (recreate_db)...[0.062 s] ok
  fabric2_db_crud_tests:41: crud_test_ (undelete_db)...[0.037 s] ok
  fabric2_db_crud_tests:42: crud_test_ (remove_deleted_db)...[0.041 s] ok
  fabric2_db_crud_tests:43: crud_test_ (scheduled_remove_deleted_db)...[1.347 s] ok
  fabric2_db_crud_tests:44: crud_test_ (scheduled_remove_deleted_dbs)...[2.015 s] ok
  fabric2_db_crud_tests:45: crud_test_ (old_db_handle)...[0.163 s] ok
  fabric2_db_crud_tests:46: crud_test_ (list_dbs)...[0.023 s] ok
  fabric2_db_crud_tests:47: crud_test_ (list_dbs_user_fun)...[0.014 s] ok
  fabric2_db_crud_tests:48: crud_test_ (list_dbs_user_fun_partial)...ok
  fabric2_db_crud_tests:49: crud_test_ (list_dbs_info)...[0.033 s] ok
  fabric2_db_crud_tests:50: crud_test_ (list_dbs_info_partial)...ok
  fabric2_db_crud_tests:51: crud_test_ (list_dbs_tx_too_old)...[0.173 s] ok
  fabric2_db_crud_tests:52: crud_test_ (list_dbs_info_tx_too_old)...[0.755 s] ok
  fabric2_db_crud_tests:53: crud_test_ (list_deleted_dbs_info)...[0.031 s] ok
  fabric2_db_crud_tests:54: crud_test_ (list_deleted_dbs_info_user_fun)...[0.030 s] ok
  fabric2_db_crud_tests:55: crud_test_ (list_deleted_dbs_info_user_fun_partial)...ok
  fabric2_db_crud_tests:56: crud_test_ (list_deleted_dbs_info_with_timestamps)...[2.301 s] ok
  fabric2_db_crud_tests:57: crud_test_ (get_info_wait_retry_on_tx_too_old)...[0.097 s] ok
  fabric2_db_crud_tests:58: crud_test_ (get_info_wait_retry_on_tx_abort)...[0.112 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 8.626 s]
=======================================================
  All 23 tests passed.
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->
https://github.com/apache/couchdb/pull/2857

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
