### PR TITLE
Improve load handling in couch_jobs and couch_views

### DIFF
--- a/src/couch_jobs/src/couch_jobs_activity_monitor.erl
+++ b/src/couch_jobs/src/couch_jobs_activity_monitor.erl
@@ -65,7 +65,14 @@ handle_cast(Msg, St) ->
 
 
 handle_info(check_activity, St) ->
-    St1 = check_activity(St),
+    St1 = try
+        check_activity(St)
+    catch
+        {error, {erlfdb_error, 1020}} ->
+            LogMsg = "~p : type:~p got 1020 error, possibly from overload",
+            couch_log:error(LogMsg, [?MODULE, St#st.type]),
+            St
+    end,
     St2 = schedule_check(St1),
     {noreply, St2};
 

--- a/src/couch_views/src/couch_views_jobs.erl
+++ b/src/couch_views/src/couch_views_jobs.erl
@@ -31,7 +31,7 @@
 
 
 set_timeout() ->
-    couch_jobs:set_type_timeout(?INDEX_JOB_TYPE, 6).
+    couch_jobs:set_type_timeout(?INDEX_JOB_TYPE, 26).
 
 
 build_view(TxDb, Mrst, UpdateSeq) ->


### PR DESCRIPTION
Increase couch_views job timeout by 20 seconds. This will set a larger jitter
when multiple nodes concurrently check and re-enqueue jobs. It would reduce the
chance of them bumping into each other and conflicting.

If they do conflict in activity monitor, catch the error and emit an error log.
We gain some more robustness under load for a longer timeout for jobs with
workers that have suddenly died getting re-enqueued.
