### PR TITLE
3.x backport - Port rev_stemming into elixir test suite

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -87,7 +87,7 @@ X means done, - means partially
   - [ ] Port replicator_db_update_security.js
   - [ ] Port replicator_db_user_ctx.js
   - [ ] Port replicator_db_write_auth.js
-  - [ ] Port rev_stemming.js
+  - [X] Port rev_stemming.js
   - [X] Port rewrite.js
   - [ ] Port rewrite_js.js
   - [X] Port security_validation.js

--- a/test/elixir/test/auth_cache_test.exs
+++ b/test/elixir/test/auth_cache_test.exs
@@ -66,14 +66,6 @@ defmodule AuthCacheTest do
     sess
   end
 
-  defp wait_until_compact_complete(db_name) do
-    retry_until(
-      fn -> Map.get(info(db_name), "compact_running") == false end,
-      200,
-      10_000
-    )
-  end
-
   defp assert_cache(event, user, password, expect \\ :expect_login_success) do
     hits_before = hits()
     misses_before = misses()
@@ -110,12 +102,6 @@ defmodule AuthCacheTest do
       _ ->
         assert false
     end
-  end
-
-  defp compact(db_name) do
-    resp = Couch.post("/#{db_name}/_compact")
-    assert resp.status_code == 202
-    resp.body
   end
 
   def save_doc(db_name, body) do
@@ -206,7 +192,6 @@ defmodule AuthCacheTest do
     # there was a cache hit
     assert_cache(:expect_hit, "johndoe", "123456")
     compact(db_name)
-    wait_until_compact_complete(db_name)
     assert_cache(:expect_hit, "johndoe", "123456")
   end
 end

--- a/test/elixir/test/compact_test.exs
+++ b/test/elixir/test/compact_test.exs
@@ -82,18 +82,6 @@ defmodule CompactTest do
     assert Couch.post("/#{db}/_ensure_full_commit").body["ok"] == true
   end
 
-  defp compact(db) do
-    assert Couch.post("/#{db}/_compact").status_code == 202
-
-    retry_until(
-      fn ->
-        Couch.get("/#{db}").body["compact_running"] == false
-      end,
-      200,
-      20_000
-    )
-  end
-
   defp get_info(db) do
     Couch.get("/#{db}").body
   end

--- a/test/elixir/test/partition_size_limit_test.exs
+++ b/test/elixir/test/partition_size_limit_test.exs
@@ -68,18 +68,6 @@ defmodule PartitionSizeLimitTest do
     assert resp.status_code in [201, 202]
   end
 
-  defp compact(db) do
-    assert Couch.post("/#{db}/_compact").status_code == 202
-
-    retry_until(
-      fn ->
-        Couch.get("/#{db}").body["compact_running"] == false
-      end,
-      200,
-      20_000
-    )
-  end
-
   test "fill partition manually", context do
     db_name = context[:db_name]
     partition = "foo"

--- a/test/elixir/test/replication_test.exs
+++ b/test/elixir/test/replication_test.exs
@@ -7,7 +7,6 @@ defmodule ReplicationTest do
   """
 
   # TODO: Parameterize these
-  @admin_account "adm:pass"
   @db_pairs_prefixes [
     {"remote-to-remote", "http://127.0.0.1:15984/", "http://127.0.0.1:15984/"}
   ]
@@ -1584,30 +1583,6 @@ defmodule ReplicationTest do
     resp.body
   end
 
-  def replicate(src, tgt, options \\ []) do
-    {userinfo, options} = Keyword.pop(options, :userinfo)
-
-    userinfo =
-      if userinfo == nil do
-        @admin_account
-      else
-        userinfo
-      end
-
-    src = set_user(src, userinfo)
-    tgt = set_user(tgt, userinfo)
-
-    defaults = [headers: [], body: %{}, timeout: 30_000]
-    options = defaults |> Keyword.merge(options) |> Enum.into(%{})
-
-    %{body: body} = options
-    body = [source: src, target: tgt] |> Enum.into(body)
-    options = Map.put(options, :body, body)
-
-    resp = Couch.post("/_replicate", Enum.to_list(options))
-    assert HTTPotion.Response.success?(resp), "#{inspect(resp)}"
-    resp.body
-  end
 
   def cancel_replication(src, tgt) do
     body = %{:cancel => true}
@@ -1735,19 +1710,6 @@ defmodule ReplicationTest do
     Enum.find(resp.body, nil, fn task ->
       task["replication_id"] == repl_id
     end)
-  end
-
-  def set_user(uri, userinfo) do
-    case URI.parse(uri) do
-      %{scheme: nil} ->
-        uri
-
-      %{userinfo: nil} = uri ->
-        URI.to_string(Map.put(uri, :userinfo, userinfo))
-
-      _ ->
-        uri
-    end
   end
 
   def get_att1_data do

--- a/test/elixir/test/rev_stemming_test.exs
+++ b/test/elixir/test/rev_stemming_test.exs
@@ -1,0 +1,193 @@
+defmodule RevStemmingTest do
+  use CouchTestCase
+
+  @moduletag :revs
+
+  @moduledoc """
+  This is a port of the rev_stemming.js suite
+  """
+
+  @new_limit 5
+
+  @tag :with_db
+  test "revs limit update", context do
+    db_name = context[:db_name]
+
+    resp = Couch.get("/#{db_name}/_revs_limit")
+    assert resp.body == 1000
+
+    create_rev_doc(db_name, "foo", @new_limit + 1)
+    resp = Couch.get("/#{db_name}/foo?revs=true")
+    assert length(resp.body["_revisions"]["ids"]) == @new_limit + 1
+
+    resp =
+      Couch.put("/#{db_name}/_revs_limit",
+        body: "#{@new_limit}",
+        headers: ["Content-type": "application/json"]
+      )
+
+    assert resp.status_code == 200
+
+    create_rev_doc(db_name, "foo", @new_limit + 1)
+    resp = Couch.get("/#{db_name}/foo?revs=true")
+    assert length(resp.body["_revisions"]["ids"]) == @new_limit
+  end
+
+  @tag :with_db
+  test "revs limit produces replication conflict ", context do
+    db_name = context[:db_name]
+
+    db_name_b = "#{db_name}_b"
+    create_db(db_name_b)
+    delete_db_on_exit([db_name_b])
+
+    resp =
+      Couch.put("/#{db_name}/_revs_limit",
+        body: "#{@new_limit}",
+        headers: ["Content-type": "application/json"]
+      )
+
+    assert resp.status_code == 200
+
+    create_rev_doc(db_name, "foo", @new_limit + 1)
+    resp = Couch.get("/#{db_name}/foo?revs=true")
+    assert length(resp.body["_revisions"]["ids"]) == @new_limit
+
+    # If you replicate after you make more edits than the limit, you'll
+    # cause a spurious edit conflict.
+    replicate(db_name, db_name_b)
+    resp = Couch.get("/#{db_name_b}/foo?conflicts=true")
+    assert not Map.has_key?(resp.body, "_conflicts")
+
+    create_rev_doc(db_name, "foo", @new_limit - 1)
+
+    # one less edit than limit, no conflict
+    replicate(db_name, db_name_b)
+    resp = Couch.get("/#{db_name_b}/foo?conflicts=true")
+    assert not Map.has_key?(resp.body, "_conflicts")
+    prev_conflicted_rev = resp.body["_rev"]
+
+    # now we hit the limit
+    create_rev_doc(db_name, "foo", @new_limit + 1)
+
+    replicate(db_name, db_name_b)
+    resp = Couch.get("/#{db_name_b}/foo?conflicts=true")
+    assert Map.has_key?(resp.body, "_conflicts")
+
+    conflicted_rev =
+      resp.body["_conflicts"]
+      |> Enum.at(0)
+
+    # we have a conflict, but the previous replicated rev is always the losing
+    # conflict
+    assert conflicted_rev == prev_conflicted_rev
+  end
+
+  @tag :with_db
+  test "revs limit is kept after compaction", context do
+    db_name = context[:db_name]
+
+    create_rev_doc(db_name, "bar", @new_limit + 1)
+    resp = Couch.get("/#{db_name}/bar?revs=true")
+    assert length(resp.body["_revisions"]["ids"]) == @new_limit + 1
+
+    resp =
+      Couch.put("/#{db_name}/_revs_limit",
+        body: "#{@new_limit}",
+        headers: ["Content-type": "application/json"]
+      )
+
+    assert resp.status_code == 200
+
+    # We having already updated bar before setting the limit, so it's still got
+    # a long rev history. compact to stem the revs.
+    resp = Couch.get("/#{db_name}/bar?revs=true")
+    assert length(resp.body["_revisions"]["ids"]) == @new_limit
+
+    compact(db_name)
+    wait_until_compact_complete(db_name)
+
+    # force reload because ETags don't honour compaction
+    resp =
+      Couch.get("/#{db_name}/bar?revs=true",
+        headers: ["if-none-match": "pommes"]
+      )
+
+    assert length(resp.body["_revisions"]["ids"]) == @new_limit
+  end
+
+  # function to create a doc with multiple revisions
+  defp create_rev_doc(db_name, id, num_revs) do
+    resp = Couch.get("/#{db_name}/#{id}")
+
+    doc =
+      if resp.status_code == 200 do
+        resp.body
+      else
+        %{_id: id, count: 0}
+      end
+
+    {:ok, resp} = create_doc(db_name, doc)
+    create_rev_doc(db_name, id, num_revs, [Map.put(doc, :_rev, resp.body["rev"])])
+  end
+
+  defp create_rev_doc(db_name, id, num_revs, revs) do
+    if length(revs) < num_revs do
+      doc = %{_id: id, _rev: Enum.at(revs, -1)[:_rev], count: length(revs)}
+      {:ok, resp} = create_doc(db_name, doc)
+
+      create_rev_doc(
+        db_name,
+        id,
+        num_revs,
+        revs ++ [Map.put(doc, :_rev, resp.body["rev"])]
+      )
+    else
+      revs
+    end
+  end
+
+  defp build_uri(db_name) do
+    username = System.get_env("EX_USERNAME") || "adm"
+    password = System.get_env("EX_PASSWORD") || "pass"
+
+    "/#{db_name}"
+    |> Couch.process_url()
+    |> URI.parse()
+    |> Map.put(:userinfo, "#{username}:#{password}")
+    |> URI.to_string()
+  end
+
+  defp replicate(src, tgt) do
+    src_uri = build_uri(src)
+    tgt_uri = build_uri(tgt)
+
+    body = %{source: src_uri, target: tgt_uri}
+
+    resp = Couch.post("/_replicate", body: body)
+    assert resp.status_code == 200
+    resp.body
+  end
+
+  def delete_db_on_exit(db_names) when is_list(db_names) do
+    on_exit(fn ->
+      Enum.each(db_names, fn name ->
+        delete_db(name)
+      end)
+    end)
+  end
+
+  defp compact(db_name) do
+    resp = Couch.post("/#{db_name}/_compact")
+    assert resp.status_code == 202
+    resp.body
+  end
+
+  defp wait_until_compact_complete(db_name) do
+    retry_until(
+      fn -> Map.get(info(db_name), "compact_running") == false end,
+      200,
+      10_000
+    )
+  end
+end

--- a/test/elixir/test/users_db_test.exs
+++ b/test/elixir/test/users_db_test.exs
@@ -50,28 +50,6 @@ defmodule UsersDbTest do
     create_db(@users_db_name)
   end
 
-  defp replicate(source, target, rep_options \\ []) do
-    headers = Keyword.get(rep_options, :headers, [])
-    body = Keyword.get(rep_options, :body, %{})
-
-    body =
-      body
-      |> Map.put("source", source)
-      |> Map.put("target", target)
-
-    retry_until(
-      fn ->
-        resp = Couch.post("/_replicate", headers: headers, body: body, timeout: 10_000)
-        assert HTTPotion.Response.success?(resp)
-        assert resp.status_code == 200
-        assert resp.body["ok"]
-        resp
-      end,
-      500,
-      20_000
-    )
-  end
-
   defp save_as(db_name, doc, options) do
     session = Keyword.get(options, :use_session)
     expect_response = Keyword.get(options, :expect_response, [201, 202])

--- a/test/javascript/tests/rev_stemming.js
+++ b/test/javascript/tests/rev_stemming.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.rev_stemming = function(debug) {
 
   var db_name_orig = get_random_db_name();


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Backport into 3.x PR #2879 - Port rev_stemming into elixir test suite

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
