### PR TITLE
Lower the default batch size for update_docs to 2.5MB

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -244,7 +244,7 @@ port = 6984
 ;binary_chunk_size = 100000
 ;
 ; Bulk docs transaction batch size in bytes
-;update_docs_batch_size = 5000000
+;update_docs_batch_size = 2500000
 
 ; [rexi]
 ; buffer_count = 2000

--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -156,7 +156,7 @@
 
 -define(RETURN(Term), throw({?MODULE, Term})).
 
--define(DEFAULT_UPDATE_DOCS_BATCH_SIZE, 5000000).
+-define(DEFAULT_UPDATE_DOCS_BATCH_SIZE, 2500000).
 
 
 -record(bacc, {


### PR DESCRIPTION
Observed a number of timeouts with the previous default

