### PR TITLE
Introduce _bulk_docs max_doc_count limit

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -55,6 +55,10 @@ changes_doc_ids_optimization_threshold = 100
 ; for size calculation instead of 7.
 max_document_size = 8000000 ; bytes
 ;
+; Maximum number of documents in a _bulk_docs request. Anything larger
+; returns a 413 error for the whole request
+;max_bulk_docs_count = 10000
+;
 ; Maximum attachment size.
 ; max_attachment_size = infinity
 ;

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -956,6 +956,8 @@ error_info(request_entity_too_large) ->
     {413, <<"too_large">>, <<"the request entity is too large">>};
 error_info({request_entity_too_large, {attachment, AttName}}) ->
     {413, <<"attachment_too_large">>, AttName};
+error_info({request_entity_too_large, {bulk_docs, Max}}) when is_integer(Max) ->
+    {413, <<"max_bulk_docs_count_exceeded">>, integer_to_binary(Max)};
 error_info({request_entity_too_large, DocID}) ->
     {413, <<"document_too_large">>, DocID};
 error_info({error, security_migration_updates_disabled}) ->

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -484,6 +484,11 @@ db_req(#httpd{method='POST',path_parts=[_,<<"_bulk_docs">>]}=Req, Db) ->
     DocsArray0 ->
         DocsArray0
     end,
+    MaxDocs = config:get_integer("couchdb", "max_bulk_docs_count", 10000),
+    case length(DocsArray) =< MaxDocs of
+        true -> ok;
+        false -> throw({request_entity_too_large, {bulk_docs, MaxDocs}})
+    end,
     couch_stats:update_histogram([couchdb, httpd, bulk_docs], length(DocsArray)),
     Options = case chttpd:header_value(Req, "X-Couch-Full-Commit") of
     "true" ->


### PR DESCRIPTION
Let users specify the maximum document count for the _bulk_docs requests. If the document count exceeds the maximum it would return a 413 HTTP error. This would also signal the replicator to try to bisect the _bulk_docs array into smaller batches.

