### PR TITLE
feat(auth): Allow a custom JWT claim for roles

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -145,6 +145,7 @@ max_db_number_for_dbs_info_req = 100
 ; can be the name of a claim like "exp" or a tuple if the claim requires
 ; a parameter
 ; required_claims = exp, {iss, "IssuerNameHere"}
+; roles_claim_name = https://example.com/roles
 ;
 ; [jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -198,7 +198,7 @@ jwt_authentication_handler(Req) ->
                         false -> throw({unauthorized, <<"Token missing sub claim.">>});
                         {_, User} -> Req#httpd{user_ctx=#user_ctx{
                             name = User,
-                            roles = couch_util:get_value(<<"_couchdb.roles">>, Claims, [])
+                            roles = couch_util:get_value(?l2b(config:get("jwt_auth", "roles_claim_name", "_couchdb.roles")), Claims, [])
                         }}
                     end;
                 {error, Reason} ->


### PR DESCRIPTION
## Overview

This PR makes the `_couchdb.roles` custom claim configurable from the `local.ini` file, so it can be used with any OpenID Connect (OIDC) compliant service, such as Auth0 (https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims)

## Testing recommendations

1. In your `local.ini` file, under the `[jwt_auth]` section, add this line:
```ini
roles_claim_name = https://example.com/roles
```
2. Use this token to send some requests to your CouchDB instance: https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJodHRwczovL2V4YW1wbGUuY29tL3JvbGVzIjpbIl9hZG1pbiIsInNvbWUtb3RoZXItcm9sZSJdfQ.gQCW8lXpdOwUwtTX3bEjir8rX_W54677KYe9OVguTC4

## Related Issues or Pull Requests

#2913

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
