### PR TITLE
Prevent eviction of newer handles from fabric2_server cache

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -70,7 +70,6 @@
 -define(PDICT_CHECKED_MD_IS_CURRENT, '$fabric_checked_md_is_current').
 -define(PDICT_TX_ID_KEY, '$fabric_tx_id').
 -define(PDICT_TX_RES_KEY, '$fabric_tx_result').
--define(PDICT_ON_COMMIT_FUN, '$fabric_on_commit_fun').
 -define(PDICT_FOLD_ACC_STATE, '$fabric_fold_acc_state').
 
 % Let's keep these in ascending order


### PR DESCRIPTION
Ensure fabric2_server operations do not evict newer handles by comparing the metadata version to the what's already in the table. Also, remove on_commit handler and instead update the fresh db handle right away to let concurrent request see the updated handle as soon as possible.
