### PR TITLE
Handle error:{timeout, _} exception in couch_jobs:accept

### DIFF
--- a/src/couch_jobs/src/couch_jobs.erl
+++ b/src/couch_jobs/src/couch_jobs.erl
@@ -300,6 +300,8 @@ accept_loop(Type, NoSched, MaxSchedTime, Timeout) ->
     AcceptResult = try
         couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(), TxFun)
     catch
+        error:{timeout, _} ->
+            retry;
         error:{erlfdb_error, Err} when Err =:= 1020 orelse Err =:= 1031 ->
             retry
     end,


### PR DESCRIPTION
Under load accept loop can blow up with timeout error from
`erlfdb:wait(...)`(https://github.com/apache/couchdb-erlfdb/blob/master/src/erlfdb.erl#L255)
so guard against it just like we do for fdb transaction timeout (1031) errors.

