### PR TITLE
Improve efficiency of couch_jobs:accept/2 for views

### DIFF
--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -44,7 +44,8 @@ spawn_link() ->
 
 
 init() ->
-    {ok, Job, Data0} = couch_jobs:accept(?INDEX_JOB_TYPE, #{}),
+    Opts = #{no_schedule => true},
+    {ok, Job, Data0} = couch_jobs:accept(?INDEX_JOB_TYPE, Opts),
     Data = upgrade_data(Data0),
     #{
         <<"db_name">> := DbName,

--- a/src/couch_views/src/couch_views_jobs.erl
+++ b/src/couch_views/src/couch_views_jobs.erl
@@ -134,7 +134,9 @@ job_id(#{name := DbName}, #mrst{sig = Sig}) ->
 
 job_id(DbName, Sig) ->
     HexSig = fabric2_util:to_hex(Sig),
-    <<DbName/binary, "-", HexSig/binary>>.
+    % Put signature first in order to be able to use the no_schedule
+    % couch_jobs:accept/2 option
+    <<HexSig/binary, "-", DbName/binary>>.
 
 
 job_data(Db, Mrst) ->

--- a/src/couch_views/test/couch_views_cleanup_test.erl
+++ b/src/couch_views/test/couch_views_cleanup_test.erl
@@ -408,4 +408,4 @@ job_id(Db, DDoc) ->
     DbName = fabric2_db:name(Db),
     {ok, #mrst{sig = Sig}} = couch_views_util:ddoc_to_mrst(DbName, DDoc),
     HexSig = fabric2_util:to_hex(Sig),
-    <<DbName/binary, "-", HexSig/binary>>.
+    <<HexSig/binary, "-", DbName/binary>>.


### PR DESCRIPTION
Use couch_jobs's `no_schedule` accept option to speed up job dequeuing.

This optimization allows dequeung jobs more efficiently if these conditions are
met:

 1) Job IDs start with a random prefix
 2) No time-based scheduling is used

Both of those can be true for views job ids can be generated such that
signature comes before the db name part, which is what this commit does.

The way the optimisation works, is random IDs are generating in pending jobs
range, then, a key selection is used to pick either a job before or after
it. That reduces each dequeue attempt to just 1 read instead of reading up to
1000 jobs.
