### PR TITLE
Include database uuid in db info result

### DIFF
--- a/src/fabric/test/fabric2_db_crud_tests.erl
+++ b/src/fabric/test/fabric2_db_crud_tests.erl
@@ -631,7 +631,7 @@ get_info_wait_retry_on_tx_too_old(_) ->
         ok = erlfdb:set_option(Tx, disallow_writes),
 
         InfoF = fabric2_fdb:get_info_future(Tx, DbPrefix),
-        {info_future, _, _, ChangesF, _, _} = InfoF,
+        {info_future, _, _, ChangesF, _, _, _} = InfoF,
 
         raise_in_erlfdb_wait(ChangesF, {erlfdb_error, 1007}, 3),
         ?assertError({erlfdb_error, 1007}, fabric2_fdb:get_info_wait(InfoF)),
@@ -659,7 +659,7 @@ get_info_wait_retry_on_tx_abort(_)->
         ok = erlfdb:set_option(Tx, disallow_writes),
 
         InfoF = fabric2_fdb:get_info_future(Tx, DbPrefix),
-        {info_future, _, _, ChangesF, _, _} = InfoF,
+        {info_future, _, _, ChangesF, _, _, _} = InfoF,
 
         raise_in_erlfdb_wait(ChangesF, {erlfdb_error, 1025}, 3),
         ?assertError({erlfdb_error, 1025}, fabric2_fdb:get_info_wait(InfoF)),

--- a/src/fabric/test/fabric2_db_misc_tests.erl
+++ b/src/fabric/test/fabric2_db_misc_tests.erl
@@ -75,7 +75,10 @@ empty_db_info({DbName, Db, _}) ->
     ?assertEqual(DbName, fabric2_util:get_value(db_name, Info)),
     ?assertEqual(0, fabric2_util:get_value(doc_count, Info)),
     ?assertEqual(0, fabric2_util:get_value(doc_del_count, Info)),
-    ?assert(is_binary(fabric2_util:get_value(update_seq, Info))).
+    ?assert(is_binary(fabric2_util:get_value(update_seq, Info))),
+    InfoUUID = fabric2_util:get_value(uuid, Info),
+    UUID = fabric2_db:get_uuid(Db),
+    ?assertEqual(UUID, InfoUUID).
 
 
 accessors({DbName, Db, _}) ->


### PR DESCRIPTION
As per ML [discussion](https://lists.apache.org/thread.html/rb328513fb932e231cf8793f92dd1cc2269044cb73cb43a6662c464a1%40%3Cdev.couchdb.apache.org%3E) add a `uuid` field to db info results in order to be able to uniquely identify a particular instance of a database. When a database is deleted and re-created with the same name, it will return a new `uuid` value.

```
$ http get $DB/db1
HTTP/1.1 200 OK

{
    "cluster": {
        "n": 0,
        "q": 0,
        "r": 0,
        "w": 0
    },
    "compact_running": false,
    "data_size": 0,
    "db_name": "db1",
    "disk_format_version": 0,
    "disk_size": 0,
    "doc_count": 0,
    "doc_del_count": 0,
    "instance_start_time": "0",
    "purge_seq": 0,
    "sizes": {
        "external": 2,
        "views": 0
    },
    "update_seq": "000000000000000000000000",
    "uuid": "b00a3d1632df7c15d12ca08299922c55"
}

$ http delete $DB/db1
$ http put $DB/db1

$ http get $DB/db1
HTTP/1.1 200 OK

{
    "cluster": {
        "n": 0,
        "q": 0,
        "r": 0,
        "w": 0
    },
    "compact_running": false,
    "data_size": 0,
    "db_name": "db1",
    "disk_format_version": 0,
    "disk_size": 0,
    "doc_count": 0,
    "doc_del_count": 0,
    "instance_start_time": "0",
    "purge_seq": 0,
    "sizes": {
        "external": 2,
        "views": 0
    },
    "update_seq": "000000000000000000000000",
    "uuid": "0e94a664c30595601c4c9bb1d8bb9f67"
}
```
