### PR TITLE
Split couch_views job accepts into acceptors and workers

### DIFF
--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -46,6 +46,9 @@ spawn_link() ->
 init() ->
     Opts = #{no_schedule => true},
     {ok, Job, Data0} = couch_jobs:accept(?INDEX_JOB_TYPE, Opts),
+
+    couch_views_server:accepted_job(self()),
+
     Data = upgrade_data(Data0),
     #{
         <<"db_name">> := DbName,


### PR DESCRIPTION
Instead of max workers all waiting on accept, and racing to grab the same job,
generating conflicts and retries in the process, switch to having `A` acceptors
and `W` workers as separate configurable items, such that `A < W`.

A smaller number of acceptors (5 by default) will be spawned and will wait to
accept jobs. As soon any one accepts a job, and start executing, they will
notify the parent server via a gen_server call. The main couch_views_server,
when notified, will mark the acceptor as a worker as long as `A + W <
max_workers`.

When any worker exists, the main server may spawn more acceptors if number of
current acceptors `A < max_acceptors` _and_ `A + W < max_workers`.

The main idea behind `A + W < max_workers` is that we consider acceptors as
potential workers, they could accept a job at any time and immediately start
executing it, so we wouldn't want to start another acceptor.

As an example here is what might happen with say max_acceptors = 5 and
max_workers = 100:

1. Starting out:
  `A = 5, W = 0`

2. After 2 acceptors get jobs and start running them:
  `A = 3, W = 2`
Then immediately spawn another 2 acceptors:
  `A = 5, W = 2`

3. After 95 workers are started it might look like:
  `A = 5, W = 95`

4. Now if 3 acceptors accept a job, it would look like:
  `A = 2, W = 98`
But no more acceptors would be started.

5. If the last 2 acceptors also accept jobs it might look like:
 `A = 0, W = 100`
This is when it reaches full utilization and doesn't accept any more jobs.

6. Then if 1 worker exits:
 `A = 0, W = 99`
And 1 acceptor will be spawned
 `A = 1, W = 99`

7. If all 99 workers exit, it will go back to:
 `A = 5, W = 0`
