### PR TITLE
add back r and w options

### DIFF
--- a/src/mango/src/mango_opts.erl
+++ b/src/mango/src/mango_opts.erl
@@ -64,6 +64,12 @@ validate_idx_create({Props}) ->
             {optional, true},
             {default, auto_name},
             {validator, fun validate_idx_name/1}
+        ]},
+        {<<"w">>, [
+            {tag, w},
+            {optional, true},
+            {default, 2},
+            {validator, fun is_pos_integer/1}
         ]}
     ],
     validate(Props, Opts).
@@ -110,6 +116,12 @@ validate_find({Props}) ->
             {optional, true},
             {default, []},
             {validator, fun validate_fields/1}
+        ]},
+        {<<"r">>, [
+            {tag, r},
+            {optional, true},
+            {default, 1},
+            {validator, fun mango_opts:is_pos_integer/1}
         ]},
         {<<"conflicts">>, [
             {tag, conflicts},


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This caused a breaking change in some client APIs. We add `w` and `r` back temporarily.

## Testing recommendations

Regression tests should be okay.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
