### PR TITLE
Fix jwt auth with not required but present iss claim

### DIFF
--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -204,6 +204,8 @@ validate_iss(Props, Checks) ->
     case {ExpectedISS, ActualISS} of
         {undefined, undefined} ->
             ok;
+        {undefined, ISS} when ISS /= undefined ->
+            ok;
         {ISS, undefined} when ISS /= undefined ->
             throw({bad_request, <<"Missing iss claim">>});
         {ISS, ISS} ->

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -138,6 +138,26 @@ defmodule JwtAuthTest do
     assert resp.body["info"]["authenticated"] == "default"
   end
 
+  test "jwt auth with not required but present (in token) iss claim", _context do
+
+    secret = "zxczxc12zxczxc12"
+
+    server_config = [
+      %{
+        :section => "jwt_keys",
+        :key => "hmac:_default",
+        :value => :base64.encode(secret)
+      },
+      %{
+        :section => "jwt_auth",
+        :key => "allowed_algorithms",
+        :value => "HS256, HS384, HS512"
+      }
+    ]
+
+    run_on_modified_server(server_config, fn -> good_iss("HS256", secret) end)
+  end
+
   test "jwt auth with required iss claim", _context do
 
     secret = "zxczxc12zxczxc12"


### PR DESCRIPTION
## Overview

When `iss` claim is present in JWT token, but `required_claims` does _not_ contain iss, then `Invalid iss claim` error happens. This is happening, because when validating iss, there is no handling for such situation.

## Testing recommendations

Added `jwt auth with not required but present (in token) iss claim`. It can be executed with

`make elixir`

## Related Issues or Pull Requests

The problem has been reported in #2931 and suggested it has been solved by #2888. However, #2888 addresses other issue, not this one.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
