### PR TITLE
Reserve aegis namespace under ?CLUSTER_CONFIG

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -28,6 +28,10 @@
 -define(EXPIRING_CACHE, 53).
 -define(TX_IDS, 255).
 
+% Cluster Level: (LayerPrefix, ?CLUSTER_CONFIG, X, ...)
+
+-define(AEGIS, 0).
+
 % Database Level: (LayerPrefix, ?DBS, DbPrefix, X, ...)
 
 -define(DB_VERSION, 0).


### PR DESCRIPTION
Reserve aegis namespace under `?CLUSTER_CONFIG` to prevent possible name clashes in the future.