### PR TITLE
Make restricted partition search parameters return bad request

### DIFF
--- a/src/dreyfus/src/dreyfus_httpd.erl
+++ b/src/dreyfus/src/dreyfus_httpd.erl
@@ -447,10 +447,15 @@ validate_search_restrictions(Db, DDoc, Args) ->
         q = Query,
         partition = Partition,
         grouping = Grouping,
-        limit = Limit
+        limit = Limit,
+        counts = Counts,
+        drilldown = Drilldown,
+        ranges = Ranges
     } = Args,
     #grouping{
-        by = GroupBy
+        by = GroupBy,
+        limit = GroupLimit,
+        sort = GroupSort
     } = Grouping,
 
     case Query of
@@ -496,9 +501,18 @@ validate_search_restrictions(Db, DDoc, Args) ->
             parse_non_negative_int_param("limit", Limit, "max_limit", MaxLimit)
     end,
 
-    case GroupBy /= nil andalso is_binary(Partition) of
+    DefaultArgs = #index_query_args{},
+
+    case is_binary(Partition) andalso (
+        Counts /= DefaultArgs#index_query_args.counts
+            orelse Drilldown /= DefaultArgs#index_query_args.drilldown
+            orelse Ranges /= DefaultArgs#index_query_args.ranges
+            orelse GroupSort /= DefaultArgs#index_query_args.grouping#grouping.sort
+            orelse GroupBy /= DefaultArgs#index_query_args.grouping#grouping.by
+            orelse GroupLimit /= DefaultArgs#index_query_args.grouping#grouping.limit
+    ) of
         true ->
-            Msg5 = <<"`group_by` and `partition` are incompatible">>,
+            Msg5 = <<"`partition` and any of `drilldown`, `ranges`, `group_field`, `group_sort`, `group_limit` or `group_by` are incompatible">>,
             throw({bad_request, Msg5});
         false ->
             ok


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
According to https://docs.couchdb.org/en/master/ddocs/search.html there
are parameters for searches that are not allowed for partitioned queries.

Those restrictions were not enforced, thus making the software and docs
inconsistent.

This PR adds them to validation so that the behavior matches the one
described in the docs.

## Testing recommendations

Run the tests included with the PR or perform them manually.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation - Not Applicable
