### PR TITLE
Add max_bulk_get_count configuration option

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -59,6 +59,10 @@ max_document_size = 8000000 ; bytes
 ; returns a 413 error for the whole request
 ;max_bulk_docs_count = 10000
 ;
+; Maximum number of documents in a _bulk_get request. Anything larger
+; returns a 413 error for the whole request
+;max_bulk_get_count = 10000
+;
 ; Maximum attachment size.
 ; max_attachment_size = infinity
 ;

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -958,6 +958,8 @@ error_info({request_entity_too_large, {attachment, AttName}}) ->
     {413, <<"attachment_too_large">>, AttName};
 error_info({request_entity_too_large, {bulk_docs, Max}}) when is_integer(Max) ->
     {413, <<"max_bulk_docs_count_exceeded">>, integer_to_binary(Max)};
+error_info({request_entity_too_large, {bulk_get, Max}}) when is_integer(Max) ->
+    {413, <<"max_bulk_get_count_exceeded">>, integer_to_binary(Max)};
 error_info({request_entity_too_large, DocID}) ->
     {413, <<"document_too_large">>, DocID};
 error_info({error, security_migration_updates_disabled}) ->

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -560,6 +560,11 @@ db_req(#httpd{method='POST', path_parts=[_, <<"_bulk_get">>],
         undefined ->
             throw({bad_request, <<"Missing JSON list of 'docs'.">>});
         Docs ->
+            MaxDocs = config:get_integer("couchdb", "max_bulk_get_count", 10000),
+            case length(Docs) =< MaxDocs of
+                true -> ok;
+                false -> throw({request_entity_too_large, {bulk_get, MaxDocs}})
+            end,
             #doc_query_args{
                 options = Options
             } = bulk_get_parse_doc_query(Req),


### PR DESCRIPTION
## Overview

Let admin users specify the maximum document count for the `_bulk_get` requests via `max_bulk_get_count` configuration. If the document count exceeds the maximum it would return a 413 HTTP error. The implementation is based on https://github.com/apache/couchdb/pull/2910.

## Testing recommendations

```
make && make eunit apps=chttpd tests=all_test_
```

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
