### PR TITLE
Port reader_acl test into elixir test suite

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -62,11 +62,11 @@ X means done, - means partially
   - [X] Port multiple_rows.js
   - [X] Port proxyauth.js
   - [X] Port purge.js
-  - [ ] Port reader_acl.js
+  - [X] Port reader_acl.js
   - [X] Port recreate_doc.js
   - [X] Port reduce_builtin.js
   - [X] Port reduce_false.js
-  - [ ] Port reduce_false_temp.js
+  - [ ] ~~Port reduce_false_temp.js~~
   - [X] Port reduce.js
   - [X] Port replication.js
   - [X] Port replicator_db_bad_rep_id.js

--- a/test/elixir/test/reader_acl_test.exs
+++ b/test/elixir/test/reader_acl_test.exs
@@ -1,0 +1,254 @@
+defmodule ReaderACLTest do
+  use CouchTestCase
+
+  @moduletag :authentication
+
+  @users_db_name "custom-users"
+  @password "funnybone"
+
+  @moduletag config: [
+               {
+                 "chttpd_auth",
+                 "authentication_db",
+                 @users_db_name
+               },
+               {
+                 "couch_httpd_auth",
+                 "authentication_db",
+                 @users_db_name
+               }
+             ]
+  setup do
+    # Create db if not exists
+    Couch.put("/#{@users_db_name}")
+
+    # create a user with top-secret-clearance
+    user_doc =
+      prepare_user_doc([
+        {:name, "bond@apache.org"},
+        {:password, @password},
+        {:roles, ["top-secret"]}
+      ])
+
+    {:ok, _} = create_doc(@users_db_name, user_doc)
+
+    # create a user with top-secret-clearance
+    user_doc =
+      prepare_user_doc([
+        {:name, "juanjo@apache.org"},
+        {:password, @password}
+      ])
+
+    {:ok, _} = create_doc(@users_db_name, user_doc)
+
+    on_exit(&tear_down/0)
+
+    :ok
+  end
+
+  defp tear_down do
+    delete_db(@users_db_name)
+  end
+
+  defp login(user, password) do
+    sess = Couch.login(user, password)
+    assert sess.cookie, "Login correct is expected"
+    sess
+  end
+
+  defp logout(session) do
+    assert Couch.Session.logout(session).body["ok"]
+  end
+
+  defp open_as(db_name, doc_id, options) do
+    use_session = Keyword.get(options, :use_session)
+    user = Keyword.get(options, :user)
+    expect_response = Keyword.get(options, :expect_response, 200)
+    expect_message = Keyword.get(options, :error_message)
+
+    session = use_session || login(user, @password)
+
+    resp =
+      Couch.Session.get(
+        session,
+        "/#{db_name}/#{URI.encode(doc_id)}"
+      )
+
+    if use_session == nil do
+      logout(session)
+    end
+
+    assert resp.status_code == expect_response
+
+    if expect_message != nil do
+      assert resp.body["error"] == expect_message
+    end
+
+    resp.body
+  end
+
+  defp set_security(db_name, security, expect_response \\ 200) do
+    resp = Couch.put("/#{db_name}/_security", body: security)
+    assert resp.status_code == expect_response
+  end
+
+  @tag :with_db
+  test "unrestricted db can be read", context do
+    db_name = context[:db_name]
+
+    doc = %{_id: "baz", foo: "bar"}
+    {:ok, _} = create_doc(db_name, doc)
+
+    # any user can read unrestricted db
+    open_as(db_name, "baz", user: "juanjo@apache.org")
+    open_as(db_name, "baz", user: "bond@apache.org")
+  end
+
+  @tag :with_db
+  test "restricted db can be read by authorized users", context do
+    db_name = context[:db_name]
+
+    doc = %{_id: "baz", foo: "bar"}
+    {:ok, _} = create_doc(db_name, doc)
+
+    security = %{
+      members: %{
+        roles: ["super-secret-club"],
+        names: ["joe", "barb"]
+      }
+    }
+
+    set_security(db_name, security)
+
+    # can't read it as bond is missing the needed role
+    open_as(db_name, "baz", user: "bond@apache.org", expect_response: 403)
+
+    # make anyone with the top-secret role an admin
+    # db admins are automatically members
+    security = %{
+      admins: %{
+        roles: ["top-secret"],
+        names: []
+      },
+      members: %{
+        roles: ["super-secret-club"],
+        names: ["joe", "barb"]
+      }
+    }
+
+    set_security(db_name, security)
+
+    # db admin can read
+    open_as(db_name, "baz", user: "bond@apache.org")
+
+    # admin now adds the top-secret role to the db's members
+    # and removes db-admins
+    security = %{
+      admins: %{
+        roles: [],
+        names: []
+      },
+      members: %{
+        roles: ["super-secret-club", "top-secret"],
+        names: ["joe", "barb"]
+      }
+    }
+
+    set_security(db_name, security)
+
+    # server _admin can always read
+    resp = Couch.get("/#{db_name}/baz")
+    assert resp.status_code == 200
+
+    open_as(db_name, "baz", user: "bond@apache.org")
+  end
+
+  @tag :with_db
+  test "works with readers (backwards compat with 1.0)", context do
+    db_name = context[:db_name]
+
+    doc = %{_id: "baz", foo: "bar"}
+    {:ok, _} = create_doc(db_name, doc)
+
+    security = %{
+      admins: %{
+        roles: [],
+        names: []
+      },
+      readers: %{
+        roles: ["super-secret-club", "top-secret"],
+        names: ["joe", "barb"]
+      }
+    }
+
+    set_security(db_name, security)
+    open_as(db_name, "baz", user: "bond@apache.org")
+  end
+
+  @tag :with_db
+  test "can't set non string reader names or roles", context do
+    db_name = context[:db_name]
+
+    security = %{
+      members: %{
+        roles: ["super-secret-club", %{"top-secret": "awesome"}],
+        names: ["joe", "barb"]
+      }
+    }
+
+    set_security(db_name, security, 500)
+
+    security = %{
+      members: %{
+        roles: ["super-secret-club", "top-secret"],
+        names: ["joe", 22]
+      }
+    }
+
+    set_security(db_name, security, 500)
+
+    security = %{
+      members: %{
+        roles: ["super-secret-club", "top-secret"],
+        names: "joe"
+      }
+    }
+
+    set_security(db_name, security, 500)
+  end
+
+  @tag :with_db
+  test "members can query views", context do
+    db_name = context[:db_name]
+
+    doc = %{_id: "baz", foo: "bar"}
+    {:ok, _} = create_doc(db_name, doc)
+
+    security = %{
+      admins: %{
+        roles: [],
+        names: []
+      },
+      members: %{
+        roles: ["super-secret-club", "top-secret"],
+        names: ["joe", "barb"]
+      }
+    }
+
+    set_security(db_name, security)
+
+    view = %{
+      _id: "_design/foo",
+      views: %{
+        bar: %{
+          map: "function(doc){emit(null, null)}"
+        }
+      }
+    }
+
+    {:ok, _} = create_doc(db_name, view)
+
+    # members can query views
+    open_as(db_name, "_design/foo/_view/bar", user: "bond@apache.org")
+  end
+end

--- a/test/javascript/tests/reader_acl.js
+++ b/test/javascript/tests/reader_acl.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true; 
 couchTests.reader_acl = function(debug) {
   // this tests read access control
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR ports `reader_acl.js` test into the elixir test suite 
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
make elixir tests=test/elixir/test/reader_acl_test.exs
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
N/A
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
