### PR TITLE
Start all required deps automatically in test

### DIFF
--- a/src/couch_epi/test/eunit/couch_epi_tests.erl
+++ b/src/couch_epi/test/eunit/couch_epi_tests.erl
@@ -162,7 +162,8 @@ start_epi(Plugins) ->
         Module
     end, Plugins),
     application:set_env(couch_epi, plugins, PluginsModules),
-    application:start(couch_epi).
+    {ok, _} = application:ensure_all_started(couch_epi),
+    ok.
 
 setup(data_file) ->
     error_logger:tty(false),


### PR DESCRIPTION
## Overview

The `couch_epi` test suite is flaky. The result of the tests depends on the order of applications eunit runs.
The failures happen when `crypto` app is not running prior to starting couch_epi test suite. This PR changes the way we start `couch_epi` to insure its dependencies are automatically started. 

## Testing recommendations

There is no good way to reproduce the issue. We just run full test suite to make sure there are no new regressions.

```
make check
```

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
