### PR TITLE
Port view_update_seq.js into elixir

### DIFF
--- a/test/elixir/lib/couch/db_test.ex
+++ b/test/elixir/lib/couch/db_test.ex
@@ -341,7 +341,7 @@ defmodule Couch.DBTest do
           Couch.get("/#{db_name}/_design/#{view_root}/_view/#{view_name}", query: options)
 
         _ ->
-          Couch.post("/#{db_name}/_design/#{view_root}/_view/#{view_name}",
+          Couch.post("/#{db_name}/_design/#{view_root}/_view/#{view_name}", query: options,
             body: %{"keys" => keys}
           )
       end

--- a/test/elixir/test/view_update_seq_test.exs
+++ b/test/elixir/test/view_update_seq_test.exs
@@ -1,0 +1,142 @@
+defmodule ViewUpdateSeqTest do
+  use CouchTestCase
+
+  @moduletag :view_update_seq
+
+  @moduledoc """
+  This is a port of the view_update_seq.js test suite.
+  """
+
+  @design_doc %{
+    _id: "_design/test",
+    language: "javascript",
+    autoupdate: false,
+    views: %{
+      all_docs: %{
+        map: "function(doc) { emit(doc.integer, doc.string) }"
+      },
+      summate: %{
+        map:
+          "function (doc) { if (typeof doc.integer === 'number') { emit(doc.integer, doc.integer)}; }",
+        reduce: "function (keys, values) { return sum(values); };"
+      }
+    }
+  }
+
+  defp seq_int(seq) do
+    {int, _} =
+      seq
+      |> String.split("-")
+      |> Enum.at(0)
+      |> Integer.parse()
+
+    int
+  end
+
+  @tag :with_db
+  test "db info update seq", context do
+    db_name = context[:db_name]
+
+    info = info(db_name)
+    assert seq_int(info["update_seq"]) == 0
+
+    create_doc(db_name, @design_doc)
+
+    info = info(db_name)
+    assert seq_int(info["update_seq"]) == 1
+  end
+
+  @tag :with_db
+  test "_all_docs update seq", context do
+    db_name = context[:db_name]
+
+    resp = Couch.get("/#{db_name}/_all_docs", query: %{:update_seq => true})
+    assert seq_int(resp.body["update_seq"]) == 0
+
+    create_doc(db_name, @design_doc)
+
+    resp = Couch.get("/#{db_name}/_all_docs", query: %{:update_seq => true})
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 1
+
+    docs = make_docs(0..99)
+    bulk_save(db_name, docs)
+
+    resp = Couch.get("/#{db_name}/_all_docs", query: %{:limit => 1})
+    assert length(resp.body["rows"]) == 1
+    assert Map.has_key?(resp.body, "update_seq") == false
+
+    resp = Couch.get("/#{db_name}/_all_docs", query: %{:limit => 1, :update_seq => true})
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 101
+  end
+
+  @tag :with_db
+  test "view update seq", context do
+    db_name = context[:db_name]
+
+    create_doc(db_name, @design_doc)
+    docs = make_docs(0..99)
+    bulk_save(db_name, docs)
+
+    resp = view(db_name, "test/all_docs", %{:limit => 1, :update_seq => true})
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 101
+
+    resp = view(db_name, "test/all_docs", %{:limit => 1, :update_seq => false})
+    assert length(resp.body["rows"]) == 1
+    assert Map.has_key?(resp.body, "update_seq") == false
+
+    resp = view(db_name, "test/summate", %{:update_seq => true})
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 101
+
+    save(db_name, %{"_id" => "A", "integer" => 1})
+
+    resp =
+      view(db_name, "test/all_docs", %{:limit => 1, :stale => "ok", :update_seq => true})
+
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 101
+
+    save(db_name, %{"_id" => "AA", "integer" => 2})
+
+    resp =
+      view(db_name, "test/all_docs", %{
+        :limit => 1,
+        :stale => "update_after",
+        :update_seq => true
+      })
+
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 101
+
+    retry_until(fn ->
+      resp =
+        view(db_name, "test/all_docs", %{:limit => 1, :stale => "ok", :update_seq => true})
+
+      assert length(resp.body["rows"]) == 1
+      seq_int(resp.body["update_seq"]) == 103
+    end)
+
+    resp =
+      view(db_name, "test/all_docs", %{:limit => 1, :stale => "ok", :update_seq => true})
+
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 103
+
+    resp = view(db_name, "test/all_docs", %{:limit => 1, :update_seq => true})
+
+    assert length(resp.body["rows"]) == 1
+    assert seq_int(resp.body["update_seq"]) == 103
+
+    resp = view(db_name, "test/all_docs", %{:update_seq => true}, ["0", "1"])
+    assert seq_int(resp.body["update_seq"]) == 103
+
+    resp = view(db_name, "test/all_docs", %{:update_seq => true}, ["0", "1"])
+    assert seq_int(resp.body["update_seq"]) == 103
+
+    resp = view(db_name, "test/summate", %{:group => true, :update_seq => true}, [0, 1])
+    assert seq_int(resp.body["update_seq"]) == 103
+  end
+end

--- a/test/javascript/tests/view_update_seq.js
+++ b/test/javascript/tests/view_update_seq.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.view_update_seq = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR ports `view_update_seq.js` into elixir test suite

There are some failures related to this test:
 https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FPullRequests/detail/PR-2973/1/pipeline/62
 https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FFullPlatformMatrix/detail/master/189/pipeline/57

I expect that the elixir version will be more robust as we remove a 5 seconds wait continuously requesting "/" from couchdb test server. 

```
[2020-06-29T16:35:18.202Z] test/javascript/tests/view_offsets.js                          ported to elixir
[2020-06-29T16:35:18.202Z] test/javascript/tests/view_pagination.js                       ported to elixir
[2020-06-29T16:35:20.581Z] test/javascript/tests/view_sandboxing.js                       pass
[2020-06-29T16:35:26.710Z] test/javascript/tests/view_update_seq.js                       fail: -11
[2020-06-29T16:35:26.710Z] =======================================================
[2020-06-29T16:35:26.710Z] JavaScript tests complete.
[2020-06-29T16:35:26.710Z]   Failed: 1.  Skipped or passed: 83.
```

## Testing recommendations
```
 make elixir tests=test/elixir/test/view_update_seq_test.exs
```

## Related Issues or Pull Requests
N/A
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
