### PR TITLE
fix: set gen_server:call() timeout to infinity on ioq bypass

### DIFF
--- a/src/ioq/src/ioq.erl
+++ b/src/ioq/src/ioq.erl
@@ -45,7 +45,7 @@ call(Fd, Msg, Metadata) ->
     Priority = io_class(Msg, Metadata),
     case bypass(Priority) of
         true ->
-            gen_server:call(Fd, Msg);
+            gen_server:call(Fd, Msg, infinity);
         false ->
             queued_call(Fd, Msg, Priority)
     end.


### PR DESCRIPTION
Before the bypass existed, ioq would call `gen_server:call()`
on hehalf of it calling module with the queueing logic in between.

Commit e641a740 introduced a way to bypass any queues, but the
delegated `gen_server:call()` there was added without a timeout
parameter, leading to a default timeout of 5000ms.

A problem manifests here when operations that are sent through
ioq that take longer than that 5000ms timeout. In practice, these
operations should be very rare and this timeout should be a help
on overloaded systems. However, one sure-fire way to cause an issue
on an otherwise idle machine is raise the max_document_size and
store unreasonably large documents, think 50MB+ of raw JSON).

Not that we recommend this, but folks have run this fine on 2.x
before the ioq changes and it isn’t too hard to support here.

By adding an `infinity` timeout delegated `gen_server:call()` in
the queue bypasse case, this no longer applies.

Thanks to Joan @wohali Touzet, Bob @rnewson Newson and
Paul @davisp Davis for helping to track this down.
