### PR TITLE
Fix auth injection in test helper

### DIFF
--- a/test/elixir/lib/couch.ex
+++ b/test/elixir/lib/couch.ex
@@ -129,7 +129,12 @@ defmodule Couch do
   end
 
   def set_auth_options(options) do
-    if Keyword.get(options, :cookie) == nil do
+    no_auth? = Keyword.get(options, :no_auth) == true
+    cookie? = Keyword.has_key?(options, :cookie)
+    basic_auth? = Keyword.has_key?(options, :basic_auth)
+    if cookie? or no_auth? or basic_auth? do
+      Keyword.delete(options, :no_auth)
+    else
       headers = Keyword.get(options, :headers, [])
 
       if headers[:basic_auth] != nil or headers[:authorization] != nil do
@@ -139,8 +144,6 @@ defmodule Couch do
         password = System.get_env("EX_PASSWORD") || "pass"
         Keyword.put(options, :basic_auth, {username, password})
       end
-    else
-      options
     end
   end
 
@@ -177,7 +180,8 @@ defmodule Couch do
       Couch.post(
         "/_session",
         body: %{:username => user, :password => pass},
-        base_url: base_url
+        base_url: base_url,
+        no_auth: true
       )
 
     if Map.get(options, :expect, :success) == :success do


### PR DESCRIPTION

## Overview

Previously the auth was injected unconidtionally. There were two problems:

1. no way to specify `basic_auth` credentials
2. no way to disable injection

Due to #2 it was impossible to use other user than hardcoded `adm` in `Couch.login/3`.

## Testing recommendations

The following should be sufficient to test for regressions

```
make exunit tests=src/chttpd/test/exunit/pagination_test.exs
```

## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
