### PR TITLE
Port view_compaction test to elixir

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -100,7 +100,7 @@ X means done, - means partially
   - [X] Port uuids.js
   - [X] Port view_collation.js
   - [X] Port view_collation_raw.js
-  - [ ] Port view_compaction.js
+  - [X] Port view_compaction.js
   - [ ] Port view_conflicts.js
   - [ ] Port view_errors.js
   - [ ] Port view_include_docs.js
@@ -110,7 +110,7 @@ X means done, - means partially
   - [X] Port view_offsets.js
   - [X] Port view_pagination.js
   - [ ] Port view_sandboxing.js
-  - [ ] Port view_update_seq.js
+  - [X] Port view_update_seq.js
 
 # Using ExUnit to write unit tests
 

--- a/test/elixir/lib/couch/db_test.ex
+++ b/test/elixir/lib/couch/db_test.ex
@@ -209,6 +209,7 @@ defmodule Couch.DBTest do
       )
 
     assert resp.status_code in [201, 202]
+    resp
   end
 
   def query(

--- a/test/elixir/test/view_compaction_test.exs
+++ b/test/elixir/test/view_compaction_test.exs
@@ -1,0 +1,105 @@
+defmodule ViewCompactionTest do
+  use CouchTestCase
+
+  @moduledoc """
+  Test CouchDB View Compaction Behavior
+  This is a port of the view_compaction.js suite
+  """
+  @num_docs 1000
+
+  @ddoc %{
+    _id: "_design/foo",
+    language: "javascript",
+    views: %{
+      view1: %{
+        map: "function(doc) { emit(doc._id, doc.value) }"
+      },
+      view2: %{
+        map:
+          "function(doc) { if (typeof(doc.integer) === 'number') {emit(doc._id, doc.integer);} }",
+        reduce: "function(keys, values, rereduce) { return sum(values); }"
+      }
+    }
+  }
+
+  defp bulk_save_for_update(db_name, docs) do
+    resp = bulk_save(db_name, docs)
+    revs = resp.body
+
+    Enum.map(docs, fn m ->
+      rev = Enum.at(revs, String.to_integer(m["_id"]))["rev"]
+
+      m
+      |> Map.put("_rev", rev)
+      |> Map.update!("integer", &(&1 + 1))
+    end)
+  end
+
+  @tag :with_db
+  test "view compaction", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    docs = make_docs(0..(@num_docs - 1))
+    docs = bulk_save_for_update(db_name, docs)
+
+    resp = view(db_name, "foo/view1")
+    assert length(resp.body["rows"]) == @num_docs
+
+    resp = view(db_name, "foo/view2")
+    assert length(resp.body["rows"]) == 1
+
+    resp = Couch.get("/#{db_name}/_design/foo/_info")
+    assert resp.body["view_index"]["update_seq"] == @num_docs + 1
+
+    docs = bulk_save_for_update(db_name, docs)
+
+    resp = view(db_name, "foo/view1")
+    assert length(resp.body["rows"]) == @num_docs
+
+    resp = view(db_name, "foo/view2")
+    assert length(resp.body["rows"]) == 1
+
+    resp = Couch.get("/#{db_name}/_design/foo/_info")
+    assert resp.body["view_index"]["update_seq"] == 2 * @num_docs + 1
+
+    bulk_save(db_name, docs)
+    resp = view(db_name, "foo/view1")
+    assert length(resp.body["rows"]) == @num_docs
+
+    resp = view(db_name, "foo/view2")
+    assert length(resp.body["rows"]) == 1
+
+    resp = Couch.get("/#{db_name}/_design/foo/_info")
+    assert resp.body["view_index"]["update_seq"] == 3 * @num_docs + 1
+
+    disk_size_before_compact = resp.body["view_index"]["sizes"]["file"]
+    data_size_before_compact = resp.body["view_index"]["sizes"]["active"]
+
+    assert is_integer(disk_size_before_compact)
+    assert data_size_before_compact < disk_size_before_compact
+
+    resp = Couch.post("/#{db_name}/_compact/foo")
+    assert resp.body["ok"] == true
+
+    retry_until(fn ->
+      resp = Couch.get("/#{db_name}/_design/foo/_info")
+      resp.body["view_index"]["compact_running"] == false
+    end)
+
+    resp = view(db_name, "foo/view1")
+    assert length(resp.body["rows"]) == @num_docs
+
+    resp = view(db_name, "foo/view2")
+    assert length(resp.body["rows"]) == 1
+
+    resp = Couch.get("/#{db_name}/_design/foo/_info")
+    assert resp.body["view_index"]["update_seq"] == 3 * @num_docs + 1
+
+    disk_size_after_compact = resp.body["view_index"]["sizes"]["file"]
+    data_size_after_compact = resp.body["view_index"]["sizes"]["active"]
+    assert disk_size_after_compact < disk_size_before_compact
+    assert is_integer(data_size_after_compact)
+    assert data_size_after_compact < disk_size_after_compact
+  end
+end

--- a/test/javascript/tests/view_compaction.js
+++ b/test/javascript/tests/view_compaction.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.view_compaction = function(debug) {
   if (debug) debugger;
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR ports view_compaction.js test into the elixir test suite

I've modified the tests to use 1.000 docs and not 10.000 docs like the original one. With this change, the execution time is reduced in 10 seconds. 

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
 make elixir tests=test/elixir/test/view_compaction_test.exs
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
N/A
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
