### PR TITLE
Simplify using `req_body` for JSON requests

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -302,10 +302,9 @@ handle_task_status_req(#httpd{method='GET'}=Req) ->
 handle_task_status_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
-handle_replicate_req(#httpd{method='POST', user_ctx=Ctx} = Req) ->
+handle_replicate_req(#httpd{method='POST', user_ctx=Ctx, req_body=PostBody} = Req) ->
     chttpd:validate_ctype(Req, "application/json"),
     %% see HACK in chttpd.erl about replication
-    PostBody = get(post_body),
     case replicate(PostBody, Ctx) of
         {ok, {continuous, RepId}} ->
             send_json(Req, 202, {[{ok, true}, {<<"_local_id">>, RepId}]});

--- a/src/chttpd/test/eunit/chttpd_handlers_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_handlers_tests.erl
@@ -70,7 +70,7 @@ request_replicate(Url, Body) ->
     Headers = [{"Content-Type", "application/json"}],
     Handler = {chttpd_misc, handle_replicate_req},
     request(post, Url, Headers, Body, Handler, fun(Req) ->
-        chttpd:send_json(Req, 200, get(post_body))
+        chttpd:send_json(Req, 200, Req#httpd.req_body)
     end).
 
 request(Method, Url, Headers, Body, {M, F}, MockFun) ->


### PR DESCRIPTION
## Overview

Currently the EPI plugins have no easy way to modify body of the document in
before request. There are complicated approaches via overriding compression header.
In any case you are obligated to serialize your data structure into JSON. 
This is due to the fact that `chttp:json_body/1` expects compressed body.
We can rely on the fact that `MochiReq:recv_body/1` returns binary to allow
passing of already parsed JSON terms (objects and lists). 
If we do so we can modify request's body as easy as:

```
Req#httpd{req_body = {[{<<"hello">>, <<"couch">>}]}}
```

## Testing recommendations

`make check`

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
