### PR TITLE
Do not fail when emilio detects errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ soak-eunit: couch
 	while [ $$? -eq 0 ] ; do $(REBAR) -r eunit $(EUNIT_OPTS) ; done
 
 emilio:
-	@bin/emilio -c emilio.config src/ | bin/warnings_in_scope -s 3
+	@bin/emilio -c emilio.config src/ | bin/warnings_in_scope -s 3 || exit 0
 
 .venv/bin/black:
 	@python3 -m venv .venv

--- a/Makefile.win
+++ b/Makefile.win
@@ -178,7 +178,7 @@ just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 
 emilio:
-	@bin\emilio -c emilio.config src\ | python.exe bin\warnings_in_scope -s 3
+	@bin\emilio -c emilio.config src\ | python.exe bin\warnings_in_scope -s 3 || exit 0
 
 .venv/bin/black:
 	@python.exe -m venv .venv


### PR DESCRIPTION
## Overview

Adding emilio check into Makefile was a mistake. Without automatic linter it is almost impossible to fix the style. Also emilio doesn’t allow disabling the checks. The idea was that by checking only warnings around (+-3 lines) modified lines we could gradually update the style as we go. However by updating these extra lines we trigger even more warnings and you end up changing style for the whole module. Things like “402 - import declaration found” is especially hard to fix.

## Testing recommendations

1. Change style for one of the erlang source files
2. Run tests `make check` - the execution output should pass the point where emilio warnings are displayed

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
