### PR TITLE
add active_tasks for view builds using version stamps

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -294,11 +294,8 @@ dbs_info_callback({error, Reason}, #vacc{resp = Resp0} = Acc) ->
 
 handle_task_status_req(#httpd{method='GET'}=Req) ->
     ok = chttpd:verify_is_server_admin(Req),
-    {Replies, _BadNodes} = gen_server:multi_call(couch_task_status, all),
-    Response = lists:flatmap(fun({Node, Tasks}) ->
-        [{[{node,Node} | Task]} || Task <- Tasks]
-    end, Replies),
-    send_json(Req, lists:sort(Response));
+    ActiveTasks = fabric2_active_tasks:get_active_tasks(),
+    send_json(Req, ActiveTasks);
 handle_task_status_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 

--- a/src/couch_jobs/src/couch_jobs.erl
+++ b/src/couch_jobs/src/couch_jobs.erl
@@ -19,6 +19,8 @@
     remove/3,
     get_job_data/3,
     get_job_state/3,
+    get_active_jobs_ids/2,
+    get_types/1,
 
     % Job processing
     accept/1,
@@ -101,6 +103,23 @@ get_job_state(Tx, Type, JobId) when is_binary(JobId) ->
             {error, Error} ->
                 {error, Error}
         end
+    end).
+
+
+-spec get_active_jobs_ids(jtx(), job_type()) -> [job_id()] | {error,
+    any()}.
+get_active_jobs_ids(Tx, Type) ->
+    couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(Tx), fun(JTx) ->
+        Since = couch_jobs_fdb:get_active_since(JTx, Type,
+            {versionstamp, 0, 0}),
+        maps:keys(Since)
+    end).
+
+
+-spec get_types(jtx()) -> [job_type()] | {error, any()}.
+get_types(Tx) ->
+    couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(Tx), fun(JTx) ->
+        couch_jobs_fdb:get_types(JTx)
     end).
 
 

--- a/src/couch_views/src/couch_views_util.erl
+++ b/src/couch_views/src/couch_views_util.erl
@@ -17,7 +17,8 @@
     ddoc_to_mrst/2,
     validate_args/1,
     validate_args/2,
-    is_paginated/1
+    is_paginated/1,
+    active_tasks_info/5
 ]).
 
 
@@ -276,3 +277,27 @@ is_paginated(#mrargs{page_size = PageSize}) when is_integer(PageSize) ->
 
 is_paginated(_) ->
     false.
+
+
+active_tasks_info(ChangesDone, DbName, DDocId, LastSeq, DBSeq) ->
+    #{
+        <<"type">> => <<"indexer">>,
+        <<"database">> => DbName,
+        <<"changes_done">> => ChangesDone,
+        <<"design_document">> => DDocId,
+        <<"current_version_stamp">> => convert_seq_to_stamp(LastSeq),
+        <<"db_version_stamp">> => convert_seq_to_stamp(DBSeq)
+    }.
+
+
+convert_seq_to_stamp(<<"0">>) ->
+    <<"0-0-0">>;
+
+convert_seq_to_stamp(undefined) ->
+    <<"0-0-0">>;
+
+convert_seq_to_stamp(Seq) ->
+    {_, Stamp, Batch, DocNumber} = fabric2_fdb:seq_to_vs(Seq),
+    VS = integer_to_list(Stamp) ++ "-" ++ integer_to_list(Batch) ++ "-"
+            ++ integer_to_list(DocNumber),
+    list_to_binary(VS).

--- a/src/couch_views/test/couch_views_active_tasks_test.erl
+++ b/src/couch_views/test/couch_views_active_tasks_test.erl
@@ -1,0 +1,155 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_views_active_tasks_test).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch_views/include/couch_views.hrl").
+-include_lib("fabric/test/fabric2_test.hrl").
+
+
+-define(MAP_FUN1, <<"map_fun1">>).
+-define(MAP_FUN2, <<"map_fun2">>).
+-define(INDEX_FOO, <<"_design/foo">>).
+-define(INDEX_BAR, <<"_design/bar">>).
+-define(TOTAL_DOCS, 1000).
+
+
+setup() ->
+    Ctx = test_util:start_couch([
+            fabric,
+            couch_jobs,
+            couch_js,
+            couch_views
+        ]),
+    Ctx.
+
+
+cleanup(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+
+foreach_setup() ->
+    {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),
+
+    DDoc = create_ddoc(?INDEX_FOO, ?MAP_FUN1),
+    Docs = make_docs(?TOTAL_DOCS),
+    fabric2_db:update_docs(Db, [DDoc | Docs]),
+
+    {Db, DDoc}.
+
+
+foreach_teardown({Db, _}) ->
+    meck:unload(),
+    ok = fabric2_db:delete(fabric2_db:name(Db), []).
+
+
+active_tasks_test_() ->
+    {
+        "Active Tasks test",
+        {
+            setup,
+            fun setup/0,
+            fun cleanup/1,
+            {
+                foreach,
+                fun foreach_setup/0,
+                fun foreach_teardown/1,
+                [
+                    ?TDEF_FE(verify_basic_active_tasks),
+                    ?TDEF_FE(verify_muliple_active_tasks)
+                ]
+            }
+        }
+    }.
+
+
+verify_basic_active_tasks({Db, DDoc}) ->
+    pause_indexer_for_changes(self()),
+    couch_views:build_indices(Db, [DDoc]),
+    {IndexerPid, {changes_done, ChangesDone}} = wait_to_reach_changes(10000),
+    [ActiveTask] = fabric2_active_tasks:get_active_tasks(),
+    ChangesDone1 = maps:get(<<"changes_done">>, ActiveTask),
+    IndexerPid ! continue,
+    % we assume the indexer has run for a bit so it has to > 0
+    ?assert(ChangesDone1 > 0),
+    ?assert(ChangesDone1 =< ChangesDone),
+    ?assertEqual(ChangesDone, ?TOTAL_DOCS).
+
+
+verify_muliple_active_tasks({Db, DDoc}) ->
+    DDoc2 = create_ddoc(?INDEX_BAR, ?MAP_FUN2),
+    fabric2_db:update_doc(Db, DDoc2, []),
+    pause_indexer_for_changes(self()),
+    couch_views:build_indices(Db, [DDoc, DDoc2]),
+
+    {IndexerPid, {changes_done, ChangesDone}} = wait_to_reach_changes(10000),
+    {IndexerPid2, {changes_done, ChangesDone2}} = wait_to_reach_changes(10000),
+
+    ActiveTasks = fabric2_active_tasks:get_active_tasks(),
+
+    ?assertEqual(length(ActiveTasks), 2),
+
+    IndexerPid ! continue,
+    IndexerPid2 ! continue,
+
+    ?assertEqual(ChangesDone, ?TOTAL_DOCS),
+    ?assertEqual(ChangesDone2, ?TOTAL_DOCS).
+
+
+create_ddoc(DDocId, IndexName) ->
+    couch_doc:from_json_obj({[
+        {<<"_id">>, DDocId},
+        {<<"views">>, {[
+            {IndexName, {[
+                {<<"map">>, <<"function(doc) {emit(doc.val, doc.val);}">>}
+            ]}}
+        ]}}
+    ]}).
+
+
+doc(Id, Val) ->
+    couch_doc:from_json_obj({[
+        {<<"_id">>, list_to_binary(integer_to_list(Id))},
+        {<<"val">>, Val}
+    ]}).
+
+
+make_docs(Count) ->
+    [doc(I, Count) || I <- lists:seq(1, Count)].
+
+
+pause_indexer_for_changes(ParentPid) ->
+    meck:new(couch_views_util, [passthrough]),
+    meck:expect(couch_views_util, active_tasks_info, fun(ChangesDone,
+        DbName, DDocId, LastSeq, DBSeq) ->
+        case ChangesDone of
+            ?TOTAL_DOCS ->
+                ParentPid ! {self(), {changes_done, ChangesDone}},
+                receive continue -> ok end;
+            _ ->
+                ok
+        end,
+        meck:passthrough([ChangesDone, DbName, DDocId, LastSeq,
+            DBSeq])
+    end).
+
+
+wait_to_reach_changes(Timeout) ->
+    receive
+        {Pid, {changes_done, ChangesDone}} when is_pid(Pid) ->
+            {Pid, {changes_done, ChangesDone}}
+    after Timeout ->
+        error(timeout_in_pause_indexer_for_changes)
+    end.

--- a/src/fabric/src/fabric2_active_tasks.erl
+++ b/src/fabric/src/fabric2_active_tasks.erl
@@ -1,0 +1,51 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+
+-module(fabric2_active_tasks).
+
+
+-export([
+    get_active_tasks/0,
+    get_active_task_info/1,
+
+    update_active_task_info/2
+]).
+
+
+-define(ACTIVE_TASK_INFO, <<"active_task_info">>).
+
+
+get_active_tasks() ->
+    couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(undefined), fun(JTx) ->
+        Types = couch_jobs:get_types(JTx),
+        lists:foldl(fun(Type, TaskAcc) ->
+            JobIds = couch_jobs:get_active_jobs_ids(JTx, Type),
+            Tasks = lists:filtermap(fun(JobId) ->
+                {ok, Data} = couch_jobs:get_job_data(JTx, Type, JobId),
+                case maps:get(?ACTIVE_TASK_INFO, Data, not_found) of
+                    not_found -> false;
+                    Info -> {true, Info}
+                end
+            end, JobIds),
+            TaskAcc ++ Tasks
+        end, [], Types)
+    end).
+
+
+get_active_task_info(JobData) ->
+    #{?ACTIVE_TASK_INFO:= ActiveTaskInfo} = JobData,
+    ActiveTaskInfo.
+
+
+update_active_task_info(JobData, ActiveTaskInfo) ->
+    JobData#{?ACTIVE_TASK_INFO => ActiveTaskInfo}.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Active Tasks requires TotalChanges and ChangesDone to show the progress
of long running tasks. This requires `count_changes_since/2` to be
implemented. Unfortunately, that is not easily done  with
foundationdb. This commit replaces TotalChanges with the
versionstamp + the number of docs as a progress indicator. This can
possibly break existing api that relys on TotalChanges. ChangesDone
will still exist, but instead of relying on the current changes seq
it is simply a reflection of how many documents were written by the
updater process.

The new responses look like this:

```
[
    {
        "node": "node1@127.0.0.1",
        "pid": "<0.622.0>",
        "changes_done": 199,
        "current_version_stamp": "8131141649532-0-198",
        "database": "testdb",
        "db_version_stamp": "8131141649532-0-999",
        "design_document": "_design/example",
        "started_on": 1594703583,
        "type": "indexer",
        "updated_on": 1594703586
    }
]

[
    {
        "node": "node1@127.0.0.1",
        "pid": "<0.1030.0>",
        "changes_done": 1000,
        "current_version_stamp": "8131194932916-0-999",
        "database": "testdb",
        "db_version_stamp": "8131194932916-0-999",
        "design_document": "_design/example",
        "started_on": 1594703636,
        "type": "indexer",
        "updated_on": 1594703665
    }
]
```

Note that this only shows one process. IIUC, we can have multiple workers indexing in parallel. I think this approach also takes care of this with the ChangesDone only reflecting how many documents have been indexed for that range.

## Testing recommendations

Tests need to be added. If this approach is accepted, I will add more precise tests. Currently ran manual tests.


## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
