### PR TITLE
Fix 'first page should not return previous bookmark' test

### DIFF
--- a/src/couch_views/src/couch_views_http.erl
+++ b/src/couch_views/src/couch_views_http.erl
@@ -177,10 +177,14 @@ maybe_add_next_bookmark(OriginalLimit, PageSize, Args0, Response, Items, KeyFun)
 
 maybe_add_previous_bookmark(#mrargs{extra = Extra} = Args, #{rows := Rows} = Result, KeyFun) ->
     StartKey = couch_util:get_value(fk, Extra),
-    case first_key(KeyFun, Rows) of
-        undefined ->
+    case {StartKey, first_key(KeyFun, Rows)} of
+        {undefined, _} ->
             Result;
-        EndKey ->
+        {_, undefined} ->
+            Result;
+        {StartKey, StartKey} ->
+            Result;
+        {StartKey, EndKey} ->
             Bookmark = bookmark_encode(
                 Args#mrargs{
                     start_key = StartKey,


### PR DESCRIPTION
## Overview

Fix a failing test case related to handling of a previous bookmark when `descending` is true. 

## Testing recommendations

```
make exunit tests=src/chttpd/test/exunit/pagination_test.exs
```

## Related Issues or Pull Requests

This is a fixup for https://github.com/apache/couchdb/pull/2904

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
