### PR TITLE
3.x backport - Port view_sandboxing, view_multi_key and update_documents tests into elixir

### DIFF
--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -93,7 +93,7 @@ X means done, - means partially
   - [X] Port security_validation.js
   - [ ] Port show_documents.js
   - [ ] Port stats.js
-  - [ ] Port update_documents.js
+  - [X] Port update_documents.js
   - [X] Port users_db.js
   - [ ] Port users_db_security.js
   - [X] Port utf8.js

--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -109,7 +109,7 @@ X means done, - means partially
   - [ ] Port view_multi_key_temp.js
   - [X] Port view_offsets.js
   - [X] Port view_pagination.js
-  - [ ] Port view_sandboxing.js
+  - [X] Port view_sandboxing.js
   - [X] Port view_update_seq.js
 
 # Using ExUnit to write unit tests

--- a/test/elixir/README.md
+++ b/test/elixir/README.md
@@ -104,9 +104,9 @@ X means done, - means partially
   - [ ] Port view_conflicts.js
   - [ ] Port view_errors.js
   - [ ] Port view_include_docs.js
-  - [ ] Port view_multi_key_all_docs.js
-  - [ ] Port view_multi_key_design.js
-  - [ ] Port view_multi_key_temp.js
+  - [X] Port view_multi_key_all_docs.js
+  - [X] Port view_multi_key_design.js
+  - [ ] ~~Port view_multi_key_temp.js~~
   - [X] Port view_offsets.js
   - [X] Port view_pagination.js
   - [X] Port view_sandboxing.js

--- a/test/elixir/test/update_documents_test.exs
+++ b/test/elixir/test/update_documents_test.exs
@@ -1,0 +1,324 @@
+defmodule UpdateDocumentsTest do
+  use CouchTestCase
+
+  @ddoc %{
+    _id: "_design/update",
+    language: "javascript",
+    updates: %{
+      hello: """
+        function(doc, req) {
+        if (!doc) {
+          if (req.id) {
+            return [
+            // Creates a new document with the PUT docid,
+            { _id : req.id,
+              reqs : [req] },
+            // and returns an HTML response to the client.
+            "<p>New World</p>"];
+          };
+          //
+          return [null, "<p>Empty World</p>"];
+        };
+        // we can update the document inline
+        doc.world = "hello";
+        // we can record aspects of the request or use them in application logic.
+        doc.reqs && doc.reqs.push(req);
+        doc.edited_by = req.userCtx;
+        return [doc, "<p>hello doc</p>"];
+      }
+      """,
+      "in-place": """
+      function(doc, req) {
+        var field = req.query.field;
+        var value = req.query.value;
+        var message = "set "+field+" to "+value;
+        doc[field] = value;
+        return [doc, message];
+      }
+      """,
+      "form-update": """
+       function(doc, req) {
+        for (var field in req.form) {
+          doc[field] = req.form[field];
+        }
+        var message = "updated doc from form";
+        return [doc, message];
+      }
+      """,
+      "bump-counter": """
+       function(doc, req) {
+        if (!doc.counter) doc.counter = 0;
+        doc.counter += 1;
+        var message = "<h1>bumped it!</h1>";
+        return [doc, message];
+      }
+      """,
+      error: """
+      function(doc, req) {
+       superFail.badCrash;
+      }
+      """,
+      "get-uuid": """
+       function(doc, req) {
+        return [null, req.uuid];
+      }
+      """,
+      "code-n-bump": """
+       function(doc,req) {
+        if (!doc.counter) doc.counter = 0;
+        doc.counter += 1;
+        var message = "<h1>bumped it!</h1>";
+        resp = {"code": 302, "body": message}
+        return [doc, resp];
+      }
+      """,
+      "resp-code": """
+       function(doc,req) {
+        resp = {"code": 302}
+        return [null, resp];
+      }
+      """,
+      "resp-code-and-json": """
+       function(doc,req) {
+        resp = {"code": 302, "json": {"ok": true}}
+        return [{"_id": req["uuid"]}, resp];
+      }
+      """,
+      binary: """
+       function(doc, req) {
+        var resp = {
+          "headers" : {
+            "Content-Type" : "application/octet-stream"
+          },
+          "base64" : "aGVsbG8gd29ybGQh" // "hello world!" encoded
+        };
+        return [doc, resp];
+      }
+      """,
+      empty: """
+       function(doc, req) {
+        return [{}, 'oops'];
+      }
+      """
+    }
+  }
+
+  @document %{word: "plankton", name: "Rusty"}
+
+  @tag :with_db
+  test "update error invalid path", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    resp = Couch.post("/#{db_name}/_design/update/_update/")
+    assert resp.status_code == 404
+    assert resp.body["reason"] == "Invalid path."
+  end
+
+  @tag :with_db
+  test "update document", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+    {:ok, resp} = create_doc(db_name, @document)
+    docid = resp.body["id"]
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/hello/#{docid}")
+    assert resp.status_code == 201
+    assert resp.body == "<p>hello doc</p>"
+    assert String.contains?(resp.headers["Content-Type"], "charset=utf-8")
+    assert resp.headers["X-Couch-Id"] == docid
+
+    resp = Couch.get("/#{db_name}/#{docid}")
+    assert resp.status_code == 200
+    assert resp.body["world"] == "hello"
+
+    # Fix for COUCHDB-379
+    assert String.starts_with?(resp.headers["Server"], "CouchDB")
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/hello")
+    assert resp.status_code == 200
+    assert resp.body == "<p>Empty World</p>"
+  end
+
+  @tag :with_db
+  test "GET is not allowed", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    resp = Couch.get("/#{db_name}/_design/update/_update/hello")
+    assert resp.body["error"] == "method_not_allowed"
+  end
+
+  @tag :with_db
+  test "doc can be created", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    resp = Couch.get("/#{db_name}/nonExistingDoc")
+    assert resp.status_code == 404
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/hello/nonExistingDoc")
+    assert resp.status_code == 201
+    assert resp.body == "<p>New World</p>"
+
+    resp = Couch.get("/#{db_name}/nonExistingDoc")
+    assert resp.status_code == 200
+  end
+
+  @tag :with_db
+  test "in place update", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    {:ok, resp} = create_doc(db_name, @document)
+    docid = resp.body["id"]
+
+    resp =
+      Couch.put(
+        "/#{db_name}/_design/update/_update/in-place/#{docid}?field=title&value=test"
+      )
+
+    assert resp.status_code == 201
+    assert resp.body == "set title to test"
+    resp = Couch.get("/#{db_name}/#{docid}")
+    assert resp.status_code == 200
+    assert resp.body["title"] == "test"
+  end
+
+  @tag :with_db
+  test "form update via application/x-www-form-urlencoded", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    {:ok, resp} = create_doc(db_name, @document)
+    docid = resp.body["id"]
+
+    resp =
+      Couch.put(
+        "/#{db_name}/_design/update/_update/form-update/#{docid}",
+        headers: ["Content-Type": "application/x-www-form-urlencoded"],
+        body: "formfoo=bar&formbar=foo"
+      )
+
+    assert resp.status_code == 201
+    assert resp.body == "updated doc from form"
+
+    resp = Couch.get("/#{db_name}/#{docid}")
+    assert resp.status_code == 200
+    assert resp.body["formfoo"] == "bar"
+    assert resp.body["formbar"] == "foo"
+  end
+
+  @tag :with_db
+  test "bump counter", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    {:ok, resp} = create_doc(db_name, @document)
+    docid = resp.body["id"]
+
+    resp =
+      Couch.put("/#{db_name}/_design/update/_update/bump-counter/#{docid}",
+        headers: ["X-Couch-Full-Commit": "true"]
+      )
+
+    assert resp.status_code == 201
+    assert resp.body == "<h1>bumped it!</h1>"
+
+    resp = Couch.get("/#{db_name}/#{docid}")
+    assert resp.status_code == 200
+    assert resp.body["counter"] == 1
+
+    resp =
+      Couch.put("/#{db_name}/_design/update/_update/bump-counter/#{docid}",
+        headers: ["X-Couch-Full-Commit": "true"]
+      )
+
+    newrev = resp.headers["X-Couch-Update-NewRev"]
+
+    resp = Couch.get("/#{db_name}/#{docid}")
+    assert resp.status_code == 200
+    assert resp.body["counter"] == 2
+    assert resp.body["_rev"] == newrev
+  end
+
+  @tag :with_db
+  test "Server provides UUID when POSTing without an ID in the URL", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+    resp = Couch.put("/#{db_name}/_design/update/_update/get-uuid/")
+    assert resp.status_code == 200
+    assert String.length(resp.body) == 32
+  end
+
+  @tag :with_db
+  test "COUCHDB-1229 - allow slashes in doc ids for update handlers", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    create_doc(db_name, %{_id: "with/slash", counter: 1})
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/bump-counter/with/slash")
+    assert resp.status_code == 201
+    assert resp.body == "<h1>bumped it!</h1>"
+
+    resp = Couch.get("/#{db_name}/with%2Fslash")
+    assert resp.status_code == 200
+    assert resp.body["counter"] == 2
+  end
+
+  @tag :with_db
+  test "COUCHDB-648 - the code in the JSON response should be honored", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    {:ok, resp} = create_doc(db_name, @document)
+    docid = resp.body["id"]
+
+    Couch.put("/#{db_name}/_design/update/_update/bump-counter/#{docid}")
+    Couch.put("/#{db_name}/_design/update/_update/bump-counter/#{docid}")
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/code-n-bump/#{docid}")
+    assert resp.status_code == 302
+    assert resp.body == "<h1>bumped it!</h1>"
+
+    resp = Couch.get("/#{db_name}/#{docid}")
+    assert resp.status_code == 200
+    assert resp.body["counter"] == 3
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/resp-code/")
+    assert resp.status_code == 302
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/resp-code-and-json/")
+    assert resp.status_code == 302
+    assert resp.body["ok"] == true
+  end
+
+  @tag :with_db
+  test "base64 response", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    {:ok, resp} = create_doc(db_name, @document)
+    docid = resp.body["id"]
+
+    resp =
+      Couch.put("/#{db_name}/_design/update/_update/binary/#{docid}",
+        body: "rubbish"
+      )
+
+    assert resp.status_code == 201
+    assert resp.body == "hello world!"
+    assert String.contains?(resp.headers["Content-Type"], "application/octet-stream")
+  end
+
+  @tag :with_db
+  test "Insert doc with empty id", context do
+    db_name = context[:db_name]
+    create_doc(db_name, @ddoc)
+
+    resp = Couch.put("/#{db_name}/_design/update/_update/empty/foo")
+    assert resp.status_code == 400
+    assert resp.body["reason"] == "Document id must not be empty"
+  end
+end

--- a/test/elixir/test/view_multi_key_all_docs_test.exs
+++ b/test/elixir/test/view_multi_key_all_docs_test.exs
@@ -1,0 +1,191 @@
+defmodule ViewMultiKeyAllDocsTest do
+  use CouchTestCase
+
+  @keys ["10", "15", "30", "37", "50"]
+
+  setup_all do
+    db_name = random_db_name()
+    {:ok, _} = create_db(db_name)
+    on_exit(fn -> delete_db(db_name) end)
+
+    bulk_save(db_name, make_docs(0..99))
+
+    {:ok, [db_name: db_name]}
+  end
+
+  test "keys in POST body", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, nil, @keys)
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+
+    rows_id = Enum.map(rows, & &1["id"])
+    assert rows_id == @keys
+  end
+
+  test "keys in GET parameters", context do
+    db_name = context[:db_name]
+    resp = all_docs(db_name, keys: :jiffy.encode(@keys))
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+    rows_id = Enum.map(rows, & &1["id"])
+    assert rows_id == @keys
+  end
+
+  test "keys in POST body (limit)", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, [limit: 1], @keys)
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 1
+    assert Enum.at(rows, 0)["id"] == Enum.at(@keys, 0)
+  end
+
+  test "keys in GET parameters (limit)", context do
+    db_name = context[:db_name]
+    resp = all_docs(db_name, limit: 1, keys: :jiffy.encode(@keys))
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 1
+    assert Enum.at(rows, 0)["id"] == Enum.at(@keys, 0)
+  end
+
+  test "keys in POST body (skip)", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, [skip: 2], @keys)
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 3
+
+    rows_id = Enum.map(rows, & &1["id"])
+    assert rows_id == Enum.drop(@keys, 2)
+  end
+
+  test "keys in GET parameters (skip)", context do
+    db_name = context[:db_name]
+    resp = all_docs(db_name, skip: 2, keys: :jiffy.encode(@keys))
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 3
+    rows_id = Enum.map(rows, & &1["id"])
+    assert rows_id == Enum.drop(@keys, 2)
+  end
+
+  test "keys in POST body (descending)", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, [descending: true], @keys)
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+
+    rows_id = Enum.map(rows, & &1["id"])
+    assert rows_id == Enum.reverse(@keys)
+  end
+
+  test "keys in GET parameters (descending)", context do
+    db_name = context[:db_name]
+    resp = all_docs(db_name, descending: true, keys: :jiffy.encode(@keys))
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+    rows_id = Enum.map(rows, & &1["id"])
+    assert rows_id == Enum.reverse(@keys)
+  end
+
+  test "keys in POST body (descending, skip, limit)", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, [descending: "true", skip: 3, limit: 1], @keys)
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 1
+
+    key =
+      @keys
+      |> Enum.reverse()
+      |> Enum.drop(3)
+      |> Enum.at(0)
+
+    assert Enum.at(rows, 0)["id"] == key
+  end
+
+  test "keys in GET parameters (descending, skip, limit)", context do
+    db_name = context[:db_name]
+
+    resp =
+      all_docs(db_name, descending: "true", skip: 3, limit: 1, keys: :jiffy.encode(@keys))
+
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 1
+
+    key =
+      @keys
+      |> Enum.reverse()
+      |> Enum.drop(3)
+      |> Enum.at(0)
+
+    assert Enum.at(rows, 0)["id"] == key
+  end
+
+  test "POST - get invalid rows when the key doesn't exist", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, nil, ["1211", "i_dont_exist", "0"])
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 3
+    assert Enum.at(rows, 0)["error"] == "not_found"
+    assert not Map.has_key?(Enum.at(rows, 0), "id")
+    assert Enum.at(rows, 1)["error"] == "not_found"
+    assert not Map.has_key?(Enum.at(rows, 1), "id")
+    assert Enum.at(rows, 2)["id"] == Enum.at(rows, 2)["key"]
+    assert Enum.at(rows, 2)["key"] == "0"
+  end
+
+  test "GET - get invalid rows when the key doesn't exist", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, keys: :jiffy.encode(["1211", "i_dont_exist", "0"]))
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert length(rows) == 3
+    assert Enum.at(rows, 0)["error"] == "not_found"
+    assert not Map.has_key?(Enum.at(rows, 0), "id")
+    assert Enum.at(rows, 1)["error"] == "not_found"
+    assert not Map.has_key?(Enum.at(rows, 1), "id")
+    assert Enum.at(rows, 2)["id"] == Enum.at(rows, 2)["key"]
+    assert Enum.at(rows, 2)["key"] == "0"
+  end
+
+  test "empty keys", context do
+    db_name = context[:db_name]
+
+    resp = all_docs(db_name, keys: :jiffy.encode([]))
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert Enum.empty?(rows)
+  end
+
+  defp all_docs(db_name, options, keys \\ nil) do
+    resp =
+      case keys do
+        nil ->
+          Couch.get("/#{db_name}/_all_docs", query: options)
+
+        _ ->
+          Couch.post("/#{db_name}/_all_docs",
+            query: options,
+            body: %{"keys" => keys}
+          )
+      end
+
+    resp
+  end
+end

--- a/test/elixir/test/view_multi_key_design_test.exs
+++ b/test/elixir/test/view_multi_key_design_test.exs
@@ -1,0 +1,316 @@
+defmodule ViewMultiKeyDesignTest do
+  use CouchTestCase
+
+  @keys [10, 15, 30, 37, 50]
+
+  @ddoc %{
+    _id: "_design/test",
+    language: "javascript",
+    views: %{
+      all_docs: %{
+        map: "function(doc) { emit(doc.integer, doc.string) }"
+      },
+      multi_emit: %{
+        map: "function(doc) {for(var i = 0 ; i < 3 ; i++) { emit(i, doc.integer) ; } }"
+      },
+      summate: %{
+        map: "function (doc) {emit(doc.integer, doc.integer)};",
+        reduce: "function (keys, values) { return sum(values); };"
+      }
+    }
+  }
+
+  setup_all do
+    db_name = random_db_name()
+    {:ok, _} = create_db(db_name)
+    on_exit(fn -> delete_db(db_name) end)
+
+    bulk_save(db_name, make_docs(0..99))
+    {:ok, _} = create_doc(db_name, @ddoc)
+
+    {:ok, [db_name: db_name]}
+  end
+
+  test "that missing keys work too", context do
+    db_name = context[:db_name]
+    keys = [101, 30, 15, 37, 50]
+    resp = view(db_name, "test/summate", [group: true], keys)
+    rows = resp.body["rows"]
+    assert length(rows) == length(keys) - 1
+
+    assert Enum.all?(rows, &Enum.member?(keys, &1["key"]))
+    assert Enum.all?(rows, &(&1["key"] == &1["value"]))
+  end
+
+  test "keys in POST body", context do
+    db_name = context[:db_name]
+    resp = view(db_name, "test/all_docs", nil, @keys)
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+    assert Enum.all?(rows, &Enum.member?(@keys, &1["key"]))
+    assert Enum.all?(rows, &(&1["key"] == String.to_integer(&1["value"])))
+  end
+
+  test "keys in GET parameters", context do
+    db_name = context[:db_name]
+    resp = view(db_name, "test/all_docs", keys: :jiffy.encode(@keys))
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+    assert Enum.all?(rows, &Enum.member?(@keys, &1["key"]))
+    assert Enum.all?(rows, &(&1["key"] == String.to_integer(&1["value"])))
+  end
+
+  test "empty keys", context do
+    db_name = context[:db_name]
+
+    resp = view(db_name, "test/all_docs", keys: :jiffy.encode([]))
+    assert resp.status_code == 200
+    rows = resp.body["rows"]
+    assert Enum.empty?(rows)
+  end
+
+  test "keys in POST body (group)", context do
+    db_name = context[:db_name]
+    resp = view(db_name, "test/summate", [group: true], @keys)
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+    assert Enum.all?(rows, &Enum.member?(@keys, &1["key"]))
+    assert Enum.all?(rows, &(&1["key"] == &1["value"]))
+  end
+
+  test "keys in GET body (group)", context do
+    db_name = context[:db_name]
+    resp = view(db_name, "test/summate", group: true, keys: :jiffy.encode(@keys))
+    rows = resp.body["rows"]
+    assert length(rows) == length(@keys)
+    assert Enum.all?(rows, &Enum.member?(@keys, &1["key"]))
+    assert Enum.all?(rows, &(&1["key"] == &1["value"]))
+  end
+
+  test "POST - invalid parameter combinations get rejected ", context do
+    db_name = context[:db_name]
+
+    badargs = [[startkey: 0], [endkey: 0], [key: 0], [group_level: 2]]
+
+    Enum.each(badargs, fn args ->
+      resp =
+        Couch.post("/#{db_name}/_design/test/_view/all_docs",
+          query: args,
+          body: %{"keys" => @keys}
+        )
+
+      assert resp.status_code == 400
+      assert resp.body["error"] == "query_parse_error"
+    end)
+
+    resp =
+      Couch.post("/#{db_name}/_design/test/_view/summate",
+        query: nil,
+        body: %{"keys" => @keys}
+      )
+
+    assert resp.status_code == 400
+    assert resp.body["error"] == "query_parse_error"
+  end
+
+  test "GET - invalid parameter combinations get rejected ", context do
+    db_name = context[:db_name]
+
+    badargs = [
+      [startkey: 0, keys: :jiffy.encode(@keys)],
+      [endkey: 0, keys: :jiffy.encode(@keys)],
+      [key: 0, keys: :jiffy.encode(@keys)],
+      [group_level: 2, keys: :jiffy.encode(@keys)]
+    ]
+
+    Enum.each(badargs, fn args ->
+      resp =
+        Couch.get("/#{db_name}/_design/test/_view/all_docs",
+          query: args
+        )
+
+      assert resp.status_code == 400
+      assert resp.body["error"] == "query_parse_error"
+    end)
+
+    resp =
+      Couch.get("/#{db_name}/_design/test/_view/summate",
+        query: [keys: :jiffy.encode(@keys)],
+        body: %{"keys" => @keys}
+      )
+
+    assert resp.status_code == 400
+    assert resp.body["error"] == "query_parse_error"
+  end
+
+  test "that a map & reduce containing func support keys when reduce=false", context do
+    db_name = context[:db_name]
+    resp = view(db_name, "test/summate", [reduce: false], @keys)
+    assert length(resp.body["rows"]) == 5
+
+    resp = view(db_name, "test/summate", reduce: false, keys: :jiffy.encode(@keys))
+    assert length(resp.body["rows"]) == 5
+  end
+
+  test "that limiting by startkey_docid and endkey_docid get applied", context do
+    db_name = context[:db_name]
+
+    exp_key = [0, 0, 0, 2, 2, 2]
+    exp_val = [21, 22, 23, 21, 22, 23]
+
+    resp =
+      view(db_name, "test/multi_emit", [startkey_docid: 21, endkey_docid: 23], [0, 2])
+
+    rows = resp.body["rows"]
+    rows_key = Enum.map(rows, & &1["key"])
+    assert rows_key == exp_key
+
+    rows_value = Enum.map(rows, & &1["value"])
+    assert rows_value == exp_val
+
+    resp =
+      view(db_name, "test/multi_emit",
+        startkey_docid: 21,
+        endkey_docid: 23,
+        keys: :jiffy.encode([0, 2])
+      )
+
+    rows = resp.body["rows"]
+    rows_key = Enum.map(rows, & &1["key"])
+    assert rows_key == exp_key
+
+    rows_value = Enum.map(rows, & &1["value"])
+    assert rows_value == exp_val
+  end
+
+  test "limit works", context do
+    db_name = context[:db_name]
+
+    resp = view(db_name, "test/all_docs", [limit: 1], @keys)
+    rows = resp.body["rows"]
+    assert length(rows) == 1
+    assert Enum.at(rows, 0)["key"] == 10
+
+    resp = view(db_name, "test/all_docs", limit: 1, keys: :jiffy.encode(@keys))
+    rows = resp.body["rows"]
+    assert length(rows) == 1
+    assert Enum.at(rows, 0)["key"] == 10
+  end
+
+  test "offset works", context do
+    db_name = context[:db_name]
+
+    resp = view(db_name, "test/multi_emit", [skip: 1], [0])
+    rows = resp.body["rows"]
+    assert length(rows) == 99
+
+    resp = view(db_name, "test/multi_emit", skip: 1, keys: :jiffy.encode([0]))
+    rows = resp.body["rows"]
+    assert length(rows) == 99
+  end
+
+  test "dir works", context do
+    db_name = context[:db_name]
+
+    resp = view(db_name, "test/multi_emit", [descending: true], [1])
+    rows = resp.body["rows"]
+    assert length(rows) == 100
+
+    resp = view(db_name, "test/multi_emit", descending: true, keys: :jiffy.encode([1]))
+    rows = resp.body["rows"]
+    assert length(rows) == 100
+  end
+
+  test "argument combinations", context do
+    db_name = context[:db_name]
+
+    resp = view(db_name, "test/multi_emit", [descending: true, skip: 3, limit: 2], [2])
+    rows = resp.body["rows"]
+    assert length(rows) == 2
+
+    resp =
+      view(db_name, "test/multi_emit",
+        descending: true,
+        skip: 3,
+        limit: 2,
+        keys: :jiffy.encode([2])
+      )
+
+    rows = resp.body["rows"]
+    assert length(rows) == 2
+
+    resp =
+      view(db_name, "test/multi_emit", [skip: 0, limit: 1, startkey_docid: "13"], [0])
+
+    rows = resp.body["rows"]
+    assert length(rows) == 1
+    assert Enum.at(rows, 0)["value"] == 13
+
+    resp =
+      view(db_name, "test/multi_emit", [skip: 2, limit: 3, startkey_docid: "13"], [0])
+
+    rows = resp.body["rows"]
+    assert length(rows) == 3
+
+    resp =
+      view(db_name, "test/multi_emit",
+        skip: 2,
+        limit: 3,
+        startkey_docid: "13",
+        keys: :jiffy.encode([0])
+      )
+
+    rows = resp.body["rows"]
+    assert length(rows) == 3
+
+    resp =
+      view(
+        db_name,
+        "test/multi_emit",
+        [skip: 1, limit: 5, startkey_docid: "25", endkey_docid: "27"],
+        [1]
+      )
+
+    rows = resp.body["rows"]
+    assert length(rows) == 2
+    assert Enum.at(rows, 0)["value"] == 26 or assert(Enum.at(rows, 0)["value"] == 27)
+
+    resp =
+      view(db_name, "test/multi_emit",
+        skip: 1,
+        limit: 5,
+        startkey_docid: "25",
+        endkey_docid: "27",
+        keys: :jiffy.encode([1])
+      )
+
+    rows = resp.body["rows"]
+    assert length(rows) == 2
+    assert Enum.at(rows, 0)["value"] == 26 or assert(Enum.at(rows, 0)["value"] == 27)
+
+    resp =
+      view(
+        db_name,
+        "test/multi_emit",
+        [skip: 1, limit: 5, startkey_docid: "28", endkey_docid: "26", descending: true],
+        [1]
+      )
+
+    rows = resp.body["rows"]
+    assert length(rows) == 2
+    assert Enum.at(rows, 0)["value"] == 26 or assert(Enum.at(rows, 0)["value"] == 27)
+
+    resp =
+      view(db_name, "test/multi_emit",
+        skip: 1,
+        limit: 5,
+        startkey_docid: "28",
+        endkey_docid: "26",
+        descending: true,
+        keys: :jiffy.encode([1])
+      )
+
+    rows = resp.body["rows"]
+    assert length(rows) == 2
+  end
+end

--- a/test/elixir/test/view_sandboxing_test.exs
+++ b/test/elixir/test/view_sandboxing_test.exs
@@ -1,0 +1,191 @@
+defmodule ViewSandboxingTest do
+  use CouchTestCase
+
+  @document %{integer: 1, string: "1", array: [1, 2, 3]}
+
+  @tag :with_db
+  test "attempting to change the document has no effect", context do
+    db_name = context[:db_name]
+
+    {:ok, _} = create_doc(db_name, @document)
+
+    map_fun = """
+    function(doc) {
+      doc.integer = 2;
+      emit(null, doc);
+    }
+    """
+
+    resp = query(db_name, map_fun, nil, %{include_docs: true})
+    rows = resp["rows"]
+    # either we have an error or our doc is unchanged
+    assert resp["total_rows"] == 0 or Enum.at(rows, 0)["doc"]["integer"] == 1
+
+    map_fun = """
+    function(doc) {
+      doc.array[0] = 0;
+      emit(null, doc);
+    }
+    """
+
+    resp = query(db_name, map_fun, nil, %{include_docs: true})
+    row = Enum.at(resp["rows"], 0)
+    # either we have an error or our doc is unchanged
+    assert resp["total_rows"] == 0 or Enum.at(row["doc"]["array"], 0) == 1
+  end
+
+  @tag :with_db
+  test "view cannot invoke interpreter internals", context do
+    db_name = context[:db_name]
+    {:ok, _} = create_doc(db_name, @document)
+
+    map_fun = """
+    function(doc) {
+      gc();
+      emit(null, doc);
+    }
+    """
+
+    # make sure that a view cannot invoke interpreter internals such as the
+    # garbage collector
+    resp = query(db_name, map_fun)
+    assert resp["total_rows"] == 0
+  end
+
+  @tag :with_db
+  test "view cannot access the map_funs and map_results array", context do
+    db_name = context[:db_name]
+    {:ok, _} = create_doc(db_name, @document)
+
+    map_fun = """
+    function(doc) {
+      map_funs.push(1);
+      emit(null, doc);
+    }
+    """
+
+    resp = query(db_name, map_fun)
+    assert resp["total_rows"] == 0
+
+    map_fun = """
+    function(doc) {
+      map_results.push(1);
+      emit(null, doc);
+    }
+    """
+
+    resp = query(db_name, map_fun)
+    assert resp["total_rows"] == 0
+  end
+
+  @tag :with_db
+  test "COUCHDB-925 - altering 'doc' variable in map function affects other map functions",
+       context do
+    db_name = context[:db_name]
+
+    ddoc = %{
+      _id: "_design/foobar",
+      language: "javascript",
+      views: %{
+        view1: %{
+          map: """
+             function(doc) {
+              if (doc.values) {
+                doc.values = [666];
+              }
+              if (doc.tags) {
+                doc.tags.push("qwerty");
+              }
+              if (doc.tokens) {
+                doc.tokens["c"] = 3;
+              }
+            }
+          """
+        },
+        view2: %{
+          map: """
+          function(doc) {
+            if (doc.values) {
+              emit(doc._id, doc.values);
+            }
+            if (doc.tags) {
+              emit(doc._id, doc.tags);
+            }
+            if (doc.tokens) {
+              emit(doc._id, doc.tokens);
+            }
+          }
+          """
+        }
+      }
+    }
+
+    doc1 = %{
+      _id: "doc1",
+      values: [1, 2, 3]
+    }
+
+    doc2 = %{
+      _id: "doc2",
+      tags: ["foo", "bar"],
+      tokens: %{a: 1, b: 2}
+    }
+
+    {:ok, _} = create_doc(db_name, ddoc)
+    {:ok, _} = create_doc(db_name, doc1)
+    {:ok, _} = create_doc(db_name, doc2)
+
+    resp1 = view(db_name, "foobar/view1")
+    resp2 = view(db_name, "foobar/view2")
+
+    assert Enum.empty?(resp1.body["rows"])
+    assert length(resp2.body["rows"]) == 3
+
+    assert doc1[:_id] == Enum.at(resp2.body["rows"], 0)["key"]
+    assert doc2[:_id] == Enum.at(resp2.body["rows"], 1)["key"]
+    assert doc2[:_id] == Enum.at(resp2.body["rows"], 2)["key"]
+
+    assert length(Enum.at(resp2.body["rows"], 0)["value"]) == 3
+
+    row0_values = Enum.at(resp2.body["rows"], 0)["value"]
+
+    assert Enum.at(row0_values, 0) == 1
+    assert Enum.at(row0_values, 1) == 2
+    assert Enum.at(row0_values, 2) == 3
+
+    row1_values = Enum.at(resp2.body["rows"], 1)["value"]
+    row2_values = Enum.at(resp2.body["rows"], 2)["value"]
+
+    # we can't be 100% sure about the order for the same key
+    assert (is_map(row1_values) and row1_values["a"] == 1) or
+             (is_list(row1_values) and Enum.at(row1_values, 0) == "foo")
+
+    assert (is_map(row1_values) and row1_values["b"] == 2) or
+             (is_list(row1_values) and Enum.at(row1_values, 1) == "bar")
+
+    assert (is_map(row2_values) and row2_values["a"] == 1) or
+             (is_list(row2_values) and Enum.at(row2_values, 0) == "foo")
+
+    assert (is_map(row2_values) and row2_values["b"] == 2) or
+             (is_list(row2_values) and Enum.at(row2_values, 1) == "bar")
+
+    assert is_list(row1_values) or !Map.has_key?(row1_values, "c")
+    assert is_list(row2_values) or !Map.has_key?(row2_values, "c")
+  end
+
+  @tag :with_db
+  test "runtime code evaluation can be prevented", context do
+    db_name = context[:db_name]
+    {:ok, _} = create_doc(db_name, @document)
+
+    map_fun = """
+    function(doc) {
+      var glob = emit.constructor('return this')();
+      emit(doc._id, null);
+    }
+    """
+
+    resp = query(db_name, map_fun)
+    assert resp["total_rows"] == 0
+  end
+end

--- a/test/javascript/tests/update_documents.js
+++ b/test/javascript/tests/update_documents.js
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-
+couchTests.elixir = true
 couchTests.update_documents = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/view_multi_key_all_docs.js
+++ b/test/javascript/tests/view_multi_key_all_docs.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.view_multi_key_all_docs = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/view_multi_key_design.js
+++ b/test/javascript/tests/view_multi_key_design.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true;
 couchTests.view_multi_key_design = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/view_multi_key_temp.js
+++ b/test/javascript/tests/view_multi_key_temp.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.skip = true;
 couchTests.view_multi_key_temp = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});

--- a/test/javascript/tests/view_sandboxing.js
+++ b/test/javascript/tests/view_sandboxing.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+couchTests.elixir = true
 couchTests.view_sandboxing = function(debug) {
   var db_name = get_random_db_name();
   var db = new CouchDB(db_name, {"X-Couch-Full-Commit":"false"});


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR backports #3022, #3021  and #2992 to 3.x branch

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
 make elixir
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
#3022, #3021  and #2992
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
