### PR TITLE
fix: finish_cluster failure due to missing uuid

### DIFF
--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -198,6 +198,9 @@ setup_node(NewCredentials, NewBindAddress, NodeCount, Port) ->
 
 
 finish_cluster(Options) ->
+    % ensure that uuid is set
+    couch_server:get_uuid(),
+
     ok = wait_connected(),
     ok = sync_admins(),
     ok = sync_uuid(),


### PR DESCRIPTION
Resolves #2858

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Fixes cluster setup failure when uuid is not set. 
Added code to call `couch_server:get_uuid()` to ensure that uuid is set. 
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
Sample docker-compose file
```
version: '3'
services:
  couch1:
    image: couchdev
#    image: couchdb:3
    environment:
      - COUCHDB_USER=user
      - COUCHDB_PASSWORD=pass
      - COUCHDB_SECRET=secret
      - NODENAME=10.0.0.10
    networks:
      couch:
        ipv4_address: 10.0.0.10
    command: "-setcookie cookie"
    volumes:
      - ./data1:/opt/couchdb/data

  couch2:
    image: couchdev
#    image: couchdb:3
    environment:
      - COUCHDB_USER=user
      - COUCHDB_PASSWORD=pass
      - COUCHDB_SECRET=secret
      - NODENAME=10.0.0.11
    networks:
      couch:
        ipv4_address: 10.0.0.11
    command: "-setcookie cookie"
    volumes:
      - ./data2:/opt/couchdb/data

networks:
    couch:
      driver: bridge
      ipam:
        config:
          - subnet: 10.0.0.0/16

```

Sample script
```
# curl http://10.0.0.10:5984
# curl http://10.0.0.11:5984
curl http://user:pass@10.0.0.10:5984/_cluster_setup

curl --request POST \
  --url http://user:pass@10.0.0.10:5984/_cluster_setup \
  --header 'content-type: application/json' \
  --data '{
	"action": "enable_cluster",
	"bind_address": "0.0.0.0",
	"username": "user",
	"password": "pass",
	"port": 5984,
	"node_count": 2,
	"remote_node": "10.0.0.11",
	"remote_current_user": "user",
	"remote_current_password": "pass"
}'
curl --request POST \
  --url http://user:pass@10.0.0.10:5984/_cluster_setup \
  --header 'content-type: application/json' \
  --data '{
    "action": "add_node",
    "host": "10.0.0.11",
    "port": 5984,
    "username": "user",
    "password": "pass",
    "singlenode": false
}'
# curl http://couchdb1:5984/
curl --request POST \
  --url http://user:pass@10.0.0.10:5984/_cluster_setup \
  --header 'content-type: application/json' \
  --data '{ "action": "finish_cluster" }'
curl http://user:pass@10.0.0.10:5984/_cluster_setup
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
#2797 #2858 
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
