### PR TITLE
New mango operator proposal : match keys of a map

### DIFF
--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -138,6 +138,11 @@ norm_ops({[{<<"$allMatch">>, {_}=Arg}]}) ->
 norm_ops({[{<<"$allMatch">>, Arg}]}) ->
     ?MANGO_ERROR({bad_arg, '$allMatch', Arg});
 
+norm_ops({[{<<"$keyMapMatch">>, {_}=Arg}]}) ->
+    {[{<<"$keyMapMatch">>, norm_ops(Arg)}]};
+norm_ops({[{<<"$keyMapMatch">>, Arg}]}) ->
+    ?MANGO_ERROR({bad_arg, '$keyMapMatch', Arg});
+
 norm_ops({[{<<"$size">>, Arg}]}) when is_integer(Arg), Arg >= 0 ->
     {[{<<"$size">>, Arg}]};
 norm_ops({[{<<"$size">>, Arg}]}) ->
@@ -253,6 +258,10 @@ norm_fields({[{<<"$allMatch">>, Arg}]}, Path) ->
     Cond = {[{<<"$allMatch">>, norm_fields(Arg)}]},
     {[{Path, Cond}]};
 
+norm_fields({[{<<"$keyMapMatch">>, Arg}]}, Path) ->
+    Cond = {[{<<"$keyMapMatch">>, norm_fields(Arg)}]},
+    {[{Path, Cond}]};
+
 
 % The text operator operates against the internal
 % $default field. This also asserts that the $default
@@ -333,6 +342,9 @@ norm_negations({[{<<"$elemMatch">>, Arg}]}) ->
 
 norm_negations({[{<<"$allMatch">>, Arg}]}) ->
     {[{<<"$allMatch">>, norm_negations(Arg)}]};
+
+norm_negations({[{<<"$keyMapMatch">>, Arg}]}) ->
+    {[{<<"$keyMapMatch">>, norm_negations(Arg)}]};
 
 % All other conditions can't introduce negations anywhere
 % further down the operator tree.
@@ -489,6 +501,26 @@ match({[{<<"$allMatch">>, Arg}]}, [_ | _] = Values, Cmp) ->
             false
     end;
 match({[{<<"$allMatch">>, _Arg}]}, _Value, _Cmp) ->
+    false;
+
+% Matches when any key in the map value matches the
+% sub-selector Arg.
+match({[{<<"$keyMapMatch">>, Arg}]}, Value, Cmp) when is_tuple(Value) ->
+    try
+        lists:foreach(fun(V) ->
+            case match(Arg, V, Cmp) of
+                true -> throw(matched);
+                _ -> ok
+            end
+        end, [Key || {Key, _} <- element(1, Value)]),
+        false
+    catch
+        throw:matched ->
+            true;
+        _:_ ->
+            false
+    end;
+match({[{<<"$keyMapMatch">>, _Arg}]}, _Value, _Cmp) ->
     false;
 
 % Our comparison operators are fairly straight forward

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -66,6 +66,15 @@ class OperatorTests:
         docs = self.db.find({"emptybang": {"$allMatch": {"foo": {"$eq": 2}}}})
         self.assertEqual(len(docs), 0)
 
+    def test_keymap_match(self):
+        amdocs = [
+            {"foo": {"aa": "bar", "bb": "bang"}},
+            {"foo": {"cc": "bar", "bb": "bang"}},
+        ]
+        self.db.save_docs(amdocs, w=3)
+        docs = self.db.find({"foo": {"$keyMapMatch": {"$eq": "aa"}}})
+        self.assertEqual(len(docs), 1)
+
     def test_in_operator_array(self):
         docs = self.db.find({"manager": True, "favorites": {"$in": ["Ruby", "Python"]}})
         self.assertUserIds([2, 6, 7, 9, 11, 12], docs)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Proposition of a new Mango query operator that allows to query on the keys of a map.
It is related to the already existing `$elemMatch` but instead on the elements of an array it is applied on the keys 
of a map.

For the name of the operator I don't know what's best suited, I used `$keyMapMatch`.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Related Issues or Pull Requests
https://github.com/apache/couchdb-documentation/pull/574

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
