### PR TITLE
add local_seq option to views

### DIFF
--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -408,7 +408,8 @@ fetch_docs(Db, DesignOpts, Changes) ->
         }
     end, #{}, erlfdb:wait_for_all(RevFutures)),
 
-    AddLocalSeq = lists:keymember(<<"local_seq">>, 1, DesignOpts),
+    AddLocalSeq = fabric2_util:get_value(<<"local_seq">>, DesignOpts, false),
+
     BodyFutures = maps:keys(BodyState),
     ChangesWithDocs = lists:map(fun (BodyFuture) ->
         {Id, RevInfo, Change} = maps:get(BodyFuture, BodyState),

--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -380,7 +380,7 @@ write_docs(TxDb, Mrst, Docs, State) ->
     DocsNumber.
 
 
-fetch_docs(Db, DesignOpts ,Changes) ->
+fetch_docs(Db, DesignOpts, Changes) ->
     {Deleted, NotDeleted} = lists:partition(fun(Doc) ->
         #{deleted := Deleted} = Doc,
         Deleted

--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -414,15 +414,14 @@ fetch_docs(Db, DesignOpts ,Changes) ->
         {Id, RevInfo, Change} = maps:get(BodyFuture, BodyState),
         Doc = fabric2_fdb:get_doc_body_wait(Db, Id, RevInfo, BodyFuture),
 
-        BranchCount = maps:get(branch_count, RevInfo, 1),
-        Doc1 = case BranchCount == 1 of
-            true when AddLocalSeq ->
+        Doc1 = case maps:get(branch_count, RevInfo, 1) of
+            1 when AddLocalSeq ->
                 {ok, DocWithLocalSeq} = fabric2_db:apply_open_doc_opts(Doc,
                     [RevInfo], [local_seq]),
                 DocWithLocalSeq;
-            true ->
+            1 ->
                 Doc;
-            false ->
+            _ ->
                 RevConflicts = fabric2_fdb:get_all_revs(Db, Id),
                 DocOpts = if not AddLocalSeq -> []; true -> [local_seq] end,
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add support for the `_local_seq` option to views https://docs.couchdb.org/en/stable/api/ddoc/views.html#view-options

## Testing recommendations

`make check` should pass

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
