### PR TITLE
Allow interactive requests to reopen a re-created db instance

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -395,7 +395,8 @@ delete_db_req(#httpd{user_ctx=Ctx}=Req, DbName) ->
     end.
 
 do_db_req(#httpd{path_parts=[DbName|_], user_ctx=Ctx}=Req, Fun) ->
-    {ok, Db} = fabric2_db:open(DbName, [{user_ctx, Ctx}]),
+    Options = [{user_ctx, Ctx}, {interactive, true}],
+    {ok, Db} = fabric2_db:open(DbName, Options),
     Fun(Req, Db).
 
 db_req(#httpd{method='GET',path_parts=[_DbName]}=Req, Db) ->

--- a/src/fabric/src/fabric2_db.erl
+++ b/src/fabric/src/fabric2_db.erl
@@ -201,7 +201,8 @@ open(DbName, Options) ->
     case fabric2_server:fetch(DbName, UUID) of
         #{} = Db ->
             Db1 = maybe_set_user_ctx(Db, Options),
-            {ok, require_member_check(Db1)};
+            Db2 = maybe_set_interactive(Db1, Options),
+            {ok, require_member_check(Db2)};
         undefined ->
             Result = fabric2_fdb:transactional(DbName, Options, fun(TxDb) ->
                 fabric2_fdb:open(TxDb, Options)
@@ -1424,6 +1425,11 @@ get_all_docs_meta(TxDb, Options) ->
         _ ->
             []
     end ++ [{total, DocCount}, {offset, null}].
+
+
+maybe_set_interactive(#{} = Db, Options) ->
+    Interactive = fabric2_util:get_value(interactive, Options, false),
+    Db#{interactive := Interactive}.
 
 
 maybe_set_user_ctx(Db, Options) ->

--- a/src/fabric/src/fabric2_server.erl
+++ b/src/fabric/src/fabric2_server.erl
@@ -271,5 +271,6 @@ sanitize(#{} = Db) ->
     Db#{
         tx := undefined,
         user_ctx := #user_ctx{},
-        security_fun := undefined
+        security_fun := undefined,
+        interactive := false
     }.

--- a/src/fabric/test/fabric2_db_crud_tests.erl
+++ b/src/fabric/test/fabric2_db_crud_tests.erl
@@ -38,6 +38,8 @@ crud_test_() ->
                     ?TDEF_FE(open_db),
                     ?TDEF_FE(delete_db),
                     ?TDEF_FE(recreate_db),
+                    ?TDEF_FE(recreate_db_interactive),
+                    ?TDEF_FE(recreate_db_non_interactive),
                     ?TDEF_FE(undelete_db),
                     ?TDEF_FE(remove_deleted_db),
                     ?TDEF_FE(scheduled_remove_deleted_db, 15),
@@ -177,6 +179,32 @@ recreate_db(_) ->
     % Remove from cache to force it to open through fabric2_fdb:open
     fabric2_server:remove(DbName),
     ?assertError(database_does_not_exist, fabric2_db:open(DbName, BadOpts)).
+
+
+recreate_db_interactive(_) ->
+    DbName = ?tempdb(),
+    ?assertMatch({ok, _}, fabric2_db:create(DbName, [])),
+
+    {ok, Db1} = fabric2_db:open(DbName, [{interactive, true}]),
+
+    ?assertEqual(ok, fabric2_db:delete(DbName, [])),
+    ?assertMatch({ok, _}, fabric2_db:create(DbName, [])),
+
+    ?assertMatch({ok, _}, fabric2_db:get_db_info(Db1)).
+
+
+recreate_db_non_interactive(_) ->
+    % This is also the default case, but we check that parsing the `false` open
+    % value works correctly.
+    DbName = ?tempdb(),
+    ?assertMatch({ok, _}, fabric2_db:create(DbName, [])),
+
+    {ok, Db1} = fabric2_db:open(DbName, [{interactive, false}]),
+
+    ?assertEqual(ok, fabric2_db:delete(DbName, [])),
+    ?assertMatch({ok, _}, fabric2_db:create(DbName, [])),
+
+    ?assertError(database_does_not_exist, fabric2_db:get_db_info(Db1)).
 
 
 undelete_db(_) ->


### PR DESCRIPTION
Previously, if a database was re-created on another node, a request with that database might have found the previous db instance in the cache. In that case it would have correctly reopened the db while in a transaction, but, because
the old db instance was deleted it would throw a database_does_not_exist which was not the correct behavior.

To prevent that from happening, introduce an `interactive = true|false` option when opening a database. User requests may specify that option and then when the db is re-opened, it will allow it to automatically upgrade to the new db instance instead of returning an error.

Background processes will still get a `database_doest_not_exist` error if they keep a db open which has now been re-created.

The interactive option may also be used in the future to set other transaction parameters like timeouts and retries that might be different for interactive requests vs background tasks.

~Previously the UUID was checked in an attempt to prevent successfully re-opening an old database instance, in case it was deleted and re-created. However that is not necessary as the open line above would have already fetched the current db version~

