### PR TITLE
Windows: provide full path to epmd

### DIFF
--- a/rel/files/couchdb.cmd.in
+++ b/rel/files/couchdb.cmd.in
@@ -31,6 +31,7 @@ IF NOT DEFINED COUCHDB_FAUXTON_DOCROOT SET COUCHDB_FAUXTON_DOCROOT={{fauxton_roo
 
 "%BINDIR%\erl" -boot "%ROOTDIR%\releases\%APP_VSN%\couchdb" ^
 -args_file "%ROOTDIR%\etc\vm.args" ^
+-epmd "%BINDIR%\epmd.exe" ^
 -config "%ROOTDIR%\releases\%APP_VSN%\sys.config" %*
 
 :: EXIT /B


### PR DESCRIPTION
## Overview

Provide full path to `epmd.exe` on Windows at startup time.

## Testing recommendations

0. `make -f Makefile.win release`
1. Ensure `epmd.exe` is not running
2. Start `rel\couchdb\bin\couchdb.cmd`
3. Validate that Erlang directly launches `epmd.exe` using Procmon

## Related Issues or Pull Requests

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests