### PR TITLE
Handle jiffy returning an iolist when encoding atts_since query string

### DIFF
--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -546,7 +546,7 @@ options_to_query_args(HttpDb, Path, Options0) ->
             length("GET " ++ FullUrl ++ " HTTP/1.1\r\n") +
             length("&atts_since=") + 6,  % +6 = % encoded [ and ]
             PAs, MaxLen, []),
-        [{"atts_since", ?JSON_ENCODE(RevList)} | QueryArgs1]
+        [{"atts_since", ?b2l(iolist_to_binary(?JSON_ENCODE(RevList)))} | QueryArgs1]
     end.
 
 


### PR DESCRIPTION
Backport of https://github.com/apache/couchdb/pull/3089 to 3.x

If we don't handle it, it throws an error when trying to encode the full URL
string, for example:

```
badarg,[
 {mochiweb_util,quote_plus,2,[{file,"src/mochiweb_util.erl"},{line,192}]},
 {couch_replicator_httpc,query_args_to_string,2,[{file,"src/couch_replicator_httpc.erl"},{line,421}]},
 {couch_replicator_httpc,full_url,2,[{file,"src/couch_replicator_httpc.erl"},{line,413}]},
 {couch_replicator_api_wrap,open_doc_revs,6,[{file,"src/couch_replicator_api_wrap.erl"},{line,255}]}
]
```

This is also similar to what we did for open_revs encoding: https://github.com/apache/couchdb/commit/a2d0c4290dde2015e5fb6184696fec3f89c81a4b
