### PR TITLE
Fix ordering of page_size based pagination for views

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -864,7 +864,9 @@ paginate_multi_all_docs_view(Req, Db, OP, Args0, Queries) ->
     ArgQueries = chttpd_view:parse_queries(Req, Args1, Queries, fun(QArgs) ->
         set_namespace(OP, QArgs)
     end),
-    KeyFun = fun({Props}) -> couch_util:get_value(id, Props) end,
+    KeyFun = fun({Props}) ->
+        {couch_util:get_value(id, Props), undefined}
+    end,
     #mrargs{page_size = PageSize} = Args0,
     #httpd{path_parts = Parts} = Req,
     UpdateSeq = fabric2_db:get_update_seq(Db),
@@ -911,7 +913,9 @@ paginate_all_docs_view(Req, Db, Args0, OP) ->
     Args1 = Args0#mrargs{view_type=map},
     Args2 = chttpd_view:validate_args(Req, Args1),
     Args3 = set_namespace(OP, Args2),
-    KeyFun = fun({Props}) -> couch_util:get_value(id, Props) end,
+    KeyFun = fun({Props}) ->
+        {couch_util:get_value(id, Props), undefined}
+    end,
     #httpd{path_parts = Parts} = Req,
     UpdateSeq = fabric2_db:get_update_seq(Db),
     EtagTerm = {Parts, UpdateSeq, Args3},

--- a/src/chttpd/src/chttpd_view.erl
+++ b/src/chttpd/src/chttpd_view.erl
@@ -58,7 +58,9 @@ paginate_multi_query_view(Req, Db, DDoc, ViewName, Args0, Queries) ->
     ArgQueries = parse_queries(Req, Args0, Queries, fun(QueryArg) ->
         couch_mrview_util:set_view_type(QueryArg, ViewName, Views)
     end),
-    KeyFun = fun({Props}) -> couch_util:get_value(id, Props) end,
+    KeyFun = fun({Props}) ->
+        {couch_util:get_value(id, Props), couch_util:get_value(key, Props)}
+    end,
     #mrargs{page_size = PageSize} = Args0,
     #httpd{path_parts = Parts} = Req,
     UpdateSeq = fabric2_db:get_update_seq(Db),
@@ -100,7 +102,9 @@ stream_fabric_query_view(Db, Req, DDoc, ViewName, Args) ->
 
 
 paginate_fabric_query_view(Db, Req, DDoc, ViewName, Args0) ->
-    KeyFun = fun({Props}) -> couch_util:get_value(id, Props) end,
+    KeyFun = fun({Props}) ->
+        {couch_util:get_value(id, Props), couch_util:get_value(key, Props)}
+    end,
     #httpd{path_parts = Parts} = Req,
     UpdateSeq = fabric2_db:get_update_seq(Db),
     ETagTerm = {Parts, UpdateSeq, Args0},


### PR DESCRIPTION
## Overview

The pagination relied on id of the document. However for views it should use
combination of key and id.


## Testing recommendations

The change is covered by tests. 
```
make exunit tests=src/chttpd/test/exunit/pagination_test.exs
```

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/pull/2870 - Pagination API 
- https://github.com/apache/couchdb/pull/2904 - Add support for previous bookmark

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
