### PR TITLE
clear jobs data in active area during removal

### DIFF
--- a/src/couch_jobs/src/couch_jobs_fdb.erl
+++ b/src/couch_jobs/src/couch_jobs_fdb.erl
@@ -119,8 +119,9 @@ remove(#{jtx := true} = JTx0, #{job := true} = Job) ->
     #{type := Type, id := JobId} = Job,
     Key = job_key(JTx, Job),
     case get_job_val(Tx, Key) of
-        #jv{stime = STime} ->
+        #jv{stime = STime, seq = Seq} ->
             couch_jobs_pending:remove(JTx, Type, JobId, STime),
+            clear_activity(JTx, Type, Seq),
             erlfdb:clear(Tx, Key),
             update_watch(JTx, Type),
             ok;


### PR DESCRIPTION
## Overview

During job removal, it was not cleared from the active area so
active_tasks would mistakenly believe the job still existed. When we
try to actually open the data it is not there and not_found error
would be issued. @nickva  found this issue during replication work.


## Testing recommendations

Regression test run passes.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
