### PR TITLE
3.x backport: don't log client disconnects

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -970,6 +970,8 @@ maybe_handle_error(Error) ->
             Result;
         {Err, Reason} ->
             {500, couch_util:to_binary(Err), couch_util:to_binary(Reason)};
+        normal ->
+            exit(normal);
         Error ->
             {500, <<"unknown_error">>, couch_util:to_binary(Error)}
     end.


### PR DESCRIPTION
Backport #3092 to 3.x.

Closes #1600 and closes #2877 and closes #2041 .