### PR TITLE
bypass partition query limit for mango

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -427,7 +427,10 @@ def boot_haproxy(ctx):
 def hack_default_ini(ctx, node, contents):
 
     contents = re.sub(
-        "^\[httpd\]$", "[httpd]\nenable = true", contents, flags=re.MULTILINE,
+        "^\[httpd\]$",
+        "[httpd]\nenable = true",
+        contents,
+        flags=re.MULTILINE,
     )
 
     if ctx["enable_erlang_views"]:

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -425,9 +425,12 @@ validate_args(#mrst{} = State, Args0) ->
 
 
 apply_limit(ViewPartitioned, Args) ->
-    LimitType = case ViewPartitioned of
-        true -> "partition_query_limit";
-        false -> "query_limit"
+    Options = Args#mrargs.extra,
+    IgnorePQLimit = lists:keyfind(ignore_partition_query_limit, 1, Options),
+    LimitType = case {ViewPartitioned, IgnorePQLimit} of
+        {true, false} -> "partition_query_limit";
+        {true, _} -> "query_limit";
+        {false, _} -> "query_limit"
     end,
 
     MaxLimit = config:get_integer("query_server_config",

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -116,7 +116,11 @@ base_args(#cursor{index = Idx, selector = Selector} = Cursor) ->
         start_key = StartKey,
         end_key = EndKey,
         include_docs = true,
-        extra = [{callback, {?MODULE, view_cb}}, {selector, Selector}]
+        extra = [
+            {callback, {?MODULE, view_cb}},
+            {selector, Selector},
+            {ignore_partition_query_limit, true}
+        ]
     }.
 
 


### PR DESCRIPTION
## Overview
When partition_query_limit is set for couch_mrview, it limits how many
docs can be scanned when executing partitioned queries. But this limits
mango's doc scans internally. This leads to documents not being scanned
to fulfill a query. This fixes:
https://github.com/apache/couchdb/issues/2795

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
Unit Test added.
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
