### PR TITLE
Tag elixir test modules in meaningful groups

### DIFF
--- a/test/elixir/test/all_docs_test.exs
+++ b/test/elixir/test/all_docs_test.exs
@@ -2,6 +2,7 @@ defmodule AllDocsTest do
   use CouchTestCase
 
   @moduletag :all_docs
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB _all_docs

--- a/test/elixir/test/attachment_names_test.exs
+++ b/test/elixir/test/attachment_names_test.exs
@@ -2,6 +2,7 @@ defmodule AttachmentNamesTest do
   use CouchTestCase
 
   @moduletag :attachments
+  @moduletag kind: :single_node
 
   @good_doc """
    {

--- a/test/elixir/test/attachment_paths_test.exs
+++ b/test/elixir/test/attachment_paths_test.exs
@@ -2,6 +2,7 @@ defmodule AttachmentPathsTest do
   use CouchTestCase
 
   @moduletag :attachments
+  @moduletag kind: :single_node
 
   @bin_att_doc """
   {

--- a/test/elixir/test/attachment_ranges_test.exs
+++ b/test/elixir/test/attachment_ranges_test.exs
@@ -2,6 +2,7 @@ defmodule AttachmentRangesTest do
   use CouchTestCase
 
   @moduletag :attachments
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB attachment range requests

--- a/test/elixir/test/attachment_views_test.exs
+++ b/test/elixir/test/attachment_views_test.exs
@@ -2,6 +2,7 @@ defmodule AttachmentViewTest do
   use CouchTestCase
 
   @moduletag :attachments
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB attachment views requests

--- a/test/elixir/test/attachments_multipart_test.exs
+++ b/test/elixir/test/attachments_multipart_test.exs
@@ -2,6 +2,7 @@ defmodule AttachmentMultipartTest do
   use CouchTestCase
 
   @moduletag :attachments
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB attachment multipart requests

--- a/test/elixir/test/attachments_test.exs
+++ b/test/elixir/test/attachments_test.exs
@@ -2,6 +2,7 @@ defmodule AttachmentsTest do
   use CouchTestCase
 
   @moduletag :attachments
+  @moduletag kind: :single_node
 
   #  MD5 Digests of compressible attachments and therefore Etags
   #  will vary depending on platform gzip implementation.

--- a/test/elixir/test/auth_cache_test.exs
+++ b/test/elixir/test/auth_cache_test.exs
@@ -2,6 +2,7 @@ defmodule AuthCacheTest do
   use CouchTestCase
 
   @moduletag :authentication
+  @moduletag kind: :single_node
 
   @tag :pending
   @tag :with_db

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -2,6 +2,7 @@ defmodule BasicsTest do
   use CouchTestCase
 
   @moduletag :basics
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB basics.

--- a/test/elixir/test/batch_save_test.exs
+++ b/test/elixir/test/batch_save_test.exs
@@ -2,6 +2,7 @@ defmodule BatchSaveTest do
   use CouchTestCase
 
   @moduletag :batch_save
+  @moduletag kind: :performance
 
   @moduledoc """
   Test CouchDB batch save

--- a/test/elixir/test/bulk_docs_test.exs
+++ b/test/elixir/test/bulk_docs_test.exs
@@ -2,6 +2,7 @@ defmodule BulkDocsTest do
   use CouchTestCase
 
   @moduletag :bulk_docs
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB bulk docs

--- a/test/elixir/test/changes_async_test.exs
+++ b/test/elixir/test/changes_async_test.exs
@@ -2,6 +2,7 @@ defmodule ChangesAsyncTest do
   use CouchTestCase
 
   @moduletag :changes
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB /{db}/_changes

--- a/test/elixir/test/changes_test.exs
+++ b/test/elixir/test/changes_test.exs
@@ -2,6 +2,7 @@ defmodule ChangesTest do
   use CouchTestCase
 
   @moduletag :changes
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB /{db}/_changes

--- a/test/elixir/test/cluster_with_quorum_test.exs
+++ b/test/elixir/test/cluster_with_quorum_test.exs
@@ -2,6 +2,7 @@ defmodule WithQuorumTest do
   use CouchTestCase
 
   @moduletag :with_quorum_test
+  @moduletag kind: :cluster
 
   @moduledoc """
   Test CouchDB API in a cluster without quorum.

--- a/test/elixir/test/cluster_without_quorum_test.exs
+++ b/test/elixir/test/cluster_without_quorum_test.exs
@@ -2,6 +2,7 @@ defmodule WithoutQuorumTest do
   use CouchTestCase
 
   @moduletag :without_quorum_test
+  @moduletag kind: :degraded_cluster
 
   @moduledoc """
   Test CouchDB API in a cluster without quorum.

--- a/test/elixir/test/coffee_test.exs
+++ b/test/elixir/test/coffee_test.exs
@@ -2,6 +2,7 @@ defmodule CoffeeTest do
   use CouchTestCase
 
   @moduletag :coffee
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test basic coffeescript functionality.

--- a/test/elixir/test/compact_test.exs
+++ b/test/elixir/test/compact_test.exs
@@ -2,6 +2,7 @@ defmodule CompactTest do
   use CouchTestCase
 
   @moduletag :compact
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB compaction

--- a/test/elixir/test/config_test.exs
+++ b/test/elixir/test/config_test.exs
@@ -2,6 +2,7 @@ defmodule ConfigTest do
   use CouchTestCase
 
   @moduletag :config
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB config API

--- a/test/elixir/test/conflicts_test.exs
+++ b/test/elixir/test/conflicts_test.exs
@@ -2,6 +2,7 @@ defmodule RevisionTest do
   use CouchTestCase
 
   @moduletag :conflicts
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB conflicts

--- a/test/elixir/test/cookie_auth_test.exs
+++ b/test/elixir/test/cookie_auth_test.exs
@@ -2,6 +2,7 @@ defmodule CookieAuthTest do
   use CouchTestCase
 
   @moduletag :authentication
+  @moduletag kind: :single_node
 
   @users_db "_users"
 

--- a/test/elixir/test/copy_doc_test.exs
+++ b/test/elixir/test/copy_doc_test.exs
@@ -2,6 +2,7 @@ defmodule CopyDocTest do
   use CouchTestCase
 
   @moduletag :copy_doc
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB Copy Doc

--- a/test/elixir/test/design_docs_query_test.exs
+++ b/test/elixir/test/design_docs_query_test.exs
@@ -2,6 +2,7 @@ defmodule DesignDocsQueryTest do
   use CouchTestCase
 
   @moduletag :design_docs
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB /{db}/_design_docs

--- a/test/elixir/test/design_docs_test.exs
+++ b/test/elixir/test/design_docs_test.exs
@@ -2,6 +2,7 @@ defmodule DesignDocsTest do
   use CouchTestCase
 
   @moduletag :design_docs
+  @moduletag kind: :single_node
 
   @design_doc %{
     _id: "_design/test",

--- a/test/elixir/test/design_options_test.exs
+++ b/test/elixir/test/design_options_test.exs
@@ -2,6 +2,7 @@ defmodule DesignOptionsTest do
   use CouchTestCase
 
   @moduletag :design_docs
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB design documents options include_design and local_seq

--- a/test/elixir/test/design_paths_test.exs
+++ b/test/elixir/test/design_paths_test.exs
@@ -2,6 +2,7 @@ defmodule DesignPathTest do
   use CouchTestCase
 
   @moduletag :design_docs
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB design documents path

--- a/test/elixir/test/erlang_views_test.exs
+++ b/test/elixir/test/erlang_views_test.exs
@@ -2,6 +2,7 @@ defmodule ErlangViewsTest do
   use CouchTestCase
 
   @moduletag :erlang_views
+  @moduletag kind: :single_node
 
   @moduledoc """
   basic 'smoke tests' of erlang views.

--- a/test/elixir/test/etags_head_test.exs
+++ b/test/elixir/test/etags_head_test.exs
@@ -2,6 +2,7 @@ defmodule EtagsHeadTest do
   use CouchTestCase
 
   @moduletag :etags
+  @moduletag kind: :single_node
 
   @tag :with_db
   test "etag header on creation", context do

--- a/test/elixir/test/form_submit_test.exs
+++ b/test/elixir/test/form_submit_test.exs
@@ -2,6 +2,7 @@ defmodule FormSubmitTest do
   use CouchTestCase
 
   @moduletag :form_submit
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test that form submission is invalid

--- a/test/elixir/test/helper_test.exs
+++ b/test/elixir/test/helper_test.exs
@@ -5,6 +5,9 @@ defmodule HelperTest do
   Test helper code
   """
 
+  @moduletag :helper
+  @moduletag kind: :single_node
+
   test "retry_until handles boolean conditions", _context do
     retry_until(fn ->
       true

--- a/test/elixir/test/http_test.exs
+++ b/test/elixir/test/http_test.exs
@@ -2,6 +2,7 @@ defmodule HttpTest do
   use CouchTestCase
 
   @moduletag :http
+  @moduletag kind: :single_node
 
   @tag :with_db
   test "location header", context do

--- a/test/elixir/test/invalid_docids_test.exs
+++ b/test/elixir/test/invalid_docids_test.exs
@@ -2,6 +2,7 @@ defmodule InvalidDocIDsTest do
   use CouchTestCase
 
   @moduletag :invalid_doc_ids
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test invalid document ids

--- a/test/elixir/test/jsonp_test.exs
+++ b/test/elixir/test/jsonp_test.exs
@@ -2,6 +2,7 @@ defmodule JsonpTest do
   use CouchTestCase
 
   @moduletag :jsonp
+  @moduletag kind: :single_node
 
   @tag :with_db
   test "jsonp not configured callbacks", context do

--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -2,6 +2,7 @@ defmodule JwtAuthTest do
   use CouchTestCase
 
   @moduletag :authentication
+  @moduletag kind: :single_node
 
   test "jwt auth with HMAC secret", _context do
 

--- a/test/elixir/test/large_docs_text.exs
+++ b/test/elixir/test/large_docs_text.exs
@@ -2,6 +2,8 @@ defmodule LargeDocsTest do
   use CouchTestCase
 
   @moduletag :large_docs
+  @moduletag kind: :single_node
+
   @long_string "0123456789\n"
 
   @moduledoc """

--- a/test/elixir/test/local_docs_test.exs
+++ b/test/elixir/test/local_docs_test.exs
@@ -2,6 +2,7 @@ defmodule LocalDocsTest do
   use CouchTestCase
 
   @moduletag :local_docs
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB _local_docs

--- a/test/elixir/test/lots_of_docs_test.exs
+++ b/test/elixir/test/lots_of_docs_test.exs
@@ -2,6 +2,8 @@ defmodule LotsOfDocsTest do
   use CouchTestCase
 
   @moduletag :lots_of_docs
+  @moduletag kind: :performance
+  
   @docs_range 0..499
 
   @moduledoc """

--- a/test/elixir/test/method_override_test.exs
+++ b/test/elixir/test/method_override_test.exs
@@ -2,6 +2,7 @@ defmodule MethodOverrideTest do
   use CouchTestCase
 
   @moduletag :http
+  @moduletag kind: :single_node
 
   @moduledoc """
    Allow broken HTTP clients to fake a full method vocabulary with an

--- a/test/elixir/test/multiple_rows_test.exs
+++ b/test/elixir/test/multiple_rows_test.exs
@@ -2,6 +2,7 @@ defmodule MultipleRowsTest do
   use CouchTestCase
 
   @moduletag :multiple_rows
+  @moduletag kind: :single_node
 
   @north_carolina_cities ["Charlotte", "Raleigh"]
   @massachussets_cities ["Boston", "Lowell", "Worcester", "Cambridge", "Springfield"]

--- a/test/elixir/test/partition_all_docs_test.exs
+++ b/test/elixir/test/partition_all_docs_test.exs
@@ -6,6 +6,9 @@ defmodule PartitionAllDocsTest do
   Test Partition functionality for for all_docs
   """
 
+  @moduletag :partition
+  @moduletag kind: :cluster
+
   setup_all do
     db_name = random_db_name()
     {:ok, _} = create_db(db_name, query: %{partitioned: true, q: 1})

--- a/test/elixir/test/partition_crud_test.exs
+++ b/test/elixir/test/partition_crud_test.exs
@@ -1,6 +1,9 @@
 defmodule PartitionCrudTest do
   use CouchTestCase
 
+  @moduletag :partition
+  @moduletag kind: :cluster
+
   @tag :with_partitioned_db
   test "Sets partition in db info", context do
     db_name = context[:db_name]

--- a/test/elixir/test/partition_ddoc_test.exs
+++ b/test/elixir/test/partition_ddoc_test.exs
@@ -4,6 +4,9 @@ defmodule PartitionDDocTest do
   @moduledoc """
   Test partition design doc interactions
   """
+  
+  @moduletag :partition
+  @moduletag kind: :cluster
 
   setup do
     db_name = random_db_name()

--- a/test/elixir/test/partition_design_docs_test.exs
+++ b/test/elixir/test/partition_design_docs_test.exs
@@ -5,6 +5,9 @@ defmodule PartitionDesignDocsTest do
   Test Partition functionality for partition design docs
   """
 
+  @moduletag :partition
+  @moduletag kind: :cluster
+
   @tag :with_partitioned_db
   test "/_partition/:pk/_design/doc 404", context do
     db_name = context[:db_name]

--- a/test/elixir/test/partition_mango_test.exs
+++ b/test/elixir/test/partition_mango_test.exs
@@ -5,6 +5,10 @@ defmodule PartitionMangoTest do
   @moduledoc """
   Test Partition functionality for mango
   """
+
+  @moduletag :partition
+  @moduletag kind: :cluster
+
   def create_index(db_name, fields \\ ["some"], opts \\ %{}) do
     default_index = %{
       index: %{

--- a/test/elixir/test/partition_size_limit_test.exs
+++ b/test/elixir/test/partition_size_limit_test.exs
@@ -5,6 +5,9 @@ defmodule PartitionSizeLimitTest do
   Test Partition size limit functionality
   """
 
+  @moduletag :partition
+  @moduletag kind: :cluster
+
   @max_size 10_240
 
   setup do

--- a/test/elixir/test/partition_size_test.exs
+++ b/test/elixir/test/partition_size_test.exs
@@ -4,6 +4,9 @@ defmodule PartitionSizeTest do
   @moduledoc """
   Test Partition size functionality
   """
+  
+  @moduletag :partition
+  @moduletag kind: :cluster
 
   setup do
     db_name = random_db_name()

--- a/test/elixir/test/partition_view_test.exs
+++ b/test/elixir/test/partition_view_test.exs
@@ -5,6 +5,9 @@ defmodule ViewPartitionTest do
   @moduledoc """
   Test Partition functionality for views
   """
+  
+  @moduletag :partition
+  @moduletag kind: :cluster
 
   setup_all do
     db_name = random_db_name()

--- a/test/elixir/test/partition_view_update_test.exs
+++ b/test/elixir/test/partition_view_update_test.exs
@@ -5,6 +5,10 @@ defmodule PartitionViewUpdateTest do
   @moduledoc """
   Test Partition view update functionality
   """
+  
+  @moduletag :partition
+  @moduletag kind: :cluster
+
   @tag :with_partitioned_db
   test "view updates properly remove old keys", context do
     db_name = context[:db_name]

--- a/test/elixir/test/proxyauth_test.exs
+++ b/test/elixir/test/proxyauth_test.exs
@@ -2,6 +2,7 @@ defmodule ProxyAuthTest do
   use CouchTestCase
 
   @moduletag :authentication
+  @moduletag kind: :single_node
 
   @tag :with_db
   test "proxy auth with secret", context do

--- a/test/elixir/test/purge_test.exs
+++ b/test/elixir/test/purge_test.exs
@@ -2,6 +2,7 @@ defmodule PurgeTest do
   use CouchTestCase
 
   @moduletag :purge
+  @moduletag kind: :single_node
 
   @tag :with_db
   test "purge documents", context do

--- a/test/elixir/test/reader_acl_test.exs
+++ b/test/elixir/test/reader_acl_test.exs
@@ -2,6 +2,7 @@ defmodule ReaderACLTest do
   use CouchTestCase
 
   @moduletag :authentication
+  @moduletag kind: :single_node
 
   @users_db_name "custom-users"
   @password "funnybone"

--- a/test/elixir/test/recreate_doc_test.exs
+++ b/test/elixir/test/recreate_doc_test.exs
@@ -2,6 +2,7 @@ defmodule RecreateDocTest do
   use CouchTestCase
 
   @moduletag :recreate_doc
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB document recreation

--- a/test/elixir/test/reduce_builtin_test.exs
+++ b/test/elixir/test/reduce_builtin_test.exs
@@ -2,6 +2,7 @@ defmodule ReduceBuiltinTest do
   use CouchTestCase
 
   @moduletag :views
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB view builtin reduce functions

--- a/test/elixir/test/reduce_false_test.exs
+++ b/test/elixir/test/reduce_false_test.exs
@@ -2,6 +2,7 @@ defmodule ReduceFalseTest do
   use CouchTestCase
 
   @moduletag :views
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB view without reduces

--- a/test/elixir/test/reduce_test.exs
+++ b/test/elixir/test/reduce_test.exs
@@ -2,6 +2,7 @@ defmodule ReduceTest do
   use CouchTestCase
 
   @moduletag :views
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB view reduces

--- a/test/elixir/test/replication_test.exs
+++ b/test/elixir/test/replication_test.exs
@@ -5,6 +5,9 @@ defmodule ReplicationTest do
   Test CouchDB Replication Behavior
   This is a port of the view_collation.js suite
   """
+  
+  @moduletag kind: :cluster
+  @moduletag :replication
 
   # TODO: Parameterize these
   @db_pairs_prefixes [

--- a/test/elixir/test/replicator_db_bad_rep_id_test.exs
+++ b/test/elixir/test/replicator_db_bad_rep_id_test.exs
@@ -5,6 +5,9 @@ defmodule ReplicationBadIdTest do
   This is a port of the replicator_db_bad_rep_id.js suite
   """
 
+  @moduletag :replication
+  @moduletag kind: :cluster
+
   @docs [
     %{
       _id: "foo1",

--- a/test/elixir/test/replicator_db_by_doc_id_test.exs
+++ b/test/elixir/test/replicator_db_by_doc_id_test.exs
@@ -5,6 +5,9 @@ defmodule ReplicatorDBByDocIdTest do
   This is a port of the replicator_db_by_doc_id.js suite
   """
 
+  @moduletag :replication
+  @moduletag kind: :cluster
+
   @docs [
     %{
       _id: "foo1",

--- a/test/elixir/test/reshard_all_docs_test.exs
+++ b/test/elixir/test/reshard_all_docs_test.exs
@@ -6,6 +6,8 @@ defmodule ReshardAllDocsTest do
   Test _all_docs interaction with resharding
   """
 
+  @moduletag kind: :cluster
+
   setup do
     db = random_db_name()
     {:ok, _} = create_db(db, query: %{q: 2})

--- a/test/elixir/test/reshard_basic_test.exs
+++ b/test/elixir/test/reshard_basic_test.exs
@@ -5,6 +5,8 @@ defmodule ReshardBasicTest do
   @moduledoc """
   Test resharding basic functionality
   """
+  
+  @moduletag kind: :cluster
 
   setup_all do
     db1 = random_db_name()

--- a/test/elixir/test/reshard_changes_feed.exs
+++ b/test/elixir/test/reshard_changes_feed.exs
@@ -6,6 +6,8 @@ defmodule ReshardChangesFeedTest do
   Test _changes interaction with resharding
   """
 
+  @moduletag kind: :cluster
+
   setup do
     db = random_db_name()
     {:ok, _} = create_db(db, query: %{q: 2})

--- a/test/elixir/test/rev_stemming_test.exs
+++ b/test/elixir/test/rev_stemming_test.exs
@@ -2,6 +2,7 @@ defmodule RevStemmingTest do
   use CouchTestCase
 
   @moduletag :revs
+  @moduletag kind: :single_node
 
   @moduledoc """
   This is a port of the rev_stemming.js suite

--- a/test/elixir/test/rewrite_test.exs
+++ b/test/elixir/test/rewrite_test.exs
@@ -2,6 +2,7 @@ defmodule RewriteTest do
   use CouchTestCase
 
   @moduletag :js_engine
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB rewrites

--- a/test/elixir/test/security_validation_test.exs
+++ b/test/elixir/test/security_validation_test.exs
@@ -2,6 +2,7 @@ defmodule SecurityValidationTest do
   use CouchTestCase
 
   @moduletag :security
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB Security Validations

--- a/test/elixir/test/update_documents_test.exs
+++ b/test/elixir/test/update_documents_test.exs
@@ -1,6 +1,8 @@
 defmodule UpdateDocumentsTest do
   use CouchTestCase
 
+  @moduletag kind: :single_node
+
   @ddoc %{
     _id: "_design/update",
     language: "javascript",

--- a/test/elixir/test/users_db_test.exs
+++ b/test/elixir/test/users_db_test.exs
@@ -2,6 +2,7 @@ defmodule UsersDbTest do
   use CouchTestCase
 
   @moduletag :authentication
+  @moduletag kind: :single_node
 
   @users_db_name "_users"
 

--- a/test/elixir/test/utf8_test.exs
+++ b/test/elixir/test/utf8_test.exs
@@ -2,6 +2,7 @@ defmodule UTF8Test do
   use CouchTestCase
 
   @moduletag :utf8
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB UTF8 support

--- a/test/elixir/test/uuids_test.exs
+++ b/test/elixir/test/uuids_test.exs
@@ -6,6 +6,9 @@ defmodule UUIDsTest do
   This is a port of the uuids.js suite
   """
 
+  @moduletag :docs
+  @moduletag kind: :single_node
+
   test "cache busting headers are set" do
     resp = Couch.get("/_uuids")
     assert resp.status_code == 200

--- a/test/elixir/test/view_collation_raw_test.exs
+++ b/test/elixir/test/view_collation_raw_test.exs
@@ -6,6 +6,8 @@ defmodule ViewCollationRawTest do
   This is a port of the view_collation_raw.js suite
   """
 
+  @moduletag kind: :single_node
+
   @values [
     # Then numbers
     1,

--- a/test/elixir/test/view_collation_test.exs
+++ b/test/elixir/test/view_collation_test.exs
@@ -6,6 +6,8 @@ defmodule ViewCollationTest do
   This is a port of the view_collation.js suite
   """
 
+  @moduletag kind: :single_node
+
   @values [
     # Special values sort before all other types
     :null,

--- a/test/elixir/test/view_compaction_test.exs
+++ b/test/elixir/test/view_compaction_test.exs
@@ -5,6 +5,9 @@ defmodule ViewCompactionTest do
   Test CouchDB View Compaction Behavior
   This is a port of the view_compaction.js suite
   """
+  
+  @moduletag kind: :single_node
+  
   @num_docs 1000
 
   @ddoc %{

--- a/test/elixir/test/view_multi_key_all_docs_test.exs
+++ b/test/elixir/test/view_multi_key_all_docs_test.exs
@@ -1,6 +1,8 @@
 defmodule ViewMultiKeyAllDocsTest do
   use CouchTestCase
 
+  @moduletag kind: :single_node
+
   @keys ["10", "15", "30", "37", "50"]
 
   setup_all do

--- a/test/elixir/test/view_multi_key_design_test.exs
+++ b/test/elixir/test/view_multi_key_design_test.exs
@@ -1,5 +1,7 @@
 defmodule ViewMultiKeyDesignTest do
   use CouchTestCase
+  
+  @moduletag kind: :single_node
 
   @keys [10, 15, 30, 37, 50]
 

--- a/test/elixir/test/view_offsets_test.exs
+++ b/test/elixir/test/view_offsets_test.exs
@@ -2,6 +2,7 @@ defmodule ViewOffsetTest do
   use CouchTestCase
 
   @moduletag :view_offsets
+  @moduletag kind: :single_node
 
   @moduledoc """
   Tests about view offsets.

--- a/test/elixir/test/view_pagination_test.exs
+++ b/test/elixir/test/view_pagination_test.exs
@@ -2,6 +2,7 @@ defmodule ViewPaginationTest do
   use CouchTestCase
 
   @moduletag :view_pagination
+  @moduletag kind: :single_node
 
   @moduledoc """
   Integration tests for pagination.

--- a/test/elixir/test/view_sandboxing_test.exs
+++ b/test/elixir/test/view_sandboxing_test.exs
@@ -1,6 +1,8 @@
 defmodule ViewSandboxingTest do
   use CouchTestCase
 
+  @moduletag kind: :single_node
+
   @document %{integer: 1, string: "1", array: [1, 2, 3]}
 
   @tag :with_db

--- a/test/elixir/test/view_test.exs
+++ b/test/elixir/test/view_test.exs
@@ -2,6 +2,7 @@ defmodule ViewTest do
   use CouchTestCase
 
   @moduletag :view
+  @moduletag kind: :single_node
 
   @moduledoc """
   Test CouchDB /{db}/_design/{ddoc}/_view/{view}

--- a/test/elixir/test/view_update_seq_test.exs
+++ b/test/elixir/test/view_update_seq_test.exs
@@ -2,6 +2,7 @@ defmodule ViewUpdateSeqTest do
   use CouchTestCase
 
   @moduletag :view_update_seq
+  @moduletag kind: :single_node
 
   @moduledoc """
   This is a port of the view_update_seq.js test suite.


### PR DESCRIPTION

## Overview

This is a first attempt to assign meaningful categories to tests into our Elixir integration test suite. For now I only modified the `moduletag` attribute on the single modules, once I have some positive feedback on that I'll proceed tagging single test cases.

## Testing recommendations

Just issue `make elixir` or wait for the CI

## Related Issues or Pull Requests

#1885 

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
