### PR TITLE
fix bookmark passing with text indexes

### DIFF
--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -43,7 +43,7 @@
 }).
 
 
-create(Db, Indexes, Selector, Opts0) ->
+create(Db, Indexes, Selector, Opts) ->
     Index = case Indexes of
         [Index0] ->
             Index0;
@@ -51,7 +51,7 @@ create(Db, Indexes, Selector, Opts0) ->
             ?MANGO_ERROR(multiple_text_indexes)
     end,
 
-    Opts = unpack_bookmark(couch_db:name(Db), Opts0),
+    Bookmark = unpack_bookmark(couch_db:name(Db), Opts),
 
     DreyfusLimit = get_dreyfus_limit(),
     Limit = erlang:min(DreyfusLimit, couch_util:get_value(limit, Opts, mango_opts:default_limit())),
@@ -66,7 +66,8 @@ create(Db, Indexes, Selector, Opts0) ->
         opts = Opts,
         limit = Limit,
         skip = Skip,
-        fields = Fields
+        fields = Fields,
+        bookmark = Bookmark
     }}.
 
 
@@ -90,7 +91,8 @@ execute(Cursor, UserFun, UserAcc) ->
         skip = Skip,
         selector = Selector,
         opts = Opts,
-        execution_stats = Stats
+        execution_stats = Stats,
+        bookmark = Bookmark
     } = Cursor,
     Query = mango_selector_text:convert(Selector),
     QueryArgs = #index_query_args{
@@ -104,7 +106,7 @@ execute(Cursor, UserFun, UserAcc) ->
         dbname = couch_db:name(Db),
         ddocid = ddocid(Idx),
         idx_name = mango_idx:name(Idx),
-        bookmark = get_bookmark(Opts),
+        bookmark = Bookmark,
         limit = Limit,
         skip = Skip,
         query_args = QueryArgs,
@@ -282,7 +284,7 @@ pack_bookmark(Bookmark) ->
 
 
 unpack_bookmark(DbName, Opts) ->
-    NewBM = case lists:keyfind(bookmark, 1, Opts) of
+    case lists:keyfind(bookmark, 1, Opts) of
         {_, nil} ->
             [];
         {_, Bin} ->
@@ -291,8 +293,7 @@ unpack_bookmark(DbName, Opts) ->
             catch _:_ ->
                 ?MANGO_ERROR({invalid_bookmark, Bin})
             end
-    end,
-    lists:keystore(bookmark, 1, Opts, {bookmark, NewBM}).
+    end.
 
 
 ddocid(Idx) ->

--- a/src/mango/test/08-text-limit-test.py
+++ b/src/mango/test/08-text-limit-test.py
@@ -133,3 +133,13 @@ class LimitTests(mango.LimitDocsTextTests):
             assert json["bookmark"] != bm
             bm = json["bookmark"]
         assert len(seen_docs) == len(limit_docs.DOCS)
+
+    def run_explain_check(self, size):
+        q = {"age": {"$gt": 0}}
+        seen_docs = set()
+        bm = None
+        results1 = self.db.find(q, limit=size, bookmark=bm, return_raw=True)
+        assert results1["bookmark"] != bm
+        bm = results1["bookmark"]
+        results2 = self.db.find(q, limit=size, bookmark=bm, explain=True)
+        assert results2["bookmark"] == bm


### PR DESCRIPTION
## Overview

Previously, we passed in the unpacked version of the bookmark with
the cursor inside the options field. This worked fine for _find because
we didn't need to return it to the user. But for _explain, we return
the value back as unpacked tuple instead of a string and jiffy:encode/1
complains. Now we correctly extract the bookmark out of options, unpack
it, and then pass it separately in it's own field. This way options
retains it's original string form for the user so that invalid_ejson
is not thrown.


## Testing recommendations

Regression tests should pass. If you create a text index, simply use _explain with a bookmark and verify the results. 

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
