### PR TITLE
3.x backport: Allow to continue to cleanup search index even if there is invalid ddoc

### DIFF
--- a/src/dreyfus/src/dreyfus_fabric_cleanup.erl
+++ b/src/dreyfus/src/dreyfus_fabric_cleanup.erl
@@ -30,12 +30,16 @@ go(DbName) ->
     ok.
 
 active_sigs(#doc{body={Fields}}=Doc) ->
-    {RawIndexes} = couch_util:get_value(<<"indexes">>, Fields, {[]}),
-    {IndexNames, _} = lists:unzip(RawIndexes),
-    [begin
-         {ok, Index} = dreyfus_index:design_doc_to_index(Doc, IndexName),
-         Index#index.sig
-     end || IndexName <- IndexNames].
+    try
+        {RawIndexes} = couch_util:get_value(<<"indexes">>, Fields, {[]}),
+        {IndexNames, _} = lists:unzip(RawIndexes),
+        [begin
+             {ok, Index} = dreyfus_index:design_doc_to_index(Doc, IndexName),
+             Index#index.sig
+         end || IndexName <- IndexNames]
+    catch error:{badmatch, _Error} ->
+        []
+    end.
 
 cleanup_local_purge_doc(DbName, ActiveSigs) ->
     {ok, BaseDir} = clouseau_rpc:get_root_dir(),


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

backport https://github.com/apache/couchdb/pull/3118 to 3.x

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

make elixir tests=src/dreyfus/test/elixir/test/search_test.exs

```

SearchTest
  * test clean up search index with invalid design document (55.1ms)

ReshardHelpers

PartitionHelpers


Finished in 0.07 seconds
1 test, 0 failures
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
