### PR TITLE
Fix stale=false for views

### DIFF
--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -527,6 +527,8 @@ parse_param(Key, Val, Args, IsDecoded) ->
             Args#mrargs{stable=true, update=false};
         "stale" when Val == "update_after" orelse Val == <<"update_after">> ->
             Args#mrargs{stable=true, update=lazy};
+        "stale" when Val == "false" orelse Val == <<"false">> ->
+            Args#mrargs{stable=false, update=true};
         "stale" ->
             throw({query_parse_error, <<"Invalid value for `stale`.">>});
         "stable" when Val == "true" orelse Val == <<"true">> ->

--- a/src/couch_mrview/test/eunit/couch_mrview_http_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_http_tests.erl
@@ -24,5 +24,17 @@ mrview_http_test_() ->
 
          ?_assertEqual(#mrargs{group_level=1, group=undefined},
                        couch_mrview_http:parse_params([{"group_level", "1"}],
+                                            undefined, #mrargs{})),
+
+         ?_assertEqual(#mrargs{stable=true, update=false, group_level=undefined, group=undefined},
+                       couch_mrview_http:parse_params([{"stale", "ok"}],
+                                            undefined, #mrargs{})),
+
+         ?_assertEqual(#mrargs{stable=true, update=lazy, group_level=undefined, group=undefined},
+                       couch_mrview_http:parse_params([{"stale", "update_after"}],
+                                            undefined, #mrargs{})),
+
+         ?_assertEqual(#mrargs{stable=false, update=true, group_level=undefined, group=undefined},
+                       couch_mrview_http:parse_params([{"stale", "false"}],
                                             undefined, #mrargs{}))
     ].


### PR DESCRIPTION
## Overview

The docs mention an option of "false" for "stale" which is currently not supported and is rejected by validation.

This commit fixes the problem described above.

## Testing recommendations

`make eunit apps=couch_mrview suites=couch_mrview_http`

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini` -- not applicable
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation -- this PR makes behavior match behavior described in https://docs.couchdb.org/en/stable/api/ddoc/views.html#api-ddoc-view