### PR TITLE
Report if FIPS mode is enabled

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -246,6 +246,16 @@ init([]) ->
     % Mark being able to receive documents with an _access property as a supported feature
     config:enable_feature('access-ready'),
 
+    % Mark if fips is enabled
+    case
+        erlang:function_exported(crypto, info_fips, 0) andalso
+          crypto:info_fips() == enabled of
+        true ->
+            config:enable_feature('fips');
+        false ->
+            ok
+    end,
+
     % read config and register for configuration changes
 
     % just stop if one of the config settings change. couch_server_sup


### PR DESCRIPTION
This will only report "fips" in the welcome message if FIPS mode
was enabled at boot (i.e, in vm.args).

Cherry-pick backport to 3.x