### PR TITLE
Bump fauxton, docs for 3.1.1 release

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -151,9 +151,9 @@ DepDescs = [
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
-                   {tag, "3.1.0-RC1"}, [raw]},
+                   {tag, "3.1.1-RC1"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
-                   {tag, "v1.2.4"}, [raw]},
+                   {tag, "v1.2.6"}, [raw]},
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-6"}},


### PR DESCRIPTION
This can't be released until https://github.com/apache/couchdb-documentation/pull/586 and https://github.com/apache/couchdb-fauxton/pull/1292 are merged and both repos are tagged/released correctly. In Fauxton's case this involves a `grunt couchdb` run, see https://github.com/apache/couchdb-fauxton/pull/1289