### PR TITLE
Make COPY doc return only one "ok"

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1108,7 +1108,7 @@ db_doc_req(#httpd{method='COPY', user_ctx=Ctx}=Req, Db, SourceDocId) ->
     send_json(Req, HttpCode,
         [{"Location", Loc},
         {"ETag", "\"" ++ ?b2l(couch_doc:rev_to_str(NewTargetRev)) ++ "\""}],
-        {[{ok, true}] ++ PartRes});
+        {PartRes});
 
 db_doc_req(Req, _Db, _DocId) ->
     send_method_not_allowed(Req, "DELETE,GET,HEAD,POST,PUT,COPY").

--- a/src/chttpd/test/eunit/chttpd_db_test.erl
+++ b/src/chttpd/test/eunit/chttpd_db_test.erl
@@ -73,6 +73,7 @@ all_test_() ->
                     fun should_return_update_seq_when_set_on_all_docs/1,
                     fun should_not_return_update_seq_when_unset_on_all_docs/1,
                     fun should_return_correct_id_on_doc_copy/1,
+                    fun should_return_only_one_ok_on_doc_copy/1,
                     fun should_return_400_for_bad_engine/1,
                     fun should_not_change_db_proper_after_rewriting_shardmap/1,
                     fun should_succeed_on_all_docs_with_queries_keys/1,
@@ -269,6 +270,17 @@ should_return_correct_id_on_doc_copy(Url) ->
         ]
     end)}.
 
+should_return_only_one_ok_on_doc_copy(Url) ->
+    {timeout, ?TIMEOUT, ?_test(begin
+       {ok, _, _, _} = create_doc(Url, "testdoc"),
+       {_, _, _, ResultBody} = test_request:copy(Url ++ "/testdoc",
+           [?CONTENT_JSON, ?AUTH, ?DESTHEADER1]),
+       {ResultJson} = jiffy:decode(ResultBody),
+       NumOks = length(lists:filter(fun({Key, Value}) -> Key == <<"ok">> end, ResultJson)),
+       [
+           ?assertEqual(1, NumOks)
+       ]
+    end)}.
 
 attachment_doc() ->
     {ok, Data} = file:read_file(?FIXTURE_TXT),


### PR DESCRIPTION
## Overview

When copying a doc, the returned JSON contains two `"ok"` fields:
`curl -H'Destination: copied' --request COPY  http://adm:pass@127.0.0.1:15984/foo/5cdc97838a8c748f7352d488ab0004c6`
```JSON
{"ok":true,"ok":true,"id":"foo/copied","rev":"1-967a00dff5e02add41819138abb3284d"}
```

## Testing recommendations

`make eunit apps=chttpd suites=chttpd_db_test`

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation - N/A, the docs are correct: https://docs.couchdb.org/en/latest/api/document/common.html#copy--db-docid
