### PR TITLE
Update all the type monitors after setting any couch jobs type timeout

### DIFF
--- a/src/couch_jobs/src/couch_jobs.erl
+++ b/src/couch_jobs/src/couch_jobs.erl
@@ -293,7 +293,8 @@ wait(Subs, State, Timeout) when is_list(Subs),
 set_type_timeout(Type, Timeout) ->
     couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(), fun(JTx) ->
         couch_jobs_fdb:set_type_timeout(JTx, Type, Timeout)
-    end).
+    end),
+    ok = couch_jobs_server:force_check_types().
 
 
 -spec clear_type_timeout(job_type()) -> ok.


### PR DESCRIPTION
This mostly helps with flaky tests where some jobs might complete before the type monitor discovers this particular type, so opt to always re-scan and start notification monitors when any type timeout is set.
