### PR TITLE
fix race condition

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -37,6 +37,7 @@
     get_committed_update_seq/1,
     get_compacted_seq/1,
     get_compactor_pid/1,
+    get_compactor_pid_sync/1,
     get_db_info/1,
     get_partition_info/2,
     get_del_doc_count/1,
@@ -571,6 +572,14 @@ get_compacted_seq(#db{}=Db) ->
 
 get_compactor_pid(#db{compactor_pid = Pid}) ->
     Pid.
+
+get_compactor_pid_sync(#db{main_pid=Pid}=Db) ->
+    case gen_server:call(Pid, compactor_pid, infinity) of
+        CPid when is_pid(CPid) ->
+            CPid;
+        _ ->
+            nil
+    end.
 
 get_db_info(Db) ->
     #db{

--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -293,7 +293,7 @@ start_compact(State, Db) ->
 
 maybe_remonitor_cpid(State, DbName, Reason) when is_binary(DbName) ->
     {ok, Db} = couch_db:open_int(DbName, []),
-    case couch_db:get_compactor_pid(Db) of
+    case couch_db:get_compactor_pid_sync(Db) of
         nil ->
             couch_log:warning("exit for compaction of ~p: ~p",
                 [smoosh_utils:stringify(DbName), Reason]),


### PR DESCRIPTION
This fixes a94e693f32672e4613bce0d80d0b9660f85275ea because a race
condition exisited where the 'DOWN' message could be received
before the compactor pid is spawned. Adding a synchronous call to
get the compactor pid guarantees that the couch_db_updater process
handling of finish_compaction has occurred.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
