### PR TITLE
Drop Jenkins ppc64le builds (for now)

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -593,49 +593,53 @@ pipeline {
           } // post
         } // stage
 
-        stage('Debian Buster ppc64le') {
-          agent {
-            docker {
-              image 'couchdbdev/ppc64le-debian-buster-erlang-20.3.8.25-1:latest'
-              label 'ppc64le'
-              alwaysPull true
-              args "${DOCKER_ARGS}"
-            }
-          }
-          environment {
-            platform = 'buster'
-            sm_ver = '60'
-          }
-          stages {
-            stage('Build from tarball & test') {
-              steps {
-                unstash 'tarball'
-                sh( script: build_and_test )
-              }
-              post {
-                always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
-                }
-              }
-            }
-            stage('Build CouchDB packages') {
-              steps {
-                sh( script: make_packages )
-                sh( script: cleanup_and_save )
-              }
-              post {
-                success {
-                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
-                }
-              }
-            }
-          } // stages
-          post {
-            cleanup {
-              sh 'rm -rf ${WORKSPACE}/*'
-            }
-          } // post
-        } // stage
+/*
+  - Removed 2020.09.15 - VMs are offline
+*/
+
+//        stage('Debian Buster ppc64le') {
+//          agent {
+//            docker {
+//              image 'couchdbdev/ppc64le-debian-buster-erlang-20.3.8.25-1:latest'
+//              label 'ppc64le'
+//              alwaysPull true
+//              args "${DOCKER_ARGS}"
+//            }
+//          }
+//          environment {
+//            platform = 'buster'
+//            sm_ver = '60'
+//          }
+//          stages {
+//            stage('Build from tarball & test') {
+//              steps {
+//                unstash 'tarball'
+//                sh( script: build_and_test )
+//              }
+//              post {
+//                always {
+//                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
+//                }
+//              }
+//            }
+//            stage('Build CouchDB packages') {
+//              steps {
+//                sh( script: make_packages )
+//                sh( script: cleanup_and_save )
+//              }
+//              post {
+//                success {
+//                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
+//                }
+//              }
+//            }
+//          } // stages
+//          post {
+//            cleanup {
+//              sh 'rm -rf ${WORKSPACE}/*'
+//            }
+//          } // post
+//        } // stage
 
 	/*
 	 * Example of how to do a qemu-based run, please leave here


### PR DESCRIPTION
Without this, all Jenkins builds will fail.