### PR TITLE
Workaround dirty schedulers in run_queue stats

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -15,7 +15,8 @@
 
 -export([
     handle_node_req/1,
-    get_stats/0
+    get_stats/0,
+    run_queues/0
 ]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -210,10 +211,12 @@ get_stats() ->
     {CF, CDU} = db_pid_stats(),
     MessageQueues0 = [{couch_file, {CF}}, {couch_db_updater, {CDU}}],
     MessageQueues = MessageQueues0 ++ message_queues(registered()),
+    {SQ, DCQ} = run_queues(),
     [
         {uptime, couch_app:uptime() div 1000},
         {memory, {Memory}},
-        {run_queue, statistics(run_queue)},
+        {run_queue, SQ},
+        {run_queue_dirty_cpu, DCQ},
         {ets_table_count, length(ets:all())},
         {context_switches, element(1, statistics(context_switches))},
         {reductions, element(1, statistics(reductions))},
@@ -285,3 +288,13 @@ message_queues(Registered) ->
         {Type, Length} = process_info(whereis(Name), Type),
         {Name, Length}
     end, Registered).
+
+%% Workaround for https://bugs.erlang.org/browse/ERL-1355
+run_queues() ->
+    case erlang:system_info(dirty_cpu_schedulers) > 0 of
+        false ->
+            {statistics(run_queue), 0};
+        true ->
+            [DCQ | SQs] = lists:reverse(statistics(run_queue_lengths)),
+            {lists:sum(SQs), DCQ}
+    end.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This is a first pass at fixing https://github.com/apache/couchdb/issues/3160 for reporting proper run_queue statistics.


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
