### PR TITLE
Backport 3.x -Update Makefile.win to Include locad configs and clean configs in devclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,7 +482,7 @@ endif
 # target: devclean - Remove dev cluster artifacts
 devclean:
 	@rm -rf dev/lib/*/data
-
+	@rm -rf dev/lib/*/etc
 
 ################################################################################
 # Misc

--- a/Makefile.win
+++ b/Makefile.win
@@ -200,7 +200,9 @@ python-black-update: .venv/bin/black
 elixir: export MIX_ENV=integration
 elixir: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 elixir: elixir-init elixir-check-formatted elixir-credo devclean
-	@dev\run $(TEST_OPTS) -a adm:pass -n 1 --enable-erlang-views --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+	@dev\run $(TEST_OPTS) -a adm:pass -n 1 --enable-erlang-views \
+      --locald-config test/elixir/test/config/test-config.ini \
+      --no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
 
 .PHONY: elixir-init
 elixir-init: MIX_ENV=test
@@ -406,6 +408,9 @@ devclean:
 	-@rmdir /s/q dev\lib\node1\data
 	-@rmdir /s/q dev\lib\node2\data
 	-@rmdir /s/q dev\lib\node3\data
+	-@rmdir /s/q dev\lib\node1\etc
+	-@rmdir /s/q dev\lib\node2\etc
+	-@rmdir /s/q dev\lib\node3\etc
 
 
 ################################################################################


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Backport PR #2684 into 3.x
This change is required by ProxyAuthTests and JWT tests int he elixir test suite which are failing in the windows build, see #3158 and #3159 

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
This PR fixes #3158 and fixes #3159
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
