### PR TITLE
JS-Rewrite: Preserve query string rewrite when the request contains a body

### DIFF
--- a/src/chttpd/src/chttpd_rewrite.erl
+++ b/src/chttpd/src/chttpd_rewrite.erl
@@ -71,8 +71,9 @@ do_rewrite(#httpd{mochi_req=MochiReq}=Req, {Props}=Rewrite) when is_list(Props) 
                 undefined -> erlang:get(mochiweb_request_body);
                 B -> B
             end,
+            NewMochiReq:cleanup(),
             case Body of
-                undefined -> NewMochiReq:cleanup();
+                undefined -> [];
                 _ -> erlang:put(mochiweb_request_body, Body)
             end,
             couch_log:debug("rewrite to ~p", [Path]),


### PR DESCRIPTION
## Overview

During the porting of rewrite_js.js tests into the elixir test suite I've found an erroneous behavior in the JS-rewrite functionality. 

When a rewritten request contains a BODY (POST/PUT) and the rewrite rule rewrites the query string, this query string is ignored in the final request. The following case illustrates this issue.

1 - Create a design document with a rule that rewrites the query string, like this one:
```
 {
      "_id": "_design/n", 
      "rewrites": "function (r) { return {path: '../../_changes', query: {'filter': '_doc_ids'}};};"
    }
```
any request should be rewritten to `_changes?filter=_docs_ids`
```
curl -XPOST -u adm:pass -H "Content-type: application/json" \
   -d '{"_id": "_design/n", "rewrites": "function (r) { return {path: '\''../../_changes'\'', query: {'\''filter'\'': '\''_doc_ids'\''}};};"}' \
   http://127.0.0.1:15984/test
```
2 - Create a couple of docs
```
curl -XPUT -u adm:pass -H "Content-type: application/json" -d '{}' http://127.0.0.1:15984/test/1 
curl -XPUT -u adm:pass -H "Content-type: application/json" -d '{}' http://127.0.0.1:15984/test/2
```
3 - Perform a POST request to be rewritten
```
 curl -XPOST -u adm:pass -H "Content-type: application/json" \
    -d '{"doc_ids": ["2"]}' \
     http://127.0.0.1:15984/test/_design/n/_rewrite
```

The expected result for this case is to have only the change for the doc with id 2 in the response, but the full change list is returned. The `filter=_doc_ids` is ignored after the rewritten.

This PR changes this behavior and the query string is preserved, so the result for the previous case is the excepted one returning only the change for the doc with id 2.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
The previous test case has been added to rewrite_js.js tests
```
 make javascript suites="rewrite_js, rewrite"
```

## Related Issues or Pull Requests

This issue #1612 and the companion PR #1620 are related to this issue

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
