### PR TITLE
Fix transient replication jobs failure handling

### DIFF
--- a/src/couch_replicator/src/couch_replicator_filters.erl
+++ b/src/couch_replicator/src/couch_replicator_filters.erl
@@ -150,7 +150,7 @@ fetch_internal(DDocName, FilterName, Source) ->
                      couch_replicator_api_wrap:db_uri(Source),
                      couch_util:to_binary(CodeError)]
                  ),
-                 throw({fetch_error, CodeErrorMsg})
+                 throw({fetch_error, iolist_to_binary(CodeErrorMsg)})
          end
     after
         couch_replicator_api_wrap:db_close(Db)

--- a/src/couch_replicator/src/couch_replicator_job.erl
+++ b/src/couch_replicator/src/couch_replicator_job.erl
@@ -810,9 +810,8 @@ get_rep_id(JTx, Job, #{} = JobData) ->
     try
         couch_replicator_ids:replication_id(Rep)
     catch
-        throw:{filter_fetch_error, Error} ->
-            Error1 = io_lib:format("Filter fetch error ~p", [Error]),
-            reschedule_on_error(JTx, Job, JobData, Error1),
+        throw:{filter_fetch_error, _} = Error ->
+            reschedule_on_error(JTx, Job, JobData, {error, Error}),
             exit({shutdown, finished})
     end.
 

--- a/src/couch_replicator/src/couch_replicator_jobs.erl
+++ b/src/couch_replicator/src/couch_replicator_jobs.erl
@@ -170,12 +170,14 @@ wait_running(JobId) ->
 
 
 wait_running(JobId, SubId) ->
-    case couch_jobs:wait(SubId, running, infinity) of
+    case couch_jobs:wait(SubId, infinity) of
         {?REP_JOBS, _, running, #{?STATE := ?ST_PENDING}} ->
             wait_running(JobId, SubId);
         {?REP_JOBS, _, running, JobData} ->
             ok = couch_jobs:unsubscribe(SubId),
             {ok, JobData};
+        {?REP_JOBS, _, pending, _} ->
+            wait_running(JobId, SubId);
         {?REP_JOBS, _, finished, JobData} ->
             ok = couch_jobs:unsubscribe(SubId),
             {ok, JobData}


### PR DESCRIPTION
There are two fixes:

1)  Fix transient replication job state wait logic

Make sure to handle both `finished` and `pending` states when waiting for a
transient jobs. A transient job will go to the `failed` state if it cannot
fetch the filter from the source endpoint. For completeness, we also account
for `pending` states in there in the remote chance the job get rescheduled
again.

2) Fix error reporting when fetching replication filters

Don't unnecessarily unwrap the fetch error since `error_info/1` can already
handle the current shape. Also, make sure to translate the reason to binary for
consistency with the other filter fetching errors in the
`couch_replicator_filters` module.

The end-to-end test in the second commits checks the waiting behavior and the error reporting.
