### PR TITLE
Smoosh update operator guide to use rpc:multicall

### DIFF
--- a/src/smoosh/operator_guide.md
+++ b/src/smoosh/operator_guide.md
@@ -146,47 +146,35 @@ along with the other defaults.
 
 ```bash
 # Define the new channel
-(couchdb@db1.foo.bar)3> s:set_config("smoosh.big_dbs", "min_size", "20000000000", global).
+(couchdb@db1.foo.bar)3> rpc:multicall(config, set, ["smoosh.big_dbs", "min_size", "20000000000"]).
 {[ok,ok,ok],[]}
-(couchdb@db1.foo.bar)3> s:set_config("smoosh.big_dbs", "concurrency", "2", global).
+(couchdb@db1.foo.bar)3> rpc:multicall(config, set, ["smoosh.big_dbs", "concurrency", "2"]).
 {[ok,ok,ok],[]}
 
 # Add the channel to the db_channels set -- note we need to get the original
 # value first so we can add the new one to the existing list!
-(couchdb@db1.foo.bar)5> s:get_config("smoosh", "db_channels", global).
-{[{'couchdb@db1.foo.bar',"ratio_dbs"},
-{'couchdb@db3.foo.bar',"ratio_dbs"},
-{'couchdb@db2.foo.bar',"ratio_dbs"}],
-[]}
-(couchdb@db1.foo.bar)6> s:set_config("smoosh", "db_channels", "ratio_dbs,big_dbs", global).
+(couchdb@db1.foo.bar)5> rpc:multicall(config, get, ["smoosh", "db_channels"]).
+{["ratio_dbs","ratio_dbs","ratio_dbs"],[]}
+(couchdb@db1.foo.bar)6> rpc:multicall(config, set, ["smoosh", "db_channels", "ratio_dbs,big_dbs"]).
 {[ok,ok,ok],[]}
 ```
 
 ### Viewing active channels
 
 ```bash
-(couchdb@db3.foo.bar)3> s:get_config("smoosh", "db_channels", global).
-{[{'couchdb@db3.foo.bar',"ratio_dbs,big_dbs"},
-  {'couchdb@db1.foo.bar',"ratio_dbs,big_dbs"},
-  {'couchdb@db2.foo.bar',"ratio_dbs,big_dbs"}],
- []}
-(couchdb@db3.foo.bar)4> s:get_config("smoosh", "view_channels", global).
-{[{'couchdb@db3.foo.bar',"ratio_views"},
-  {'couchdb@db1.foo.bar',"ratio_views"},
-  {'couchdb@db2.foo.bar',"ratio_views"}],
- []}
+(couchdb@db3.foo.bar)3> rpc:multicall(config, get, ["smoosh", "db_channels"]).
+{["ratio_dbs,big_dbs","ratio_dbs,big_dbs","ratio_dbs,big_dbs"],[]}
+(couchdb@db3.foo.bar)4> rpc:multicall(config, get, ["smoosh", "view_channels"]).
+{["ratio_views","ratio_views","ratio_views"],[]}
 ```
 
 ### Removing a channel
 
 ```bash
 # Remove it from the active set
-(couchdb@db1.foo.bar)5> s:get_config("smoosh", "db_channels", global).
-{[{'couchdb@db1.foo.bar',"ratio_dbs,big_dbs"},
-{'couchdb@db3.foo.bar',"ratio_dbs,big_dbs"},
-{'couchdb@db2.foo.bar',"ratio_dbs,big_dbs"}],
-[]}
-(couchdb@db1.foo.bar)6> s:set_config("smoosh", "db_channels", "ratio_dbs", global).
+(couchdb@db1.foo.bar)5> rpc:multicall(config, get, ["smoosh", "db_channels"]).
+{["ratio_dbs,big_dbs", "ratio_dbs,big_dbs", "ratio_dbs,big_dbs"],[]}
+(couchdb@db1.foo.bar)6> rpc:multicall(config, set, ["smoosh", "db_channels", "ratio_dbs"]).
 {[ok,ok,ok],[]}
 
 # Delete the config -- you need to do each value
@@ -201,11 +189,8 @@ along with the other defaults.
 As far as I know, you have to get each setting separately:
 
 ```
-(couchdb@db1.foo.bar)1> s:get_config("smoosh.big_dbs", "concurrency", global).
-{[{'couchdb@db3.foo.bar',"2"},
-  {'couchdb@db1.foo.bar',"2"},
-  {'couchdb@db2.foo.bar',"2"}],
- []}
+(couchdb@db1.foo.bar)1> rpc:multicall(config, get, ["smoosh.big_dbs", "concurrency"]).
+{["2","2","2"],[]}
 
 ```
 
@@ -214,7 +199,7 @@ As far as I know, you have to get each setting separately:
 The same as defining a channel, you just need to set the new value:
 
 ```
-(couchdb@db1.foo.bar)2> s:set_config("smoosh.ratio_dbs", "concurrency", "1", global).
+(couchdb@db1.foo.bar)2> rpc:multicall(config, set, ["smoosh.ratio_dbs", "concurrency", "1"]).
 {[ok,ok,ok],[]}
 ```
 
@@ -298,11 +283,8 @@ If it's falling behind (big queues), try increasing compaction priority.
 Smoosh's IOQ priority is controlled via the `ioq` -> `compaction` queue.
 
 ```
-> s:get_config("ioq", "compaction", global).
-{[{'couchdb@db1.foo.bar',undefined},
-  {'couchdb@db2.foo.bar',undefined},
-  {'couchdb@db3.foo.bar',undefined}],
- []}
+> rpc:multicall(config, get, ["ioq", "compaction"]).
+{[undefined,undefined,undefined],[]}
 
 ```
 
@@ -315,7 +297,7 @@ doesn't adversely impact the customer experience. If it will, and
 it's urgent, at least drop them a warning.
 
 ```
-> s:set_config("ioq", "compaction", "0.5", global).
+> rpc:multicall(config, set, ["ioq", "compaction", "0.5"]).
 {[ok,ok,ok],[]}
 ```
 
@@ -338,11 +320,8 @@ higher concurrency.
 The current setting can be seen for a channel like so:
 
 ```
-> s:get_config("smoosh.ratio_dbs", "concurrency", global).
-{[{'couchdb@db1.foo.bar',undefined},
-  {'couchdb@db2.foo.bar',undefined},
-  {'couchdb@db3.foo.bar',undefined}],
- []}
+> rpc:multicall(config, get, ["smoosh.ratio_dbs", "concurrency"]).
+{["2","2","2"], []}
 ```
 
 `undefined` means the default is used.
@@ -354,7 +333,7 @@ but evaluate this based on the current status.
 If we want to increase the ratio_dbs setting:
 
 ```
-> s:set_config("smoosh.ratio_dbs", "concurrency", "2", global).
+> rpc:multicall(config, set, ["smoosh.ratio_dbs", "concurrency", "2"]).
 {[ok,ok,ok],[]}
 ```
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The smoosh `operator_guide.md` has been updated to use rpc:multicall in the examples. The previous examples used a library not included in CouchDB for some of the rpc commands.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
