### PR TITLE
Split and prioritize integration tests execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ elixir-cluster: export MIX_ENV=integration
 elixir-cluster: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 elixir-cluster: devclean
 	@dev/run "$(TEST_OPTS)" -a adm:pass -n 3 \
+		--degrade-cluster 2 \
 		--enable-erlang-views \
 		--erlang-config rel/files/eunit.config \
 		--locald-config test/elixir/test/config/test-config.ini \
@@ -270,6 +271,7 @@ elixir-degraded-cluster: export MIX_ENV=integration
 elixir-degraded-cluster: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 elixir-degraded-cluster: devclean
 	@dev/run "$(TEST_OPTS)" -a adm:pass -n 1 \
+		--degrade-cluster 1 \
 		--enable-erlang-views \
 		--erlang-config rel/files/eunit.config \
 		--locald-config test/elixir/test/config/test-config.ini \

--- a/test/elixir/test/cluster_with_quorum_test.exs
+++ b/test/elixir/test/cluster_with_quorum_test.exs
@@ -8,6 +8,7 @@ defmodule WithQuorumTest do
   Test CouchDB API in a cluster without quorum.
   """
   @tag :with_db_name
+  @tag kind: :pending
   test "Creating/Deleting DB should return 201-Created/202-Acepted", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}")
@@ -46,6 +47,7 @@ defmodule WithQuorumTest do
   end
 
   @tag :with_db_name
+  @tag kind: :pending
   test "Creating-Updating/Deleting doc with overriden quorum should return 202-Acepted/200-OK",
        context do
     db_name = context[:db_name]
@@ -115,6 +117,7 @@ defmodule WithQuorumTest do
   end
 
   @tag :with_db_name
+  @tag kind: :pending
   test "Bulk docs overriden quorum should return 202-Acepted", context do
     db_name = context[:db_name]
     Couch.put("/#{db_name}")
@@ -153,6 +156,7 @@ defmodule WithQuorumTest do
   end
 
   @tag :with_db_name
+  @tag kind: :pending
   test "Attachments overriden quorum should return 202-Acepted", context do
     db_name = context[:db_name]
     Couch.put("/#{db_name}")

--- a/test/elixir/test/cluster_without_quorum_test.exs
+++ b/test/elixir/test/cluster_without_quorum_test.exs
@@ -8,6 +8,7 @@ defmodule WithoutQuorumTest do
   Test CouchDB API in a cluster without quorum.
   """
   @tag :with_db_name
+  @tag kind: :pending
   test "Creating/Deleting DB should return 202-Acepted", context do
     db_name = context[:db_name]
     resp = Couch.put("/#{db_name}")
@@ -18,6 +19,7 @@ defmodule WithoutQuorumTest do
   end
 
   @tag :with_db_name
+  @tag kind: :pending
   test "Creating/Updating/Deleting doc should return 202-Acepted", context do
     db_name = context[:db_name]
     Couch.put("/#{db_name}")
@@ -83,6 +85,7 @@ defmodule WithoutQuorumTest do
   end
 
   @tag :with_db_name
+  @tag kind: :pending
   test "Copy doc should return 202-Acepted", context do
     db_name = context[:db_name]
     Couch.put("/#{db_name}")
@@ -102,6 +105,7 @@ defmodule WithoutQuorumTest do
   @doc_range 1..5
 
   @tag :with_db_name
+  @tag kind: :pending
   test "Bulk docs should return 202-Acepted", context do
     db_name = context[:db_name]
     Couch.put("/#{db_name}")
@@ -126,6 +130,7 @@ defmodule WithoutQuorumTest do
   end
 
   @tag :with_db_name
+  @tag kind: :pending
   test "Attachments should return 202-Acepted", context do
     db_name = context[:db_name]
     Couch.put("/#{db_name}")

--- a/test/elixir/test/config_test.exs
+++ b/test/elixir/test/config_test.exs
@@ -73,6 +73,7 @@ defmodule ConfigTest do
 
   # TODO: port sever_port tests from config.js
   @tag :pending
+  @tag kind: :pending
   test "CouchDB respects configured protocols"
 
   test "Standard config options are present", context do
@@ -101,6 +102,7 @@ defmodule ConfigTest do
   end
 
   @tag :pending
+  @tag kind: :pending
   test "PORT `BUGGED` ?raw tests from config.js"
 
   test "Non-term whitelist values allow further modification of the whitelist", context do


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR is a follow-up to #3110 and a should allows us to close #1885.

We want to adopt a _fail-fast_ approach so we split tests in several categories and we're running them from the fastest one to the slowest.

## Testing recommendations

If `make elixir` is ok, then you'll probably be ok. I didn't know if there would be a better way of handling these modifications in the Makefile.

## Related Issues or Pull Requests

#3110, #1885 

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
