### PR TITLE
Keep auth properties as a map in replicator's httpdb record

### DIFF
--- a/src/couch_replicator/include/couch_replicator_api_wrap.hrl
+++ b/src/couch_replicator/include/couch_replicator_api_wrap.hrl
@@ -14,7 +14,7 @@
 
 -record(httpdb, {
     url,
-    auth_props = [],
+    auth_props = #{},
     headers = [
         {"Accept", "application/json"},
         {"User-Agent", "CouchDB-Replicator/" ++ couch_server:get_version()}

--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -917,7 +917,7 @@ db_from_json(#{} = DbMap) ->
     end,
     #httpdb{
         url = binary_to_list(Url),
-        auth_props = maps:to_list(Auth),
+        auth_props = Auth,
         headers = Headers,
         ibrowse_options = IBrowseOptions,
         timeout = Timeout,

--- a/src/couch_replicator/src/couch_replicator_utils.erl
+++ b/src/couch_replicator/src/couch_replicator_utils.erl
@@ -281,7 +281,10 @@ normalize_rep_test_() ->
 normalize_endpoint() ->
     HttpDb =  #httpdb{
         url = "http://host/db",
-        auth_props = [{"key", "val"}],
+        auth_props = #{
+            "key" => "val",
+            "nested" => #{<<"other_key">> => "other_val"}
+        },
         headers = [{"k2","v2"}, {"k1","v1"}],
         timeout = 30000,
         ibrowse_options = [{k2, v2}, {k1, v1}],


### PR DESCRIPTION
Previously there was an attempt to keep backwards compatibility with 3.x replicator plugins by transforming the auth into a proplist with `maps:to_list/1`. However, that didn't account for nested properties, so we could have ended up with a top level of props with maps for some values. Instead of making things too complicating, and doing a nested transform to proplists, just keep the auth object as a map and let the plugins handle the compatibility issue.
