### PR TITLE
Merge commits main

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,7 +20,7 @@ github:
   enabled_merge_buttons:
     squash: true
     rebase: true
-    merge: false
+    merge: true
 
 notifications:
   commits: commits@couchdb.apache.org


### PR DESCRIPTION
This PR re-enables merge commits (disabled in https://github.com/apache/couchdb/pull/3020). As such I will follow the same stipulations there before merging, that we need 3 +1 votes to proceed.