### PR TITLE
Fix boolean POST to view-like endpoints

### DIFF
--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -529,15 +529,15 @@ parse_param(Key, Val, Args, IsDecoded) ->
             Args#mrargs{stable=true, update=lazy};
         "stale" ->
             throw({query_parse_error, <<"Invalid value for `stale`.">>});
-        "stable" when Val == "true" orelse Val == <<"true">> ->
+        "stable" when Val == "true" orelse Val == <<"true">> orelse Val == true ->
             Args#mrargs{stable=true};
-        "stable" when Val == "false" orelse Val == <<"false">> ->
+        "stable" when Val == "false" orelse Val == <<"false">> orelse Val == false ->
             Args#mrargs{stable=false};
         "stable" ->
             throw({query_parse_error, <<"Invalid value for `stable`.">>});
-        "update" when Val == "true" orelse Val == <<"true">> ->
+        "update" when Val == "true" orelse Val == <<"true">> orelse Val == true ->
             Args#mrargs{update=true};
-        "update" when Val == "false" orelse Val == <<"false">> ->
+        "update" when Val == "false" orelse Val == <<"false">> orelse Val == false ->
             Args#mrargs{update=false};
         "update" when Val == "lazy" orelse Val == <<"lazy">> ->
             Args#mrargs{update=lazy};

--- a/test/elixir/test/all_docs_test.exs
+++ b/test/elixir/test/all_docs_test.exs
@@ -297,4 +297,22 @@ defmodule AllDocsTest do
     assert resp.status_code == 200
     assert length(Map.get(resp, :body)["rows"]) == 1
   end
+
+  @tag :with_db
+  test "POST boolean", context do
+    db_name = context[:db_name]
+
+    resp = Couch.post("/#{db_name}/_bulk_docs", body: %{docs: create_docs(0..3)})
+    assert resp.status_code in [201, 202]
+
+    resp = Couch.post(
+      "/#{db_name}/_all_docs",
+      body: %{
+        :stable => true,
+        :update => true
+      }
+    )
+
+    assert resp.status_code == 200
+  end
 end

--- a/test/elixir/test/view_test.exs
+++ b/test/elixir/test/view_test.exs
@@ -141,4 +141,16 @@ defmodule ViewTest do
     assert resp.status_code == 200
     assert length(Map.get(resp, :body)["rows"]) == 1
   end
+
+  test "POST with boolean parameter", context do
+    resp = Couch.post(
+      "/#{context[:db_name]}/_design/map/_view/some",
+      body: %{
+        :stable => true,
+        :update => true
+      }
+    )
+
+    assert resp.status_code == 200
+  end
 end


### PR DESCRIPTION
## Overview
When using a POST with request body to pass parameters to a view-like request the boolean parameters are accepting only JSON strings, but not booleans. For example the stable parameter works with "true" and "false" but not true and false.

## Testing recommendations

`mix test --trace test/elixir/test/all_docs_test.exs`
and
`mix test --trace test/elixir/test/view_test.exs`

## Related Issues or Pull Requests

This fixes #3200 .

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini` -- N/A
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation -- N/A
