### PR TITLE
Do not shortcut replicator job initialization if replication ID matches

### DIFF
--- a/src/couch_replicator/src/couch_replicator_job.erl
+++ b/src/couch_replicator/src/couch_replicator_job.erl
@@ -505,10 +505,6 @@ do_init(Job, #{} = JobData) ->
     update_job_state(State1).
 
 
-init_job_data(#{jtx := true} = JTx, Job, #{?REP_ID := RepId} = JobData, RepId,
-        _BaseId) ->
-    {Job, JobData, check_ownership(JTx, Job, JobData)};
-
 init_job_data(#{jtx := true} = JTx, Job, #{} = JobData, RepId, BaseId) ->
     #{
         ?REP := Rep,


### PR DESCRIPTION
Previously there was an attempt to shortcut some of the job initialization if replication ID in the job data and the newly computed one matched. However, that logic was wrong as it skipped over the job data state update.

The effect was that if a job was in a pending state, and it re-initialized, say when a node restarted, its job data would still indicate it as "pending" until the next checkpoint. If the job is continuous, and there are no more updates on the source, the state of the job would stay in "pending" indefinitely.
