### PR TITLE
Removed unused variable in merge headers unit test

### DIFF
--- a/src/couch_replicator/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc.erl
@@ -507,7 +507,6 @@ merge_headers(Headers1, Headers2) when is_list(Headers1), is_list(Headers2) ->
 
 
 merge_headers_test() ->
-    Headers1 = [{"a", "x"}, {"a", "y"}, {"A", "z"}],
     ?assertEqual([], merge_headers([], [])),
     ?assertEqual([{"a", "x"}], merge_headers([], [{"a", "x"}])),
     ?assertEqual([{"a", "x"}], merge_headers([{"a", "x"}], [])),


### PR DESCRIPTION
`Headers1` is not used anywhere