### PR TITLE
convert erlfdb_error 2101 to transaction_too_large

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -362,6 +362,8 @@ catch_error(HttpReq, error, decryption_failed) ->
     send_error(HttpReq, decryption_failed);
 catch_error(HttpReq, error, not_ciphertext) ->
     send_error(HttpReq, not_ciphertext);
+catch_error(HttpReq, error, {erlfdb_error, 2101}) ->
+    send_error(HttpReq, transaction_too_large);
 catch_error(HttpReq, Tag, Error) ->
     Stack = erlang:get_stacktrace(),
     % TODO improve logging and metrics collection for client disconnects
@@ -1009,6 +1011,9 @@ error_info({request_entity_too_large, {bulk_get, Max}}) when is_integer(Max) ->
     {413, <<"max_bulk_get_count_exceeded">>, integer_to_binary(Max)};
 error_info({request_entity_too_large, DocID}) ->
     {413, <<"document_too_large">>, DocID};
+error_info(transaction_too_large) ->
+    {413, <<"transaction_too_large">>,
+        <<"The request transaction is larger than 10MB" >>};
 error_info({error, security_migration_updates_disabled}) ->
     {503, <<"security_migration">>, <<"Updates to security docs are disabled during "
         "security migration.">>};

--- a/test/elixir/test/bulk_docs_test.exs
+++ b/test/elixir/test/bulk_docs_test.exs
@@ -129,6 +129,17 @@ defmodule BulkDocsTest do
     assert Enum.at(rows, 2)["error"] == "conflict"
   end
 
+  @tag :with_db
+  test "bulk docs raises transaction_too_large error for transaction larger than 10MB", ctx do
+    docs = [%{_id: "0", a: random_string(16_000_000)}]
+    old_size = Couch.get("/_node/node1@127.0.0.1/_config/couchdb/max_document_size").body
+    set_config_raw("couchdb", "max_document_size", "67108864") # 64M
+    resp = Couch.post("/#{ctx[:db_name]}/_bulk_docs", body: %{docs: docs})
+    set_config_raw("couchdb", "max_document_size", old_size) # set back
+    assert resp.status_code == 413
+    assert resp.body["error"] == "transaction_too_large"
+  end
+
   defp bulk_post(docs, db) do
     retry_until(fn ->
       resp = Couch.post("/#{db}/_bulk_docs", body: %{docs: docs})
@@ -150,5 +161,12 @@ defmodule BulkDocsTest do
     assert resp.status_code == 400
     assert resp.body["error"] == "bad_request"
     assert resp.body["reason"] == reason
+  end
+
+  defp random_string(length) do
+    raw = :crypto.strong_rand_bytes(length)
+    raw
+    |> Base.url_encode64
+    |> binary_part(0, length)
   end
 end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
If transaction exceeds byte limit using the `_bulk_docs` endpoint,  the `{u'reason': u'2101', u'ref': 3853288219, u'error': u'erlfdb_error'}` with 500 error code was returned.  This is user-friendly. Using this PR is to provide meaningful error message to users. 

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
The test python code:
```
import requests, json, random, string, os
print(requests.post(
    "http://127.0.0.1:15984/foo/_bulk_docs"
    , json={
        "docs":
            [
                {"foo": "".join(random.choice(string.ascii_lowercase) for x in range(16000000))}
            ]}
    , auth=('foo', 'bar')
).json())
```
Original response:
```
{u'reason': u'2101', u'ref': 3853288219, u'error': u'erlfdb_error'}
```
New response:
```
{u'reason': u'The request transaction is larger than 10MB', u'error': u'transaction_too_large'}
```
 make elixir tests=test/elixir/test/bulk_docs_test.exs
make exunit tests=src/couchdb/test/elixir/test/bulk_docs_test.exs

```
BulkDocsTest
  * test bulk docs raises error for invlaid `docs` parameter (75.5ms)
  * test bulk docs supplies `id` if not provided in doc (38.9ms)
  * test bulk docs can detect conflicts (64.4ms)
  * test bulk docs raises error for invlaid `new_edits` parameter (13.3ms)
  * test bulk docs raises error for missing `docs` parameter (13.0ms)
  * test bulk docs raises transaction_too_large error for transaction larger than 10MB (1384.9ms)
  * test bulk docs raises error for `all_or_nothing` option (13.6ms)
  * test bulk docs raises conflict error for combined update & delete (40.6ms)
  * test bulk docs emits conflict error for duplicate doc `_id`s (23.2ms)
  * test bulk docs can create, update, & delete many docs per request (78.3ms)


Finished in 2.0 seconds
10 tests, 0 failures

Randomized with seed 913112
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->


## Checklist

- [X] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
