### PR TITLE
3.x backport - Fix apache/couchdb#1988 -  Validate attachment names

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -437,6 +437,7 @@ db_req(#httpd{method='POST', path_parts=[DbName], user_ctx=Ctx}=Req, Db) ->
     Options = [{user_ctx,Ctx}, {w,W}],
 
     Doc = couch_db:doc_from_json_obj_validate(Db, chttpd:json_body(Req)),
+    validate_attachment_names(Doc),
     Doc2 = case Doc#doc.id of
         <<"">> ->
             Doc#doc{id=couch_uuids:new(), revs={0, []}};

--- a/test/elixir/test/attachment_names_test.exs
+++ b/test/elixir/test/attachment_names_test.exs
@@ -93,5 +93,20 @@ defmodule AttachmentNamesTest do
 
     assert resp.body["reason"] ==
              "Attachment name '_foo.txt' starts with prohibited character '_'"
+
+    resp =
+      Couch.post(
+        "/#{db_name}",
+        body: @leading_underscores_att
+      )
+
+    assert resp.status_code == 400
+
+    assert resp.body["reason"] ==
+             "Attachment name '_foo.txt' starts with prohibited character '_'"
+
+    resp = Couch.get("/#{db_name}/bin_doc2/_foo.txt")
+
+    assert resp.status_code == 404
   end
 end


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR backports the fix for apache/couchdb#1988 into 3.x branch.

This change has been merged into main with PR #1997 
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
 make elixir
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
PR #1997 
Issue #1988
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
