### PR TITLE
Fix empty reduce output to match 3.x behavior

### DIFF
--- a/src/couch_views/src/couch_views_trees.erl
+++ b/src/couch_views/src/couch_views_trees.erl
@@ -279,9 +279,6 @@ min_order(V) ->
 
 make_read_only_reduce_fun(Lang, View, NthRed) ->
     RedFuns = [Src || {_, Src} <- View#mrview.reduce_funs],
-    if RedFuns /= [] -> ok; true ->
-        io:format(standard_error, "~p~n", [process_info(self(), current_stacktrace)])
-    end,
     LPad = lists:duplicate(NthRed - 1, []),
     RPad = lists:duplicate(length(RedFuns) - NthRed, []),
     FunSrc = lists:nth(NthRed, RedFuns),

--- a/src/couch_views/test/couch_views_red_test.erl
+++ b/src/couch_views/test/couch_views_red_test.erl
@@ -213,7 +213,7 @@ should_reduce_empty_range({Db, _}) ->
         end_key => 100001
     },
     Result = run_query(Db, <<"baz_count">>, Args),
-    Expect = {ok, [row(null, 0)]},
+    Expect = {ok, []},
     ?assertEqual(Expect, Result).
 
 
@@ -224,7 +224,7 @@ should_reduce_empty_range_rev({Db, _}) ->
         end_key => 100000
     },
     Result = run_query(Db, <<"baz_count">>, Args),
-    Expect = {ok, [row(null, 0)]},
+    Expect = {ok, []},
     ?assertEqual(Expect, Result).
 
 


### PR DESCRIPTION
## Overview

Before this change a reduce call that contained no rows would end up
returning the "default" value of the given reduce function which is
whatever it would return when given an empty array as input. This
changes the behavior to return `{"rows": []"}` when there are no
rows in the requested range.

## Testing recommendations

`make check`

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
