### PR TITLE
Use snapshot for expiring cache insertion

### DIFF
--- a/src/couch_expiring_cache/.suppressed
+++ b/src/couch_expiring_cache/.suppressed
@@ -1,0 +1,1 @@
+no_return

--- a/src/couch_expiring_cache/src/couch_expiring_cache.erl
+++ b/src/couch_expiring_cache/src/couch_expiring_cache.erl
@@ -31,8 +31,9 @@ insert(Name, Key, Value, StaleTS, ExpiresTS)
     insert(undefined, Name, Key, Value, StaleTS, ExpiresTS).
 
 
--spec insert(Tx :: jtx(), Name :: binary(), Key :: binary(), Value :: binary(),
-    StaleTS :: ?TIME_UNIT(), ExpiresTS :: ?TIME_UNIT()) -> ok.
+-spec insert(Tx :: jtx() | undefined, Name :: binary(), Key :: binary(),
+    Value :: binary(), StaleTS :: ?TIME_UNIT(), ExpiresTS :: ?TIME_UNIT()) -> ok.
+-dialyzer({no_return, insert/6}).
 insert(Tx, Name, Key, Value, StaleTS, ExpiresTS)
         when is_binary(Name), is_binary(Key), is_binary(Value),
         is_integer(StaleTS), is_integer(ExpiresTS) ->

--- a/src/couch_expiring_cache/src/couch_expiring_cache_fdb.erl
+++ b/src/couch_expiring_cache/src/couch_expiring_cache_fdb.erl
@@ -41,7 +41,8 @@
 insert(#{jtx := true} = JTx, Name, Key, Val, StaleTS, ExpiresTS) ->
     #{tx := Tx, layer_prefix := LayerPrefix} = couch_jobs_fdb:get_jtx(JTx),
     PK = primary_key(Name, Key, LayerPrefix),
-    case get_val(Tx, PK) of
+    % Use snapshot here to minimize conflicts on parallel inserts
+    case get_val(erlfdb:snapshot(Tx), PK) of
         not_found ->
             ok;
         {_OldVal, _OldStaleTS, OldExpiresTS} ->

--- a/src/couch_expiring_cache/src/couch_expiring_cache_fdb.erl
+++ b/src/couch_expiring_cache/src/couch_expiring_cache_fdb.erl
@@ -37,7 +37,7 @@
 
 
 -spec insert(JTx :: jtx(), Name :: binary(), Key :: binary(), Value :: binary(),
-    StaleTS :: ?TIME_UNIT, ExpiresTS :: ?TIME_UNIT) -> ok.
+    StaleTS :: millisecond(), ExpiresTS :: millisecond()) -> ok.
 insert(#{jtx := true} = JTx, Name, Key, Val, StaleTS, ExpiresTS) ->
     #{tx := Tx, layer_prefix := LayerPrefix} = couch_jobs_fdb:get_jtx(JTx),
     PK = primary_key(Name, Key, LayerPrefix),
@@ -86,7 +86,7 @@ clear_all(Name) ->
     end).
 
 
--spec clear_range_to(Name :: binary(), EndTS :: ?TIME_UNIT,
+-spec clear_range_to(Name :: binary(), EndTS :: millisecond(),
     Limit :: non_neg_integer()) ->
         OldestTS :: ?TIME_UNIT.
 clear_range_to(Name, EndTS, Limit) when Limit > 0 ->
@@ -98,7 +98,7 @@ clear_range_to(Name, EndTS, Limit) when Limit > 0 ->
         end, 0).
 
 
--spec get_range_to(Name :: binary(), EndTS :: ?TIME_UNIT,
+-spec get_range_to(Name :: binary(), EndTS :: millisecond(),
     Limit :: non_neg_integer()) ->
         [{Key :: binary(), Val :: binary()}].
 get_range_to(Name, EndTS, Limit) when Limit > 0 ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

 Too many parallel attempts to insert the same keys can result in
`{erlfdb_error, 1020}`, which translates to:
"Transaction not committed due to conflict with another transaction"

This attempts to mitigate the problem by using a snapshot to
read the primary key during cache insertion.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
make eunit apps=couch_expiring_cache
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
