### PR TITLE
Better haproxy cfg (3.x)

### DIFF
--- a/rel/haproxy.cfg
+++ b/rel/haproxy.cfg
@@ -13,6 +13,8 @@
 global
         maxconn 512
         spread-checks 5
+        nbproc 1
+        daemon
 
 defaults
         mode http


### PR DESCRIPTION
## Overview

haproxy v1.8+ now requires the `daemon` argument to run in the background.

Also, per https://www.haproxy.com/blog/multithreading-in-haproxy/ and https://www.haproxy.com/blog/haproxy-1-9-has-arrived/ , multithreading is higher perf than multiprocessing. So, let's do that by default, and assume 4 cores (seems safe).

## Testing recommendations

`dev/run --with-haproxy`

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [N/A] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [N/A] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
