### PR TITLE
Remove '--production' flag when building Fauxton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ endif
 share/www:
 ifeq ($(with_fauxton), 1)
 	@echo "Building Fauxton"
-	@cd src/fauxton && npm install --production && ./node_modules/grunt-cli/bin/grunt couchdb
+	@cd src/fauxton && npm install && ./node_modules/grunt-cli/bin/grunt couchdb
 endif
 
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -419,7 +419,7 @@ endif
 share\www:
 ifeq ($(with_fauxton), 1)
 	@echo 'Building Fauxton'
-	@cd src\fauxton && npm install --production && .\node_modules\.bin\grunt couchdb
+	@cd src\fauxton && npm install && .\node_modules\.bin\grunt couchdb
 endif
 
 derived:


### PR DESCRIPTION
## Overview

Currently `npm install --production` is used when creating the Fauxton release. Due to changes in https://github.com/apache/couchdb-fauxton/pull/1299, build time tools (like `grunt`) will no longer be available when installing dependencies with the `--production` flag.

To account for this new behavior, this PR removes the `--production` flag on both Makefiles. 

Note this change only impacts what is installed inside the `node_modules` folder, but it has no impact on the Fauxton assets generated and copied to the `share/www` folder.

## Testing recommendations

```
git clone https://github.com/apache/couchdb-fauxton src/fauxton
make fauxton with_fauxton=1
```
Then `ls share/www` to verify the assets were created.

## Related Issues or Pull Requests

https://github.com/apache/couchdb-fauxton/pull/1299

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
