### PR TITLE
reuse GRV within an http request

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -153,6 +153,7 @@ stop() ->
     mochiweb_http:stop(?MODULE).
 
 handle_request(MochiReq0) ->
+    fabric2_fdb:init_grv_cache(),
     erlang:put(?REWRITE_COUNT, 0),
     MochiReq = couch_httpd_vhost:dispatch_host(MochiReq0),
     handle_request_int(MochiReq).

--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -76,6 +76,8 @@
 -define(PDICT_TX_ID_KEY, '$fabric_tx_id').
 -define(PDICT_TX_RES_KEY, '$fabric_tx_result').
 -define(PDICT_FOLD_ACC_STATE, '$fabric_fold_acc_state').
+-define(PDICT_GRV_CACHE_ENABLED, '$fabric_grv_cache_enabled').
+-define(PDICT_GRV_CACHE, '$fabric_grv_cache').
 
 % Let's keep these in ascending order
 -define(TRANSACTION_TOO_OLD, 1007).


### PR DESCRIPTION
## Overview

Cache the read version and use it for all transactions started within the context of an http request (but not elsewhere!)

## Testing recommendations

Should be undetectable.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
