### PR TITLE
Add an "encryption" object to db info

### DIFF
--- a/src/aegis/src/aegis.erl
+++ b/src/aegis/src/aegis.erl
@@ -20,6 +20,7 @@
 -export([
     init_db/2,
     open_db/1,
+    get_db_info/1,
 
     decrypt/2,
     decrypt/3,
@@ -37,6 +38,16 @@ open_db(#{} = Db) ->
     Db#{
         is_encrypted => aegis_server:open_db(Db)
     }.
+
+
+get_db_info(#{is_encrypted := IsEncrypted} = Db) ->
+    KeyManagerInfo = case erlang:function_exported(?AEGIS_KEY_MANAGER, get_db_info, 1) of
+        true ->
+            ?AEGIS_KEY_MANAGER:get_db_info(Db);
+        false ->
+            []
+    end,
+    [{enabled, IsEncrypted}, {key_manager, {KeyManagerInfo}}].
 
 
 encrypt(#{} = _Db, _Key, <<>>) ->

--- a/src/aegis/src/aegis_key_manager.erl
+++ b/src/aegis/src/aegis_key_manager.erl
@@ -20,3 +20,11 @@
 
 
 -callback open_db(Db :: #{}) -> {ok, binary()} | false.
+
+
+-callback get_db_info(Db :: #{}) -> list().
+
+
+-optional_callbacks([
+    get_db_info/1
+]).

--- a/src/aegis/test/aegis_server_test.erl
+++ b/src/aegis/test/aegis_server_test.erl
@@ -35,6 +35,8 @@ basic_test_() ->
             {timeout, ?TIMEOUT, fun test_init_db/0}},
             {"open_db returns true when encryption enabled",
             {timeout, ?TIMEOUT, fun test_open_db/0}},
+            {"get_db_info returns encryption enabled true",
+            {timeout, ?TIMEOUT, fun test_get_db_info/0}},
             {"init_db caches key",
             {timeout, ?TIMEOUT, fun test_init_db_cache/0}},
             {"open_db caches key",
@@ -68,6 +70,11 @@ test_init_db() ->
 test_open_db() ->
     ?assert(aegis_server:open_db(?DB)),
     ?assertEqual(1, meck:num_calls(?AEGIS_KEY_MANAGER, open_db, 1)).
+
+
+test_get_db_info() ->
+    ?assertEqual([{enabled,true},{key_manager,{[]}}],
+        aegis:get_db_info(#{is_encrypted => true})).
 
 
 test_init_db_cache() ->

--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -495,7 +495,9 @@ get_info(#{} = Db) ->
         tx := Tx,
         db_prefix := DbPrefix
     } = ensure_current(Db),
-    get_info_wait(get_info_future(Tx, DbPrefix)).
+    DbInfo = get_info_wait(get_info_future(Tx, DbPrefix)),
+    AegisProps = aegis:get_db_info(Db),
+    [{encryption, {AegisProps}} | DbInfo].
 
 
 get_info_future(Tx, DbPrefix) ->


### PR DESCRIPTION
## Overview

This PR adds encryption-related information to the db info blob (GET /dbname). At
minimum a boolean "enabled" flag is present, but the key manager might add additional fields.

## Testing recommendations

eunit

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
