### PR TITLE
Retry filter_docs sequentially if the patch exceeds couchjs stack

### DIFF
--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -500,9 +500,21 @@ filter_docs(Req, Db, DDoc, FName, Docs) ->
     end,
     Options = json_doc_options(),
     JsonDocs = [json_doc(Doc, Options) || Doc <- Docs],
+    try
+        {ok, filter_docs_int(DDoc, FName, JsonReq, JsonDocs)}
+    catch
+        throw:{os_process_error,{exit_status,1}} ->
+            %% batch used too much memory, retry sequentially.
+            Fun = fun(JsonDoc) ->
+                filter_docs_int(DDoc, FName, JsonReq, [JsonDoc])
+            end,
+            {ok, lists:flatmap(Fun, JsonDocs)}
+    end.
+
+filter_docs_int(DDoc, FName, JsonReq, JsonDocs) ->
     [true, Passes] = ddoc_prompt(DDoc, [<<"filters">>, FName],
         [JsonDocs, JsonReq]),
-    {ok, Passes}.
+    Passes.
 
 ddoc_proc_prompt({Proc, DDocId}, FunPath, Args) ->
     proc_prompt(Proc, [<<"ddoc">>, DDocId, FunPath, Args]).


### PR DESCRIPTION
## Overview

A document with lots of conflicts can blow up couchjs if the user
calls _changes with a javascript filter and with `style=all_docs` as
this option causes up to fetch all the conflicts.

All leaf revisions of the document are then passed in a single call to
ddoc_prompt, which can fail if there's a lot of them.

In that event, we simply try them sequentially and assemble the
response from each call.

Should be backported to 3.x

## Testing recommendations

Covered by unit test but a manual test would proceed as follows;

You need to create a highly conflicted document and lower couchjs's memory allowance for a practical test. Here's how I did it;

1) edit dev/run;

```
-    qs_javascript = toposixpath("%s %s" % (couchjs, mainjs))
+    qs_javascript = toposixpath("%s -S 1048576 %s" % (couchjs, mainjs))
```

2) create a filter;

```
curl 'foo:bar@localhost:15984/db1/_design/foo' -XPUT -d '{"filters":{"pass":"function(doc,req) { log(JSON.stringify(doc)); return true; }"}}'
```

3) create a highly conflicted doc;

```
for I in {1..2000}; do curl 'foo:bar@localhost:15984/db1/bigdoc?new_edits=false' -XPUT -d "{\"_rev\":\"1-conflict$I\", \"foo\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}" ; done
```

4) then run it through filter_docs;

```
curl 'foo:bar@localhost:15984/db1/_changes?filter=foo/pass&style=all_docs'
```

Without the patch, this will fail with an {exit_status, 1} error from couchjs. With it, it succeeds.

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/3249

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
