### PR TITLE
Expose `couch_util:json_decode/2` to support jiffy options

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -21,7 +21,7 @@
 -export([get_nested_json_value/2, json_user_ctx/1]).
 -export([proplist_apply_field/2, json_apply_field/2]).
 -export([to_binary/1, to_integer/1, to_list/1, url_encode/1]).
--export([json_encode/1, json_decode/1]).
+-export([json_encode/1, json_decode/1, json_decode/2]).
 -export([verify/2,simple_call/2,shutdown_sync/1]).
 -export([get_value/2, get_value/3]).
 -export([reorder_results/2]).
@@ -499,8 +499,11 @@ json_encode(V) ->
     jiffy:encode(V, [force_utf8]).
 
 json_decode(V) ->
+    json_decode(V, []).
+
+json_decode(V, Opts) ->
     try
-        jiffy:decode(V, [dedupe_keys])
+        jiffy:decode(V, [dedupe_keys | Opts])
     catch
         error:Error ->
             throw({invalid_json, Error})

--- a/src/couch/test/eunit/couch_util_tests.erl
+++ b/src/couch/test/eunit/couch_util_tests.erl
@@ -168,3 +168,10 @@ to_hex_test_() ->
         ?_assertEqual("", couch_util:to_hex(<<>>)),
         ?_assertEqual("010203faff", couch_util:to_hex(<<1, 2, 3, 250, 255>>))
     ].
+
+json_decode_test_() ->
+    [
+        ?_assertEqual({[]}, couch_util:json_decode(<<"{}">>)),
+        ?_assertEqual({[]}, couch_util:json_decode(<<"{}">>, [])),
+        ?_assertEqual(#{}, couch_util:json_decode(<<"{}">>, [return_maps]))
+    ].


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Cherry picked from `main` branch.

It can be desirable in some cases for decoded JSON to e.g. return
maps instead of the default data structure, which is not currently
possible.

This exposes a new function `couch_util:json_decode/2`, the second
parameter being a list of options passed to `jiffy:decode/2`.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
