### PR TITLE
fix check_local_dbs test

### DIFF
--- a/src/mem3/test/eunit/mem3_seeds_test.erl
+++ b/src/mem3/test/eunit/mem3_seeds_test.erl
@@ -59,11 +59,10 @@ check_nodelist() ->
     end.
 
 check_local_dbs() ->
-    ?assertEqual([<<"_dbs">>, <<"_nodes">>],
-        lists:sort(mem3_sync:local_dbs())),
+    LocalDbs = mem3_sync:local_dbs(),
     {ok, _} = couch_server:create(<<"_users">>, []),
-    ?assertEqual([<<"_dbs">>, <<"_nodes">>, <<"_users">>],
-        lists:sort(mem3_sync:local_dbs())).
+    ?assertEqual(lists:append(LocalDbs, [<<"_users">>]),
+        mem3_sync:local_dbs()).
 
 cleanup() ->
     application:stop(mem3),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
This is to fix the possible failure of `mem3_seeds_test: a_test_ (optional local _users db in mem3_sync:local_dbs())...[0.029 s] ok` because local databases do not always include `_dbs` and `_nodes`.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
 make check skip_deps+=couch_epi apps=mem3

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
