### PR TITLE
Ensure view build progress

### DIFF
--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -235,10 +235,8 @@ do_update(Db, Mrst0, State0) ->
 
         case is_update_finished(State2) of
             true ->
-                maybe_set_build_status(TxDb, Mrst2, ViewVS,
-                    ?INDEX_READY),
-                report_progress(State2#{changes_done := ChangesDone},
-                    finished),
+                maybe_set_build_status(TxDb, Mrst2, ViewVS, ?INDEX_READY),
+                report_progress(State2#{changes_done := ChangesDone}, finished),
                 {Mrst2, finished};
             false ->
                 State3 = report_progress(State2, update),

--- a/src/fabric/test/fabric2_changes_fold_tests.erl
+++ b/src/fabric/test/fabric2_changes_fold_tests.erl
@@ -40,6 +40,7 @@ changes_fold_test_() ->
                     ?TDEF_FE(fold_changes_basic_rev),
                     ?TDEF_FE(fold_changes_since_now_rev),
                     ?TDEF_FE(fold_changes_since_seq_rev),
+                    ?TDEF_FE(fold_changes_with_end_key),
                     ?TDEF_FE(fold_changes_basic_tx_too_old),
                     ?TDEF_FE(fold_changes_reverse_tx_too_old),
                     ?TDEF_FE(fold_changes_tx_too_old_with_single_row_emits),
@@ -122,6 +123,16 @@ fold_changes_since_seq_rev({Db, DocRows}) ->
     ?assertEqual(DocRows, changes(Db, Since, Opts)),
     RestRows = lists:sublist(DocRows, length(DocRows) - 1),
     fold_changes_since_seq_rev({Db, RestRows}).
+
+
+fold_changes_with_end_key({Db, DocRows}) ->
+    lists:foldl(fun(DocRow, Acc) ->
+        EndSeq = maps:get(sequence, DocRow),
+        Changes = changes(Db, 0, [{end_key, EndSeq}]),
+        NewAcc = [DocRow | Acc],
+        ?assertEqual(Changes, NewAcc),
+        NewAcc
+    end, [], DocRows).
 
 
 fold_changes_basic_tx_too_old({Db, DocRows0}) ->

--- a/src/fabric/test/fabric2_snapshot_tests.erl
+++ b/src/fabric/test/fabric2_snapshot_tests.erl
@@ -1,0 +1,134 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric2_snapshot_tests).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("fabric2.hrl").
+-include("fabric2_test.hrl").
+
+
+fdb_ss_test_() ->
+    {
+        "Test snapshot usage",
+        setup,
+        fun setup/0,
+        fun cleanup/1,
+        with([
+            ?TDEF(retry_without_snapshot),
+            ?TDEF(no_retry_with_snapshot)
+        ])
+    }.
+
+
+setup() ->
+    Ctx = test_util:start_couch([fabric]),
+    {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),
+    {Db, Ctx}.
+
+
+cleanup({Db, Ctx}) ->
+    ok = fabric2_db:delete(fabric2_db:name(Db), []),
+    test_util:stop_couch(Ctx).
+
+
+retry_without_snapshot({Db, _}) ->
+    DbName = fabric2_db:name(Db),
+    put(retry_count, 0),
+    erase(conflict_pid),
+    InitDbSeq = fabric2_db:get_update_seq(Db),
+    DbSeq = fabric2_fdb:transactional(Db, fun(TxDb) ->
+        put(retry_count, get(retry_count) + 1),
+
+        % Fetch the update_seq
+        Seq = fabric2_db:get_update_seq(TxDb),
+
+        % Generate a no-op write so that we don't hit the
+        % optimization to skip commits on read-only
+        % transactions
+        bump_view_size(TxDb),
+
+        % Generate a conflicting transaction while
+        % we're not yet committed
+        case get(conflict_pid) of
+            undefined ->
+                {Pid, Ref} = spawn_monitor(fun() -> generate_conflict(DbName) end),
+                receive {'DOWN', Ref, _, _, normal} -> ok end,
+                put(conflict_pid, Pid);
+            Pid when is_pid(Pid) ->
+                ok
+        end,
+
+        Seq
+    end),
+
+    ?assertEqual(2, get(retry_count)),
+    ?assertNotEqual(InitDbSeq, DbSeq).
+
+
+no_retry_with_snapshot({Db, _}) ->
+    DbName = fabric2_db:name(Db),
+    put(retry_count, 0),
+    erase(conflict_pid),
+    InitDbSeq = fabric2_db:get_update_seq(Db),
+    DbSeq = fabric2_fdb:transactional(Db, fun(TxDb) ->
+        put(retry_count, get(retry_count) + 1),
+    
+        % Fetch the update_seq
+        Seq = fabric2_fdb:with_snapshot(TxDb, fun(SSDb) ->
+            fabric2_db:get_update_seq(SSDb)
+        end),
+    
+        % Generate a no-op write so that we don't hit the
+        % optimization to skip commits on read-only
+        % transactions
+        bump_view_size(TxDb),
+    
+        % Generate a conflicting transaction while
+        % we're not yet committed
+        case get(conflict_pid) of
+            undefined ->
+                {Pid, Ref} = spawn_monitor(fun() -> generate_conflict(DbName) end),
+                receive {'DOWN', Ref, _, _, normal} -> ok end,
+                put(conflict_pid, Pid);
+            Pid when is_pid(Pid) ->
+                ok
+        end,
+    
+        Seq
+    end),
+    
+    ?assertEqual(1, get(retry_count)),
+    ?assertEqual(InitDbSeq, DbSeq).
+
+
+bump_view_size(TxDb) ->
+    #{
+        tx := Tx,
+        db_prefix := DbPrefix
+    } = TxDb,
+    
+    DbTuple = {?DB_STATS, <<"sizes">>, <<"views">>},
+    DbKey = erlfdb_tuple:pack(DbTuple, DbPrefix),
+    erlfdb:add(Tx, DbKey, 0).
+
+
+generate_conflict(DbName) ->
+    {ok, Db} = fabric2_db:open(DbName, [{user_ctx, ?ADMIN_USER}]),
+    Doc = #doc{
+        id = fabric2_util:uuid(),
+        body = {[{<<"foo">>, <<"bar">>}]}
+    },
+    {ok, _} = fabric2_db:update_doc(Db, Doc).


### PR DESCRIPTION
## Overview

View indexers create conflicts when reading from the changes feed which can prevent the indexer from making progress on databases that are being updated continuously.

I'm marking this as a draft because it doesn't yet address the situation of a single doc being updated repeatedly and there's no tests proving it works either. (Second time's a charm!)

## Testing recommendations

I should add a test.

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
