### PR TITLE
Couch att erroneous md5 mismatch

### DIFF
--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -593,13 +593,9 @@ flush_data(Db, {stream, StreamEngine}, Att) ->
             % Already written
             Att;
         false ->
-            NewAtt = couch_db:with_stream(Db, Att, fun(OutputStream) ->
+            couch_db:with_stream(Db, Att, fun(OutputStream) ->
                 couch_stream:copy(StreamEngine, OutputStream)
-            end),
-            InMd5 = fetch(md5, Att),
-            OutMd5 = fetch(md5, NewAtt),
-            couch_util:check_md5(OutMd5, InMd5),
-            NewAtt
+            end)
     end.
 
 


### PR DESCRIPTION
## Overview

If an attachment was stored uncompressed but later is replicated
internally to a node that wants to compress it (based on
content-type), couchdb compares the uncompressed md5 with the
compressed md5 and fails. This breaks eventual consistency between
replicas.

This PR removes the unnecessary MD5 check that is, in these specific
circumstances, always called with mismatched arguments.

## Testing recommendations

1. Upload an attachment with a content-type not included in compressible_type config
2. change compressible_type to include this content-type
3. stop a node
4. delete the hosting shard of the attachment
5. start the node.
6. observe md5_mismatch errors in the log.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
