### PR TITLE
Use `req_body` field if present

### DIFF
--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -599,13 +599,16 @@ body(#httpd{mochi_req=MochiReq, req_body=undefined}) ->
 body(#httpd{req_body=ReqBody}) ->
     ReqBody.
 
-json_body(Httpd) ->
+json_body(#httpd{req_body=undefined} = Httpd) ->
     case body(Httpd) of
         undefined ->
             throw({bad_request, "Missing request body"});
         Body ->
             ?JSON_DECODE(maybe_decompress(Httpd, Body))
-    end.
+    end;
+
+json_body(#httpd{req_body=ReqBody}) ->
+    ReqBody.
 
 json_body_obj(Httpd) ->
     case json_body(Httpd) of


### PR DESCRIPTION
When we call `couch_httpd:json_body/1` we can have `req_body` already set.
In this case we should return the field as is without any attempt to
decompress or decode it. This PR brings the approach we use in `chttpd`
into `couch_httpd`.

backported from https://github.com/apache/couchdb/pull/3268 