### PR TITLE
Add missing default headers to responses

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1270,12 +1270,11 @@ chunked_response_buffer_size() ->
 basic_headers(Req, Headers0) ->
     Headers = Headers0
         ++ server_header()
-        ++ couch_httpd_auth:cookie_auth_header(Req, Headers0)
-        ++ [timing()]
-        ++ [reqid()],
+        ++ couch_httpd_auth:cookie_auth_header(Req, Headers0),
     Headers1 = chttpd_cors:headers(Req, Headers),
 	  Headers2 = chttpd_xframe_options:header(Req, Headers1),
-    chttpd_prefer_header:maybe_return_minimal(Req, Headers2).
+    Headers3 = [reqid(), timing() | Headers2],
+    chttpd_prefer_header:maybe_return_minimal(Req, Headers3).
 
 handle_response(Req0, Code0, Headers0, Args0, Type) ->
     {ok, {Req1, Code1, Headers1, Args1}} =

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1272,7 +1272,7 @@ basic_headers(Req, Headers0) ->
         ++ server_header()
         ++ couch_httpd_auth:cookie_auth_header(Req, Headers0),
     Headers1 = chttpd_cors:headers(Req, Headers),
-	  Headers2 = chttpd_xframe_options:header(Req, Headers1),
+    Headers2 = chttpd_xframe_options:header(Req, Headers1),
     Headers3 = [reqid(), timing() | Headers2],
     chttpd_prefer_header:maybe_return_minimal(Req, Headers3).
 

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1270,9 +1270,11 @@ chunked_response_buffer_size() ->
 basic_headers(Req, Headers0) ->
     Headers = Headers0
         ++ server_header()
-        ++ couch_httpd_auth:cookie_auth_header(Req, Headers0),
+        ++ couch_httpd_auth:cookie_auth_header(Req, Headers0)
+        ++ [timing()]
+        ++ [reqid()],
     Headers1 = chttpd_cors:headers(Req, Headers),
-	Headers2 = chttpd_xframe_options:header(Req, Headers1),
+	  Headers2 = chttpd_xframe_options:header(Req, Headers1),
     chttpd_prefer_header:maybe_return_minimal(Req, Headers2).
 
 handle_response(Req0, Code0, Headers0, Args0, Type) ->

--- a/src/couch_replicator/src/couch_replicator_httpd.erl
+++ b/src/couch_replicator/src/couch_replicator_httpd.erl
@@ -17,7 +17,7 @@
     handle_scheduler_req/1
 ]).
 
--import(couch_httpd, [
+-import(chttpd, [
     send_json/2,
     send_json/3,
     send_method_not_allowed/2

--- a/src/couch_replicator/test/eunit/couch_replicator_db_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_db_tests.erl
@@ -36,6 +36,7 @@ couch_replicator_db_test_() ->
                     ?TDEF_FE(replicator_db_deleted, 15),
                     ?TDEF_FE(replicator_db_recreated, 15),
                     ?TDEF_FE(invalid_replication_docs),
+                    ?TDEF_FE(scheduler_default_headers_returned),
                     ?TDEF_FE(duplicate_persistent_replication, 15),
                     ?TDEF_FE(duplicate_transient_replication, 30)
                 ]
@@ -248,6 +249,14 @@ duplicate_transient_replication({Source, Target, RepDb}) ->
 
     delete_doc(RepDb, DocId),
     wait_scheduler_docs_not_found(RepDb, DocId).
+
+
+scheduler_default_headers_returned({_, _, _}) ->
+    SUrl = couch_replicator_test_helper:server_url(),
+    Url = lists:flatten(io_lib:format("~s/_scheduler/jobs", [SUrl])),
+    {ok, _, Headers, _} = test_request:get(Url, []),
+    ?assertEqual(true, lists:keymember("X-Couch-Request-ID", 1, Headers)),
+    ?assertEqual(true, lists:keymember("X-CouchDB-Body-Time", 1, Headers)).
 
 
 scheduler_jobs(Id) ->

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -518,4 +518,14 @@ defmodule BasicsTest do
     assert resp.status_code == 200
     assert resp.body == 999
   end
+
+  @tag :with_db
+  test "Default headers are returned for doc with open_revs=all", context do
+    db_name = context[:db_name]
+    post_response = Couch.post("/#{db_name}", body: %{:foo => :bar})
+    id = post_response.body["id"]
+    head_response = Couch.head("/#{db_name}/#{id}?open_revs=all")
+    assert head_response.headers["X-Couch-Request-ID"]
+    assert head_response.headers["X-CouchDB-Body-Time"]
+  end
 end


### PR DESCRIPTION
## Overview

Some responses are missing default headers. This PR fixes that issue.

## Testing recommendations

Run the tests included and/or the manual ones mentioned in the original issue ticket.
`make eunit apps=couch_replicator suites=couch_replicator_db_tests`
and
`mix test --trace test/elixir/test/basics_test.exs:523`.

## Related Issues or Pull Requests

#3261

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation - N/A
