### PR TITLE
Backport add missing default headers to responses to 3.x

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1233,8 +1233,9 @@ basic_headers(Req, Headers0) ->
         ++ server_header()
         ++ couch_httpd_auth:cookie_auth_header(Req, Headers0),
     Headers1 = chttpd_cors:headers(Req, Headers),
-	Headers2 = chttpd_xframe_options:header(Req, Headers1),
-    chttpd_prefer_header:maybe_return_minimal(Req, Headers2).
+    Headers2 = chttpd_xframe_options:header(Req, Headers1),
+    Headers3 = [reqid(), timing() | Headers2],
+    chttpd_prefer_header:maybe_return_minimal(Req, Headers3).
 
 handle_response(Req0, Code0, Headers0, Args0, Type) ->
     {ok, {Req1, Code1, Headers1, Args1}} =

--- a/src/couch_replicator/src/couch_replicator_httpd.erl
+++ b/src/couch_replicator/src/couch_replicator_httpd.erl
@@ -20,7 +20,7 @@
     handle_scheduler_req/1
 ]).
 
--import(couch_httpd, [
+-import(chttpd, [
     send_json/2,
     send_json/3,
     send_method_not_allowed/2

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -304,4 +304,14 @@ defmodule BasicsTest do
     # TODO
     assert true
   end
+
+  @tag :with_db
+  test "Default headers are returned for doc with open_revs=all", context do
+    db_name = context[:db_name]
+    post_response = Couch.post("/#{db_name}", body: %{:foo => :bar})
+    id = post_response.body["id"]
+    head_response = Couch.head("/#{db_name}/#{id}?open_revs=all")
+    assert head_response.headers["X-Couch-Request-ID"]
+    assert head_response.headers["X-CouchDB-Body-Time"]
+  end
 end

--- a/test/elixir/test/replication_test.exs
+++ b/test/elixir/test/replication_test.exs
@@ -188,6 +188,20 @@ defmodule ReplicationTest do
     assert resp.status_code == 200
   end
 
+  test "default headers returned for _scheduler/jobs" do
+    resp = Couch.get("/_scheduler/jobs")
+    assert resp.headers["Content-Type"] == "application/json"
+    assert resp.headers["X-Couch-Request-ID"]
+    assert resp.headers["X-CouchDB-Body-Time"]
+  end
+
+  test "default headers returned for _scheduler/docs " do
+    resp = Couch.get("/_scheduler/docs")
+    assert resp.headers["Content-Type"] == "application/json"
+    assert resp.headers["X-Couch-Request-ID"]
+    assert resp.headers["X-CouchDB-Body-Time"]
+  end
+
   Enum.each(@db_pairs_prefixes, fn {name, src_prefix, tgt_prefix} ->
     @src_prefix src_prefix
     @tgt_prefix tgt_prefix


### PR DESCRIPTION
This is a backport of #3279 .
This closes #3261 .