### PR TITLE
2906 couchjs sm version (#2911)

### DIFF
--- a/src/couch/priv/couch_js/1.8.5/help.h
+++ b/src/couch/priv/couch_js/1.8.5/help.h
@@ -16,7 +16,7 @@
 #include "config.h"
 
 static const char VERSION_TEMPLATE[] =
-    "%s - %s\n"
+    "%s - %s (SpiderMonkey 1.8.5)\n"
     "\n"
     "Licensed under the Apache License, Version 2.0 (the \"License\"); you may "
         "not use\n"

--- a/src/couch/priv/couch_js/60/help.h
+++ b/src/couch/priv/couch_js/60/help.h
@@ -16,7 +16,7 @@
 #include "config.h"
 
 static const char VERSION_TEMPLATE[] =
-    "%s - %s\n"
+    "%s - %s (SpiderMonkey 60)\n"
     "\n"
     "Licensed under the Apache License, Version 2.0 (the \"License\"); you may "
         "not use\n"

--- a/src/couch/priv/couch_js/68/help.h
+++ b/src/couch/priv/couch_js/68/help.h
@@ -16,7 +16,7 @@
 #include "config.h"
 
 static const char VERSION_TEMPLATE[] =
-    "%s - %s\n"
+    "%s - %s (SpiderMonkey 68)\n"
     "\n"
     "Licensed under the Apache License, Version 2.0 (the \"License\"); you may "
         "not use\n"

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -76,7 +76,7 @@ ConfigH = [
     {"JSSCRIPT_TYPE", "JSObject*"},
     {"COUCHJS_NAME", "\"" ++ CouchJSName++ "\""},
     {"PACKAGE", "\"apache-couchdb\""},
-    {"PACKAGE_BUGREPORT", "\"https://issues.apache.org/jira/browse/COUCHDB\""},
+    {"PACKAGE_BUGREPORT", "\"https://github.com/apache/couchdb/issues\""},
     {"PACKAGE_NAME", "\"Apache CouchDB\""},
     {"PACKAGE_STRING", "\"Apache CouchDB " ++ Version ++ "\""},
     {"PACKAGE_VERSION", "\"" ++ Version ++ "\""}


### PR DESCRIPTION
Closes #2906 

* Added a suffix to the first line of couchjs with the (static) version number compiled
* Update rebar.config.script
* In couchjs -h replaced the link to jira with a link to github

Co-authored-by: simon.klassen <simon.klassen>
Co-authored-by: Jan Lehnardt <jan@apache.org