### PR TITLE
Support pluggable custodian monitor

### DIFF
--- a/src/custodian/rebar.config.script
+++ b/src/custodian/rebar.config.script
@@ -1,0 +1,35 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+
+CouchConfig = case filelib:is_file(os:getenv("COUCHDB_CONFIG")) of
+    true ->
+        {ok, Result} = file:consult(os:getenv("COUCHDB_CONFIG")),
+        Result;
+    false ->
+        []
+end,
+
+CustodianMonitor = case lists:keyfind(custodian_monitor, 1, CouchConfig) of
+    {custodian_monitor, Module} when Module /= "" ->
+        list_to_atom(Module);
+    _ ->
+        custodian_noop_monitor
+end,
+
+CurrentOpts = case lists:keyfind(erl_opts, 1, CONFIG) of
+    {erl_opts, Opts} -> Opts;
+    false -> []
+end,
+
+CustodianOpts = {d, 'CUSTODIAN_MONITOR', CustodianMonitor},
+lists:keystore(erl_opts, 1, CONFIG, {erl_opts, [CustodianOpts | CurrentOpts]}).

--- a/src/custodian/src/custodian.app.src.script
+++ b/src/custodian/src/custodian.app.src.script
@@ -1,0 +1,48 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+CouchConfig = case filelib:is_file(os:getenv("COUCHDB_CONFIG")) of
+    true ->
+        {ok, Result} = file:consult(os:getenv("COUCHDB_CONFIG")),
+        Result;
+    false ->
+        []
+end.
+
+CustodianMonitorApp = case lists:keyfind(custodian_monitor_app, 1, CouchConfig) of
+    {custodian_monitor_app, AppName} when AppName /= "" ->
+        [list_to_atom(AppName)];
+    _ ->
+        []
+end.
+
+BaseApplications = [
+    kernel,
+    stdlib,
+    couch_log,
+    config,
+    couch_event,
+    couch,
+    mem3
+].
+
+Applications = CustodianMonitorApp ++ BaseApplications.
+
+{application, custodian,
+ [
+  {description, "in your cluster, looking after your stuff"},
+  {vsn, git},
+  {registered, []},
+  {applications, Applications},
+  {mod, { custodian_app, []}},
+  {env, []}
+ ]}.

--- a/src/custodian/src/custodian_db_checker.erl
+++ b/src/custodian/src/custodian_db_checker.erl
@@ -149,17 +149,9 @@ get_stats_db() ->
 
 send_missing_db_alert(DbName) ->
     couch_log:notice("Missing system database ~s", [DbName]),
-    Command = [
-        "send-sensu-event --standalone --critical",
-        " --output=\"Missing system database ",
-        binary_to_list(DbName),
-        "\" --handler=default custodian-missing-db-check"],
-    os:cmd(lists:concat(Command)).
+    ?CUSTODIAN_MONITOR:send_missing_db_alert(DbName).
+
 
 clear_missing_dbs_alert() ->
     couch_log:notice("All system databases exist.", []),
-    Command = [
-        "send-sensu-event --standalone --ok",
-        " --output=\"All system databases exist\"",
-        " --handler=default custodian-missing-db-check"],
-    os:cmd(lists:concat(Command)).
+    ?CUSTODIAN_MONITOR:clear_missing_dbs_alert().

--- a/src/custodian/src/custodian_monitor.erl
+++ b/src/custodian/src/custodian_monitor.erl
@@ -10,20 +10,19 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
-{application, custodian,
- [
-  {description, "in your cluster, looking after your stuff"},
-  {vsn, git},
-  {registered, []},
-  {applications, [
-                  kernel,
-                  stdlib,
-                  couch_log,
-                  config,
-                  couch_event,
-                  couch,
-                  mem3
-                 ]},
-  {mod, { custodian_app, []}},
-  {env, []}
- ]}.
+-module(custodian_monitor).
+
+
+% N.B. that callback return values are ignored
+
+-callback send_missing_db_alert(DbName :: binary()) ->
+    Ignored :: any().
+
+
+-callback clear_missing_dbs_alert() ->
+    Ignored :: any().
+
+
+-callback send_event(
+    Name :: string(), Count :: non_neg_integer(), Description :: string()) ->
+    Ignored :: any().

--- a/src/custodian/src/custodian_noop_monitor.erl
+++ b/src/custodian/src/custodian_noop_monitor.erl
@@ -1,0 +1,35 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(custodian_noop_monitor).
+
+
+-behaviour(custodian_monitor).
+
+
+-export([
+    send_missing_db_alert/1,
+    clear_missing_dbs_alert/0,
+    send_event/3
+]).
+
+
+send_missing_db_alert(_DbName) ->
+    false.
+
+
+clear_missing_dbs_alert() ->
+    false.
+
+
+send_event(_Name, _Count, _Description) ->
+    false.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Enable build time configurable monitor for custodian and remove custom
sensu events.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=custodian
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
