### PR TITLE
Allow gzipped requests to _session

### DIFF
--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -39,6 +39,7 @@
 -export([check_max_request_length/1]).
 -export([handle_request/1]).
 -export([set_auth_handlers/0]).
+-export([maybe_decompress/2]).
 
 -define(HANDLER_NAME_IN_MODULE_POS, 6).
 -define(MAX_DRAIN_BYTES, 1048576).

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -33,7 +33,7 @@
 
 -export([jwt_authentication_handler/1]).
 
--import(couch_httpd, [header_value/2, send_json/2,send_json/4, send_method_not_allowed/2]).
+-import(couch_httpd, [header_value/2, send_json/2, send_json/4, send_method_not_allowed/2, maybe_decompress/2]).
 
 -compile({no_auto_import,[integer_to_binary/1, integer_to_binary/2]}).
 
@@ -329,7 +329,7 @@ handle_session_req(#httpd{method='POST', mochi_req=MochiReq}=Req, AuthModule) ->
         "application/x-www-form-urlencoded" ++ _ ->
             mochiweb_util:parse_qs(ReqBody);
         "application/json" ++ _ ->
-            {Pairs} = ?JSON_DECODE(ReqBody),
+            {Pairs} = ?JSON_DECODE(maybe_decompress(Req, ReqBody)),
             lists:map(fun({Key, Value}) ->
               {?b2l(Key), ?b2l(Value)}
             end, Pairs);


### PR DESCRIPTION
## Overview
All endpoints but `_session` support gzip encoding and there's no practical reason for that.
This PR enables gzip decoding on compressed requests to `_session`.

## Testing recommendations

`make eunit apps=chttpd suites=chttpd_session_tests`

## Related Issues or Pull Requests

This fixes #3300 .
This is #3322 cherry-picked to `main`.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini` - N/A
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation - N/A
