### PR TITLE
Timeout transaction

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -364,6 +364,8 @@ catch_error(HttpReq, error, not_ciphertext) ->
     send_error(HttpReq, not_ciphertext);
 catch_error(HttpReq, error, {erlfdb_error, 2101}) ->
     send_error(HttpReq, transaction_too_large);
+catch_error(HttpReq, error, {erlfdb_error, 1031}) ->
+    send_error(HttpReq, transaction_timeout);
 catch_error(HttpReq, Tag, Error) ->
     Stack = erlang:get_stacktrace(),
     % TODO improve logging and metrics collection for client disconnects
@@ -999,6 +1001,9 @@ error_info({doc_validation, Reason}) ->
     {400, <<"doc_validation">>, Reason};
 error_info({invalid_since_seq, Reason}) ->
     {400, <<"invalid_since_seq">>, Reason};
+error_info(transaction_timeout) ->
+    {408, <<"transaction_timeout">>,
+        <<"The request transaction timed out" >>};
 error_info({missing_stub, Reason}) ->
     {412, <<"missing_stub">>, Reason};
 error_info(request_entity_too_large) ->

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -137,8 +137,7 @@ execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFu
             Result = case mango_idx:def(Idx) of
                 all_docs ->
                     CB = fun ?MODULE:handle_all_docs_message/2,
-                    AllDocOpts = fabric2_util:all_docs_view_opts(Args)
-                        ++ [{restart_tx, true}],
+                    AllDocOpts = fabric2_util:all_docs_view_opts(Args),
                     fabric2_db:fold_docs(Db, CB, Cursor, AllDocOpts);
                 _ ->
                     CB = fun ?MODULE:handle_message/2,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

If a mango query exceeds the 5 seconds for a transaction it sends a nasty error:
```
89e90f4c55 req_err(2721591552) erlfdb_error : 1031
    [<<"erlfdb_nif:erlfdb_future_get/1">>,<<"erlfdb:do_transaction/2 L686">>,<<"fabric2_fdb:do_transaction/2 L171">>,<<"fabric2_fdb:transactional/2 L142">>,<<"mango_cursor_view:execute/3 L142">>,<<"mango_httpd:handle_find_req/2 L197">>,<<"mango_httpd:handle_req/2 L37">>,<<"chttpd:handle_req_after_auth/2 L330">>]
```

This cleans that up and adds a better error. We also remove the `{restart_tx, true}` for a mango query that uses `_all_docs` to make it consistent with a mango query that uses a view.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
