### PR TITLE
Add a .devcontainer configuration for 3.x

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Based on erlang:22 (we need elixir for the test suite)
-FROM elixir:1.10
+ARG ELIXIR_VERSION
+FROM elixir:${ELIXIR_VERSION}
 
 # Use NodeSource binaries for Node.js (Fauxton dependency)
 RUN set -ex; \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,19 @@
 # Based on erlang:22
 FROM elixir:1.10
 
-RUN apt-get update -y && apt-get install -y \
+RUN set -ex; \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
+    echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list
+
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
         libmozjs-60-dev \
         libicu-dev \
-        python3-venv
+        python3-venv \
+        python3-pip \
+        python3-sphinx \
+        nodejs
+
+RUN pip3 install sphinx_rtd_theme

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,19 @@
 ARG ELIXIR_VERSION
 FROM elixir:${ELIXIR_VERSION}
 
+# Install SpiderMonkey 60 and tell CouchDB to use it in configure
+ENV SM_VSN=60
+
 # Use NodeSource binaries for Node.js (Fauxton dependency)
 RUN set -ex; \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
     echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list; \
     echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list
 
-# Using SM 60 here so be sure to set --spidermonkey-version 60 in configure
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        libmozjs-60-dev \
+        libmozjs-${SM_VSN}-dev \
         libicu-dev \
         python3-venv \
         python3-pip \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,13 @@
-# Based on erlang:22
+# Based on erlang:22 (we need elixir for the test suite)
 FROM elixir:1.10
 
+# Use NodeSource binaries for Node.js (Fauxton dependency)
 RUN set -ex; \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
     echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list; \
     echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list
 
+# Using SM 60 here so be sure to set --spidermonkey-version 60 in configure
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -16,4 +18,5 @@ RUN set -ex; \
         python3-sphinx \
         nodejs
 
+# Documentation theme
 RUN pip3 install sphinx_rtd_theme

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+# Based on erlang:22
+FROM elixir:1.10
+
+RUN apt-get update -y && apt-get install -y \
+        libmozjs-60-dev \
+        libicu-dev \
+        python3-venv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,17 @@
 {
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile",
+        "args": {
+            // Useful choices include:
+            // 1.11 -> Erlang 23, Debian Buster
+            // 1.10 -> Erlang 22, Debian Buster
+            // 1.9  -> Erlang 22, Debian Buster
+            //
+            // Older versions based on Debian Stretch will not include
+            // SpiderMonkey 60, which the Dockerfile expects to be able
+            // to install via apt-get.
+            "ELIXIR_VERSION": "1.10"
+        }
     },
     "extensions": [
         "erlang-ls.erlang-ls"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "extensions": [
+        "erlang-ls.erlang-ls"
+    ]
+}

--- a/README-DEV.rst
+++ b/README-DEV.rst
@@ -15,6 +15,7 @@ Dependencies
 You need the following to run tests:
 
 * `Python 3               <https://www.python.org/>`_
+* `Elixir                 <https://elixir-lang.org/>`_
 
 You need the following optionally to build documentation:
 
@@ -50,6 +51,18 @@ sufficient to enable a Fauxton build.
 
 Here is a list of *optional* dependencies for various operating systems.
 Installation will be easiest, when you install them all.
+
+Docker
+~~~~~~
+
+CouchDB maintains a ``Dockerfile`` based on Debian that includes all
+the dependencies noted above in the `.devcontainer <https://github.com/apache/couchdb/tree/main/.devcontainer>`_
+folder.
+
+The ``Dockerfile`` can be used on its own, or together with the
+associated ``devcontainer.json`` file to quickly provision a
+development environment using `GitHub Codespaces <https://github.com/features/codespaces>`_
+or `Visual Studio Code <https://code.visualstudio.com/docs/remote/containers>`_.
 
 Debian-based (inc. Ubuntu) Systems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/configure
+++ b/configure
@@ -29,7 +29,7 @@ ERLANG_MD5="false"
 SKIP_DEPS=0
 
 COUCHDB_USER="$(whoami 2>/dev/null || echo couchdb)"
-SM_VSN="1.8.5"
+SM_VSN=${SM_VSN:-"1.8.5"}
 ARCH="$(uname -m)"
 
 . ${rootdir}/version.mk

--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,0 +1,2 @@
+include_dirs:
+    - "src/"


### PR DESCRIPTION
## Overview

This PR adds a Dockerfile and associated configuration to enable developers to quickly provision an environment with all dependencies installed to work on CouchDB 3.x.

The container configuration also installs the [Erlang Language Server](https://erlang-ls.github.io) extension. That extension needs a minimal configuration file in the root of the project in order to find the include files, so I've added that as well. We could likely iterate and enhance that configuration file further with linters, dialyzers configurations, etc.

## Testing recommendations

If you have VS Code with the "Remote - Containers" extension installed, opening the CouchDB repo should cause the editor to offer to start the development container. The container will include all the dependences necessary to

* build CouchDB using `./configure; make`
* run the full test suite
* build the documentation
* build Fauxton

## Checklist

(No code changes here, just a quicker Getting Started experience)

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
