### PR TITLE
Simplify and speedup dev node startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ bin/
 config.erl
 *.tar.gz
 *.tar.bz2
-dev/boot_node.beam
+dev/*.beam
 dev/devnode.*
 dev/lib/
 dev/logs/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ config.erl
 *.tar.gz
 *.tar.bz2
 dev/boot_node.beam
+dev/devnode.*
 dev/lib/
 dev/logs/
 ebin/

--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ clean:
 	@rm -rf src/mango/.venv
 	@rm -f src/couch/priv/couchspawnkillable
 	@rm -f src/couch/priv/couch_js/config.h
-	@rm -f dev/boot_node.beam dev/pbkdf2.pyc log/crash.log
+	@rm -f dev/boot_node.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
 
 
 .PHONY: distclean

--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ clean:
 	@rm -rf src/mango/.venv
 	@rm -f src/couch/priv/couchspawnkillable
 	@rm -f src/couch/priv/couch_js/config.h
-	@rm -f dev/boot_node.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
+	@rm -f dev/*.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
 
 
 .PHONY: distclean

--- a/dev/boot_node.erl
+++ b/dev/boot_node.erl
@@ -16,13 +16,6 @@
 
 
 start() ->
-    monitor_parent(),
-    Apps = load_apps(),
-    Deps = load_deps(Apps),
-    start_all_apps(Deps).
-
-
-monitor_parent() ->
     {ok, [[PPid]]} = init:get_argument(parent_pid),
     spawn(fun() -> monitor_parent(PPid) end).
 
@@ -46,103 +39,5 @@ monitor_parent(PPid) ->
                     monitor_parent(PPid);
                 nomatch ->
                     init:stop()
-            end
-    end.
-
-
-load_apps() ->
-    {ok, [[Config]]} = init:get_argument(reltool_config),
-    {ok, Terms} = file:consult(Config),
-    load_apps(Terms).
-
-
-load_apps([]) ->
-    erlang:error(failed_to_load_apps);
-load_apps([{sys, Terms} | _]) ->
-    load_apps(Terms);
-load_apps([{rel, "couchdb", _Vsn, Apps} | _]) ->
-    Apps;
-load_apps([_ | Rest]) ->
-    load_apps(Rest).
-
-
-load_deps(Apps) ->
-    load_deps(Apps, dict:new()).
-
-
-load_deps([], Deps) ->
-    Deps;
-load_deps([App | Rest], Deps) ->
-    load_app(App),
-    case application:get_key(App, applications) of
-        {ok, AppDeps0} ->
-            NewDeps = dict:store(App, AppDeps0, Deps),
-            Filter = fun(A) -> not dict:is_key(A, Deps) end,
-            AppDeps = lists:filter(Filter, AppDeps0),
-            load_deps(AppDeps ++ Rest, NewDeps);
-        _ ->
-            NewDeps = dict:store(App, [], Deps),
-            load_deps(Rest, NewDeps)
-    end.
-
-
-load_app(App) ->
-    case application:load(App) of
-        ok ->
-            case application:get_key(App, modules) of
-                {ok, Modules} ->
-                    lists:foreach(fun(Mod) ->
-                        case load_app_module(Mod) of
-                            ok -> ok;
-                            E -> io:format("~p = load_app_module(~p)~n", [E, Mod])
-                        end
-                    end, Modules);
-                undefined ->
-                    ok
-            end;
-        {error, {already_loaded, App}} ->
-            ok;
-        Error ->
-            Error
-    end.
-
-
-load_app_module(Mod) ->
-    case code:is_loaded(Mod) of
-        {file, _} ->
-            ok;
-        _ ->
-            case code:load_file(Mod) of
-                {module, Mod} ->
-                    ok;
-                Error ->
-                    Error
-            end
-    end.
-
-
-start_all_apps(Deps) ->
-    lists:foldl(fun(App, Started) ->
-        start_app(App, Deps, Started)
-    end, [], dict:fetch_keys(Deps)).
-
-
-start_app(App, Deps, Started) ->
-    case lists:member(App, Started) of
-        true ->
-            Started;
-        false ->
-            AppDeps = dict:fetch(App, Deps),
-            NowStarted = lists:foldl(fun(Dep, Acc) ->
-                start_app(Dep, Deps, Acc)
-            end, Started, AppDeps),
-            case application:start(App) of
-                ok ->
-                    [App | NowStarted];
-                {error, {already_started,App}} ->
-                    % Kernel causes this
-                    [App | NowStarted];
-                Else ->
-                    erlang:error(Else)
             end
     end.

--- a/dev/make_boot_script
+++ b/dev/make_boot_script
@@ -1,0 +1,9 @@
+#!/usr/bin/env escript
+
+main(_) ->
+    {ok, Server} = reltool:start_server([
+        {config, "../rel/reltool.config"}
+    ]),
+    {ok, Release} = reltool:get_rel(Server, "couchdb"),
+    ok = file:write_file("devnode.rel", io_lib:format("~p.~n", [Release])),
+    ok = systools:make_script("devnode", [local]).

--- a/dev/monitor_parent.erl
+++ b/dev/monitor_parent.erl
@@ -10,7 +10,7 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
--module(boot_node).
+-module(monitor_parent).
 
 -export([start/0]).
 

--- a/dev/run
+++ b/dev/run
@@ -101,6 +101,7 @@ def setup():
     setup_logging(ctx)
     setup_dirs(ctx)
     check_beams(ctx)
+    check_boot_script(ctx)
     setup_configs(ctx)
     return ctx
 
@@ -267,6 +268,12 @@ def check_beams(ctx):
     for fname in glob.glob(os.path.join(ctx["devdir"], "*.erl")):
         sp.check_call(["erlc", "-o", ctx["devdir"] + os.sep, fname])
 
+@log("Ensure Erlang boot script exists")
+def check_boot_script(ctx):
+    if not os.path.exists(os.path.join(ctx["devdir"], "devnode.boot")):
+        env = os.environ.copy()
+        env["ERL_LIBS"] = os.path.join(ctx["rootdir"], "src")
+        sp.check_call(["escript", "make_boot_script"], env=env, cwd=ctx["devdir"])
 
 @log("Prepare configuration files")
 def setup_configs(ctx):
@@ -592,10 +599,9 @@ def set_boot_env(ctx):
 
 @log("Start node {node}")
 def boot_node(ctx, node):
-    erl_libs = os.path.join(ctx["rootdir"], "src")
     set_boot_env(ctx)
     env = os.environ.copy()
-    env["ERL_LIBS"] = os.pathsep.join([erl_libs])
+    env["ERL_LIBS"] = os.path.join(ctx["rootdir"], "src")
 
     node_etcdir = os.path.join(ctx["devdir"], "lib", node, "etc")
     reldir = os.path.join(ctx["rootdir"], "rel")
@@ -614,10 +620,11 @@ def boot_node(ctx, node):
         os.path.join(reldir, "reltool.config"),
         "-parent_pid",
         str(os.getpid()),
+        "-boot",
+        os.path.join(ctx["devdir"], "devnode"),
         "-pa",
         ctx["devdir"],
     ]
-    cmd += [p[:-1] for p in glob.glob(erl_libs + "/*/")]
     cmd += ["-s", "boot_node"]
     if ctx["reset_logs"]:
         mode = "wb"

--- a/dev/run
+++ b/dev/run
@@ -624,8 +624,8 @@ def boot_node(ctx, node):
         os.path.join(ctx["devdir"], "devnode"),
         "-pa",
         ctx["devdir"],
+        "-s monitor_parent"
     ]
-    cmd += ["-s", "boot_node"]
     if ctx["reset_logs"]:
         mode = "wb"
     else:

--- a/dev/run
+++ b/dev/run
@@ -268,12 +268,14 @@ def check_beams(ctx):
     for fname in glob.glob(os.path.join(ctx["devdir"], "*.erl")):
         sp.check_call(["erlc", "-o", ctx["devdir"] + os.sep, fname])
 
+
 @log("Ensure Erlang boot script exists")
 def check_boot_script(ctx):
     if not os.path.exists(os.path.join(ctx["devdir"], "devnode.boot")):
         env = os.environ.copy()
         env["ERL_LIBS"] = os.path.join(ctx["rootdir"], "src")
         sp.check_call(["escript", "make_boot_script"], env=env, cwd=ctx["devdir"])
+
 
 @log("Prepare configuration files")
 def setup_configs(ctx):
@@ -624,7 +626,7 @@ def boot_node(ctx, node):
         os.path.join(ctx["devdir"], "devnode"),
         "-pa",
         ctx["devdir"],
-        "-s monitor_parent"
+        "-s monitor_parent",
     ]
     if ctx["reset_logs"]:
         mode = "wb"


### PR DESCRIPTION
## Overview

This patch introduces an escript that generates an Erlang .boot script to start CouchDB using the in-place .beam files produced by the compile phase of the build. This allows us to radically simplify the boot process for dev nodes as Erlang computes the optimal order for loading the necessary modules, and the previous logic in `boot_node` was, well, _not_ optimal 😄 
    
In addition to the simplification this approach offers a nice startup time speedup, at least when working inside a container environment. In my test with the stock .devcontainer it reduces startup time from about 75 seconds down to under 5 seconds 🚀 

I had initially introduced a new `devnode` target in the Makefile but figured just invoking the script if the `devnode.boot` file is missing would be sufficient. Note that this file can become outdated on the following conditions:

- Change in Erlang version 
- A new application is introduced to the source tree
- Modules are removed from existing applications

In each case running `make clean` or simply deleting the `devnode.boot` file will fix it. We could generate it every time but I figured it was maybe overkill for infrequent occurrences, and `make clean` is an easy fix.

## Testing recommendations

Start a dev node with `./dev/run`. Try doing this after a `make clean; make` cycle and you should see a ~5 second delay during "Ensure Erlang boot script exists". Subsequent runs should be instantaneous at that step.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
