### PR TITLE
Add a development container for VS Code / GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,47 @@
+ARG FDB_VERSION
+ARG ELIXIR_VERSION
+
+# Grab fdbcli and client library from same image as server
+FROM foundationdb/foundationdb:${FDB_VERSION} as fdb
+
+# Debian image with Erlang + Elixir installed (we need elixir for test suite)
+FROM elixir:${ELIXIR_VERSION}
+
+# The FROM directive above sweeps out the ARGs so we need to re-declare here
+# in order to use it again to download the FDB client package
+ARG FDB_VERSION
+
+# Install SpiderMonkey 60 and tell CouchDB to use it in configure
+ARG SM_VSN
+ENV SM_VSN=${SM_VSN:-60}
+
+# Workaround for Debian's temporary lack of trust in FDB Root CA
+RUN set -ex; \
+    wget https://www.geotrust.com/resources/root_certificates/certificates/GeoTrust_Global_CA.pem; \
+    wget --ca-certificate=GeoTrust_Global_CA.pem https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
+    mkdir /var/lib/foundationdb; \
+    dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb
+
+# Use NodeSource binaries for Node.js (Fauxton dependency)
+RUN set -ex; \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
+    echo "deb https://deb.nodesource.com/node_10.x buster main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    echo "deb-src https://deb.nodesource.com/node_10.x buster main" | tee -a /etc/apt/sources.list.d/nodesource.list
+
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        dnsutils \
+        libmozjs-${SM_VSN}-dev \
+        libicu-dev \
+        python3-venv \
+        python3-pip \
+        python3-sphinx \
+        nodejs
+
+# Documentation theme
+RUN pip3 install sphinx_rtd_theme
+
+COPY --from=fdb /var/fdb/scripts/create_cluster_file.bash /usr/local/bin/
+
+CMD sleep infinity

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "dockerComposeFile": "docker-compose.yaml",
+    "service": "couch",
+    "workspaceFolder": "/usr/src/couchdb",
+
+    // Needs to run at start to translate service name into coordinator IP
+    "postStartCommand": ["bash", "/usr/local/bin/create_cluster_file.bash"],
+
+    "extensions": [
+        "erlang-ls.erlang-ls"
+    ]
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,52 @@
+services:
+  couch:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Base image for Erlang and Elixir. Useful choices include:
+        # 1.11 -> Erlang 23, Debian Buster
+        # 1.10 -> Erlang 22, Debian Buster
+        # 1.9  -> Erlang 22, Debian Buster
+        #
+        # Older versions based on Debian Stretch will not include
+        # SpiderMonkey 60, which the Dockerfile expects to be able
+        # to install via apt-get.
+        ELIXIR_VERSION: "1.10"
+
+        # SpiderMonkey version to install with apt-get
+        SM_VSN: "60"
+
+        # This should always match the value in fdb.image
+        FDB_VERSION: "6.2.28"
+
+    environment:
+      # This needs to match the name of the FoundationDB service below
+      FDB_COORDINATOR: fdb
+
+      # The location where the Dockerfile installs the FDB cluster file
+      # retrieved from the `fdb` image. CouchDB looks for the cluster file in
+      # this location by default. If you want to install it somewhere else you
+      # you need to change "[erlfdb] cluster_file" and ERL_ZFLAGS to match.
+      FDB_CLUSTER_FILE: /usr/local/etc/foundationdb/fdb.cluster
+
+      # The test suite will default to trying to start its own fdbserver
+      # process. This environment variable tells it to use the fdbserver
+      # running in the `fdb` image instead. Quite a hacky solution. An
+      # alternative might be to parameterize the Makefile so we can swap
+      # `eunit.config` for a `devcontainer.config` via an environment variable
+      # and maintain both config files in the repo.
+      ERL_ZFLAGS: "-erlfdb test_cluster_file <<\\\"/usr/local/etc/foundationdb/fdb.cluster\\\">>"
+
+    volumes:
+      # Mounts the project folder to '/usr/src/couchdb'. The target path inside
+      # the container should match what your application expects. In this case,
+      # the compose file is in a sub-folder, so you will mount '..'. You would
+      # then reference this path as the 'workspaceFolder' in
+      # '.devcontainer/devcontainer.json' so VS Code starts here.
+      - ..:/usr/src/couchdb:cached
+
+    network_mode: service:fdb
+
+  fdb:
+    image: foundationdb/foundationdb:6.2.28

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ check-all-tests: all python-black
 	@$(MAKE) elixir
 
 ifdef apps
-subdirs = $(apps)
+subdirs=$(shell echo $(apps) | sed 's/,/ /g')
 else
 subdirs=$(shell ls src)
 endif

--- a/configure
+++ b/configure
@@ -29,7 +29,7 @@ ERLANG_MD5="false"
 SKIP_DEPS=0
 
 COUCHDB_USER="$(whoami 2>/dev/null || echo couchdb)"
-SM_VSN="1.8.5"
+SM_VSN=${SM_VSN:-"1.8.5"}
 ARCH="$(uname -m)"
 
 . ${rootdir}/version.mk

--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,0 +1,3 @@
+include_dirs:
+    - "src/"
+    - "src/*/include"

--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,3 +1,10 @@
 include_dirs:
     - "src/"
-    - "src/*/include"
+    - "src/*/include/"
+macros:
+    - name: COUCHDB_VERSION
+      value: erlangls
+    - name: COUCHDB_GIT_SHA
+      value: deadbeef
+    - name: AEGIS_KEY_MANAGER
+      value: aegis_noop_key_manager

--- a/rel/files/eunit.config
+++ b/rel/files/eunit.config
@@ -13,5 +13,18 @@
 [
     {kernel, [{error_logger, silent}]},
     {sasl, [{sasl_error_logger, false}]},
-    {fabric, [{eunit_run, true}]}
+    {fabric, [{eunit_run, true}]},
+
+    % When fabric is configured with eunit_run=true it will ask erlfdb for a
+    % test database. The default behavior for erlfdb in this case is start a
+    % new fdbserver process for the test. If you would rather have erlfdb
+    % connect to an existing FoundationDB cluster, you can supply the path
+    % to the cluster file as a binary string here.
+    %
+    % NOTE: the unit tests will erase all the data in the cluster!
+    %
+    % The docker-compose configuration in the .devcontainer activates this
+    % application setting using ERL_ZFLAGS in the container environment, so
+    % any tests will use the fdbserver running in the fdb container.
+    % {erlfdb, [{test_cluster_file, <<"/usr/local/etc/foundationdb/fdb.cluster">>}]}
 ].

--- a/rel/files/eunit.config
+++ b/rel/files/eunit.config
@@ -13,7 +13,6 @@
 [
     {kernel, [{error_logger, silent}]},
     {sasl, [{sasl_error_logger, false}]},
-    {fabric, [{eunit_run, true}]},
 
     % When fabric is configured with eunit_run=true it will ask erlfdb for a
     % test database. The default behavior for erlfdb in this case is start a
@@ -26,5 +25,6 @@
     % The docker-compose configuration in the .devcontainer activates this
     % application setting using ERL_ZFLAGS in the container environment, so
     % any tests will use the fdbserver running in the fdb container.
-    % {erlfdb, [{test_cluster_file, <<"/usr/local/etc/foundationdb/fdb.cluster">>}]}
+    % {erlfdb, [{test_cluster_file, <<"/usr/local/etc/foundationdb/fdb.cluster">>}]},
+    {fabric, [{eunit_run, true}]}
 ].


### PR DESCRIPTION
## Overview

This creates a development environment with a FoundationDB server and a CouchDB layer in two containers, sharing a network through Docker Compose.

It uses the FDB image published to Docker Hub for the FDB container, and downloads the FDB client packages from foundationdb.org to provide the development headers and libraries. www.foundationdb.org is actually not trusted in Debian Buster by default, so we have to download the GeoTrust_Global_CA.pem. The following link has more details:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962596

Once the Docker Compose setup is running, VS Code executes the `create_cluster_file.bash` script to write down a cluster file containing the IP address in the compose network where the FDB service can be found. This cluster file is used both for a user-driven invocation of `./dev/run`, as well as for unit tests that require a running CouchDB.

Additionally, I've got a small fix to the Makefile that corrects the approach used to running eunit tests with multiple apps specified on the command line to match the behavior of `make eunit` without any arguments.

## Testing recommendations

If you have VS Code with the "Remote - Containers" extension installed, opening the CouchDB repo should cause the editor to offer to start the development container. The container will include all the dependences necessary to

- build CouchDB using ./configure; make
- run the full test suite
- build the documentation
- build Fauxton

## Related Issues or Pull Requests

#3336 added a container configuration for 3.x. This one is a step more involved because of the use of Docker Compose with a separate FDB container.

## Checklist

(No code changes here, just a quicker Getting Started experience)

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
