### PR TITLE
Set a finite default for max_attachment_size

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -47,7 +47,7 @@ changes_doc_ids_optimization_threshold = 100
 max_document_size = 8000000 ; bytes
 ;
 ; Maximum attachment size.
-; max_attachment_size = infinity
+; max_attachment_size = 1073741824 : 1 gibibyte
 ;
 ; Do not update the least recently used DB cache on reads, only writes
 ;update_lru_on_read = false

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -47,7 +47,7 @@ changes_doc_ids_optimization_threshold = 100
 max_document_size = 8000000 ; bytes
 ;
 ; Maximum attachment size.
-; max_attachment_size = 1073741824 : 1 gibibyte
+; max_attachment_size = 1073741824 ; 1 gibibyte
 ;
 ; Do not update the least recently used DB cache on reads, only writes
 ;update_lru_on_read = false

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -960,7 +960,7 @@ test_transform() ->
 
 max_attachment_size_test_() ->
     {"Max attachment size tests", [
-        ?_assertEqual(infinity, max_attachment_size(infinity)),
+        ?_assertEqual(infinity, max_attachment_size("infinity")),
         ?_assertEqual(5, max_attachment_size(5)),
         ?_assertEqual(5, max_attachment_size("5"))
     ]}.

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -178,8 +178,7 @@
 
 -type att() :: #att{} | attachment() | disk_att().
 
-% 1024 * 1024 * 1024
--define(GB, 1073741824).
+-define(GB, (1024*1024*1024)).
 
 new() ->
     %% We construct a record by default for compatability. This will be

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -743,11 +743,17 @@ max_attachment_size(MaxAttSizeConfig) ->
         "infinity" ->
             infinity;
         MaxAttSize when is_list(MaxAttSize) ->
-            list_to_integer(MaxAttSize);
+            try list_to_integer(MaxAttSize) of
+                Result -> Result
+            catch _:_ ->
+                couch_log:error("invalid config value for max attachment size: ~p ", [MaxAttSize]),
+                throw(internal_server_error)
+            end;
         MaxAttSize when is_integer(MaxAttSize) ->
             MaxAttSize;
         MaxAttSize ->
-            erlang:error({invalid_max_attachment_size, MaxAttSize})
+            couch_log:error("invalid config value for max attachment size: ~p ", [MaxAttSize]),
+            throw(internal_server_error)
     end.
 
 

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -734,7 +734,7 @@ upgrade_encoding(Encoding) -> Encoding.
 
 
 max_attachment_size() ->
-    case config:get("couchdb", "max_attachment_size", "infinity") of
+    case config:get("couchdb", "max_attachment_size", 1024 * 1024 * 1024) of
         "infinity" ->
             infinity;
         MaxAttSize ->

--- a/src/couch/test/eunit/couch_doc_tests.erl
+++ b/src/couch/test/eunit/couch_doc_tests.erl
@@ -139,6 +139,7 @@ mock_config() ->
     meck:expect(config, get,
         fun("couchdb", "max_document_id_length", "infinity") -> "1024";
            ("couchdb", "max_attachment_size", "infinity") -> "infinity";
+           ("couchdb", "max_attachment_size", 1073741824) -> 1073741824;
            ("mem3", "shards_db", "_dbs") -> "_dbs";
             (Key, Val, Default) -> meck:passthrough([Key, Val, Default])
         end


### PR DESCRIPTION
## Overview
The current default for `max_attachment_size` is `infinity`. This PR changes that to 1 gibibyte.

## Testing recommendations
No testing, this is just a default change.

## Related Issues or Pull Requests
N/A

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
