### PR TITLE
Fix PUT of multipart/related attachments support for Transfer-Encoding: chunked

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1407,6 +1407,15 @@ bulk_get_multipart_boundary() ->
 receive_request_data(Req) ->
     receive_request_data(Req, chttpd:body_length(Req)).
 
+receive_request_data(Req, Len) when Len == chunked ->
+    Ref = make_ref(),
+    ChunkFun = fun({_Length, Binary}, _State) ->
+        self() ! {chunk, Ref, Binary}
+    end,
+    couch_httpd:recv_chunked(Req, 4096, ChunkFun, ok),
+    GetChunk = fun GC() -> receive {chunk, Ref, Binary} -> {Binary, GC} end end,
+    {receive {chunk, Ref, Binary} -> Binary end, GetChunk};
+
 receive_request_data(Req, LenLeft) when LenLeft > 0 ->
     Len = erlang:min(4096, LenLeft),
     Data = chttpd:recv(Req, Len),

--- a/src/chttpd/test/eunit/chttpd_db_attachment_size_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_db_attachment_size_tests.erl
@@ -56,7 +56,8 @@ attachment_size_test_() ->
                     fun put_inline/1,
                     fun put_simple/1,
                     fun put_simple_chunked/1,
-                    fun put_mp_related/1
+                    fun put_mp_related/1,
+                    fun put_chunked_mp_related/1
                 ]
             }
         }
@@ -108,6 +109,15 @@ put_mp_related(Url) ->
         Body2 = mp_body(51),
         Status2 = put_req(Url ++ "/doc3", Headers, Body2),
         ?assertEqual(413, Status2)
+    end).
+
+
+put_chunked_mp_related(Url) ->
+    ?_test(begin
+       Headers = [?CONTENT_MULTI_RELATED],
+       Body = mp_body(50),
+       Status = put_req_chunked(Url ++ "/doc4", Headers, Body),
+       ?assert(Status =:= 201 orelse Status =:= 202)
     end).
 
 

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -589,7 +589,8 @@ recv_chunked(#httpd{mochi_req=MochiReq}, MaxChunkSize, ChunkFun, InitState) ->
     % Fun is called once with each chunk
     % Fun({Length, Binary}, State)
     % called with Length == 0 on the last time.
-    MochiReq:stream_body(MaxChunkSize, ChunkFun, InitState).
+    MochiReq:stream_body(MaxChunkSize, ChunkFun, InitState,
+        config:get_integer("httpd", "max_http_request_size", 4294967296)).
 
 body_length(#httpd{mochi_req=MochiReq}) ->
     MochiReq:get(body_length).


### PR DESCRIPTION
This is the backport of 235d1e9 to `main`.

This is related to https://github.com/apache/couchdb/issues/1943