### PR TITLE
Show process status in active_tasks

### DIFF
--- a/src/couch/src/couch_task_status.erl
+++ b/src/couch/src/couch_task_status.erl
@@ -124,7 +124,7 @@ handle_call({add_task, TaskProps}, {From, _}, Server) ->
     end;
 handle_call(all, _, Server) ->
     All = [
-        [{pid, ?l2b(pid_to_list(Pid))} | TaskProps]
+        [{pid, ?l2b(pid_to_list(Pid))}, process_status(Pid) | TaskProps]
         ||
         {Pid, TaskProps} <- ets:tab2list(?MODULE)
     ],
@@ -160,3 +160,12 @@ timestamp() ->
 
 timestamp({Mega, Secs, _}) ->
     Mega * 1000000 + Secs.
+
+
+process_status(Pid) ->
+    case process_info(Pid, status) of
+        undefined ->
+            {process_status, exiting};
+        {status, Status} ->
+            {process_status, Status}
+    end.


### PR DESCRIPTION
## Overview

This allows users to verify that compaction processes are suspended
outside of any configured strict_window.

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
