### PR TITLE
Remove stack traces from HTTP responses

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1037,7 +1037,7 @@ error_info({service_unavailable, Reason}) ->
 error_info({timeout, _Reason}) ->
     error_info(timeout);
 error_info({'EXIT', {Error, Stack}}) ->
-    error_info({Error, nil, Stack});
+    error_info(Error);
 error_info({Error, null}) ->
     error_info(Error);
 error_info({_Error, _Reason} = Error) ->

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1036,6 +1036,8 @@ error_info({service_unavailable, Reason}) ->
     {503, <<"service unavailable">>, Reason};
 error_info({timeout, _Reason}) ->
     error_info(timeout);
+error_info({'EXIT', {Error, Stack}}) ->
+    error_info({Error, nil, Stack});
 error_info({Error, null}) ->
     error_info(Error);
 error_info({_Error, _Reason} = Error) ->


### PR DESCRIPTION
## Overview

Instead of returning the stack trace in HTTP response we would want to log it and return a `{"ref": stack_hash(Stack)}`.
It is implemented already, but there are an unhandled edge case to get 'ERROR', fixed in chttpd.

## Testing recommendations

I can reproduce to get some leaking information before the fix, with the following steps:

Create an empty database and add 2 new documents
To get an error, just delete some data from shard files.

When I deleted just a few bytes (few hundreds of bytes) was not enough to stable get an error, the system seems to be so robust in case of filesystem based corruptions. 

I used this small script to truncate shard files:
```
TODO: fdbcli
```

Run the script, keeps only first 1000 bytes of every related shard files.

After truncate shards, I send a simple query:

```
% curl -u adm:pass http://127.0.0.1:15984/testdb/_all_docs | jq
{
  "error": "badmatch",
  "reason": "{'EXIT',{{badmatch,eof},\n         [{couch_file,read_raw_iolist_int,3,\n
                    [{file,\"src/couch_file.erl\"},{line,714}]},\n          {couch_file,handle_call,3,
                    [{file,\"src/couch_file.erl\"},{line,493}]},\n          {gen_server,try_handle_call,4
                    [{file,\"gen_server.erl\"},{line,661}]},\n          {gen_server,handle_msg,6,
                    [{file,\"gen_server.erl\"},{line,690}]},\n          {proc_lib,init_p_do_apply,3,
                    [{file,\"proc_lib.erl\"},{line,249}]}]}}",
  "ref": 774065757
}
```

After the fix the response should looks like this:

```
% curl -u adm:pass http://127.0.0.1:15984/testdb/_all_docs | jq
{
  "error": "unknown_error",
  "reason": "eof",
  "ref": 3189254621
}
```


## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
