### PR TITLE
Add "couch_server" aggregate to _system output

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -209,7 +209,8 @@ get_stats() ->
     {NumberOfGCs, WordsReclaimed, _} = statistics(garbage_collection),
     {{input, Input}, {output, Output}} = statistics(io),
     {CF, CDU} = db_pid_stats(),
-    MessageQueues0 = [{couch_file, {CF}}, {couch_db_updater, {CDU}}],
+    MessageQueues0 = [{couch_file, {CF}}, {couch_db_updater, {CDU}},
+        {couch_server, couch_server:aggregate_queue_len()}],
     MessageQueues = MessageQueues0 ++ message_queues(registered()),
     {SQ, DCQ} = run_queues(),
     [

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -28,6 +28,7 @@
 -export([lock/2, unlock/1]).
 -export([db_updated/1]).
 -export([num_servers/0, couch_server/1, couch_dbs_pid_to_name/1, couch_dbs/1]).
+-export([aggregate_queue_len/0]).
 
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
@@ -359,7 +360,7 @@ handle_config_terminate(_Server, _Reason, N) ->
 
 
 per_couch_server(X) ->
-    erlang:max(1, X div couch_server:num_servers()).
+    erlang:max(1, X div num_servers()).
 
 
 all_databases() ->
@@ -941,6 +942,14 @@ name(BaseName, N) when is_integer(N), N > 0 ->
 
 num_servers() ->
     erlang:system_info(schedulers).
+
+
+aggregate_queue_len() ->
+    N = num_servers(),
+    Names = [couch_server(I) || I <- lists:seq(1, N)],
+    MQs = [process_info(whereis(Name), message_queue_len) ||
+        Name <- Names],
+    lists:sum([X || {_, X} <- MQs]).
 
 
 -ifdef(TEST).


### PR DESCRIPTION
## Overview

This helps ease transition from singleton couch_server to
multiple. The "couch_server" message queue is simply the sum of the
couch_server_X message queues.

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/3366

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
