### PR TITLE
Include necessary dependency in jwtf keystore test setup & teardown

### DIFF
--- a/src/jwtf/test/jwtf_keystore_tests.erl
+++ b/src/jwtf/test/jwtf_keystore_tests.erl
@@ -20,7 +20,7 @@
 -define(EC_SECRET, "-----BEGIN PUBLIC KEY-----\\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDsr0lz/Dg3luarb+Kua0Wcj9WrfR23os\\nwHzakglb8GhWRDn+oZT0Bt/26sX8uB4/ij9PEOLHPo+IHBtX4ELFFVr5GTzlqcJe\\nyctaTDd1OOAPXYuc67EWtGZ3pDAzztRs\\n-----END PUBLIC KEY-----\\n").
 
 setup() ->
-    test_util:start_applications([config, jwtf]),
+    test_util:start_applications([couch_log, config, jwtf]),
     config:set("jwt_keys", "hmac:hmac", ?HMAC_SECRET),
     config:set("jwt_keys", "rsa:hmac", ?HMAC_SECRET),
     config:set("jwt_keys", "ec:hmac", ?HMAC_SECRET),
@@ -34,7 +34,7 @@ setup() ->
     config:set("jwt_keys", "ec:ec", ?EC_SECRET).
 
 teardown(_) ->
-    test_util:stop_applications([config, jwtf]).
+    test_util:stop_applications([couch_log, config, jwtf]).
 
 jwtf_keystore_test_() ->
     {


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The `config` application depends on `couch_log`, so include it when setting up and tearing down tests.

Without this change, I'm seeing e.g.
```
module 'jwtf_keystore'
  module 'jwtf_keystore_tests'
    *** context setup failed ***
**in function gen_server:call/3 (gen_server.erl, line 223)
in call from jwtf_keystore_tests:setup/0 (test/jwtf_keystore_tests.erl, line 24)
**exit:{{noproc,{gen_server,call,
                     [couch_log_server,
                      {log,{log_entry,notice,<0.19418.3>,
                                      ["config",58,32,91,[...]|...],
                                      "--------",
                                      "2021-02-16T05:56:53.981693Z"}}]}},
 {gen_server,call,
             [config,
              {set,"jwt_keys","hmac:hmac","aGVsbG8=",
                   #{persist => true,reason => nil}},
              30000]}}
```

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make check apps=jwtf
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
