### PR TITLE
Clean up logs 3.x

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -144,7 +144,7 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{config,           "config",           {tag, "2.1.7"}},
+{config,           "config",           {tag, "2.1.8"}},
 {b64url,           "b64url",           {tag, "1.0.2"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},

--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -71,7 +71,9 @@ handle_node_req(#httpd{method='PUT', path_parts=[_, Node, <<"_config">>, Section
     Value = couch_util:trim(chttpd:json_body(Req)),
     Persist = chttpd:header_value(Req, "X-Couch-Persist") /= "false",
     OldValue = call_node(Node, config, get, [Section, Key, ""]),
-    case call_node(Node, config, set, [Section, Key, ?b2l(Value), Persist]) of
+    IsSensitive = Section == <<"admins">>,
+    Opts = #{persisit => Persist, sensitive => IsSensitive},
+    case call_node(Node, config, set, [Section, Key, ?b2l(Value), Opts]) of
         ok ->
             send_json(Req, 200, list_to_binary(OldValue));
         {error, Reason} ->

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -219,3 +219,16 @@
 -type sec_props() :: [tuple()].
 -type sec_obj() :: {sec_props()}.
 
+-define(record_to_keyval(Name, Record),
+    lists:zip(record_info(fields, Name), tl(tuple_to_list(Record)))).
+
+-define(record_to_map(RecordName, Record),
+    element(1, lists:foldl(fun(Field, {Map, Idx}) ->
+        {
+            maps:put(Field, element(Idx, Record), Map),
+            Idx + 1
+        }
+    end, {#{}, 2}, record_info(fields, RecordName)))).
+
+-define(record_without(RecordName, Record, Keys),
+    maps:without(Keys, ?record_to_map(RecordName, Record))).

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -15,7 +15,15 @@
 -vsn(1).
 
 -export([add_sizes/3, upgrade_sizes/1]).
--export([init/1,terminate/2,handle_call/3,handle_cast/2,code_change/3,handle_info/2]).
+-export([
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    code_change/3,
+    handle_info/2,
+    format_status/2
+]).
 
 -include_lib("couch/include/couch_db.hrl").
 -include("couch_db_int.hrl").
@@ -242,6 +250,11 @@ handle_info(Msg, Db) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(Opt, Args) ->
+    couch_db_engine:format_status(Opt, Args).
+
 
 sort_and_tag_grouped_docs(Client, GroupedDocs) ->
     % These groups should already be sorted but sometimes clients misbehave.

--- a/src/couch/src/couch_multidb_changes.erl
+++ b/src/couch/src/couch_multidb_changes.erl
@@ -24,7 +24,8 @@
    handle_call/3,
    handle_info/2,
    handle_cast/2,
-   code_change/3
+   code_change/3,
+   format_status/2
 ]).
 
 -export([
@@ -173,6 +174,12 @@ handle_info(_Msg, State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    #state{pids = Pids} = State,
+    StateMap = maps:put(number_of_pids, length(Pids),
+        ?record_without(state, State, [pids])),
+    [{data, [{"State", StateMap}]}].
 
 % Private functions
 

--- a/src/couch/src/couch_native_process.erl
+++ b/src/couch/src/couch_native_process.erl
@@ -42,7 +42,7 @@
 -vsn(1).
 
 -export([start_link/0,init/1,terminate/2,handle_call/3,handle_cast/2,code_change/3,
-         handle_info/2]).
+         handle_info/2, format_status/2]).
 -export([set_timeout/2, prompt/2]).
 
 -define(STATE, native_proc_state).
@@ -124,6 +124,25 @@ handle_info({'EXIT',_,Reason}, State) ->
     {stop, Reason, State}.
 terminate(_Reason, _State) -> ok.
 code_change(_OldVersion, State, _Extra) -> {ok, State}.
+
+format_status(_Opt, [_PDict, State]) ->
+    #evstate{
+        ddocs = DDocs,
+        funs = Funs,
+        list_pid = ListPid,
+        query_config = QueryConfig,
+        timeout = TimeOut,
+        idle = Idle
+    } = State,
+    MapState = #{
+        number_of_ddocs => dict:size(DDocs),
+        number_of_funs => length(Funs),
+        list_pid => couch_term:format_pid(ListPid),
+        query_config => QueryConfig,
+        timeout => TimeOut,
+        idle => Idle
+    },
+    [{data, [{"State", MapState}]}].
 
 run(#evstate{list_pid=Pid}=State, [<<"list_row">>, Row]) when is_pid(Pid) ->
     Pid ! {self(), list_row, Row},

--- a/src/couch/src/couch_os_process.erl
+++ b/src/couch/src/couch_os_process.erl
@@ -14,7 +14,7 @@
 -behaviour(gen_server).
 -vsn(1).
 
--export([start_link/1, start_link/2, start_link/3, stop/1]).
+-export([start_link/1, start_link/2, start_link/3, stop/1, format_status/2]).
 -export([set_timeout/2, prompt/2, killer/1]).
 -export([send/2, writeline/2, readline/1, writejson/2, readjson/1]).
 -export([init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2, code_change/3]).
@@ -255,6 +255,24 @@ code_change(_, {os_proc, Cmd, Port, W, R, Timeout} , _) ->
     {ok, State};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+format_status(_Opt, [_PDict, #os_proc{} = State]) ->
+    % command field can potentially contain secrets
+    #os_proc{
+        port = Port,
+        writer = Writer,
+        reader = Reader,
+        timeout = TimeOut,
+        idle = Idle
+    } = State,
+    MapState = #{
+        port => couch_term:format_port(Port),
+        writer => couch_term:format_fun(Writer),
+        reader => couch_term:format_fun(Reader),
+        timeout => TimeOut,
+        idle => Idle
+    },
+    [{data, [{"State", MapState}]}].
 
 killer(KillCmd) ->
     receive _ ->

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -31,7 +31,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 -export([
@@ -268,6 +269,11 @@ handle_info(_Msg, State) ->
 
 code_change(_OldVsn, #state{}=State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    [{data, [{"State", ?record_to_map(state, State)}]}].
+
 
 handle_config_terminate(_, stop, _) ->
     ok;

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -18,7 +18,7 @@
 -export([open/2,create/2,delete/2,get_version/0,get_version/1,get_git_sha/0,get_uuid/0]).
 -export([all_databases/0, all_databases/2]).
 -export([init/1, handle_call/3,sup_start_link/1]).
--export([handle_cast/2,code_change/3,handle_info/2,terminate/2]).
+-export([handle_cast/2,code_change/3,handle_info/2,terminate/2,format_status/2]).
 -export([dev_start/0,is_admin/2,has_admins/0,get_stats/0]).
 -export([close_db_if_idle/1]).
 -export([delete_compaction_files/1]).
@@ -313,6 +313,11 @@ terminate(Reason, Srv) ->
         end
     end, nil, couch_dbs(Srv)),
     ok.
+
+
+format_status(_Opt, [_PDict, #server{} = State]) ->
+    [{data, [{"State", ?record_without(server, State, [lru])}]}].
+
 
 handle_config_change("couchdb", "database_dir", _, _, _) ->
     exit(whereis(couch_server), config_change),

--- a/src/couch/src/couch_stream.erl
+++ b/src/couch/src/couch_stream.erl
@@ -36,7 +36,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 
@@ -293,6 +294,9 @@ handle_info({'DOWN', Ref, _, _, _}, #stream{opener_monitor=Ref} = State) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
+
+format_status(_Opt, [_PDict, #stream{} = State]) ->
+    [{data, [{"State", ?record_without(stream, State, [buffer_list])}]}].
 
 do_seek({Engine, EngineState}, Offset) ->
     {ok, NewState} = Engine:seek(EngineState, Offset),

--- a/src/couch/src/couch_term.erl
+++ b/src/couch/src/couch_term.erl
@@ -1,0 +1,95 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_term).
+
+-include("couch_db.hrl").
+-include("couch_db_int.hrl").
+
+-export([
+    format_record/1,
+    format_term/1,
+    format_fun/1,
+    format_pid/1,
+    format_port/1,
+    format_ref/1,
+    record_to_map/1
+]).
+
+format_record(#db{} = Db) ->
+    couch_db:format_record(Db);
+
+format_record(#user_ctx{} = UserCtx) ->
+    ?record_to_map(user_ctx, UserCtx);
+
+format_record(_) ->
+    nil.
+
+format_term(Fun) when is_function(Fun) ->
+    format_fun(Fun);
+
+format_term(Atom) when is_atom(Atom) ->
+    Atom;
+
+format_term(Pid) when is_pid(Pid) ->
+    format_pid(Pid);
+
+format_term(Number) when is_number(Number) ->
+    Number;
+
+format_term(Reference) when is_reference(Reference) ->
+    format_ref(Reference);
+
+format_term(Port) when is_port(Port) ->
+    format_ref(Port);
+
+% we strip any term which can leak user data
+format_term(_) ->
+    nil.
+
+
+format_fun(Fun) when is_function(Fun) ->
+    {module, M} = erlang:fun_info(Fun, module),
+    {name, F} = erlang:fun_info(Fun, name),
+    {arity, A} = erlang:fun_info(Fun, arity),
+    format_fun({M, F, A});
+    
+format_fun({M, F, A}) when is_atom(M) andalso is_atom(F) andalso is_integer(A) ->
+    Str = io_lib:format("~s:~s/~b", [M, F, A]),
+    lists:flatten(Str);
+
+format_fun(Term) -> 
+    format_term(Term).
+
+format_pid(Pid) when is_pid(Pid) ->
+    pid_to_list(Pid);
+
+format_pid(Term) ->
+    format_term(Term).
+
+format_port(Port) when is_port(Port) ->
+    erlang:port_to_list(Port);
+
+format_port(Term) -> 
+    format_term(Term).
+
+format_ref(Reference) when is_reference(Reference) ->
+    erlang:ref_to_list(Reference);
+
+format_ref(Term) -> 
+    format_term(Term).
+
+record_to_map(#db{} = Db) -> 
+    ?record_to_map(db, Db);
+
+record_to_map(_) ->
+        #{}.

--- a/src/couch/src/couch_work_queue.erl
+++ b/src/couch/src/couch_work_queue.erl
@@ -20,7 +20,7 @@
 -export([new/1, queue/2, dequeue/1, dequeue/2, close/1, item_count/1, size/1]).
 
 % gen_server callbacks
--export([init/1, terminate/2]).
+-export([init/1, terminate/2, format_status/2]).
 -export([handle_call/3, handle_cast/2, code_change/3, handle_info/2]).
 
 -record(q, {
@@ -186,3 +186,15 @@ code_change(_OldVsn, State, _Extra) ->
 
 handle_info(X, Q) ->
     {stop, X, Q}.
+
+
+format_status(_Opt, [_PDict, #q{} = State]) ->
+    #q{
+        blocked = Blocked,
+        work_waiters = WorkerWaiters
+    } = State,
+    MapState = maps:merge(?record_without(q, State, [queue]), #{
+        number_of_blocked => length(Blocked),
+        number_of_work_waiters => length(WorkerWaiters)
+    }),
+    [{data, [{"State", MapState}]}].

--- a/src/couch_event/src/couch_event_os_listener.erl
+++ b/src/couch_event/src/couch_event_os_listener.erl
@@ -25,7 +25,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 
@@ -74,3 +75,7 @@ handle_info(Msg, Pid) ->
 
 code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
+
+
+format_status(_Opt, [_PDict, Pid]) ->
+    [{data, [{"State", #{pid => Pid}}]}].

--- a/src/couch_index/src/couch_index.erl
+++ b/src/couch_index/src/couch_index.erl
@@ -23,7 +23,7 @@
 -export([compact/1, compact/2, get_compactor_pid/1]).
 
 %% gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2, code_change/3, format_status/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 
@@ -374,6 +374,33 @@ handle_info({'DOWN', _, _, _Pid, _}, #st{mod=Mod, idx_state=IdxState}=State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+format_status(Opt, [PDict, State]) ->
+    #st{
+        mod = Mod,
+        idx_state = IdxState,
+        updater = Updater,
+        compactor = Compactor,
+        waiters = Waiters,
+        committed = Commited,
+        shutdown = Shutdown
+    } = State,
+    IdxSafeState = case erlang:function_exported(Mod, format_status, 2) of
+        true ->
+            %% we only support maps in return
+            Mod:format_status(Opt, [PDict, IdxState]);
+        false ->
+            #{}
+    end,
+    MapState = maps:merge(#{
+        mod => Mod,
+        updater => Updater,
+        compactor => Compactor,
+        number_of_waiters => length(Waiters),
+        committed => Commited,
+        shutdown => Shutdown
+    }, IdxSafeState),
+    [{data, [{"State", MapState}]}].
 
 maybe_restart_updater(#st{waiters=[]}) ->
     ok;

--- a/src/couch_index/src/couch_index_compactor.erl
+++ b/src/couch_index/src/couch_index_compactor.erl
@@ -19,7 +19,7 @@
 
 %% gen_server callbacks
 -export([init/1, terminate/2, code_change/3]).
--export([handle_call/3, handle_cast/2, handle_info/2]).
+-export([handle_call/3, handle_cast/2, handle_info/2, format_status/2]).
 
 
 -include_lib("couch/include/couch_db.hrl").
@@ -103,6 +103,10 @@ handle_info(_Mesg, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #st{} = State]) ->
+    [{data, [{"State", ?record_to_map(st, State)}]}].
 
 
 compact(Parent, Mod, IdxState) ->

--- a/src/couch_index/src/couch_index_server.erl
+++ b/src/couch_index/src/couch_index_server.erl
@@ -18,7 +18,7 @@
 
 -export([start_link/0, validate/2, get_index/4, get_index/3, get_index/2]).
 
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2, code_change/3, format_status/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 % Exported for callbacks
@@ -202,6 +202,10 @@ handle_info(Msg, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #st{} = State]) ->
+    [{data, [{"State", ?record_to_map(st, State)}]}].
 
 
 handle_config_change("couchdb", "index_dir", RootDir, _, RootDir) ->

--- a/src/couch_index/src/couch_index_updater.erl
+++ b/src/couch_index/src/couch_index_updater.erl
@@ -21,7 +21,7 @@
 -export([update/3]).
 
 %% gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2, code_change/3, format_status/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -124,6 +124,10 @@ handle_info(_Mesg, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #st{} = State]) ->
+    [{data, [{"State", ?record_to_map(st, State)}]}].
 
 
 update(Idx, Mod, IdxState) ->

--- a/src/couch_log/src/couch_log_config.erl
+++ b/src/couch_log/src/couch_log_config.erl
@@ -49,7 +49,8 @@ entries() ->
     [
         {level, "level", "info"},
         {level_int, "level", "info"},
-        {max_message_size, "max_message_size", "16000"}
+        {max_message_size, "max_message_size", "16000"},
+        {strip_last_msg, "strip_last_msg", "true"}
      ].
 
 
@@ -97,4 +98,10 @@ transform(max_message_size, SizeStr) ->
         Size -> Size
     catch _:_ ->
         16000
-    end.
+    end;
+
+transform(strip_last_msg, "false") ->
+    false;
+
+transform(strip_last_msg, _) ->
+    true.

--- a/src/couch_log/src/couch_log_config_dyn.erl
+++ b/src/couch_log/src/couch_log_config_dyn.erl
@@ -25,4 +25,5 @@
 
 get(level) -> info;
 get(level_int) -> 2;
-get(max_message_size) -> 16000.
+get(max_message_size) -> 16000;
+get(strip_last_msg) -> true.

--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -68,7 +68,13 @@ format(Event) ->
 
 do_format({error, _GL, {Pid, "** Generic server " ++ _, Args}}) ->
     %% gen_server terminate
-    [Name, LastMsg, State, Reason | Extra] = Args,
+    [Name, LastMsg0, State, Reason | Extra] = Args,
+    LastMsg = case couch_log_config:get(strip_last_msg) of
+        true ->
+            redacted;
+        false ->
+            LastMsg0
+    end,
     MsgFmt = "gen_server ~w terminated with reason: ~s~n" ++
                 "  last msg: ~p~n     state: ~p~n    extra: ~p",
     MsgArgs = [Name, format_reason(Reason), LastMsg, State, Extra],
@@ -76,7 +82,13 @@ do_format({error, _GL, {Pid, "** Generic server " ++ _, Args}}) ->
 
 do_format({error, _GL, {Pid, "** State machine " ++ _, Args}}) ->
     %% gen_fsm terminate
-    [Name, LastMsg, StateName, State, Reason | Extra] = Args,
+    [Name, LastMsg0, StateName, State, Reason | Extra] = Args,
+    LastMsg = case couch_log_config:get(strip_last_msg) of
+        true ->
+            redacted;
+        false ->
+            LastMsg0
+    end,
     MsgFmt = "gen_fsm ~w in state ~w terminated with reason: ~s~n" ++
                 " last msg: ~p~n     state: ~p~n    extra: ~p",
     MsgArgs = [Name, StateName, format_reason(Reason), LastMsg, State, Extra],
@@ -84,7 +96,13 @@ do_format({error, _GL, {Pid, "** State machine " ++ _, Args}}) ->
 
 do_format({error, _GL, {Pid, "** gen_event handler" ++ _, Args}}) ->
     %% gen_event handler terminate
-    [ID, Name, LastMsg, State, Reason] = Args,
+    [ID, Name, LastMsg0, State, Reason] = Args,
+    LastMsg = case couch_log_config:get(strip_last_msg) of
+        true ->
+            redacted;
+        false ->
+            LastMsg0
+    end,
     MsgFmt = "gen_event ~w installed in ~w terminated with reason: ~s~n" ++
                 "  last msg: ~p~n     state: ~p",
     MsgArgs = [ID, Name, format_reason(Reason), LastMsg, State],

--- a/src/couch_log/src/couch_log_sup.erl
+++ b/src/couch_log/src/couch_log_sup.erl
@@ -63,6 +63,8 @@ handle_config_change("log", Key, _, _, S) ->
             couch_log_config:reconfigure();
         "max_message_size" ->
             couch_log_config:reconfigure();
+        "strip_last_msg" ->
+            couch_log_config:reconfigure();
         _ ->
             % Someone may have changed the config for
             % the writer so we need to re-initialize.

--- a/src/couch_log/test/eunit/couch_log_config_test.erl
+++ b/src/couch_log/test/eunit/couch_log_config_test.erl
@@ -25,7 +25,9 @@ couch_log_config_test_() ->
             fun check_level/0,
             fun check_max_message_size/0,
             fun check_bad_level/0,
-            fun check_bad_max_message_size/0
+            fun check_bad_max_message_size/0,
+            fun check_strip_last_msg/0,
+            fun check_bad_strip_last_msg/0
         ]
     }.
 
@@ -107,4 +109,37 @@ check_bad_max_message_size() ->
         config:delete("log", "max_message_size"),
         couch_log_test_util:wait_for_config(),
         ?assertEqual(16000, couch_log_config:get(max_message_size))
+    end).
+
+
+check_strip_last_msg() ->
+    % Default is true
+    ?assertEqual(true, couch_log_config:get(strip_last_msg)),
+
+    couch_log_test_util:with_config_listener(fun() ->
+        config:set("log", "strip_last_msg", "false"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(false, couch_log_config:get(strip_last_msg)),
+
+        config:delete("log", "strip_last_msg"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(true, couch_log_config:get(strip_last_msg))
+    end).
+
+check_bad_strip_last_msg() ->
+    % Default is true
+    ?assertEqual(true, couch_log_config:get(strip_last_msg)),
+
+    couch_log_test_util:with_config_listener(fun() ->
+        config:set("log", "strip_last_msg", "false"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(false, couch_log_config:get(strip_last_msg)),
+
+        config:set("log", "strip_last_msg", "this is not a boolean"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(true, couch_log_config:get(strip_last_msg)),
+
+        config:delete("log", "strip_last_msg"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(true, couch_log_config:get(strip_last_msg))
     end).

--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -20,6 +20,7 @@
 -export([index_file_exists/1]).
 -export([update_local_purge_doc/2, verify_index_exists/2]).
 -export([ensure_local_purge_docs/2]).
+-export([format_status/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch_mrview/include/couch_mrview.hrl").
@@ -315,3 +316,9 @@ update_local_purge_doc(Db, State, PSeq) ->
             BaseDoc
     end,
     couch_db:update_doc(Db, Doc, []).
+
+
+format_status(_Opt, [_PDict, State]) ->
+    [{data, [{"State", ?record_without(mrst, State, [
+        lib, views, id_btree, doc_acc, doc_queue, write_queue
+    ])}]}].

--- a/src/couch_peruser/src/couch_peruser.erl
+++ b/src/couch_peruser/src/couch_peruser.erl
@@ -19,7 +19,7 @@
 
 % gen_server callbacks
 -export([start_link/0, init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         terminate/2, code_change/3, format_status/2]).
 
 -export([init_changes_handler/1, changes_handler/3]).
 
@@ -410,3 +410,31 @@ terminate(_Reason, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    #state{
+        parent = Parent,
+        db_name = DbName,
+        delete_dbs = DeleteDbs,
+        states = States,
+        mem3_cluster_pid = Mem3Cluster,
+        cluster_stable = ClusterStable,
+        q_for_peruser_db = Q,
+        peruser_dbname_prefix = PerUserDbPrefix
+    } = State,
+    Length = fun
+        (undefined) -> 0;
+        (List) -> length(List)
+    end,
+    MapState = #{
+        parent => Parent,
+        db_name => DbName,
+        delete_dbs => DeleteDbs,
+        states => Length(States),
+        mem3_cluster_pid => Mem3Cluster,
+        cluster_stable => ClusterStable,
+        q_for_peruser_db => Q,
+        peruser_dbname_prefix => PerUserDbPrefix
+    },
+    [{data, [{"State", MapState}]}].

--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -184,12 +184,12 @@ code_change(_OldVsn, State, _Extra) ->
 
 
 format_status(_Opt, [_PDict, State]) ->
-    [
-        {epoch, State#state.epoch},
-        {user, State#state.user},
-        {session_url, State#state.session_url},
-        {refresh_tstamp, State#state.refresh_tstamp}
-    ].
+    [{data, [{"State", #{
+        epoch => State#state.epoch,
+        user => State#state.user,
+        session_url => couch_util:url_strip_password(State#state.session_url),
+        refresh_tstamp => State#state.refresh_tstamp
+    }}]}].
 
 
 %% Private helper functions

--- a/src/couch_replicator/src/couch_replicator_connection.erl
+++ b/src/couch_replicator/src/couch_replicator_connection.erl
@@ -25,7 +25,8 @@
    handle_call/3,
    handle_info/2,
    handle_cast/2,
-   code_change/3
+   code_change/3,
+   format_status/2
 ]).
 
 -export([
@@ -226,6 +227,17 @@ code_change(_OldVsn, State, _Extra) ->
 
 terminate(_Reason, _State) ->
     ok.
+
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    #state{
+        close_interval = CloseInterval,
+        timer = Timer
+    } = State,
+    [{data, [{"State", #{
+        close_interval => CloseInterval,
+        timer => Timer
+    }}]}].
 
 
 maybe_log_worker_death(_Host, _Port, normal) ->

--- a/src/couch_replicator/src/couch_replicator_httpc_pool.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc_pool.erl
@@ -20,7 +20,7 @@
 
 % gen_server API
 -export([init/1, handle_call/3, handle_info/2, handle_cast/2]).
--export([code_change/3, terminate/2]).
+-export([code_change/3, terminate/2, format_status/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -144,6 +144,20 @@ code_change(_OldVsn, #state{}=State, _Extra) ->
 
 terminate(_Reason, _State) ->
     ok.
+
+
+format_status(_Opt, [_PDict, State]) ->
+    #state{
+        url = Url,
+        proxy_url = ProxyURL,
+        limit = Limit
+    } = State,
+    [{data, [{"State", #{
+        url => couch_util:url_strip_password(Url),
+        proxy_url => ProxyURL,
+        limit => Limit
+    }}]}].
+
 
 monitor_client(Callers, Worker, {ClientPid, _}) ->
     [{Worker, erlang:monitor(process, ClientPid)} | Callers].

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -344,11 +344,11 @@ terminate(_Reason, _State) ->
 
 
 format_status(_Opt, [_PDict, State]) ->
-    [
-         {max_jobs, State#state.max_jobs},
-         {running_jobs, running_job_count()},
-         {pending_jobs, pending_job_count()}
-    ].
+    [{data, [{"State", #{
+        max_jobs => State#state.max_jobs,
+        running_jobs => running_job_count(),
+        pending_jobs => pending_job_count()
+    }}]}].
 
 
 %% config listener functions

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -430,20 +430,21 @@ format_status(_Opt, [_PDict, State]) ->
        doc_id = DocId,
        db_name = DbName
     } = RepDetails,
-    [
-        {rep_id, RepId},
-        {source, couch_replicator_api_wrap:db_uri(Source)},
-        {target, couch_replicator_api_wrap:db_uri(Target)},
-        {db_name, DbName},
-        {doc_id, DocId},
-        {options, Options},
-        {session_id, SessionId},
-        {start_seq, StartSeq},
-        {source_seq, SourceSeq},
-        {committed_seq, CommitedSeq},
-        {current_through_seq, ThroughSeq},
-        {highest_seq_done, HighestSeqDone}
-    ].
+    [{data, [{"State", #{
+        rep_id => RepId,
+        source => couch_replicator_api_wrap:db_uri(Source),
+        target => couch_replicator_api_wrap:db_uri(Target),
+        db_name => DbName,
+        doc_id => DocId,
+        options => Options,
+        session_id => SessionId,
+        start_seq => StartSeq,
+        source_seq => SourceSeq,
+        committed_seq => CommitedSeq,
+        current_through_seq => ThroughSeq,
+        highest_seq_done => HighestSeqDone
+    }}]}].
+
 
 
 startup_jitter() ->
@@ -1072,19 +1073,18 @@ scheduler_job_format_status_test() ->
         current_through_seq = <<"4">>,
         highest_seq_done = <<"5">>
     },
-    Format = format_status(opts_ignored, [pdict, State]),
-    ?assertEqual("http://u:*****@h1/d1/", proplists:get_value(source, Format)),
-    ?assertEqual("http://u:*****@h2/d2/", proplists:get_value(target, Format)),
-    ?assertEqual({"base", "+ext"}, proplists:get_value(rep_id, Format)),
-    ?assertEqual([{create_target, true}], proplists:get_value(options, Format)),
-    ?assertEqual(<<"mydoc">>, proplists:get_value(doc_id, Format)),
-    ?assertEqual(<<"mydb">>, proplists:get_value(db_name, Format)),
-    ?assertEqual(<<"a">>, proplists:get_value(session_id, Format)),
-    ?assertEqual(<<"1">>, proplists:get_value(start_seq, Format)),
-    ?assertEqual(<<"2">>, proplists:get_value(source_seq, Format)),
-    ?assertEqual(<<"3">>, proplists:get_value(committed_seq, Format)),
-    ?assertEqual(<<"4">>, proplists:get_value(current_through_seq, Format)),
-    ?assertEqual(<<"5">>, proplists:get_value(highest_seq_done, Format)).
-
+    [{data, [{"State", Format}]}] = format_status(opts_ignored, [pdict, State]),
+    ?assertEqual("http://u:*****@h1/d1/", maps:get(source, Format)),
+    ?assertEqual("http://u:*****@h2/d2/", maps:get(target, Format)),
+    ?assertEqual({"base", "+ext"}, maps:get(rep_id, Format)),
+    ?assertEqual([{create_target, true}], maps:get(options, Format)),
+    ?assertEqual(<<"mydoc">>, maps:get(doc_id, Format)),
+    ?assertEqual(<<"mydb">>, maps:get(db_name, Format)),
+    ?assertEqual(<<"a">>, maps:get(session_id, Format)),
+    ?assertEqual(<<"1">>, maps:get(start_seq, Format)),
+    ?assertEqual(<<"2">>, maps:get(source_seq, Format)),
+    ?assertEqual(<<"3">>, maps:get(committed_seq, Format)),
+    ?assertEqual(<<"4">>, maps:get(current_through_seq, Format)),
+    ?assertEqual(<<"5">>, maps:get(highest_seq_done, Format)).
 
 -endif.

--- a/src/couch_replicator/src/couch_replicator_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_worker.erl
@@ -195,15 +195,16 @@ format_status(_Opt, [_PDict, State]) ->
         pending_fetch = PendingFetch,
         batch = #batch{size = BatchSize}
     } = State,
-    [
-        {main_pid, MainJobPid},
-        {loop, LoopPid},
-        {source, couch_replicator_api_wrap:db_uri(Source)},
-        {target, couch_replicator_api_wrap:db_uri(Target)},
-        {num_readers, length(Readers)},
-        {pending_fetch, PendingFetch},
-        {batch_size, BatchSize}
-    ].
+    [{data, [{"State", #{
+        main_pid => MainJobPid,
+        loop => LoopPid,
+        source => couch_replicator_api_wrap:db_uri(Source),
+        target => couch_replicator_api_wrap:db_uri(Target),
+        num_readers => length(Readers),
+        pending_fetch => PendingFetch,
+        batch_size => BatchSize
+    }}]}].
+
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -478,13 +479,14 @@ replication_worker_format_status_test() ->
         pending_fetch = nil,
         batch = #batch{size = 5}
     },
-    Format = format_status(opts_ignored, [pdict, State]),
-    ?assertEqual(self(), proplists:get_value(main_pid, Format)),
-    ?assertEqual(self(), proplists:get_value(loop, Format)),
-    ?assertEqual("http://u:*****@h/d1", proplists:get_value(source, Format)),
-    ?assertEqual("http://u:*****@h/d2", proplists:get_value(target, Format)),
-    ?assertEqual(3, proplists:get_value(num_readers, Format)),
-    ?assertEqual(nil, proplists:get_value(pending_fetch, Format)),
-    ?assertEqual(5, proplists:get_value(batch_size, Format)).
+    [{data, [{"State", Format}]}] = format_status(opts_ignored, [pdict, State]),
+    io:format(user, "Format: ~p~n", [Format]),
+    ?assertEqual(self(), maps:get(main_pid, Format)),
+    ?assertEqual(self(), maps:get(loop, Format)),
+    ?assertEqual("http://u:*****@h/d1", maps:get(source, Format)),
+    ?assertEqual("http://u:*****@h/d2", maps:get(target, Format)),
+    ?assertEqual(3, maps:get(num_readers, Format)),
+    ?assertEqual(nil, maps:get(pending_fetch, Format)),
+    ?assertEqual(5, maps:get(batch_size, Format)).
 
 -endif.

--- a/src/custodian/src/custodian_db_checker.erl
+++ b/src/custodian/src/custodian_db_checker.erl
@@ -24,7 +24,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 -export([
@@ -82,6 +83,10 @@ handle_info(Msg, St) ->
 
 code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
+
+
+format_status(_Opt, [_PDict, #st{checker = Checker} = State]) ->
+    [{data, [{"State", #{checker => Checker}}]}].
 
 
 restart_checker(#st{checker=undefined}=St) ->

--- a/src/custodian/src/custodian_server.erl
+++ b/src/custodian/src/custodian_server.erl
@@ -20,7 +20,7 @@
 
 % gen_server api.
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-    code_change/3, terminate/2]).
+    code_change/3, terminate/2, format_status/2]).
 
 % exported for callback.
 -export([
@@ -118,6 +118,19 @@ code_change(?VSN_0_2_7, State, _Extra) ->
     {ok, State};
 code_change(_OldVsn, #state{}=State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    #state{
+        event_listener = EventListener,
+        shard_checker = ShardChecker,
+        rescan = Rescan
+    } = State,
+    [{data, [{"State", #{
+        event_listener => EventListener,
+        shard_checker => ShardChecker,
+        rescan => Rescan
+    }}]}].
 
 % private functions
 

--- a/src/ddoc_cache/src/ddoc_cache.hrl
+++ b/src/ddoc_cache/src/ddoc_cache.hrl
@@ -32,6 +32,16 @@
     clients
 }).
 
+-define(record_to_map(RecordName, Record),
+    element(1, lists:foldl(fun(Field, {Map, Idx}) ->
+        {
+            maps:put(Field, element(Idx, Record), Map),
+            Idx + 1
+        }
+    end, {#{}, 2}, record_info(fields, RecordName)))).
+
+-define(record_without(RecordName, Record, Keys),
+    maps:without(Keys, ?record_to_map(RecordName, Record))).
 
 -ifdef(TEST).
 -define(EVENT(Name, Arg), ddoc_cache_ev:event(Name, Arg)).

--- a/src/ddoc_cache/src/ddoc_cache_entry.erl
+++ b/src/ddoc_cache/src/ddoc_cache_entry.erl
@@ -34,7 +34,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 -export([
@@ -280,6 +281,17 @@ handle_info(Msg, St) ->
 
 code_change(_, St, _) ->
     {ok, St}.
+
+
+format_status(_Opt, [_PDict, #st{waiters = undefined} = State]) ->
+    MapState = maps:put(number_of_waiters, 0,
+        ?record_without(st, State, [waiters])),
+    [{data, [{"State", MapState}]}];
+
+format_status(_Opt, [_PDict, #st{waiters = Waiters} = State]) ->
+    MapState = maps:put(number_of_waiters, length(Waiters),
+        ?record_without(st, State, [waiters])),
+    [{data, [{"State", MapState}]}].
 
 
 spawn_opener(Key) ->

--- a/src/ddoc_cache/src/ddoc_cache_lru.erl
+++ b/src/ddoc_cache/src/ddoc_cache_lru.erl
@@ -28,7 +28,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 -export([
@@ -225,6 +226,10 @@ handle_info(Msg, St) ->
 
 code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
+
+
+format_status(_Opt, [_PDict, #st{} = State]) ->
+    [{data, [{"State", ?record_to_map(st, State)}]}].
 
 
 handle_db_event(ShardDbName, created, St) ->

--- a/src/dreyfus/src/dreyfus_index.erl
+++ b/src/dreyfus/src/dreyfus_index.erl
@@ -29,7 +29,7 @@
 
 % gen_server api.
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
-    code_change/3]).
+    code_change/3, format_status/2]).
 
 % private definitions.
 -record(state, {
@@ -243,6 +243,12 @@ terminate(_Reason, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #state{waiting_list = Waiters} = State]) ->
+    MapState = maps:put(number_of_waiters, length(Waiters),
+        ?record_without(state, State, [waiting_list])),
+    [{data, [{"State", MapState}]}].
 
 % private functions.
 

--- a/src/global_changes/src/global_changes_server.erl
+++ b/src/global_changes/src/global_changes_server.erl
@@ -25,7 +25,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 -export([
@@ -143,6 +144,9 @@ handle_info(_, State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    [{data, [{"State", ?record_without(state, State, [pending_updates])}]}].
 
 
 flush_updates(State) ->

--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -29,7 +29,8 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3
+    code_change/3,
+    format_status/2
 ]).
 
 
@@ -126,6 +127,13 @@ handle_info(Msg, St) ->
 
 code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
+
+
+format_status(_Opt, [_PDict, State]) ->
+    #st{
+        timeout = Timeout
+    } = State,
+    [{data, [{"State", #{timeout => Timeout}}]}].
 
 
 map_doc(#st{indexes=Indexes}, Doc) ->

--- a/src/rexi/src/rexi_buffer.erl
+++ b/src/rexi/src/rexi_buffer.erl
@@ -16,7 +16,7 @@
 
 %  gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         terminate/2, code_change/3, format_status/2]).
 
 -export ([
     send/2,
@@ -94,6 +94,19 @@ code_change(_OldVsn, {state, Buffer, Sender, Count}, _Extra) ->
     {ok, #state{buffer=Buffer, sender=Sender, count=Count, max_count=Max}};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    %% We don't include queue:len(State#state.buffer), because it is O(n)
+    #state{
+        sender = Sender,
+        count = Count,
+        max_count = MaxCount
+    } = State,
+    [{data, [{"State", #{
+            sender => Sender,
+            count => Count,
+            max_count => MaxCount
+    }}]}].
 
 should_drop(#state{count = Count, max_count = Max}) ->
     Count >= Max.

--- a/src/rexi/src/rexi_server.erl
+++ b/src/rexi/src/rexi_server.erl
@@ -14,7 +14,7 @@
 -behaviour(gen_server).
 -vsn(1).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
-    code_change/3]).
+    code_change/3, format_status/2]).
 
 -export([start_link/1, init_p/2, init_p/3]).
 
@@ -124,6 +124,17 @@ terminate(_Reason, St) ->
 
 code_change(_OldVsn, #st{}=State, _Extra) ->
     {ok, State}.
+
+format_status(_Opt, [_PDict, #st{} = State]) ->
+    #st{
+        error_limit = ErrorLimit,
+        error_count = ErrorCount
+    } = State,
+    %% We don't return ets tables because they are gone anyway
+    [{data, [{"State", #{
+        error_limit => ErrorLimit,
+        error_count => ErrorCount
+    }}]}].
 
 init_p(From, MFA) ->
     init_p(From, MFA, undefined).

--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -165,7 +165,7 @@ enable_cluster_int(Options, false) ->
     couch_log:debug("Enable Cluster: ~p~n", [Options]).
 
 set_admin(Username, Password) ->
-    config:set("admins", binary_to_list(Username), binary_to_list(Password)).
+    config:set("admins", binary_to_list(Username), binary_to_list(Password), #{sensitive => true}).
 
 setup_node(NewCredentials, NewBindAddress, NodeCount, Port) ->
     case NewCredentials of

--- a/src/setup/src/setup_httpd.erl
+++ b/src/setup/src/setup_httpd.erl
@@ -19,7 +19,7 @@ handle_setup_req(#httpd{method='POST'}=Req) ->
     ok = chttpd:verify_is_server_admin(Req),
     couch_httpd:validate_ctype(Req, "application/json"),
     Setup = get_body(Req),
-    couch_log:notice("Setup: ~p~n", [Setup]),
+    couch_log:notice("Setup: ~p~n", [remove_sensitive(Setup)]),
     Action = binary_to_list(couch_util:get_value(<<"action">>, Setup, <<"missing">>)),
     case handle_action(Action, Setup) of
     ok ->
@@ -91,7 +91,7 @@ handle_action("enable_cluster", Setup) ->
 
 
 handle_action("finish_cluster", Setup) ->
-    couch_log:notice("finish_cluster: ~p~n", [Setup]),
+    couch_log:notice("finish_cluster: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {ensure_dbs_exist, <<"ensure_dbs_exist">>}
@@ -105,7 +105,7 @@ handle_action("finish_cluster", Setup) ->
     end;
 
 handle_action("enable_single_node", Setup) ->
-    couch_log:notice("enable_single_node: ~p~n", [Setup]),
+    couch_log:notice("enable_single_node: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {ensure_dbs_exist, <<"ensure_dbs_exist">>},
@@ -125,7 +125,7 @@ handle_action("enable_single_node", Setup) ->
 
 
 handle_action("add_node", Setup) ->
-    couch_log:notice("add_node: ~p~n", [Setup]),
+    couch_log:notice("add_node: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {username, <<"username">>},
@@ -147,10 +147,10 @@ handle_action("add_node", Setup) ->
     end;
 
 handle_action("remove_node", Setup) ->
-    couch_log:notice("remove_node: ~p~n", [Setup]);
+    couch_log:notice("remove_node: ~p~n", [remove_sensitive(Setup)]);
 
 handle_action("receive_cookie", Setup) ->
-    couch_log:notice("receive_cookie: ~p~n", [Setup]),
+    couch_log:notice("receive_cookie: ~p~n", [remove_sensitive(Setup)]),
     Options = get_options([
        {cookie, <<"cookie">>}
     ], Setup),
@@ -173,3 +173,8 @@ get_body(Req) ->
         couch_log:notice("Body Fail: ~p~n", [Else]),
         couch_httpd:send_error(Req, 400, <<"bad_request">>, <<"Missing JSON body'">>)
     end.
+
+remove_sensitive(KVList0) ->
+    KVList1 = lists:keyreplace(<<"username">>, 1, KVList0, {<<"username">>, <<"****">>}),
+    KVList2 = lists:keyreplace(<<"password">>, 1, KVList1, {<<"password">>, <<"****">>}),
+    KVList2.

--- a/src/smoosh/src/smoosh_server.erl
+++ b/src/smoosh/src/smoosh_server.erl
@@ -32,7 +32,7 @@
 
 % gen_server api.
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-    code_change/3, terminate/2]).
+    code_change/3, terminate/2, format_status/2]).
 
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
@@ -221,6 +221,27 @@ code_change(_OldVsn, {state, DbChannels, ViewChannels, Tab,
             waiting=Waiting}};
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    #state{
+        db_channels = DbChannels,
+        view_channels = ViewChannels,
+        schema_channels = SchemaChannels,
+        tab = Tab,
+        event_listener = EventListener,
+        waiting = Waiters
+    } = State,
+    MapState = #{
+        number_of_db_channels => length(DbChannels),
+        number_of_view_channels => length(ViewChannels),
+        number_of_schema_channels => length(SchemaChannels),
+        tab => Tab,
+        event_listener => EventListener,
+        number_of_waiters => dict:size(Waiters)
+    },
+    [{data, [{"State", MapState}]}].
+
 
 % private functions.
 


### PR DESCRIPTION
## Overview

Port https://github.com/apache/couchdb/pull/3031 (Clean up logs) into 3.x branch.

This PR deals with cleaning up logs from user's data (potentially sensitive) in the cases when OTP processes crash. All commits except "Add format_status/2 callback in gen_server implementations" were cherry picked from https://github.com/apache/couchdb/pull/3031. The "Add format_status/2 callback in gen_server implementations" was extended to include applications relevant for 3.x.

## Testing recommendations

I tested it by running test suite and by comparing logs before and after. I did use following query to reduce noise.

```
find src/ -name couch.log | xargs -I '{}' cat '{}' | grep error | grep -v 'No Admin Account configured' | grep -v 'no_db_file' | grep -v 'no such file' | grep -v 'Request to create N=' | grep -v 'ddoc_cache_ev :: ' | grep -v '"error":"not_found"' | grep -v 'httpd 404' | grep -v boom | grep -v bam | grep -v forbidden | grep -v request_body_too | grep -v xxxxxxxxxxxxxxxxxxxxxxxxx | grep -v 'http 405' | grep -v method_not_allowed | grep -v db_not_found | grep -v 'source missing' | grep -v missing_source | grep -v 'list of tags' | grep -v 'Failed to set security object on' | grep -v 'fabric_rpc:group_info/2 exit:{killed,' | grep -v 'mem3_reshard db monitor' | grep -v unauthorized | grep -v too_large | grep -v 'httpd 413' | grep -v 'httpd 405' | grep -v not_acceptable | grep -v 'httpd [0-9]*' | grep -v 'unsupported encoding' | grep -v content_md5_mismatch | grep -v changes_req_failed | grep -v 'ignoring document with empty ID' | grep -v 'some_id <<"fail">>' | grep -v query_parse_error | grep -v 'Db was deleted' | grep -v kapow | grep -v bad_content_type | grep -v 'purge-test-stuff' | grep -v '{file,"src/couch_native_process.erl"},{line,258}' | grep -v 'file already exists' | grep -v 'Expression does not eval' | grep -v 'Transient job' | grep -v 'mem3_reshard_job cleaning' | grep -v 'mem3_reshard_job source' | grep -v 'Purge checkpoin' | grep -v 'missing_target' | grep -v 'target db missing'
```

I did run `make eunit` on vanilla 3.x branch and redirected the output of the above query into a file `3.x.vanilla.log`. Then I did remove all `couch.log` files and switched to `clean-up-logs-3.x` branch and repeated the process. The result is saved in `3.x.updated.log`. I did compare two files manually.

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/pull/3031

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
