### PR TITLE
Read and validate JSON payload on POST to _changes

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -85,7 +85,13 @@ handle_request(#httpd{path_parts=[DbName|RestParts],method=Method}=Req)->
 
 handle_changes_req(#httpd{method='POST'}=Req, Db) ->
     chttpd:validate_ctype(Req, "application/json"),
-    handle_changes_req1(Req, Db);
+    case chttpd:body_length(Req) of
+        0 ->
+            handle_changes_req1(Req, Db);
+        _ ->
+            {JsonProps} = chttpd:json_body_obj(Req),
+            handle_changes_req1(Req#httpd{req_body = {JsonProps}}, Db)
+    end;
 handle_changes_req(#httpd{method='GET'}=Req, Db) ->
     handle_changes_req1(Req, Db);
 handle_changes_req(#httpd{path_parts=[_,<<"_changes">>]}=Req, _Db) ->

--- a/src/couch/src/couch_changes.erl
+++ b/src/couch/src/couch_changes.erl
@@ -238,7 +238,7 @@ filter(Db, DocInfo, {view, Style, DDoc, VName}) ->
 filter(Db, DocInfo, {custom, Style, Req0, DDoc, FName}) ->
     Req = case Req0 of
         {json_req, _} -> Req0;
-        #httpd{} -> {json_req, couch_httpd_external:json_req_obj(Req0, Db)}
+        #httpd{} -> {json_req, chttpd_external:json_req_obj(Req0, Db)}
     end,
     Docs = open_revs(Db, DocInfo, Style),
     {ok, Passes} = couch_query_servers:filter_docs(Req, Db, DDoc, FName, Docs),


### PR DESCRIPTION
## Overview

During `POST` on `/{db}/_changes` with a custom filter, nodes attempt to [read the request payload](https://github.com/apache/couchdb/blob/3.x/src/couch/src/couch_changes.erl#L241), unless the request body already stored on a request record. When this is happening on a node foreign to the original http request, reader process quits with `exit:normal` and as a result the whole fabric request hangs until a timeout.

This patch switches filter reader to `chttpd_external:json_req_obj/2` for more descriptive exit message, adds reading of the payload on the request handler and validates that payload, when present, is a proper JSON object.

## Testing recommendations

Related tests been added to the elixir tests

`make elixir tests=test/elixir/test/changes_test.exs`

## Related Issues or Pull Requests

Closes #3087 

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
