### PR TITLE
Configure sensitive config values for redaction

### DIFF
--- a/rel/apps/config.config
+++ b/rel/apps/config.config
@@ -1,0 +1,4 @@
+{sensitive, #{
+    "admins" => all,
+    "replicator" => ["password"]
+}}.


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This defines a configuration file which specifies sections and fields
for config values that are redacted from logs. Specifically, all
values from the "admins" section and the value of "password" in the
"replicator" section are redacted.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

This must be tested with its companion PR below.

In a remsh, set an admin password: `config:set("admins", "admin1", "secretpassword").`, and then reload: `config:reload().` and you should see the following redactions in the log:
```
[notice] 2021-02-20T06:16:30.672944Z node1@127.0.0.1 <0.196.0> -------- config: [admins] admin1 set to '****' for reason nil
[notice] 2021-02-20T06:17:13.720003Z node1@127.0.0.1 <0.196.0> -------- Reload detected config change admins.admin1 = '****'
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

https://github.com/apache/couchdb-config/pull/35

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
