### PR TITLE
Clean up logs 3.x.v2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -144,7 +144,7 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{config,           "config",           {tag, "2.1.7"}},
+{config,           "config",           {tag, "2.1.8"}},
 {b64url,           "b64url",           {tag, "1.0.2"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},

--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -71,7 +71,9 @@ handle_node_req(#httpd{method='PUT', path_parts=[_, Node, <<"_config">>, Section
     Value = couch_util:trim(chttpd:json_body(Req)),
     Persist = chttpd:header_value(Req, "X-Couch-Persist") /= "false",
     OldValue = call_node(Node, config, get, [Section, Key, ""]),
-    case call_node(Node, config, set, [Section, Key, ?b2l(Value), Persist]) of
+    IsSensitive = Section == <<"admins">>,
+    Opts = #{persist => Persist, sensitive => IsSensitive},
+    case call_node(Node, config, set, [Section, Key, ?b2l(Value), Opts]) of
         ok ->
             send_json(Req, 200, list_to_binary(OldValue));
         {error, Reason} ->

--- a/src/couch_log/src/couch_log_config.erl
+++ b/src/couch_log/src/couch_log_config.erl
@@ -49,7 +49,8 @@ entries() ->
     [
         {level, "level", "info"},
         {level_int, "level", "info"},
-        {max_message_size, "max_message_size", "16000"}
+        {max_message_size, "max_message_size", "16000"},
+        {strip_last_msg, "strip_last_msg", "true"}
      ].
 
 
@@ -97,4 +98,10 @@ transform(max_message_size, SizeStr) ->
         Size -> Size
     catch _:_ ->
         16000
-    end.
+    end;
+
+transform(strip_last_msg, "false") ->
+    false;
+
+transform(strip_last_msg, _) ->
+    true.

--- a/src/couch_log/src/couch_log_config_dyn.erl
+++ b/src/couch_log/src/couch_log_config_dyn.erl
@@ -25,4 +25,5 @@
 
 get(level) -> info;
 get(level_int) -> 2;
-get(max_message_size) -> 16000.
+get(max_message_size) -> 16000;
+get(strip_last_msg) -> true.

--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -68,7 +68,13 @@ format(Event) ->
 
 do_format({error, _GL, {Pid, "** Generic server " ++ _, Args}}) ->
     %% gen_server terminate
-    [Name, LastMsg, State, Reason | Extra] = Args,
+    [Name, LastMsg0, State, Reason | Extra] = Args,
+    LastMsg = case couch_log_config:get(strip_last_msg) of
+        true ->
+            redacted;
+        false ->
+            LastMsg0
+    end,
     MsgFmt = "gen_server ~w terminated with reason: ~s~n" ++
                 "  last msg: ~p~n     state: ~p~n    extra: ~p",
     MsgArgs = [Name, format_reason(Reason), LastMsg, State, Extra],
@@ -76,7 +82,13 @@ do_format({error, _GL, {Pid, "** Generic server " ++ _, Args}}) ->
 
 do_format({error, _GL, {Pid, "** State machine " ++ _, Args}}) ->
     %% gen_fsm terminate
-    [Name, LastMsg, StateName, State, Reason | Extra] = Args,
+    [Name, LastMsg0, StateName, State, Reason | Extra] = Args,
+    LastMsg = case couch_log_config:get(strip_last_msg) of
+        true ->
+            redacted;
+        false ->
+            LastMsg0
+    end,
     MsgFmt = "gen_fsm ~w in state ~w terminated with reason: ~s~n" ++
                 " last msg: ~p~n     state: ~p~n    extra: ~p",
     MsgArgs = [Name, StateName, format_reason(Reason), LastMsg, State, Extra],
@@ -84,7 +96,13 @@ do_format({error, _GL, {Pid, "** State machine " ++ _, Args}}) ->
 
 do_format({error, _GL, {Pid, "** gen_event handler" ++ _, Args}}) ->
     %% gen_event handler terminate
-    [ID, Name, LastMsg, State, Reason] = Args,
+    [ID, Name, LastMsg0, State, Reason] = Args,
+    LastMsg = case couch_log_config:get(strip_last_msg) of
+        true ->
+            redacted;
+        false ->
+            LastMsg0
+    end,
     MsgFmt = "gen_event ~w installed in ~w terminated with reason: ~s~n" ++
                 "  last msg: ~p~n     state: ~p",
     MsgArgs = [ID, Name, format_reason(Reason), LastMsg, State],

--- a/src/couch_log/src/couch_log_sup.erl
+++ b/src/couch_log/src/couch_log_sup.erl
@@ -63,6 +63,8 @@ handle_config_change("log", Key, _, _, S) ->
             couch_log_config:reconfigure();
         "max_message_size" ->
             couch_log_config:reconfigure();
+        "strip_last_msg" ->
+            couch_log_config:reconfigure();
         _ ->
             % Someone may have changed the config for
             % the writer so we need to re-initialize.

--- a/src/couch_log/test/eunit/couch_log_config_test.erl
+++ b/src/couch_log/test/eunit/couch_log_config_test.erl
@@ -25,7 +25,9 @@ couch_log_config_test_() ->
             fun check_level/0,
             fun check_max_message_size/0,
             fun check_bad_level/0,
-            fun check_bad_max_message_size/0
+            fun check_bad_max_message_size/0,
+            fun check_strip_last_msg/0,
+            fun check_bad_strip_last_msg/0
         ]
     }.
 
@@ -107,4 +109,37 @@ check_bad_max_message_size() ->
         config:delete("log", "max_message_size"),
         couch_log_test_util:wait_for_config(),
         ?assertEqual(16000, couch_log_config:get(max_message_size))
+    end).
+
+
+check_strip_last_msg() ->
+    % Default is true
+    ?assertEqual(true, couch_log_config:get(strip_last_msg)),
+
+    couch_log_test_util:with_config_listener(fun() ->
+        config:set("log", "strip_last_msg", "false"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(false, couch_log_config:get(strip_last_msg)),
+
+        config:delete("log", "strip_last_msg"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(true, couch_log_config:get(strip_last_msg))
+    end).
+
+check_bad_strip_last_msg() ->
+    % Default is true
+    ?assertEqual(true, couch_log_config:get(strip_last_msg)),
+
+    couch_log_test_util:with_config_listener(fun() ->
+        config:set("log", "strip_last_msg", "false"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(false, couch_log_config:get(strip_last_msg)),
+
+        config:set("log", "strip_last_msg", "this is not a boolean"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(true, couch_log_config:get(strip_last_msg)),
+
+        config:delete("log", "strip_last_msg"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(true, couch_log_config:get(strip_last_msg))
     end).

--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -165,7 +165,7 @@ enable_cluster_int(Options, false) ->
     couch_log:debug("Enable Cluster: ~p~n", [Options]).
 
 set_admin(Username, Password) ->
-    config:set("admins", binary_to_list(Username), binary_to_list(Password)).
+    config:set("admins", binary_to_list(Username), binary_to_list(Password), #{sensitive => true}).
 
 setup_node(NewCredentials, NewBindAddress, NodeCount, Port) ->
     case NewCredentials of

--- a/src/setup/src/setup_httpd.erl
+++ b/src/setup/src/setup_httpd.erl
@@ -19,7 +19,7 @@ handle_setup_req(#httpd{method='POST'}=Req) ->
     ok = chttpd:verify_is_server_admin(Req),
     couch_httpd:validate_ctype(Req, "application/json"),
     Setup = get_body(Req),
-    couch_log:notice("Setup: ~p~n", [Setup]),
+    couch_log:notice("Setup: ~p~n", [remove_sensitive(Setup)]),
     Action = binary_to_list(couch_util:get_value(<<"action">>, Setup, <<"missing">>)),
     case handle_action(Action, Setup) of
     ok ->
@@ -91,7 +91,7 @@ handle_action("enable_cluster", Setup) ->
 
 
 handle_action("finish_cluster", Setup) ->
-    couch_log:notice("finish_cluster: ~p~n", [Setup]),
+    couch_log:notice("finish_cluster: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {ensure_dbs_exist, <<"ensure_dbs_exist">>}
@@ -105,7 +105,7 @@ handle_action("finish_cluster", Setup) ->
     end;
 
 handle_action("enable_single_node", Setup) ->
-    couch_log:notice("enable_single_node: ~p~n", [Setup]),
+    couch_log:notice("enable_single_node: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {ensure_dbs_exist, <<"ensure_dbs_exist">>},
@@ -125,7 +125,7 @@ handle_action("enable_single_node", Setup) ->
 
 
 handle_action("add_node", Setup) ->
-    couch_log:notice("add_node: ~p~n", [Setup]),
+    couch_log:notice("add_node: ~p~n", [remove_sensitive(Setup)]),
 
     Options = get_options([
         {username, <<"username">>},
@@ -147,10 +147,10 @@ handle_action("add_node", Setup) ->
     end;
 
 handle_action("remove_node", Setup) ->
-    couch_log:notice("remove_node: ~p~n", [Setup]);
+    couch_log:notice("remove_node: ~p~n", [remove_sensitive(Setup)]);
 
 handle_action("receive_cookie", Setup) ->
-    couch_log:notice("receive_cookie: ~p~n", [Setup]),
+    couch_log:notice("receive_cookie: ~p~n", [remove_sensitive(Setup)]),
     Options = get_options([
        {cookie, <<"cookie">>}
     ], Setup),
@@ -173,3 +173,6 @@ get_body(Req) ->
         couch_log:notice("Body Fail: ~p~n", [Else]),
         couch_httpd:send_error(Req, 400, <<"bad_request">>, <<"Missing JSON body'">>)
     end.
+
+remove_sensitive(KVList) ->
+    lists:keyreplace(<<"password">>, 1, KVList, {<<"password">>, <<"****">>}).


### PR DESCRIPTION
## Overview

This PR started as a port of https://github.com/apache/couchdb/pull/3031 (Clean up logs) into 3.x branch. The main goal of the PR is to remove sensitive data from the logs.
However as it was pointed out by reviewers it might be not the right approach to convert shape of gen_server state for a CouchDB version which is already widely deployed. Another problem with the scope of the PR is lack of definition of sensitive data. There are multiple points of view on the sensitive data:

- user credentials
- user documents
- design documents 

This means that there is no generic solution which would fit all. In order to solve this problem for the purposes of this PR the sensitive data are defined as "user credentials". 

Before going further down with description of the solution presented in the PR. I wanted to mention the requirements as I understood them:

1) `sys:get_status/1` should return state as is (wrapped in `[{data, [{"State", Term}]}]`) see http://erlang.org/doc/man/gen_server.html#Module:format_status-2
2) the `couch_log_formatter` should be able to call a configurable sanitizer module which would deal with changing the shape of log entries and removing user's data from terms
3) "user credentials" should be removed from state for both `sys:get_status/1` use case and termination of a process.

In order to achieve 1) we need to handle `:format_status(normal, ...)` and `:format_status(terminate, ...)` differently.

In order to achieve 2) we need to pass the callback module name so it is available in `couch_log_formatter`. We also pass the process dictionary so sanitizer module could get some meta information about the process (for example tracing span_id). The process dictionary is not logged by default. However sanitizer module can include elements from process dictionary in a term it returns. 

The approach to `format_status/2` is to return term as is when first argument is `normal` in order for `sys:get_status` to return original term. In both cases we remove "sensitive data" before returning the term from `format_status/2`. The `terminate` clause of a `format_status/2` returns `{Term, Ctx :: map()}`. The `Ctx` includes `module` and `dictionary` keys for now. We need this information so sanitizer could distinguish messages coming from different gen_servers.

## Testing recommendations

`make eunit`

## Related Issues or Pull Requests

- [ ] https://github.com/apache/couchdb/pull/3372 - previous attempt
- [ ] https://github.com/apache/couchdb/pull/3031 - implementation on main

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
