### PR TITLE
Fix view row bug

### DIFF
--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -42,10 +42,10 @@ indexer_test_() ->
                     ?TDEF_FE(updated_docs_without_changes_are_reindexed),
                     ?TDEF_FE(deleted_docs_not_indexed),
                     ?TDEF_FE(deleted_docs_are_unindexed),
-                    ?TDEF_FE(multipe_docs_with_same_key),
-                    ?TDEF_FE(multipe_keys_from_same_doc),
-                    ?TDEF_FE(multipe_identical_keys_from_same_doc),
-                    ?TDEF_FE(fewer_multipe_identical_keys_from_same_doc),
+                    ?TDEF_FE(multiple_docs_with_same_key),
+                    ?TDEF_FE(multiple_keys_from_same_doc),
+                    ?TDEF_FE(multiple_identical_keys_from_same_doc),
+                    ?TDEF_FE(fewer_multiple_identical_keys_from_same_doc),
                     ?TDEF_FE(multiple_design_docs),
                     ?TDEF_FE(handle_size_key_limits),
                     ?TDEF_FE(handle_size_value_limits),
@@ -216,7 +216,7 @@ deleted_docs_are_unindexed(Db) ->
     end).
 
 
-multipe_docs_with_same_key(Db) ->
+multiple_docs_with_same_key(Db) ->
     DDoc = create_ddoc(),
     Doc1 = doc(0, 1),
     Doc2 = doc(1, 1),
@@ -232,7 +232,7 @@ multipe_docs_with_same_key(Db) ->
     ], Out).
 
 
-multipe_keys_from_same_doc(Db) ->
+multiple_keys_from_same_doc(Db) ->
     DDoc = create_ddoc(multi_emit_different),
     Doc = doc(0, 1),
 
@@ -247,7 +247,7 @@ multipe_keys_from_same_doc(Db) ->
     ], Out).
 
 
-multipe_identical_keys_from_same_doc(Db) ->
+multiple_identical_keys_from_same_doc(Db) ->
     DDoc = create_ddoc(multi_emit_same),
     Doc = doc(0, 1),
 
@@ -262,7 +262,7 @@ multipe_identical_keys_from_same_doc(Db) ->
     ], Out).
 
 
-fewer_multipe_identical_keys_from_same_doc(Db) ->
+fewer_multiple_identical_keys_from_same_doc(Db) ->
     DDoc = create_ddoc(multi_emit_same),
     Doc0 = #doc{
             id = <<"0">>,

--- a/src/ebtree/src/ebtree.erl
+++ b/src/ebtree/src/ebtree.erl
@@ -173,18 +173,17 @@ lookup_multi_fold(_, {_, [], _} = Acc) ->
     {stop, Acc};
 
 lookup_multi_fold({visit, Key1, Value}, {Tree, [Key2 | Rest], Acc}) ->
-    {NewKeys, NewAcc} = case collate(Tree, Key1, Key2) of
+    case collate(Tree, Key1, Key2) of
         lt ->
             % Still looking for the next user key
-            {[Key2 | Rest], Acc};
+            {ok, {Tree, [Key2 | Rest], Acc}};
         eq ->
             % Found a requested key
-            {Rest, [{Key2, Value} | Acc]};
+            {ok, {Tree, Rest, [{Key2, Value} | Acc]}};
         gt ->
             % The user key wasn't found so we drop it
-            {Rest, Acc}
-    end,
-    {ok, {Tree, NewKeys, NewAcc}};
+            lookup_multi_fold({visit, Key1, Value}, {Tree, Rest, Acc})
+    end;
 
 lookup_multi_fold({traverse, FKey, LKey, R}, {Tree, [UKey | Rest], Acc}) ->
     case collate(Tree, FKey, UKey, [gt]) of

--- a/src/ebtree/src/ebtree.erl
+++ b/src/ebtree/src/ebtree.erl
@@ -1394,7 +1394,8 @@ lookup_multi_test() ->
     validate_tree(Db, Tree),
     ?assertEqual([{1, 2}], lookup_multi(Db, Tree, [1])),
     ?assertEqual([{15, 16}, {2, 3}], lookup_multi(Db, Tree, [2, 15])),
-    ?assertEqual([{15, 16}, {4, 5}, {2, 3}], lookup_multi(Db, Tree, [2, 101, 15, 4, -3])).
+    ?assertEqual([{15, 16}, {4, 5}, {2, 3}], lookup_multi(Db, Tree, [2, 101, 15, 4, -3])),
+    ?assertEqual([{2, 3}], lookup_multi(Db, Tree, [1.5, 2])).
 
 
 insert_multi_test() ->


### PR DESCRIPTION
## Overview

There was a bug in `ebtree:lookup_multi/3` that prevented some lookup keys from matching if they happened to first be compared against another lookup key that doesn't exist.

## Testing recommendations

`make check`

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
