### PR TITLE
Set default nodes in dev/run to 1

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -128,7 +128,7 @@ def get_args_parser():
         "-n",
         "--nodes",
         metavar="nodes",
-        default=3,
+        default=1,
         type=int,
         help="Number of development nodes to be spun up",
     )
@@ -155,7 +155,7 @@ def get_args_parser():
     parser.add_option(
         "--no-join",
         dest="no_join",
-        default=False,
+        default=True,
         action="store_true",
         help="Do not join nodes on boot",
     )


### PR DESCRIPTION
## Overview

Since `main` isn't necessarily clustered as it was "pre-`main`", setting the default node number to 1 makes startup times quicker.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests - N/A
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini` - N/A
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation - N/A
