### PR TITLE
Consistent view emits using indexer's GRVs and committed versionstamps

### DIFF
--- a/src/couch_views/include/couch_views.hrl
+++ b/src/couch_views/include/couch_views.hrl
@@ -40,3 +40,8 @@
 % indexing progress
 -define(INDEX_BUILDING, <<"building">>).
 -define(INDEX_READY, <<"ready">>).
+
+% Views/db marker to indicate that the current (latest) FDB GRV version should
+% be used. Use `null` so it can can be round-tripped through json serialization
+% with couch_jobs.
+-define(VIEW_CURRENT_VSN, null).

--- a/src/couch_views/src/couch_views_jobs.erl
+++ b/src/couch_views/src/couch_views_jobs.erl
@@ -122,10 +122,6 @@ wait_for_job(JobId, Subscription, DDocId, UpdateSeq) ->
             {ok, idx_vstamps(JobData)};
         {finished, _} ->
             wait_for_job(JobId, DDocId, UpdateSeq);
-        {_State, #{<<"view_seq">> := ViewSeq} = JobData}
-                when ViewSeq >= UpdateSeq ->
-            couch_jobs:unsubscribe(Subscription),
-            {ok, idx_vstamps(JobData)};
         {_, _} ->
             wait_for_job(JobId, Subscription, DDocId, UpdateSeq)
     end.

--- a/src/couch_views/test/couch_views_active_tasks_test.erl
+++ b/src/couch_views/test/couch_views_active_tasks_test.erl
@@ -55,6 +55,9 @@ foreach_setup() ->
 
 foreach_teardown({Db, _}) ->
     meck:unload(),
+    fabric2_fdb:transactional(Db, fun(TxDb) ->
+        couch_views:cleanup_indices(TxDb, [])
+    end),
     ok = fabric2_db:delete(fabric2_db:name(Db), []).
 
 

--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -373,7 +373,8 @@ index_autoupdater_callback(Db) ->
     ?assertMatch([{ok, <<_/binary>>}], Result),
     [{ok, JobId}] = Result,
 
-    ?assertEqual(ok, couch_views_jobs:wait_for_job(JobId, DDoc#doc.id, DbSeq)).
+    ?assertMatch({ok, {_, _}},
+        couch_views_jobs:wait_for_job(JobId, DDoc#doc.id, DbSeq)).
 
 
 multiple_design_docs(Db) ->


### PR DESCRIPTION

View indexer saves both the GRV it used during the view update, and
the committed versionstamp in the couch_jobs job data section. Then,
the view reader uses those versionstamps to emit a consistent snapshot
of the view.

  * The committed versionstamp ensures that the view results can be
    emitted even if the view gets updated between the time the view
    finished and the reader gets notified.

  * The indexer GRV ensures that the view will emit the same doc
    revisions in case when include_docs=true option is used as what it
    read during the time it indexed the data.

The view reader uses those two versionstamps only if it initiates the
view build itself and then waits for it to build, to ensure that it
doesn't operate on stale GRVs.

Because the committed version is only available after the main
transaction commits, during view indexing finalization there is now a
separate transaction which runs at the end which reads the committed
version then marks the view as `finished`.

Since included docs have to be read at the indexer's GRV version, and,
that version is different than the committed version, those documents
are loaded in from a separate process.

There are a few complications introduced by this commit:

   * The versionstamps, especially the indexer GRV ones, may become
     stale (older than 5 seconds) quickly and start throwing 1007
     (transaction_too_old) errors. This could be mitigated by forcing
     the indexer to commit after a shorter interval (1-2 seconds).

   * There is some fragility introduced in respect to how included
     docs are loaded in a separate process. When that crashes or does
     timeout it maybe throw a new type of un-expected error that we
     don't catch properly.

For this to properly work it needs at least two more updates:

https://github.com/apache/couchdb/commit/2e40063aae17658138bfaffa2304b5e461e43e30

https://github.com/apache/couchdb/commit/dbbab649dc5cbca50664ab3f7c33147e6010a106

Issue: https://github.com/apache/couchdb/issues/3381