### PR TITLE
Ignore unchecked JWT claims

### DIFF
--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -188,8 +188,7 @@ validate_alg(Props, Checks) ->
     end.
 
 
-%% Not all these fields have to be present, but if they _are_ present
-%% they must be valid.
+%% Only validate required checks.
 validate_payload(Props, Checks) ->
     validate_iss(Props, Checks),
     validate_iat(Props, Checks),
@@ -202,7 +201,7 @@ validate_iss(Props, Checks) ->
     ActualISS = prop(<<"iss">>, Props),
 
     case {ExpectedISS, ActualISS} of
-        {undefined, undefined} ->
+        {undefined, _} -> % ignore unrequired check
             ok;
         {ISS, undefined} when ISS /= undefined ->
             throw({bad_request, <<"Missing iss claim">>});
@@ -218,11 +217,11 @@ validate_iat(Props, Checks) ->
     IAT = prop(<<"iat">>, Props),
 
     case {Required, IAT} of
-        {undefined, undefined} ->
+        {undefined, _} -> % ignore unrequired check
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing iat claim">>});
-        {_, IAT} when is_integer(IAT) ->
+        {true, IAT} when is_integer(IAT) ->
             ok;
         {true, _} ->
             throw({bad_request, <<"Invalid iat claim">>})
@@ -234,12 +233,12 @@ validate_nbf(Props, Checks) ->
     NBF = prop(<<"nbf">>, Props),
 
     case {Required, NBF} of
-        {undefined, undefined} ->
+        {undefined, _} -> % ignore unrequired check
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing nbf claim">>});
-        {_, IAT} ->
-            assert_past(<<"nbf">>, IAT)
+        {true, NBF} ->
+            assert_past(<<"nbf">>, NBF)
     end.
 
 
@@ -248,11 +247,11 @@ validate_exp(Props, Checks) ->
     EXP = prop(<<"exp">>, Props),
 
     case {Required, EXP} of
-        {undefined, undefined} ->
+        {undefined, _} -> % ignore unrequired check
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing exp claim">>});
-        {_, EXP} ->
+        {true, EXP} ->
             assert_future(<<"exp">>, EXP)
     end.
 
@@ -351,3 +350,20 @@ now_seconds() ->
 
 prop(Prop, Props) ->
     proplists:get_value(Prop, Props).
+
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+validate_payload_ignore_unchecked_props_test() ->
+    ?assertEqual(ok, validate_payload(_Props = [], _Checks = [])),
+    BogusProps = [
+        {iss, bogus},
+        {iat, bogus},
+        {nbf, bogus},
+        {exp, bogus}
+    ],
+    ?assertEqual(ok, validate_payload(BogusProps, _Checks = [])),
+    ok.
+
+-endif.


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Previously, if a JWT claim was present, it was validated regardless of
whether it was required.

However, [according to the spec](https://tools.ietf.org/html/rfc7519#section-4):

> all claims that are not understood by implementations MUST be ignored

which we interpret to mean that we should not attempt to validate
claims we don't require.

With this change, only claims listed in required checks are validated.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=jwtf
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
