### PR TITLE
Relax isolation level when indexer reads from DB

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -153,7 +153,7 @@ DepDescs = [
 %% Independent Apps
 {config,           "config",           {tag, "2.1.8"}},
 {b64url,           "b64url",           {tag, "1.0.2"}},
-{erlfdb,           "erlfdb",           {tag, "v1.2.3"}},
+{erlfdb,           "erlfdb",           {tag, "v1.2.5"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.4"}},


### PR DESCRIPTION
## Overview

This patch causes the indexing subsystem to use snapshot isolation when reading from the database. This reduces commit conflicts and ensures the index can make progress even in the case of frequently updated docs.

In the pathological case, a document updated in a fast loop can cause the indexer to stall out entirely when using serializable reads. Each successful update of the doc will cause the indexer to fail to commit if it processed that document. The indexer will retry with a new GRV but the same target DbSeq. In the meantime, our frequently updated document will have advanced beyond `DbSeq` and so the indexer will finish its job without indexing the document at all. This process can be repeated ad infinitum and the document will never actually show up in a view response.

Snapshot reads are safe for this use case precisely because we do have the _changes feed, which guarantees that a concurrent doc update will show up again later in the feed.

As an aside, I'm not entirely happy with the API for changing the isolation level on reads. It seems designed to run an entire transaction at a single isolation level, where I think we often want to be more selectively about modifying isolation levels within a transaction. But I didn't bother suggesting any changes on that front in this PR.

## Testing recommendations

I posted a rudimentary Python script in a [gist](https://gist.github.com/kocolosk/6a4410b3ee8c6c06ed8d86deb6c76f19). It updates a single document in a loop and tries to run that document through an expensive `map` function. Running this script against `main` should show you the view almost never makes progress; every once in a while it might win the race, but most of the time it is returning a response that does not include recent updates to the document.

Running the script against this branch should show the view essentially keeping up, although the included document will still be a few revisions ahead.

## Related Issues or Pull Requests

See #3391 for work to make the included doc version consistent with the version observed by the view index function.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
