### PR TITLE
Lower the view indexer transaction retry limit

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -351,6 +351,19 @@ iterations = 10 ; iterations for password hashing
 ; batch_max_tx_size_bytes = 9000000 ; Maximum transaction size in bytes
 ; batch_max_tx_time_msec = 4500 ; Maximum transaction time in milliseconds
 ; batch_thresold_penalty = 0.2 ; Amount to reduce batch size when crossing a threshold
+;
+; Set the FDB transaction retry limit applied to the main indexing transaction
+; for retriable errors. These errors include 1007 (transaction_too_old), 1020
+; (commit conflict) and others. This value overrides the retry_limit setting
+; from fdb transaction settings in the [fdb_tx_options] section. Setting this
+; value may interfere with the batching algorithm as it's designed to adjust
+; the batch size in response to erlfdb errors. A too large a value, would
+; re-run the same transaction too many times in a row wasting resources.
+; However, the value shouldn't be too small as in some cases the errors are
+; recoverable such as when the FDB server fast-forwards time during the
+; transaction system recovery.
+;
+;indexer_tx_retry_limit = 5
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]


### PR DESCRIPTION
Previously, the view indexer used the default retry limit (100) from the `fdb_tx_options` config section. However, since the batching algorithm relies on sensing errors and reacting to them, retrying the batch 100 times before erroring out was not optimal. So value is lowered down to 5 and it's also made configurable.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
