### PR TITLE
Bump erlfdb to v1.2.8

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -153,7 +153,7 @@ DepDescs = [
 %% Independent Apps
 {config,           "config",           {tag, "2.1.8"}},
 {b64url,           "b64url",           {tag, "1.0.2"}},
-{erlfdb,           "erlfdb",           {tag, "v1.2.6"}},
+{erlfdb,           "erlfdb",           {tag, "v1.2.8"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.4"}},


### PR DESCRIPTION
The main feature is a fix to use buggify settings on the client

(`enc` update was reverted from an intermediate release)

https://github.com/apache/couchdb-erlfdb/releases/tag/v1.2.7
https://github.com/apache/couchdb-erlfdb/releases/tag/v1.2.8