### PR TITLE
Support Erlang/OTP 23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ exunit: export ERL_LIBS = $(shell pwd)/src
 exunit: export ERL_AFLAGS = -config $(shell pwd)/rel/files/eunit.config
 exunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell pwd)/bin/couchjs $(shell pwd)/share/server/main.js
 exunit: couch elixir-init setup-eunit elixir-check-formatted elixir-credo
-	@mix test --cover --trace $(EXUNIT_OPTS)
+	@mix test --trace $(EXUNIT_OPTS)
 
 setup-eunit: export BUILDDIR = $(shell pwd)
 setup-eunit: export ERL_AFLAGS = -config $(shell pwd)/rel/files/eunit.config

--- a/configure
+++ b/configure
@@ -239,9 +239,6 @@ install_local_rebar() {
         if [ ! -d "${rootdir}/src/rebar" ]; then
             # git clone --depth 1 https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
             git clone https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
-            cd ${rootdir}/src/rebar
-              git checkout origin/feat/otp23
-            cd -
         fi
         make -C ${rootdir}/src/rebar
         mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar

--- a/configure
+++ b/configure
@@ -237,7 +237,11 @@ EOF
 install_local_rebar() {
     if [ ! -x "${rootdir}/bin/rebar" ]; then
         if [ ! -d "${rootdir}/src/rebar" ]; then
-            git clone --depth 1 https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
+            # git clone --depth 1 https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
+            git clone https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
+            cd ${rootdir}/src/rebar
+              git checkout origin/feat/otp23
+            cd -
         fi
         make -C ${rootdir}/src/rebar
         mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -151,7 +151,7 @@ DepDescs = [
 {b64url,           "b64url",           {tag, "1.0.2"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},
-{snappy,           "snappy",           {branch, "feat/otp23"}},
+{snappy,           "snappy",           {tag, "CouchDB-1.0.6"}},
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
@@ -162,7 +162,7 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-6"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
-{jiffy,            "jiffy",            {branch, "main"}},
+{jiffy,            "jiffy",            {tag, "CouchDB-1.0.5-1"}},
 {mochiweb,         "mochiweb",         {tag, "v2.20.0"}},
 {meck,             "meck",             {tag, "0.8.8"}},
 {recon,            "recon",            {tag, "2.5.0"}}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -148,7 +148,7 @@ DepDescs = [
 {b64url,           "b64url",           {tag, "1.0.2"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},
-{snappy,           "snappy",           {tag, "CouchDB-1.0.4"}},
+{snappy,           "snappy",           {branch, "feat/otp23"}},
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
@@ -159,7 +159,7 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-6"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
-{jiffy,            "jiffy",            {tag, "CouchDB-1.0.4-1"}},
+{jiffy,            "jiffy",            {branch, "main"}},
 {mochiweb,         "mochiweb",         {tag, "v2.20.0"}},
 {meck,             "meck",             {tag, "0.8.8"}},
 {recon,            "recon",            {tag, "2.5.0"}}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -195,7 +195,7 @@ ErlOpts = case os:getenv("ERL_OPTS") of
 end.
 
 AddConfig = [
-    {require_otp_vsn, "19|20|21|22"},
+    {require_otp_vsn, "19|20|21|22|23"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -92,6 +92,9 @@ case VerList of
     _ -> ok
 end.
 
+[OptMajorVersion|_] = VerList.
+OtpMajorVersion20 = case OptMajorVersion of 20 -> "true"; _ -> "false" end.
+os:putenv("COUCHDB_OTP_MAJOR_VERSION_20", OtpMajorVersion20).
 % Set the path to the configuration environment generated
 % by `./configure`.
 
@@ -200,7 +203,7 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, [{i, "../"} | ErlOpts]},
+    {erl_opts, [{i, "../"}, {d, 'OTP_MAJOR_VSN_20', os:getenv("COUCHDB_OTP_MAJOR_VERSION_20")}, verbose] ++ ErlOpts},
     {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]},
     {plugins, [eunit_plugin]},
     {dialyzer, [

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -92,9 +92,6 @@ case VerList of
     _ -> ok
 end.
 
-[OptMajorVersion|_] = VerList.
-OtpMajorVersion20 = case OptMajorVersion of 20 -> "true"; _ -> "false" end.
-os:putenv("COUCHDB_OTP_MAJOR_VERSION_20", OtpMajorVersion20).
 % Set the path to the configuration environment generated
 % by `./configure`.
 
@@ -203,7 +200,7 @@ AddConfig = [
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, [{i, "../"}, {d, 'OTP_MAJOR_VSN_20', os:getenv("COUCHDB_OTP_MAJOR_VERSION_20")}, verbose] ++ ErlOpts},
+    {erl_opts, [{i, "../"}] ++ ErlOpts},
     {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]},
     {plugins, [eunit_plugin]},
     {dialyzer, [

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -268,15 +268,15 @@ before_request(HttpReq) ->
     try
         chttpd_stats:init(),
         chttpd_plugin:before_request(HttpReq)
-    catch ?STACKTRACE(Tag, Error, Stack)
-        {error, catch_error(HttpReq, Tag, Error, Stack)}
+    catch ?STACKTRACE(ErrorType, Error, Stack)
+        {error, catch_error(HttpReq, ErrorType, Error, Stack)}
     end.
 
 after_request(HttpReq, HttpResp0) ->
     {ok, HttpResp1} =
         try
             chttpd_plugin:after_request(HttpReq, HttpResp0)
-        catch ?STACKTRACE(_Tag, Error, Stack)
+        catch ?STACKTRACE(_ErrorType, Error, Stack)
             send_error(HttpReq, {Error, nil, Stack}),
             {ok, HttpResp0#httpd_resp{status = aborted}}
         end,
@@ -309,8 +309,8 @@ process_request(#httpd{mochi_req = MochiReq} = HttpReq) ->
         Response ->
             {HttpReq, Response}
         end
-    catch ?STACKTRACE(Tag, Error, Stack)
-        {HttpReq, catch_error(HttpReq, Tag, Error, Stack)}
+    catch ?STACKTRACE(ErrorType, Error, Stack)
+        {HttpReq, catch_error(HttpReq, ErrorType, Error, Stack)}
     end.
 
 handle_req_after_auth(HandlerKey, HttpReq) ->
@@ -320,8 +320,8 @@ handle_req_after_auth(HandlerKey, HttpReq) ->
         AuthorizedReq = chttpd_auth:authorize(possibly_hack(HttpReq),
             fun chttpd_auth_request:authorize_request/1),
         {AuthorizedReq, HandlerFun(AuthorizedReq)}
-    catch ?STACKTRACE(Tag, Error, Stack)
-        {HttpReq, catch_error(HttpReq, Tag, Error, Stack)}
+    catch ?STACKTRACE(ErrorType, Error, Stack)
+        {HttpReq, catch_error(HttpReq, ErrorType, Error, Stack)}
     end.
 
 catch_error(_HttpReq, throw, {http_head_abort, Resp}, _Stack) ->

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -268,16 +268,15 @@ before_request(HttpReq) ->
     try
         chttpd_stats:init(),
         chttpd_plugin:before_request(HttpReq)
-    catch Tag:Error ->
-        {error, catch_error(HttpReq, Tag, Error)}
+    catch ?STACKTRACE(Tag, Error, Stack)
+        {error, catch_error(HttpReq, Tag, Error, Stack)}
     end.
 
 after_request(HttpReq, HttpResp0) ->
     {ok, HttpResp1} =
         try
             chttpd_plugin:after_request(HttpReq, HttpResp0)
-        catch _Tag:Error ->
-            Stack = erlang:get_stacktrace(),
+        catch ?STACKTRACE(_Tag, Error, Stack)
             send_error(HttpReq, {Error, nil, Stack}),
             {ok, HttpResp0#httpd_resp{status = aborted}}
         end,
@@ -310,8 +309,8 @@ process_request(#httpd{mochi_req = MochiReq} = HttpReq) ->
         Response ->
             {HttpReq, Response}
         end
-    catch Tag:Error ->
-        {HttpReq, catch_error(HttpReq, Tag, Error)}
+    catch ?STACKTRACE(Tag, Error, Stack)
+        {HttpReq, catch_error(HttpReq, Tag, Error, Stack)}
     end.
 
 handle_req_after_auth(HandlerKey, HttpReq) ->
@@ -321,17 +320,17 @@ handle_req_after_auth(HandlerKey, HttpReq) ->
         AuthorizedReq = chttpd_auth:authorize(possibly_hack(HttpReq),
             fun chttpd_auth_request:authorize_request/1),
         {AuthorizedReq, HandlerFun(AuthorizedReq)}
-    catch Tag:Error ->
-        {HttpReq, catch_error(HttpReq, Tag, Error)}
+    catch ?STACKTRACE(Tag, Error, Stack)
+        {HttpReq, catch_error(HttpReq, Tag, Error, Stack)}
     end.
 
-catch_error(_HttpReq, throw, {http_head_abort, Resp}) ->
+catch_error(_HttpReq, throw, {http_head_abort, Resp}, _Stack) ->
     {ok, Resp};
-catch_error(_HttpReq, throw, {http_abort, Resp, Reason}) ->
+catch_error(_HttpReq, throw, {http_abort, Resp, Reason}, _Stack) ->
     {aborted, Resp, Reason};
-catch_error(HttpReq, throw, {invalid_json, _}) ->
+catch_error(HttpReq, throw, {invalid_json, _}, _Stack) ->
     send_error(HttpReq, {bad_request, "invalid UTF-8 JSON"});
-catch_error(HttpReq, exit, {mochiweb_recv_error, E}) ->
+catch_error(HttpReq, exit, {mochiweb_recv_error, E}, _Stack) ->
     #httpd{
         mochi_req = MochiReq,
         peer = Peer,
@@ -343,16 +342,15 @@ catch_error(HttpReq, exit, {mochiweb_recv_error, E}) ->
         MochiReq:get(raw_path),
         E]),
     exit(normal);
-catch_error(HttpReq, exit, {uri_too_long, _}) ->
+catch_error(HttpReq, exit, {uri_too_long, _}, _Stack) ->
     send_error(HttpReq, request_uri_too_long);
-catch_error(HttpReq, exit, {body_too_large, _}) ->
+catch_error(HttpReq, exit, {body_too_large, _}, _Stack) ->
     send_error(HttpReq, request_entity_too_large);
-catch_error(HttpReq, throw, Error) ->
+catch_error(HttpReq, throw, Error, _Stack) ->
     send_error(HttpReq, Error);
-catch_error(HttpReq, error, database_does_not_exist) ->
+catch_error(HttpReq, error, database_does_not_exist, _Stack) ->
     send_error(HttpReq, database_does_not_exist);
-catch_error(HttpReq, Tag, Error) ->
-    Stack = erlang:get_stacktrace(),
+catch_error(HttpReq, Tag, Error, Stack) ->
     % TODO improve logging and metrics collection for client disconnects
     case {Tag, Error, Stack} of
         {exit, normal, [{mochiweb_request, send, _, _} | _]} ->

--- a/src/chttpd/src/chttpd_stats.erl
+++ b/src/chttpd/src/chttpd_stats.erl
@@ -1,3 +1,4 @@
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License.  You may obtain a copy of
 % the License at
@@ -12,6 +13,8 @@
 
 -module(chttpd_stats).
 
+% for the stacktrace macro only so far
+-include_lib("couch/include/couch_db.hrl").
 
 -export([
     init/0,
@@ -50,8 +53,7 @@ report(HttpReq, HttpResp) ->
             _ ->
                 ok
         end
-    catch T:R ->
-        S = erlang:get_stacktrace(),
+    catch ?STACKTRACE(T, R, S)
         Fmt = "Failed to report chttpd request stats: ~p:~p ~p",
         couch_log:error(Fmt, [T, R, S])
     end.

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -232,16 +232,16 @@
 % end,
 
 % for features specific to Erlang/OTP version 20.x (and later versions)
--ifdef(ERLANG_OTP_VERSION_20).
+-ifdef(OTP_MAJOR_VSN_20).
 -else.
 -define(ERLANG_OTP_VERSION_21_FEATURES, true).
 -endif.
 % Get the stacktrace in a way that is backwards compatible
 -ifdef(ERLANG_OTP_VERSION_21_FEATURES).
--define(STACKTRACE(ErrorType, Error, ErrorStackTrace),
-        ErrorType:Error:ErrorStackTrace ->).
+-define(STACKTRACE(ErrorType, Error, Stack),
+        ErrorType:Error:Stack ->).
 -else.
--define(STACKTRACE(ErrorType, Error, ErrorStackTrace),
+-define(STACKTRACE(ErrorType, Error, Stack),
         ErrorType:Error ->
-            ErrorStackTrace = erlang:get_stacktrace(),).
+            Stack = erlang:get_stacktrace(),).
 -endif.

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -219,3 +219,29 @@
 -type sec_props() :: [tuple()].
 -type sec_obj() :: {sec_props()}.
 
+%% Erlang/OTP 21 deprecates and 23 removes get_stacktrace(), so 
+%% we have to monkey around until we can drop support < 21.
+%% h/t https://github.com/erlang/otp/pull/1783#issuecomment-386190970
+
+%% use like so:
+% try function1(Arg1)
+% catch
+%     ?STACKTRACE(exit, badarg, ErrorStackTrace)
+%         % do stuff with ErrorStackTrace
+%         % ...
+% end,
+
+% for features specific to Erlang/OTP version 20.x (and later versions)
+-ifdef(ERLANG_OTP_VERSION_20).
+-else.
+-define(ERLANG_OTP_VERSION_21_FEATURES, true).
+-endif.
+% Get the stacktrace in a way that is backwards compatible
+-ifdef(ERLANG_OTP_VERSION_21_FEATURES).
+-define(STACKTRACE(ErrorType, Error, ErrorStackTrace),
+        ErrorType:Error:ErrorStackTrace ->).
+-else.
+-define(STACKTRACE(ErrorType, Error, ErrorStackTrace),
+        ErrorType:Error ->
+            ErrorStackTrace = erlang:get_stacktrace(),).
+-endif.

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -231,13 +231,10 @@
 %         % ...
 % end,
 
-% for features specific to Erlang/OTP version 20.x (and later versions)
--ifdef(OTP_MAJOR_VSN_20).
--else.
--define(ERLANG_OTP_VERSION_21_FEATURES, true).
--endif.
 % Get the stacktrace in a way that is backwards compatible
--ifdef(ERLANG_OTP_VERSION_21_FEATURES).
+% OTP_VERSION is only available in OTP 21 and later, so we don’t need
+% to do any other version magic here.
+-ifdef(OTP_VERSION).
 -define(STACKTRACE(ErrorType, Error, Stack),
         ErrorType:Error:Stack ->).
 -else.

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -215,7 +215,8 @@ AddConfig = [
     {erl_opts, PlatformDefines ++ [
         {d, 'COUCHDB_VERSION', Version},
         {d, 'COUCHDB_GIT_SHA', GitSha},
-        {i, "../"}
+        {i, "../"},
+        {d, 'OTP_MAJOR_VSN_20', os:getenv("COUCHDB_OTP_MAJOR_VERSION_20")}
     ] ++ MD5Config ++ ProperConfig},
     {port_env, PortEnvOverrides},
     {eunit_compile_opts, PlatformDefines}

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -215,8 +215,7 @@ AddConfig = [
     {erl_opts, PlatformDefines ++ [
         {d, 'COUCHDB_VERSION', Version},
         {d, 'COUCHDB_GIT_SHA', GitSha},
-        {i, "../"},
-        {d, 'OTP_MAJOR_VSN_20', os:getenv("COUCHDB_OTP_MAJOR_VERSION_20")}
+        {i, "../"}
     ] ++ MD5Config ++ ProperConfig},
     {port_env, PortEnvOverrides},
     {eunit_compile_opts, PlatformDefines}

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -375,9 +375,9 @@ handle_request_int(MochiReq, DefaultFun,
             couch_log:error("function_clause error in HTTP request",[]),
             couch_log:info("Stacktrace: ~p",[Stack]),
             send_error(HttpReq, function_clause);
-        ?STACKTRACE(Tag, Error, Stack)
+        ?STACKTRACE(ErrorType, Error, Stack)
             couch_log:error("Uncaught error in HTTP request: ~p",
-                            [{Tag, Error}]),
+                            [{ErrorType, Error}]),
             couch_log:info("Stacktrace: ~p",[Stack]),
             send_error(HttpReq, Error)
     end,

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -363,23 +363,19 @@ handle_request_int(MochiReq, DefaultFun,
             send_error(HttpReq, request_entity_too_large);
         exit:{uri_too_long, _} ->
             send_error(HttpReq, request_uri_too_long);
-        throw:Error ->
-            Stack = erlang:get_stacktrace(),
+        ?STACKTRACE(throw, Error, Stack)
             couch_log:debug("Minor error in HTTP request: ~p",[Error]),
             couch_log:debug("Stacktrace: ~p",[Stack]),
             send_error(HttpReq, Error);
-        error:badarg ->
-            Stack = erlang:get_stacktrace(),
+        ?STACKTRACE(error, badarg, Stack)
             couch_log:error("Badarg error in HTTP request",[]),
             couch_log:info("Stacktrace: ~p",[Stack]),
             send_error(HttpReq, badarg);
-        error:function_clause ->
-            Stack = erlang:get_stacktrace(),
+        ?STACKTRACE(error, function_clause, Stack)
             couch_log:error("function_clause error in HTTP request",[]),
             couch_log:info("Stacktrace: ~p",[Stack]),
             send_error(HttpReq, function_clause);
-        Tag:Error ->
-            Stack = erlang:get_stacktrace(),
+        ?STACKTRACE(Tag, Error, Stack)
             couch_log:error("Uncaught error in HTTP request: ~p",
                             [{Tag, Error}]),
             couch_log:info("Stacktrace: ~p",[Stack]),

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -308,8 +308,7 @@ find_proc(#client{lang = Lang, ddoc = DDoc, ddoc_key = DDocKey} = Client) ->
 
 find_proc(Lang, Fun) ->
     try iter_procs(Lang, Fun)
-    catch error:Reason ->
-        StackTrace = erlang:get_stacktrace(),
+    catch ?STACKTRACE(error, Reason, StackTrace)
         couch_log:error("~p ~p ~p", [?MODULE, Reason, StackTrace]),
         {error, Reason}
     end.

--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -527,8 +527,7 @@ with_ddoc_proc(#doc{id=DDocId,revs={Start, [DiskRev|_]}}=DDoc, Fun) ->
         Resp ->
             ok = ret_os_process(Proc),
             Resp
-    catch Tag:Err ->
-        Stack = erlang:get_stacktrace(),
+    catch ?STACKTRACE(Tag, Err, Stack)
         catch proc_stop(Proc),
         erlang:raise(Tag, Err, Stack)
     end.

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -319,9 +319,9 @@ handle_info(timeout, InitArgs) ->
     catch
         exit:{http_request_failed, _, _, max_backoff} ->
             {stop, {shutdown, max_backoff}, {error, InitArgs}};
-        Class:Error ->
+        ?STACKTRACE(Class, Error, Stack)
             ShutdownReason = {error, replication_start_error(Error)},
-            StackTop2 = lists:sublist(erlang:get_stacktrace(), 2),
+            StackTop2 = lists:sublist(Stack, 2),
             % Shutdown state is a hack as it is not really the state of the
             % gen_server (it failed to initialize, so it doesn't have one).
             % Shutdown state is used to pass extra info about why start failed.

--- a/src/ddoc_cache/src/ddoc_cache_entry.erl
+++ b/src/ddoc_cache/src/ddoc_cache_entry.erl
@@ -14,6 +14,8 @@
 -behaviour(gen_server).
 -vsn(1).
 
+% for the stacktrace macro only so far
+-include_lib("couch/include/couch_db.hrl").
 
 -export([
     dbname/1,
@@ -297,8 +299,7 @@ do_open(Key) ->
     try recover(Key) of
         Resp ->
             erlang:exit({open_ok, Key, Resp})
-    catch T:R ->
-        S = erlang:get_stacktrace(),
+    catch ?STACKTRACE(T, R, S)
         erlang:exit({open_error, Key, {T, R, S}})
     end.
 

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -330,9 +330,9 @@ with_db(DbName, Options, {M,F,A}) ->
             apply(M, F, [Db | A])
         catch Exception ->
             Exception;
-        error:Reason ->
+        ?STACKTRACE(error, Reason, Stack)
             couch_log:error("rpc ~p:~p/~p ~p ~p", [M, F, length(A)+1, Reason,
-                clean_stack()]),
+                clean_stack(Stack)]),
             {error, Reason}
         end);
     Error ->
@@ -596,9 +596,8 @@ make_att_reader({fabric_attachment_receiver, Middleman, Length}) ->
 make_att_reader(Else) ->
     Else.
 
-clean_stack() ->
-    lists:map(fun({M,F,A}) when is_list(A) -> {M,F,length(A)}; (X) -> X end,
-        erlang:get_stacktrace()).
+clean_stack(S) ->
+    lists:map(fun({M,F,A}) when is_list(A) -> {M,F,length(A)}; (X) -> X end, S).
 
 set_io_priority(DbName, Options) ->
     case lists:keyfind(io_priority, 1, Options) of

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -296,8 +296,7 @@ open_doc(DbName, Options, Id, IncludeDocs) ->
     try open_doc_int(DbName, Options, Id, IncludeDocs) of
         #view_row{} = Row ->
             exit(Row)
-    catch Type:Reason ->
-        Stack = erlang:get_stacktrace(),
+    catch ?STACKTRACE(Type, Reason, Stack)
         couch_log:error("_all_docs open error: ~s ~s :: ~w ~w", [
                 DbName, Id, {Type, Reason}, Stack]),
         exit({Id, Reason})

--- a/src/mango/rebar.config.script
+++ b/src/mango/rebar.config.script
@@ -18,7 +18,10 @@ if not HaveDreyfus -> CONFIG; true ->
         {erl_opts, Opts} -> Opts;
         false -> []
     end,
-    NewOpts = [{d, 'HAVE_DREYFUS'} | CurrOpts],
+    NewOpts = [
+        {d, 'HAVE_DREYFUS'},
+        {d, 'OTP_MAJOR_VSN_20', os:getenv("COUCHDB_OTP_MAJOR_VERSION_20")}
+    ] ++ CurrOpts,
     lists:keystore(erl_opts, 1, CONFIG, {erl_opts, NewOpts})
 end.
 

--- a/src/mango/rebar.config.script
+++ b/src/mango/rebar.config.script
@@ -19,8 +19,7 @@ if not HaveDreyfus -> CONFIG; true ->
         false -> []
     end,
     NewOpts = [
-        {d, 'HAVE_DREYFUS'},
-        {d, 'OTP_MAJOR_VSN_20', os:getenv("COUCHDB_OTP_MAJOR_VERSION_20")}
+        {d, 'HAVE_DREYFUS'}
     ] ++ CurrOpts,
     lists:keystore(erl_opts, 1, CONFIG, {erl_opts, NewOpts})
 end.

--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -37,10 +37,9 @@ handle_req(#httpd{} = Req, Db0) ->
         Db = set_user_ctx(Req, Db0),
         handle_req_int(Req, Db)
     catch
-        throw:{mango_error, Module, Reason} ->
+        ?STACKTRACE(throw, {mango_error, Module, Reason}, Stack)
             case mango_error:info(Module, Reason) of
             {500, ErrorStr, ReasonStr} ->
-                Stack = erlang:get_stacktrace(),
                 chttpd:send_error(Req, {ErrorStr, ReasonStr, Stack});
             {Code, ErrorStr, ReasonStr} ->
                 chttpd:send_error(Req, Code, ErrorStr, ReasonStr)

--- a/src/mango/src/mango_util.erl
+++ b/src/mango/src/mango_util.erl
@@ -138,16 +138,13 @@ do_defer(Mod, Fun, Args) ->
         Resp ->
             erlang:exit({mango_defer_ok, Resp})
     catch
-        throw:Error ->
-            Stack = erlang:get_stacktrace(),
+        ?STACKTRACE(throw, Error, Stack)
             couch_log:error("Defered error: ~w~n    ~p", [{throw, Error}, Stack]),
             erlang:exit({mango_defer_throw, Error});
-        error:Error ->
-            Stack = erlang:get_stacktrace(),
+        ?STACKTRACE(error, Error, Stack)
             couch_log:error("Defered error: ~w~n    ~p", [{error, Error}, Stack]),
             erlang:exit({mango_defer_error, Error});
-        exit:Error ->
-            Stack = erlang:get_stacktrace(),
+        ?STACKTRACE(exit, Error, Stack)
             couch_log:error("Defered error: ~w~n    ~p", [{exit, Error}, Stack]),
             erlang:exit({mango_defer_exit, Error})
     end.


### PR DESCRIPTION
this PR pulls together all the various sub-module changes required to support Erlang/OTP 23.

Closes https://github.com/apache/couchdb/issues/3115

This currently includes a commit from https://github.com/apache/couchdb/pull/3421 because I couldn't run this locally otherwise. The PRs can land one after another, though.