### PR TITLE
Support uri_file write for chttpd

### DIFF
--- a/src/chttpd/src/chttpd_sup.erl
+++ b/src/chttpd/src/chttpd_sup.erl
@@ -26,7 +26,16 @@
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 100, Type, [I]}).
 
 start_link(Args) ->
-    supervisor:start_link({local,?MODULE}, ?MODULE, Args).
+    case supervisor:start_link({local, ?MODULE}, ?MODULE, Args) of
+        {ok, _} = Resp ->
+            notify_started(),
+            notify_uris(),
+            write_uris(),
+            Resp;
+        Else ->
+            notify_error(Else),
+            Else
+    end.
 
 init([]) ->
     Children = [
@@ -95,3 +104,62 @@ append_if_set({Key, Value}, Opts) ->
         "The value for `~s` should be string convertable "
         "to integer which is >= 0 (got `~p`)", [Key, Value]),
     Opts.
+
+notify_started() ->
+    couch_log:info("Apache CouchDB has started. Time to relax.~n", []).
+
+notify_error(Error) ->
+    couch_log:error("Error starting Apache CouchDB:~n~n    ~p~n~n", [Error]).
+
+notify_uris() ->
+    lists:foreach(fun(Uri) ->
+        couch_log:info("Apache CouchDB has started on ~s", [Uri])
+    end, get_uris()).
+
+write_uris() ->
+    case config:get("couchdb", "uri_file", undefined) of
+        undefined ->
+            ok;
+        UriFile ->
+            Lines = [io_lib:format("~s~n", [Uri]) || Uri <- get_uris()],
+            write_file(UriFile, Lines)
+    end.
+
+get_uris() ->
+    Ip = config:get("chttpd", "bind_address"),
+    lists:flatmap(fun(Uri) ->
+        case get_uri(Uri, Ip) of
+            undefined -> [];
+            Else -> [Else]
+        end
+    end, [chttpd, couch_httpd, https]).
+
+get_uri(Name, Ip) ->
+    case get_port(Name) of
+        undefined ->
+            undefined;
+        Port ->
+            io_lib:format("~s://~s:~w/", [get_scheme(Name), Ip, Port])
+    end.
+
+get_scheme(chttpd) -> "http";
+get_scheme(couch_httpd) -> "http";
+get_scheme(https) -> "https".
+
+get_port(Name) ->
+    try
+        mochiweb_socket_server:get(Name, port)
+    catch
+        exit:{noproc, _} ->
+            undefined
+    end.
+
+write_file(FileName, Contents) ->
+    case file:write_file(FileName, Contents) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            Args = [FileName, file:format_error(Reason)],
+            couch_log:error("Failed ot write ~s :: ~s", Args),
+            throw({error, Reason})
+    end.


### PR DESCRIPTION
## Overview

The uri_file config parameter was not supported in the switch to chttpd. Pulling the relevant section of code in from couch_sup.erl.

## Testing recommendations
Booting up couchdb with specific cluster port set and port 0. 
