### PR TITLE
Remove CentOS 6 from CI

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -194,49 +194,6 @@ pipeline {
           } // post
         } // stage macOS
 
-        stage('CentOS 6') {
-          agent {
-            docker {
-              image 'couchdbdev/centos-6-erlang-20.3.8.25-1:latest'
-              label 'docker'
-              args "${DOCKER_ARGS}"
-            }
-          }
-          environment {
-            platform = 'centos6'
-            sm_ver = '1.8.5'
-          }
-          stages {
-            stage('Build from tarball & test') {
-              steps {
-                unstash 'tarball'
-                sh( script: build_and_test )
-              }
-              post {
-                always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
-                }
-              }
-            }
-            stage('Build CouchDB packages') {
-              steps {
-                sh( script: make_packages )
-                sh( script: cleanup_and_save )
-              }
-              post {
-                success {
-                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
-                }
-              }
-            }
-          } // stages
-          post {
-            cleanup {
-              sh 'rm -rf ${WORKSPACE}/*'
-            }
-          } // post
-        } // stage
-
         stage('CentOS 7') {
           agent {
             docker {
@@ -743,10 +700,8 @@ pipeline {
 
           echo 'Building CentOS repos...'
           sh '''
-            cp js/centos-6/*rpm pkgs/centos6
             cp js/centos-7/*rpm pkgs/centos7
             cp js/centos-8/*rpm pkgs/centos8
-            cd pkgs/centos6 && createrepo --database .
             cd ../centos7 && createrepo --database .
             cd ../centos8 && createrepo --database .
           '''
@@ -755,7 +710,6 @@ pipeline {
           sh '''
             mv couchdb-pkg/repo/pool $BRANCH_NAME/debian
             mv couchdb-pkg/repo/dists $BRANCH_NAME/debian
-            mv pkgs/centos6/* $BRANCH_NAME/el6
             mv pkgs/centos7/* $BRANCH_NAME/el7
             mv pkgs/centos8/* $BRANCH_NAME/el8
             mv apache-couchdb-*.tar.gz $BRANCH_NAME/source


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

According to https://wiki.centos.org/FAQ/General#What_is_the_support_.27.27end_of_life.27.27_for_each_CentOS_release.3F  CentOS 6 is now discontinued. This PR removes it from the matrix.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
