### PR TITLE
Fix typo causing not saving of configuration changes from chttpd_node

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -72,7 +72,7 @@ handle_node_req(#httpd{method='PUT', path_parts=[_, Node, <<"_config">>, Section
     Persist = chttpd:header_value(Req, "X-Couch-Persist") /= "false",
     OldValue = call_node(Node, config, get, [Section, Key, ""]),
     IsSensitive = Section == <<"admins">>,
-    Opts = #{persisit => Persist, sensitive => IsSensitive},
+    Opts = #{persist => Persist, sensitive => IsSensitive},
     case call_node(Node, config, set, [Section, Key, ?b2l(Value), Opts]) of
         ok ->
             send_json(Req, 200, list_to_binary(OldValue));


### PR DESCRIPTION
## Overview

Fix typo causing not saving of configuration changes from chttpd_node

## Testing recommendations

N/A

## Related Issues or Pull Requests

- The bug was introduced in https://github.com/apache/couchdb/pull/3031

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
