### PR TITLE
Add Secondary data tests with updates test

### DIFF
--- a/test/elixir/test/concurrent_writes_test.exs
+++ b/test/elixir/test/concurrent_writes_test.exs
@@ -48,4 +48,28 @@ defmodule ConcurrentWritesTest do
     assert result == Enum.sum(1..n)
   end
 
+  @tag :with_db
+  test "Secondary data tests with updates", context do
+    n = 120
+    db_name = context[:db_name]
+    map_fun = "function(doc) { emit(null, doc.a); }"
+    red_fun = "_sum"
+    ddoc_id = "_design/foo"
+    ddoc = %{:views => %{:foo => %{:map => map_fun, :reduce => red_fun}}}
+    Couch.put("/#{db_name}/#{ddoc_id}", body: ddoc)
+    parent = self()
+    Enum.each(1..n,
+      fn x -> spawn fn ->
+          r = Couch.put("/#{db_name}/doc#{x}", body: %{:a => x})
+          assert r.status_code == 201
+          rev = r.body["rev"]
+          Couch.put("/#{db_name}/doc#{x}", body: %{:_rev => rev, :a => x + 1})
+          send parent, :done
+        end end)
+    Enum.each(1..n, fn _x -> receive do :done -> :done end end)
+    rows = Couch.get("/#{db_name}/#{ddoc_id}/_view/foo").body["rows"]
+    result = hd(rows)["value"]
+    assert result == Enum.sum(2..n + 1)
+  end
+
 end

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -133,7 +133,8 @@
   ],
   "ConcurrentWritesTest": [
     "Primary data tests",
-    "Secondary data tests"
+    "Secondary data tests",
+    "Secondary data tests with updates"
   ],
   "ConfigTest": [
     "Atoms, binaries, and strings suffice as whitelist sections and keys.",


### PR DESCRIPTION
## Overview

Add a variant of the concurrent write test that updates each document with a different value and assert that the view has the right answer.

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
