### PR TITLE
Fix error_logger reports for OTP >= 21

### DIFF
--- a/src/couch_log/src/couch_log_monitor.erl
+++ b/src/couch_log/src/couch_log_monitor.erl
@@ -37,10 +37,23 @@ start_link() ->
     gen_server:start_link(?MODULE, [], []).
 
 
+% OTP_RELEASE defined in OTP >= 21 only
+-ifdef(OTP_RELEASE).
+
+init(_) ->
+    % see https://erlang.org/doc/man/error_logger.html#add_report_handler-1
+    ok = error_logger:add_report_handler(?HANDLER_MOD),
+    ok = gen_event:add_sup_handler(error_logger, ?HANDLER_MOD, []),
+    {ok, nil}.
+
+-else.
+
 init(_) ->
     error_logger:start(),
     ok = gen_event:add_sup_handler(error_logger, ?HANDLER_MOD, []),
     {ok, nil}.
+
+-endif.
 
 
 terminate(_, _) ->


### PR DESCRIPTION
This is the cherry pick of the already approved PR on 3.x: https://github.com/apache/couchdb/pull/3433

Starting with OTP 21 there is a new logging system, and we forgot to
add the legacy error logger handler for it. Without it `couch_log`
cannot emit gen_server, supervisor and other such system events.

Luckily, there is OTP support to enable legacy error_logger behavior and
that's what we're doing here. The `add_report_handler/1` call will
auto-start the `error_logger` app if needed, and it will also add an
`error_logger` handler to the global `logger` system.

We also keep the `gen_event:add_sup_handler/3` call, as that will
ensure we'll find out when `error_logger` dies so that
`couch_log_monitor` can restart everything.

Someday(TM) we'll write a proper log event handler for the new logger
and have nicely formatted structured logs, but it's better to do that
once we don't have to support OTP versions =< 20.

Issue: https://github.com/apache/couchdb/pull/3422
