### PR TITLE
Decrease the view indexer transaction time

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -343,15 +343,31 @@ iterations = 10 ; iterations for password hashing
 ;
 ; The maximum size of B+Tree nodes used by view btrees
 ;view_btree_node_size = 100
-;
+
 ; Batch size sensing parameters
-; batch_initial_size = 100 ; Initial batch size in number of documents
-; batch_search_increment = 500 ; Size change when searching for the threshold
-; batch_sense_increment = 100 ; Size change increment after hitting a threshold
-; batch_max_tx_size_bytes = 9000000 ; Maximum transaction size in bytes
-; batch_max_tx_time_msec = 4500 ; Maximum transaction time in milliseconds
-; batch_thresold_penalty = 0.2 ; Amount to reduce batch size when crossing a threshold
 ;
+; Initial batch size in number of documents
+;batch_initial_size = 100
+;
+; Size change when searching for the threshold
+;batch_search_increment = 500
+;
+; Size change increment after hitting a threshold
+;batch_sense_increment = 100
+;
+; Maximum transaction size in bytes
+;batch_max_tx_size_bytes = 9000000
+;
+; Maximum transaction time used by the view indexer in
+; milliseconds. This value should be set such that the indexing
+; transaction GRVs would live long enough for clients waiting on the
+; indexer to have be able re-use the same GRVs to emit include_docs
+; bodies.
+;batch_max_tx_time_msec = 1500
+;
+; Amount to reduce batch size when crossing a threshold;
+;batch_thresold_penalty = 0.2
+
 ; Set the FDB transaction retry limit applied to the main indexing transaction
 ; for retriable errors. These errors include 1007 (transaction_too_old), 1020
 ; (commit conflict) and others. This value overrides the retry_limit setting

--- a/src/couch_views/src/couch_views_batch_impl.erl
+++ b/src/couch_views/src/couch_views_batch_impl.erl
@@ -48,7 +48,7 @@ start(Mrst, undefined) ->
         search_incr = get_config(batch_search_increment, "500"),
         sense_incr = get_config(batch_sense_increment, "100"),
         max_tx_size_bytes = get_config(batch_max_tx_size_bytes, "9000000"),
-        max_tx_time_msec = get_config(batch_max_tx_time_msec, "4500"),
+        max_tx_time_msec = get_config(batch_max_tx_time_msec, "1500"),
         threshold_penalty = get_config(
                 batch_threshold_penalty,
                 "0.2",


### PR DESCRIPTION
The indexer transaction time is decreased in order to allow enough time for the client to re-use the same GRV to emit doc bodies.

This PR goes along with another [PR], where emitted doc bodies in a view responses now come from the same database read version as the one used by the indexer. Since the batcher previously used 4.5 seconds as the maximum, that left little time to read any doc bodies.

[PR]: https://github.com/apache/couchdb/pull/3391

Issue: https://github.com/apache/couchdb/issues/3381
