### PR TITLE
Couch server shard simplification

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -10,10 +10,9 @@ view_index_dir = {{view_index_dir}}
 ; plugin_dir =
 os_process_timeout = 5000 ; 5 seconds. for view servers.
 
-; Maximum number of .couch files to open at once.
-; The actual limit may be slightly lower depending on how
-; many schedulers you have as the allowance is divided evenly
-; among them.
+; Maximum number of .couch files to open at once per couch_server
+; process. There will be as many couch_server processes as there are
+; schedulers (typically the same as the number of cores in the host)
 max_dbs_open = 500
 
 ; Method used to compress everything that is appended to database and view index files, except

--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -209,8 +209,7 @@ get_stats() ->
     {NumberOfGCs, WordsReclaimed, _} = statistics(garbage_collection),
     {{input, Input}, {output, Output}} = statistics(io),
     {CF, CDU} = db_pid_stats(),
-    MessageQueues0 = [{couch_file, {CF}}, {couch_db_updater, {CDU}},
-        {couch_server, couch_server:aggregate_queue_len()}],
+    MessageQueues0 = [{couch_file, {CF}}, {couch_db_updater, {CDU}}],
     MessageQueues = MessageQueues0 ++ message_queues(registered()),
     {SQ, DCQ} = run_queues(),
     [

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -28,7 +28,6 @@
 -export([lock/2, unlock/1]).
 -export([db_updated/1]).
 -export([num_servers/0, couch_server/1, couch_dbs_pid_to_name/1, couch_dbs/1]).
--export([aggregate_queue_len/0]).
 
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
@@ -355,6 +354,7 @@ handle_config_terminate(_, stop, _) ->
     ok;
 handle_config_terminate(_Server, _Reason, N) ->
     erlang:send_after(?RELISTEN_DELAY, whereis(?MODULE), {restart_config_listener, N}).
+
 
 all_databases() ->
     {ok, DbList} = all_databases(
@@ -935,14 +935,6 @@ name(BaseName, N) when is_integer(N), N > 0 ->
 
 num_servers() ->
     erlang:system_info(schedulers).
-
-
-aggregate_queue_len() ->
-    N = num_servers(),
-    Names = [couch_server(I) || I <- lists:seq(1, N)],
-    MQs = [process_info(whereis(Name), message_queue_len) ||
-        Name <- Names],
-    lists:sum([X || {_, X} <- MQs]).
 
 
 -ifdef(TEST).

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -294,7 +294,7 @@ init([N]) ->
     process_flag(trap_exit, true),
     {ok, #server{root_dir=RootDir,
                 engines = Engines,
-                max_dbs_open=per_couch_server(MaxDbsOpen),
+                max_dbs_open=MaxDbsOpen,
                 update_lru_on_read=UpdateLruOnRead,
                 start_time=couch_util:rfc1123_date(),
                 couch_dbs=couch_dbs(N),
@@ -323,13 +323,11 @@ handle_config_change("couchdb", "update_lru_on_read", "true", _, N) ->
 handle_config_change("couchdb", "update_lru_on_read", _, _, N) ->
     gen_server:call(couch_server(N),{set_update_lru_on_read,false}),
     {ok, N};
-handle_config_change("couchdb", "max_dbs_open", Max0, _, N) when is_list(Max0) ->
-    Max1 = per_couch_server(list_to_integer(Max0)),
-    gen_server:call(couch_server(N),{set_max_dbs_open,Max1}),
+handle_config_change("couchdb", "max_dbs_open", Max, _, N) when is_list(Max) ->
+    gen_server:call(couch_server(N),{set_max_dbs_open,list_to_integer(Max)}),
     {ok, N};
 handle_config_change("couchdb", "max_dbs_open", _, _, N) ->
-    Max = per_couch_server(?MAX_DBS_OPEN),
-    gen_server:call(couch_server(N),{set_max_dbs_open,Max}),
+    gen_server:call(couch_server(N),{set_max_dbs_open,?MAX_DBS_OPEN}),
     {ok, N};
 handle_config_change("couchdb_engines", _, _, _, N) ->
     gen_server:call(couch_server(N), reload_engines),
@@ -357,11 +355,6 @@ handle_config_terminate(_, stop, _) ->
     ok;
 handle_config_terminate(_Server, _Reason, N) ->
     erlang:send_after(?RELISTEN_DELAY, whereis(?MODULE), {restart_config_listener, N}).
-
-
-per_couch_server(X) ->
-    erlang:max(1, X div num_servers()).
-
 
 all_databases() ->
     {ok, DbList} = all_databases(


### PR DESCRIPTION
## Overview

In testing I've found that it would be much easier if max_dbs_open defines the maximum number of .couch files on a per couch_server basis (now that we have sharded the workload over several such processes). A few reasons that come into play;

1. In many test setups, including some couchdb tests in this repo, we set max_dbs_open quite low. The runtime division of that value by the number of schedulers then causes tests to fail in a confusing way. Performance tests are particularly impacted.
2. It is surprising to find that a config setting is not honored directly.
3. max_dbs_open itself exists to address two concerns. Firstly, as a cap on the number of open files directly. Secondly, to reflect the prohibitive cost of updating the server state for very large numbers of entries. For the first item, for small systems, the number of cores will also be small, so the multiplying effect of this change should not be a concern. For the second item, max_dbs_open's new definition is a significant improvement, as it can be set to whatever an individual couch_server can handle in terms of updating the server state.

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/3366

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
