### PR TITLE
Remove stack traces on EXIT

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -998,6 +998,8 @@ error_info({service_unavailable, Reason}) ->
     {503, <<"service unavailable">>, Reason};
 error_info({timeout, _Reason}) ->
     error_info(timeout);
+error_info({'EXIT', {Error, _Stack}}) ->
+    error_info(Error);
 error_info({Error, null}) ->
     error_info(Error);
 error_info({_Error, _Reason} = Error) ->


### PR DESCRIPTION
## Overview

We've noticed that http client in some cases getting a stacktrace. This problem
can be reproduced when shard files are truncated and user try to call `/_all_docs`.
The depth of the stack trace was not sufficient to uncover that the error is
coming from
[`couch_mrview:all_docs_fold/4`](https://github.com/apache/couchdb/blob/3.x/src/couch_mrview/src/couch_mrview.erl#L383)

We've made a hypothesis that we are getting an `EXIT` whenever we call a
`gen_server` from the request process.

As a confirmation of this hypothesis there was an error logged from
[`rexi_server:init_p/3`](https://github.com/apache/couchdb/blob/3.x/src/rexi/src/rexi_server.erl#L144).

```
[error] 2021-01-28T17:06:16.357719Z node1@127.0.0.1 <0.2558.0> f674d6062d rexi_server:
   from: node1@127.0.0.1(<0.2485.0>)
   mfa: fabric_rpc:all_docs/3
   error:
   {{badmatch,{'EXIT',{{badmatch,eof},[
       {couch_file,read_raw_iolist_int,3,[{file,"src/couch_file.erl"},{line,713}]},
```

The `rexi_server` is just one of such places. There might be other places as well.
Even if we would find all such cases in the code base and add special handling to
unwrap the error to remove `EXIT`. It will not solve the problem because calls
to `gen_server` can be done in EPI plugin.

Therefore it is better to handle in one place in `chttpd:error_info/1`.

Co-authored-by: @janosgyerman

## Testing recommendations

1. create database
2. add few documents
3. truncate all shards of a database
4. issue `/_all_docs` request
5. verify that error response doesn't include the stacktrace

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/pull/3363

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
