### PR TITLE
Configurable filter fields

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -530,6 +530,9 @@ level = info
 ; Do not log last message received by terminated process
 ; strip_last_msg = true
 ;
+; List of fields to remove before logging the crash report
+; filter_fields = [pid, registered_name, error_info, messages]
+;
 ; There are four different log writers that can be configured
 ; to write log messages. The default writes to stderr of the
 ; Erlang VM which is useful for debugging/development as well

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -527,6 +527,8 @@ level = info
 ;
 ; max_message_size = 16000
 ;
+; Do not log last message received by terminated process
+; strip_last_msg = true
 ;
 ; There are four different log writers that can be configured
 ; to write log messages. The default writes to stderr of the

--- a/src/couch_log/src/couch_log_config.erl
+++ b/src/couch_log/src/couch_log_config.erl
@@ -50,7 +50,8 @@ entries() ->
         {level, "level", "info"},
         {level_int, "level", "info"},
         {max_message_size, "max_message_size", "16000"},
-        {strip_last_msg, "strip_last_msg", "true"}
+        {strip_last_msg, "strip_last_msg", "true"},
+        {filter_fields, "filter_fields", "[pid, registered_name, error_info, messages]"}
      ].
 
 
@@ -104,4 +105,23 @@ transform(strip_last_msg, "false") ->
     false;
 
 transform(strip_last_msg, _) ->
-    true.
+    true;
+
+transform(filter_fields, FieldsStr) ->
+    Default = [pid, registered_name, error_info, messages],
+    case parse_term(FieldsStr) of
+        {ok, List} when is_list(List) ->
+            case lists:all(fun erlang:is_atom/1, List) of
+                true ->
+                    List;
+                false ->
+                    Default
+            end;
+        _ ->
+            Default
+    end.
+
+
+parse_term(List) ->
+    {ok, Tokens, _} = erl_scan:string(List ++ "."),
+    erl_parse:parse_term(Tokens).

--- a/src/couch_log/src/couch_log_config_dyn.erl
+++ b/src/couch_log/src/couch_log_config_dyn.erl
@@ -26,4 +26,5 @@
 get(level) -> info;
 get(level_int) -> 2;
 get(max_message_size) -> 16000;
-get(strip_last_msg) -> true.
+get(strip_last_msg) -> true;
+get(filter_fields) -> [pid, registered_name, error_info, messages].

--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -199,7 +199,7 @@ format_crash_report(Report, Neighbours) ->
     MsgFmt = "Process ~s with ~w neighbors ~s with reason: ~s",
     Args = [Name, length(Neighbours), Type, ReasonStr],
     Msg = io_lib:format(MsgFmt, Args),
-    case filter_silly_list(Report, [pid, registered_name, error_info]) of
+    case filter_silly_list(Report) of
         [] ->
             Msg;
         Rest ->
@@ -431,6 +431,11 @@ print_val(Val) ->
     {Str, _} = couch_log_trunc_io:print(Val, 500),
     Str.
 
+filter_silly_list(KV) ->
+    %% The complete list of fields is from here
+    %% https://github.com/erlang/otp/blob/7ca7a6c59543db8a6d26b95ae434e61a044b0800/lib/stdlib/src/proc_lib.erl#L539:L553
+    FilterFields = couch_log_config:get(filter_fields),
+    filter_silly_list(KV, FilterFields).
 
 filter_silly_list([], _) ->
     [];

--- a/src/couch_log/src/couch_log_sup.erl
+++ b/src/couch_log/src/couch_log_sup.erl
@@ -65,6 +65,8 @@ handle_config_change("log", Key, _, _, S) ->
             couch_log_config:reconfigure();
         "strip_last_msg" ->
             couch_log_config:reconfigure();
+        "filter_fields" ->
+            couch_log_config:reconfigure();
         _ ->
             % Someone may have changed the config for
             % the writer so we need to re-initialize.

--- a/src/couch_log/test/eunit/couch_log_config_test.erl
+++ b/src/couch_log/test/eunit/couch_log_config_test.erl
@@ -16,18 +16,19 @@
 -include_lib("couch_log/include/couch_log.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(T(Name), {atom_to_list(Name), fun Name/0}).
 
 couch_log_config_test_() ->
     {setup,
         fun couch_log_test_util:start/0,
         fun couch_log_test_util:stop/1,
         [
-            fun check_level/0,
-            fun check_max_message_size/0,
-            fun check_bad_level/0,
-            fun check_bad_max_message_size/0,
-            fun check_strip_last_msg/0,
-            fun check_bad_strip_last_msg/0
+            ?T(check_level),
+            ?T(check_max_message_size),
+            ?T(check_bad_level),
+            ?T(check_bad_max_message_size),
+            ?T(check_strip_last_msg),
+            ?T(check_bad_strip_last_msg)
         ]
     }.
 

--- a/src/couch_log/test/eunit/couch_log_config_test.erl
+++ b/src/couch_log/test/eunit/couch_log_config_test.erl
@@ -28,7 +28,9 @@ couch_log_config_test_() ->
             ?T(check_bad_level),
             ?T(check_bad_max_message_size),
             ?T(check_strip_last_msg),
-            ?T(check_bad_strip_last_msg)
+            ?T(check_bad_strip_last_msg),
+            ?T(check_filter_fields),
+            ?T(check_bad_filter_fields)
         ]
     }.
 
@@ -143,4 +145,37 @@ check_bad_strip_last_msg() ->
         config:delete("log", "strip_last_msg"),
         couch_log_test_util:wait_for_config(),
         ?assertEqual(true, couch_log_config:get(strip_last_msg))
+    end).
+
+
+check_filter_fields() ->
+    Default = [pid, registered_name, error_info, messages],
+    ?assertEqual(Default, couch_log_config:get(filter_fields)),
+
+    couch_log_test_util:with_config_listener(fun() ->
+        config:set("log", "filter_fields", "[foo, bar, baz]"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual([foo, bar, baz], couch_log_config:get(filter_fields)),
+
+        config:delete("log", "filter_fields"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(Default, couch_log_config:get(filter_fields))
+    end).
+
+check_bad_filter_fields() ->
+    Default = [pid, registered_name, error_info, messages],
+    ?assertEqual(Default, couch_log_config:get(filter_fields)),
+
+    couch_log_test_util:with_config_listener(fun() ->
+        config:set("log", "filter_fields", "[foo, bar, baz]"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual([foo, bar, baz], couch_log_config:get(filter_fields)),
+
+        config:set("log", "filter_fields", "not a list of atoms"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(Default, couch_log_config:get(filter_fields)),
+
+        config:delete("log", "filter_fields"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(Default, couch_log_config:get(filter_fields))
     end).


### PR DESCRIPTION
## Overview

This is a port of https://github.com/apache/couchdb/pull/3485 to 3.x

Do not log by default potentially long list of messages received by terminated process. Currently we log `messages` field in the termination report. This means that we try to process whole message queue of a process before we write the log entry.
An example of a log message we are trying to reduce is as follows:

```
Jan 13 20:18:22 c-fdbcore-perf-api-546dc8d4d8-6hx5n db error [error] 2021-01-13T20:18:22.322515Z dbcore@172.30.74.10 <0.381.0> -------- CRASH REPORT Process fabric2_txids (<0.381.0>) with 0 neighbors exited with reason: {bad_info,{#Ref<0.3875778607.1050673154.132562>,ready}} at gen_server:handle_common_reply/8(line:726) <= proc_lib:init_p_do_apply/3(line:247); initial_call: {fabric2_txids,init,['Argument__1']}, ancestors: [fabric2_sup,<0.377.0>], message_queue_len: 1, messages: [{'$gen_cast',{remove,<<21,22,21,255,22,6,74,23,8,...>>}}], links: [<0.378.0>], dictionary: [{fdb_directory,[<<"perf">>]},{'$erlfdb_error',undefined},{'$fabric_db_handle',...}], trap_exit: false, status: running, heap_size: 6772, stack_size: 27, reductions: 348809
```

## Testing recommendations

The regular `make check` should work. To run tests selectively you can use:

```
make eunit apps=couch_log tests=couch_log_config_test_
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
