### PR TITLE
[CI] Move to new containers for full build

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -81,7 +81,7 @@ pipeline {
       agent {
         docker {
           label 'docker'
-          image 'couchdbdev/debian-stretch-erlang-20.3.8.25-1:latest'
+          image 'apache/couchdbci-debian:buster-erlang-20.3.8.26-1'
           args "${DOCKER_ARGS}"
         }
       }
@@ -194,53 +194,10 @@ pipeline {
           } // post
         } // stage macOS
 
-        stage('CentOS 6') {
-          agent {
-            docker {
-              image 'couchdbdev/centos-6-erlang-20.3.8.25-1:latest'
-              label 'docker'
-              args "${DOCKER_ARGS}"
-            }
-          }
-          environment {
-            platform = 'centos6'
-            sm_ver = '1.8.5'
-          }
-          stages {
-            stage('Build from tarball & test') {
-              steps {
-                unstash 'tarball'
-                sh( script: build_and_test )
-              }
-              post {
-                always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
-                }
-              }
-            }
-            stage('Build CouchDB packages') {
-              steps {
-                sh( script: make_packages )
-                sh( script: cleanup_and_save )
-              }
-              post {
-                success {
-                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
-                }
-              }
-            }
-          } // stages
-          post {
-            cleanup {
-              sh 'rm -rf ${WORKSPACE}/*'
-            }
-          } // post
-        } // stage
-
         stage('CentOS 7') {
           agent {
             docker {
-              image 'couchdbdev/centos-7-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-centos:7-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
             }
@@ -284,7 +241,7 @@ pipeline {
         stage('CentOS 8') {
           agent {
             docker {
-              image 'couchdbdev/centos-8-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-centos:8-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
             }
@@ -328,7 +285,7 @@ pipeline {
         stage('Ubuntu Xenial') {
           agent {
             docker {
-              image 'couchdbdev/ubuntu-xenial-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-ubuntu:xenial-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
             }
@@ -371,7 +328,7 @@ pipeline {
         stage('Ubuntu Bionic') {
           agent {
             docker {
-              image 'couchdbdev/ubuntu-bionic-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-ubuntu:bionic-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
             }
@@ -414,7 +371,7 @@ pipeline {
         stage('Ubuntu Focal') {
           agent {
             docker {
-              image 'couchdbdev/ubuntu-focal-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-ubuntu:focal-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
             }
@@ -457,7 +414,7 @@ pipeline {
         stage('Debian Stretch') {
           agent {
             docker {
-              image 'couchdbdev/debian-stretch-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-debian:stretch-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
             }
@@ -500,7 +457,7 @@ pipeline {
         stage('Debian Buster amd64') {
           agent {
             docker {
-              image 'couchdbdev/debian-buster-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-debian:buster-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
             }
@@ -543,7 +500,7 @@ pipeline {
         stage('Debian Buster arm64v8') {
           agent {
             docker {
-              image 'couchdbdev/arm64v8-debian-buster-erlang-20.3.8.25-1:latest'
+              image 'apache/couchdbci-debian:arm64v8-buster-erlang-20.3.8.26-1'
               label 'arm64v8'
               args "${DOCKER_ARGS}"
             }
@@ -590,7 +547,7 @@ pipeline {
 //        stage('Debian Buster ppc64le') {
 //          agent {
 //            docker {
-//              image 'couchdbdev/ppc64le-debian-buster-erlang-20.3.8.25-1:latest'
+//              image 'apache/couchdbci-debian:ppc64le-buster-erlang-20.3.8.26-1'
 //              label 'ppc64le'
 //              args "${DOCKER_ARGS}"
 //            }
@@ -658,12 +615,12 @@ pipeline {
             }
             stage('Pull latest docker image') {
               steps {
-                sh "docker pull couchdbdev/arm64v8-debian-buster-erlang-20.3.8.25-1:latest"
+                sh "docker pull apache/couchdbci-debian:arm64v8-buster-erlang-20.3.8.26-1"
               }
             }
             stage('Build from tarball & test & packages') {
               steps {
-                withDockerContainer(image: "couchdbdev/arm64v8-debian-buster-erlang-20.3.8.25-1:latest", args: "${DOCKER_ARGS}") {
+                withDockerContainer(image: "apache/couchdbci-debian:arm64v8-buster-erlang-20.3.8.26-1", args: "${DOCKER_ARGS}") {
                   unstash 'tarball'
                   withEnv(['MIX_HOME='+pwd(), 'HEX_HOME='+pwd()]) {
                     sh( script: build_and_test )
@@ -703,7 +660,7 @@ pipeline {
 
       agent {
         docker {
-          image 'couchdbdev/debian-buster-erlang-20.3.8.25-1:latest'
+          image 'apache/couchdbci-debian:buster-erlang-20.3.8.26-1'
           label 'docker'
           args "${DOCKER_ARGS}"
         }
@@ -743,11 +700,9 @@ pipeline {
 
           echo 'Building CentOS repos...'
           sh '''
-            cp js/centos-6/*rpm pkgs/centos6
             cp js/centos-7/*rpm pkgs/centos7
             cp js/centos-8/*rpm pkgs/centos8
-            cd pkgs/centos6 && createrepo --database .
-            cd ../centos7 && createrepo --database .
+            cd pkgs/centos7 && createrepo --database .
             cd ../centos8 && createrepo --database .
           '''
 
@@ -755,7 +710,6 @@ pipeline {
           sh '''
             mv couchdb-pkg/repo/pool $BRANCH_NAME/debian
             mv couchdb-pkg/repo/dists $BRANCH_NAME/debian
-            mv pkgs/centos6/* $BRANCH_NAME/el6
             mv pkgs/centos7/* $BRANCH_NAME/el7
             mv pkgs/centos8/* $BRANCH_NAME/el8
             mv apache-couchdb-*.tar.gz $BRANCH_NAME/source


### PR DESCRIPTION
This is the companion PR to #3504, and moves our "full" builds to the new containers as well.

It drops CentOS 6 because we are no longer able to build these containers, now that their repositories are gone.