### PR TITLE
Add docker creds to CI run

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -83,6 +83,8 @@ pipeline {
           label 'docker'
           image 'apache/couchdbci-debian:buster-erlang-20.3.8.26-1'
           args "${DOCKER_ARGS}"
+          registryUrl 'https://docker.io/'
+          registryCredentialsId 'dockerhub_creds'
         }
       }
       options {
@@ -200,6 +202,8 @@ pipeline {
               image 'apache/couchdbci-centos:7-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -244,6 +248,8 @@ pipeline {
               image 'apache/couchdbci-centos:8-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -288,6 +294,8 @@ pipeline {
               image 'apache/couchdbci-ubuntu:xenial-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -331,6 +339,8 @@ pipeline {
               image 'apache/couchdbci-ubuntu:bionic-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -374,6 +384,8 @@ pipeline {
               image 'apache/couchdbci-ubuntu:focal-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -417,6 +429,8 @@ pipeline {
               image 'apache/couchdbci-debian:stretch-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -460,6 +474,8 @@ pipeline {
               image 'apache/couchdbci-debian:buster-erlang-20.3.8.26-1'
               label 'docker'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -503,6 +519,8 @@ pipeline {
               image 'apache/couchdbci-debian:arm64v8-buster-erlang-20.3.8.26-1'
               label 'arm64v8'
               args "${DOCKER_ARGS}"
+              registryUrl 'https://docker.io/'
+              registryCredentialsId 'dockerhub_creds'
             }
           }
           environment {
@@ -550,6 +568,8 @@ pipeline {
 //              image 'apache/couchdbci-debian:ppc64le-buster-erlang-20.3.8.26-1'
 //              label 'ppc64le'
 //              args "${DOCKER_ARGS}"
+//              registryUrl 'https://docker.io/'
+//              registryCredentialsId 'dockerhub_creds'
 //            }
 //          }
 //          environment {
@@ -663,6 +683,8 @@ pipeline {
           image 'apache/couchdbci-debian:buster-erlang-20.3.8.26-1'
           label 'docker'
           args "${DOCKER_ARGS}"
+          registryUrl 'https://docker.io/'
+          registryCredentialsId 'dockerhub_creds'
         }
       }
       options {

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -69,6 +69,8 @@ pipeline {
           image "${DOCKER_IMAGE}"
           label 'docker'
           args "${DOCKER_ARGS}"
+          registryUrl 'https://docker.io/'
+          registryCredentialsId 'dockerhub_creds'
         }
       }
       options {


### PR DESCRIPTION
This should work around rate limiting that @bessbd and I have seen.

The creds are stored in Jenkins on https://ci-couchdb.apache.org/ . If you would like the account password, let me know.