### PR TITLE
Use correct args in get_doc_info

### DIFF
--- a/test/elixir/lib/step/user.ex
+++ b/test/elixir/lib/step/user.ex
@@ -79,7 +79,7 @@ defmodule Couch.Test.Setup.Step.User do
       :config.delete("admins", String.to_charlist(name), false)
     else
       doc_id = "org.couchdb.user:#{name}"
-      assert {:ok, doc_info(revs: [rev | _])} = :fabric.get_doc_info(users_db)
+      assert {:ok, doc_info(revs: [rev | _])} = :fabric.get_doc_info(users_db, doc_id, [])
       doc = :couch_doc.from_json_obj(%{
         _id: doc_id,
         _rev: rev,


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

`fabric.get_doc_info/3` requires three arguments, but this line was only using one.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make elixir
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
