### PR TITLE
Add batching to couch jobs

### DIFF
--- a/src/couch_jobs/src/couch_jobs.erl
+++ b/src/couch_jobs/src/couch_jobs.erl
@@ -121,9 +121,9 @@ get_job_state(Tx, Type, JobId) when is_binary(JobId) ->
 -spec get_active_jobs_ids(jtx(), job_type()) -> [job_id()] | {error,
     any()}.
 get_active_jobs_ids(Tx, Type) ->
+    SinceVS = {versionstamp, 0, 0},
     couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(Tx), fun(JTx) ->
-        Since = couch_jobs_fdb:get_active_since(JTx, Type,
-            {versionstamp, 0, 0}),
+        {Since, _} = couch_jobs_fdb:get_active_since(JTx, Type, SinceVS, []),
         maps:keys(Since)
     end).
 

--- a/src/couch_jobs/src/couch_jobs.hrl
+++ b/src/couch_jobs/src/couch_jobs.hrl
@@ -40,6 +40,12 @@
 -define(COUCH_JOBS_CURRENT, '$couch_jobs_current').
 -define(UNDEFINED_MAX_SCHEDULED_TIME, 1 bsl 36).
 
+-define(COUCH_JOBS_RETRYABLE(Tag, Err), (
+    (Tag == timeout) orelse (
+        (Tag == erlfdb_error andalso ?ERLFDB_IS_RETRYABLE(Err)) orelse
+        (Tag == erlfdb_error andalso Err =:= ?ERLFDB_TRANSACTION_TIMED_OUT))
+)).
+
 
 -type jtx() :: map() | undefined | tuple().
 -type job_id() :: binary().

--- a/src/couch_jobs/src/couch_jobs_activity_monitor.erl
+++ b/src/couch_jobs/src/couch_jobs_activity_monitor.erl
@@ -72,8 +72,7 @@ handle_info(check_activity, St) ->
     St1 = try
         check_activity(St)
     catch
-        error:{erlfdb_error, Err} when ?ERLFDB_IS_RETRYABLE(Err) orelse
-                Err =:= ?ERLFDB_TRANSACTION_TIMED_OUT ->
+        error:{Tag, Err} when ?COUCH_JOBS_RETRYABLE(Tag, Err) ->
             LogMsg = "~p : type:~p got ~p error, possibly from overload",
             couch_log:error(LogMsg, [?MODULE, St#st.type, Err]),
             St

--- a/src/couch_jobs/src/couch_jobs_activity_monitor.erl
+++ b/src/couch_jobs/src/couch_jobs_activity_monitor.erl
@@ -37,11 +37,15 @@
     type,
     tref,
     timeout = 0,
-    vs = not_found
+    vs = not_found,
+    batch_size
 }).
 
 
--define(MAX_JITTER_DEFAULT, 10000).
+-define(MAX_JITTER_DEFAULT, "10000").
+-define(INIT_BATCH_SIZE, "1000").
+-define(BATCH_FACTOR, "0.75").
+-define(BATCH_INCREMENT, "100").
 -define(MISSING_TIMEOUT_CHECK, 5000).
 
 
@@ -52,7 +56,11 @@ start_link(Type) ->
 %% gen_server callbacks
 
 init([Type]) ->
-    St = #st{jtx = couch_jobs_fdb:get_jtx(), type = Type},
+    St = #st{
+        jtx = couch_jobs_fdb:get_jtx(),
+        type = Type,
+        batch_size = init_batch_size()
+    },
     {ok, schedule_check(St)}.
 
 
@@ -98,19 +106,12 @@ code_change(_OldVsn, St, _Extra) ->
 % Private helper functions
 
 check_activity(#st{jtx = JTx, type = Type, vs = not_found} = St) ->
-    NewVS = couch_jobs_fdb:tx(JTx, fun(JTx1) ->
-        couch_jobs_fdb:get_activity_vs(JTx1, Type)
-    end),
-    St#st{vs = NewVS};
+    St#st{vs = get_activity_vs(JTx, Type)};
 
-check_activity(#st{jtx = JTx, type = Type, vs = VS} = St) ->
-    NewVS = couch_jobs_fdb:tx(JTx, fun(JTx1) ->
-        NewVS = couch_jobs_fdb:get_activity_vs(JTx1, Type),
-        JobIds = couch_jobs_fdb:get_inactive_since(JTx1, Type, VS),
-        couch_jobs_fdb:re_enqueue_inactive(JTx1, Type, JobIds),
-        NewVS
-    end),
-    St#st{vs = NewVS}.
+check_activity(#st{} = St) ->
+    #st{jtx = JTx, type = Type, vs = VS, batch_size = BatchSize} = St,
+    NewBatchSize = re_enqueue_inactive(JTx, Type, VS, BatchSize),
+    St#st{vs = get_activity_vs(JTx, Type), batch_size = NewBatchSize}.
 
 
 get_timeout_msec(JTx, Type) ->
@@ -139,6 +140,53 @@ schedule_check(#st{jtx = JTx, type = Type, timeout = OldTimeout} = St) ->
     St1#st{tref = erlang:send_after(Wait, self(), check_activity)}.
 
 
+re_enqueue_inactive(JTx, Type, VS, BatchSize) ->
+    Result = try
+        couch_jobs_fdb:tx(JTx, fun(JTx1) ->
+            Opts = [{limit, BatchSize}],
+            JobIds = couch_jobs_fdb:get_inactive_since(JTx1, Type, VS, Opts),
+            couch_jobs_fdb:re_enqueue_inactive(JTx1, Type, JobIds),
+            length(JobIds)
+        end)
+    catch
+        error:{erlfdb_error, ?ERLFDB_TRANSACTION_TOO_LARGE} ->
+            failed;
+        error:{Tag, Err} when ?COUCH_JOBS_RETRYABLE(Tag, Err) ->
+            failed
+    end,
+    case Result of
+        JobCnt when is_integer(JobCnt), JobCnt < BatchSize ->
+            BatchSize;
+        JobCnt when is_integer(JobCnt), JobCnt >= BatchSize ->
+            NewBatchSize = BatchSize + batch_increment(),
+            re_enqueue_inactive(JTx, Type, VS, NewBatchSize);
+        failed ->
+            NewBatchSize = max(1, round(BatchSize * batch_factor())),
+            re_enqueue_inactive(JTx, Type, VS, NewBatchSize)
+    end.
+
+
+get_activity_vs(JTx, Type) ->
+    couch_jobs_fdb:tx(JTx, fun(JTx1) ->
+        couch_jobs_fdb:get_activity_vs(JTx1, Type)
+    end).
+
+
 get_max_jitter_msec()->
-    config:get_integer("couch_jobs", "activity_monitor_max_jitter_msec",
+    couch_jobs_util:get_non_neg_int(activity_monitor_max_jitter_msec,
         ?MAX_JITTER_DEFAULT).
+
+
+init_batch_size() ->
+    couch_jobs_util:get_non_neg_int(activity_monitor_init_batch_size,
+        ?INIT_BATCH_SIZE).
+
+
+batch_increment() ->
+    couch_jobs_util:get_non_neg_int(activity_monitor_batch_increment,
+        ?BATCH_INCREMENT).
+
+
+batch_factor() ->
+    couch_jobs_util:get_float_0_1(activity_monitor_batch_factor,
+        ?BATCH_FACTOR).

--- a/src/couch_jobs/src/couch_jobs_server.erl
+++ b/src/couch_jobs/src/couch_jobs_server.erl
@@ -15,6 +15,9 @@
 -behaviour(gen_server).
 
 
+-include("couch_jobs.hrl").
+
+
 -export([
     start_link/0,
     get_notifier_server/1,
@@ -170,8 +173,9 @@ fdb_types() ->
             couch_jobs_fdb:get_types(JTx)
         end)
     catch
-        error:{timeout, _} ->
-            couch_log:warning("~p : Timed out connecting to FDB", [?MODULE]),
+        error:{Tag, Err} when ?COUCH_JOBS_RETRYABLE(Tag, Err) ->
+            LogMsg = "~p : Error ~p:~p connecting to FDB",
+            couch_log:warning(LogMsg, [?MODULE, Tag, Err]),
             []
     end.
 

--- a/src/couch_jobs/src/couch_jobs_server.erl
+++ b/src/couch_jobs/src/couch_jobs_server.erl
@@ -34,8 +34,8 @@
 ]).
 
 
--define(TYPE_CHECK_PERIOD_DEFAULT, 15000).
--define(MAX_JITTER_DEFAULT, 5000).
+-define(TYPE_CHECK_PERIOD_DEFAULT, "15000").
+-define(MAX_JITTER_DEFAULT, "5000").
 
 
 start_link() ->
@@ -188,10 +188,10 @@ schedule_check() ->
 
 
 get_period_msec() ->
-    config:get_integer("couch_jobs", "type_check_period_msec",
+    couch_jobs_util:get_non_neg_int(type_check_period_msec,
         ?TYPE_CHECK_PERIOD_DEFAULT).
 
 
 get_max_jitter_msec() ->
-    config:get_integer("couch_jobs", "type_check_max_jitter_msec",
+    couch_jobs_util:get_non_neg_int(type_check_max_jitter_msec,
         ?MAX_JITTER_DEFAULT).

--- a/src/couch_jobs/src/couch_jobs_util.erl
+++ b/src/couch_jobs/src/couch_jobs_util.erl
@@ -1,0 +1,58 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_jobs_util).
+
+
+-export([
+    get_non_neg_int/2,
+    get_float_0_1/2,
+    get_timeout/2
+]).
+
+
+get_non_neg_int(Key, Default) when is_atom(Key), is_list(Default) ->
+    StrVal = config:get("couch_jobs", atom_to_list(Key), Default),
+    non_neg_int(Key, StrVal).
+
+
+get_float_0_1(Key, Default) when is_atom(Key), is_list(Default) ->
+    StrVal = config:get("couch_jobs", atom_to_list(Key), Default),
+    float_0_1(Key, StrVal).
+
+
+get_timeout(Key, Default) when is_atom(Key), is_list(Default) ->
+    case config:get("couch_jobs", atom_to_list(Key), Default) of
+        "infinity" -> infinity;
+        StrVal -> non_neg_int(Key, StrVal)
+    end.
+
+
+non_neg_int(Name, Str) ->
+    try
+        Val = list_to_integer(Str),
+        true = Val > 0,
+        Val
+    catch _:_ ->
+        erlang:error({invalid_non_neg_integer, {couch_jobs, Name, Str}})
+    end.
+
+
+float_0_1(Name, Str) ->
+    Val = try
+        list_to_float(Str)
+    catch error:badarg ->
+        erlang:error({invalid_float, {couch_jobs, Name, Str}})
+    end,
+    if Val >= 0.0 andalso Val =< 1.0 -> Val; true ->
+        erlang:error({float_out_of_range, {couch_jobs, Name, Str}})
+    end.

--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -1186,18 +1186,27 @@ seq_to_vs(Seq) when is_binary(Seq) ->
 
 
 next_vs({versionstamp, VS, Batch, TxId}) ->
-    {V, B, T} = case TxId =< 65535 of
+    {V, B, T} = case TxId < 16#FFFF of
         true ->
             {VS, Batch, TxId + 1};
         false ->
-            case Batch =< 65535 of
+            case Batch < 16#FFFF of
                 true ->
                     {VS, Batch + 1, 0};
                 false ->
                     {VS + 1, 0, 0}
             end
     end,
-    {versionstamp, V, B, T}.
+    {versionstamp, V, B, T};
+
+next_vs({versionstamp, VS, Batch}) ->
+    {V, B} = case Batch < 16#FFFF of
+        true ->
+            {VS, Batch + 1};
+        false ->
+            {VS + 1, 0}
+    end,
+    {versionstamp, V, B}.
 
 
 new_versionstamp(Tx) ->

--- a/src/fabric/test/fabric2_changes_fold_tests.erl
+++ b/src/fabric/test/fabric2_changes_fold_tests.erl
@@ -22,6 +22,32 @@
 -define(DOC_COUNT, 25).
 
 
+next_vs_function_with_txid_test() ->
+    Cases = [
+        {{0, 0, 1}, {0, 0, 0}},
+        {{0, 0, 2}, {0, 0, 1}},
+        {{0, 1, 0}, {0, 0, 16#FFFF}},
+        {{0, 2, 0}, {0, 1, 16#FFFF}},
+        {{1, 0, 0}, {0, 16#FFFF, 16#FFFF}},
+        {{2, 0, 0}, {1, 16#FFFF, 16#FFFF}}
+    ],
+    Next = fun({V, B, T}) -> fabric2_fdb:next_vs({versionstamp, V, B, T}) end,
+    [?assertEqual({versionstamp, RV, RB, RT}, Next({V, B, T})) ||
+        {{RV, RB, RT}, {V, B, T}} <- Cases].
+
+
+next_vs_function_without_txid_test() ->
+    Cases = [
+        {{0, 1}, {0, 0}},
+        {{0, 2}, {0, 1}},
+        {{1, 0}, {0, 16#FFFF}},
+        {{2, 0}, {1, 16#FFFF}}
+    ],
+    Next = fun({V, B}) -> fabric2_fdb:next_vs({versionstamp, V, B}) end,
+    [?assertEqual({versionstamp, RV, RB}, Next({V, B})) ||
+        {{RV, RB}, {V, B}} <- Cases].
+
+
 changes_fold_test_() ->
     {
         "Test changes fold operations",


### PR DESCRIPTION
Add AIMD-based batching to couch_jobs activity monitor and notifier

couch_jobs activity monitor is responsible for checking jobs which have not
been updated often enough by their workers and re-enqueuing them. Previously
when the number of jobs grew high enough, couch_jobs could fail to either
iterate through all the jobs and timeout with a 1007, try to re-enqueue too
many jobs such that the sum of the commit data would end up being larger than
the 10MB FDB limit.

couch_jobs notifier is in charge notifying subscribers when job state changes.
If the jobs are updated, it would notify if it noticed updates, otherwise it
would notify if job switch to a new state, update -> pending, update ->
finished, etc. Previously if there were too many jobs and/or the cluster was
overloaded it was possible for the notifier to fail with timeouts.

To fix both of the issue, introduce batching with the batch size dynamically
adjusted based on load. As more consecutive errors occur the batch will shrink
exponentially down to 1 row per transaction. Then with each success, the batch
will grow linearly by a fixed amount. This auto-configurable behavior should
provide optimal behavior during overload and during normal operating
conditions.

For tests, since there are already tests which test enqueuing and subscription,
use the same tests but make sure they are run while errors are periodically
generated. That's accomplished with the help of `meck:loop/1` return
specification.

There are two more commits in the PR to fix and update the next_vs function and
another one to simplify handling retryable errors in couch_jobs.