### PR TITLE
Export parse_int/1, parse_pos_int/1 and parse_boolean/1

### DIFF
--- a/src/couch_views/src/couch_views_http_util.erl
+++ b/src/couch_views/src/couch_views_http_util.erl
@@ -28,7 +28,10 @@
     row_to_obj/1,
     row_to_obj/2,
     row_to_json/1,
-    row_to_json/2
+    row_to_json/2,
+    parse_boolean/1,
+    parse_int/1,
+    parse_pos_int/1
 ]).
 
 -include_lib("couch/include/couch_db.hrl").


### PR DESCRIPTION
## Overview

We used to have public `parse_pos/1`, `parse_pos_int/1` and `parse_boolean/1` and they were used by one of the EPI plugins.
This PR exports these functions again.

## Testing recommendations

Compilation without new warnings is enough to test it.

## Related Issues or Pull Requests

- This was changed in https://github.com/apache/couchdb/pull/3503

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
