### PR TITLE
Fix flaky couch_jobs metadata test

### DIFF
--- a/src/couch_jobs/test/couch_jobs_tests.erl
+++ b/src/couch_jobs/test/couch_jobs_tests.erl
@@ -757,13 +757,15 @@ metadata_version_bump(_) ->
     JTx1 = couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(), fun(Tx) -> Tx end),
     ?assertMatch(#{md_version := not_found}, JTx1),
 
-    ets:delete_all_objects(couch_jobs_fdb),
     couch_jobs_fdb:bump_metadata_version(),
+    ets:delete_all_objects(couch_jobs_fdb),
+
     JTx2 = couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(), fun(Tx) -> Tx end),
     ?assertMatch(#{md_version := Bin} when is_binary(Bin), JTx2),
 
-    ets:delete_all_objects(couch_jobs_fdb),
     couch_jobs_fdb:bump_metadata_version(),
+    ets:delete_all_objects(couch_jobs_fdb),
+
     JTx3 = couch_jobs_fdb:tx(couch_jobs_fdb:get_jtx(), fun(Tx) -> Tx end),
     OldMdv = maps:get(md_version, JTx2),
     NewMdv = maps:get(md_version, JTx3),


### PR DESCRIPTION
Previously we deleted the ets handle cache, then bumped the FDB metadata. That has a race condition if anything else, like `fabric2_indexing` or other `couch_jobs` users, tried to get a `jtx()` handle before the metadata bump. In that
case, they would have re-inserted a handle with a stale `md_version` and the test assertions would fail.

The fix is to first bump the md version, then delete the handles.