### PR TITLE
fix default values for prometheus templates

### DIFF
--- a/configure
+++ b/configure
@@ -220,6 +220,7 @@ cat > rel/couchdb.config << EOF
 {node_name, "-name couchdb@127.0.0.1"}.
 {cluster_port, 5984}.
 {backend_port, 5986}.
+{prometheus_port, 17986}.
 EOF
 
 cat > install.mk << EOF

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -694,6 +694,6 @@ writer = stderr
 ;cache_expiration_check_sec = 10
 
 [prometheus]
-additional_port = true
+additional_port = false
 bind_address = 127.0.0.1
 port = {{prometheus_port}}


### PR DESCRIPTION
## Overview
Couch_prometheus's additional http server should be off by default
and the port should have a default value of 17986 when running

`make release`.  The http server was mistakenly left on without a port
and that led to startup issues.

## Testing recommendations

`make release` should install correctly after running `configure`.
I performed the above step and the `default.ini` in `rel/couchdb` shows:

```
[prometheus]
additional_port = false
bind_address = 127.0.0.1
port = 17986
```

## Related Issues or Pull Requests

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
