### PR TITLE
Install only one couch log error handler

### DIFF
--- a/src/couch_log/src/couch_log_monitor.erl
+++ b/src/couch_log/src/couch_log_monitor.erl
@@ -41,8 +41,12 @@ start_link() ->
 -ifdef(OTP_RELEASE).
 
 init(_) ->
-    % see https://erlang.org/doc/man/error_logger.html#add_report_handler-1
-    ok = error_logger:add_report_handler(?HANDLER_MOD),
+    % See https://erlang.org/doc/man/error_logger.html#add_report_handler-1
+    % however that call doesn't call a supervised handler so we do the same
+    % thing add_report_handler/1 does but call gen_event:add_sup_handler/3
+    % instead of gen_event:add_handler/3.
+    Opts =  #{level => info, filter_default => log},
+    _ = logger:add_handler(error_logger, error_logger, Opts),
     ok = gen_event:add_sup_handler(error_logger, ?HANDLER_MOD, []),
     {ok, nil}.
 

--- a/src/couch_log/test/eunit/couch_log_config_listener_test.erl
+++ b/src/couch_log/test/eunit/couch_log_config_listener_test.erl
@@ -24,7 +24,8 @@ couch_log_config_test_() ->
         fun couch_log_test_util:stop/1,
         [
             fun check_restart_listener/0,
-            fun check_ignore_non_log/0
+            fun check_ignore_non_log/0,
+            fun check_only_one_couch_error_handler/0
         ]
     }.
 
@@ -67,6 +68,10 @@ check_ignore_non_log() ->
     end,
     ?assertError(config_change_timeout, Run()).
 
+check_only_one_couch_error_handler() ->
+    Handlers = gen_event:which_handlers(error_logger),
+    CouchHandlers = [H || H <- Handlers, H =:= couch_log_error_logger_h],
+    ?assertEqual(1, length(CouchHandlers)).
 
 get_handler() ->
     FoldFun = fun


### PR DESCRIPTION
Previously we installed two of them, one through the `error_logger:add_report_handler/1` call and another through the `gen_event:add_sup_handler/3`. The first one was to setup `logger` handler, but the second was was still needed so we're notified if event manager died.

The fix is to do what `error_logger:add_handler/1` does [1] and instead of calling the `gen_event:add_handler/3`, call `gen_server:add_sup_handler/3`.

[1] [error_logger.erl#L453-L455](https://github.com/erlang/otp/blob/40922798411c2d23ee8a99456f96d6637c62b762/lib/kernel/src/error_logger.erl#L453-L455)

