### PR TITLE
Add clause for unknown_eval_api_language

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1070,6 +1070,9 @@ error_info(not_ciphertext) ->
     {500, <<"not_ciphertext">>, <<"Not Ciphertext">>};
 error_info({service_unavailable, Reason}) ->
     {503, <<"service unavailable">>, Reason};
+error_info({unknown_eval_api_language, Language}) ->
+    {400, <<"unknown_eval_api_language">>, <<"unsupported language in design"
+        " doc: `", Language/binary, "`">>};
 error_info({timeout, _Reason}) ->
     error_info(timeout);
 error_info({Error, null}) ->


### PR DESCRIPTION
## Overview

Improve error message when unsupported language is specified for map. Without this change the error causes 500 with unclear reason. 

## Testing recommendations

1. Create database `curl -u adm:pass -X PUT -H 'Content-Type: application/json'  http://127.0.0.1:15984/test`
2. Try creating design doc with unsupported language and map function
```
curl -u adm:pass -X PUT -H 'Content-Type: application/json' -d '{"_id": "_design/python", "language": "python", "views": {"diet": {"map": ""}}}' http://127.0.0.1:15984/test/_design/python5
```
3. Make sure `#2` display following message
```
{"error":"unknown_eval_api_language","reason":"unsupported language in design doc: `python`","ref":2476823177}
```

## Related Issues or Pull Requests

- Follow up for https://github.com/apache/couchdb/pull/3481

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
