### PR TITLE
Fix bug in replicator authentication for password contains @

### DIFF
--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -288,7 +288,9 @@ extract_creds_from_url(Url) ->
             Prefix = lists:concat([Proto, "://", User, ":", Pass, "@"]),
             Suffix = lists:sublist(Url, length(Prefix) + 1, length(Url) + 1),
             NoCreds = lists:concat([Proto, "://", Suffix]),
-            {ok, User, Pass, NoCreds}
+            User1 = chttpd:unquote(User),
+            Pass1 = chttpd:unquote(Pass),
+            {ok, User1, Pass1, NoCreds}
     end.
 
 
@@ -576,12 +578,36 @@ extract_creds_success_test_() ->
             {"u", "p", #httpdb{url = "http://x.y/db"}}
         },
         {
+            #httpdb{url = "http://u%40:p%40@x.y/db"},
+            {"u@", "p@", #httpdb{url = "http://x.y/db"}}
+        },
+        {
+            #httpdb{url = "http://u%40u:p%40p@x.y/db"},
+            {"u@u", "p@p", #httpdb{url = "http://x.y/db"}}
+        },
+        {
+            #httpdb{url = "http://u%40%401:p%40%401@x.y/db"},
+            {"u@@1", "p@@1", #httpdb{url = "http://x.y/db"}}
+        },
+        {
+            #httpdb{url = "http://u%40%2540:p%40%2540@x.y/db"},
+            {"u@%40", "p@%40", #httpdb{url = "http://x.y/db"}}
+        },
+        {
             #httpdb{url = "http://u:p@h:80/db"},
             {"u", "p", #httpdb{url = "http://h:80/db"}}
         },
         {
+            #httpdb{url = "http://u%3A:p%3A@h:80/db"},
+            {"u:", "p:", #httpdb{url = "http://h:80/db"}}
+        },
+        {
             #httpdb{url = "https://u:p@h/db"},
             {"u", "p", #httpdb{url = "https://h/db"}}
+        },
+        {
+            #httpdb{url = "https://u%2F:p%2F@h/db"},
+            {"u/", "p/", #httpdb{url = "https://h/db"}}
         },
         {
             #httpdb{url = "http://u:p@127.0.0.1:5984/db"},
@@ -596,8 +622,16 @@ extract_creds_success_test_() ->
             {"u", "p", #httpdb{url = "http://[2001:db8:a1b:12f9::1]:81/db"}}
         },
         {
+            #httpdb{url = "http://u:p%3A%2F%5B%5D%40@[2001:db8:a1b:12f9::1]:81/db"},
+            {"u", "p:/[]@", #httpdb{url = "http://[2001:db8:a1b:12f9::1]:81/db"}}
+        },
+        {
             #httpdb{url = "http://u:p@x.y/db/other?query=Z&query=w"},
             {"u", "p", #httpdb{url = "http://x.y/db/other?query=Z&query=w"}}
+        },
+        {
+            #httpdb{url = "http://u:p%3F@x.y/db/other?query=Z&query=w"},
+            {"u", "p?", #httpdb{url = "http://x.y/db/other?query=Z&query=w"}}
         },
         {
             #httpdb{
@@ -607,6 +641,24 @@ extract_creds_success_test_() ->
                 ]
             },
             {"u", "p", #httpdb{url = "http://h/db"}}
+        },
+        {
+            #httpdb{
+                url = "http://h/db",
+                headers = DefaultHeaders ++ [
+                    {"Authorization", "Basic " ++ b64creds("u", "p@")}
+                ]
+            },
+            {"u", "p@", #httpdb{url = "http://h/db"}}
+        },
+        {
+            #httpdb{
+                url = "http://h/db",
+                headers = DefaultHeaders ++ [
+                    {"Authorization", "Basic " ++ b64creds("u", "p@%40")}
+                ]
+            },
+            {"u", "p@%40", #httpdb{url = "http://h/db"}}
         },
         {
             #httpdb{


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
When the username and password contains @, the replicator authentication will break.
This PR fixes that bug by unquoting the credentials.
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
make eunit apps=couch_replicator suites=couch_replicator_auth_session
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
This fixes #2892
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
