### PR TITLE
Handle the case when md5 field is undefined

### DIFF
--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -331,7 +331,8 @@ digest_from_json(Props) ->
     end.
 
 
-to_json(Att, OutputData, DataToFollow, ShowEncoding) ->
+to_json(#{md5 := Md5} = Att, OutputData, DataToFollow, ShowEncoding)
+        when is_binary(Md5) ->
     #{
         name := Name,
         type := Type,
@@ -339,7 +340,6 @@ to_json(Att, OutputData, DataToFollow, ShowEncoding) ->
         disk_len := DiskLen,
         att_len := AttLen,
         revpos := RevPos,
-        md5 := Md5,
         encoding := Encoding
     } = Att,
     Props = [
@@ -371,7 +371,10 @@ to_json(Att, OutputData, DataToFollow, ShowEncoding) ->
         true ->
             []
     end,
-    {Name, {Props ++ DigestProp ++ DataProps ++ EncodingProps}}.
+    {Name, {Props ++ DigestProp ++ DataProps ++ EncodingProps}};
+
+to_json(#{md5 := undefined} = Att, OutputData, DataToFollow, ShowEncoding) ->
+    to_json(Att#{md5 => <<>>}, OutputData, DataToFollow, ShowEncoding).
 
 
 flush(Db, DocId, Att1) ->

--- a/src/couch/test/eunit/couch_doc_json_tests.erl
+++ b/src/couch/test/eunit/couch_doc_json_tests.erl
@@ -430,6 +430,14 @@ to_json_success_cases() ->
                     {data, <<"sammich">>},
                     {md5, <<>>},
                     {encoding, identity}
+                ]),
+                couch_att:new([
+                    {name, <<"animals.json">>},
+                    {type, <<"application/json">>},
+                    {revpos, 1},
+                    {data, <<"leon">>},
+                    {md5, undefined},
+                    {encoding, identity}
                 ])
             ]},
             {[
@@ -444,6 +452,11 @@ to_json_success_cases() ->
                        {<<"content_type">>, <<"application/food">>},
                        {<<"revpos">>, 1},
                        {<<"data">>, <<"c2FtbWljaA==">>}
+                   ]}},
+                   {<<"animals.json">>, {[
+                       {<<"content_type">>, <<"application/json">>},
+                       {<<"revpos">>, 1},
+                       {<<"data">>, <<"bGVvbg==">>}
                    ]}}
                 ]}}
             ]},


### PR DESCRIPTION

## Overview

Previously the default value for md5 field was `<<>>`. This value changed to
undefined when we switch to using maps instead of erlang records.
The change break the `couch_att:to_json/4` funciton because `base64:encode/1`
cannot handle atom `undefined`.

The issue happens for inline attachments only this is why it wasn't discovered
earlier.

## Testing recommendations

1. run test suite
2. there is a manual way to test it as well
```
curl -u adm:pass -X PUT -H 'Content-Type: application/json' http://127.0.0.1:15984/test
curl -u adm:pass -X PUT -H 'Content-Type: application/json' -d '{"_id": "_design/ddd", "language": "javascript", "views": {"diet": {"map": ""}}, "_attachments": {"foo.txt": {"content_type": "text/plain", "data": "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="}}}' http://127.0.0.1:15984/test/_design/ddd
```

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
