### PR TITLE
Add offheap MQ support for dreyfus_index_manager

### DIFF
--- a/src/dreyfus/src/dreyfus_index_manager.erl
+++ b/src/dreyfus/src/dreyfus_index_manager.erl
@@ -45,6 +45,7 @@ get_disk_size(DbName, #index{sig=Sig}) ->
 % gen_server functions.
 
 init([]) ->
+    couch_util:set_mqd_off_heap(?MODULE),
     ets:new(?BY_SIG, [set, private, named_table]),
     ets:new(?BY_PID, [set, private, named_table]),
     couch_event:link_listener(?MODULE, handle_db_event, nil, [all_dbs]),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This enables offheap message queue support for the `dreyfus_index_manager` process. Like the `couch_server` process, this process can become overloaded with messages which very quickly causes issues. Switching the message queue off heap helps alleviate that to some extent.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
