### PR TITLE
Bump ibrowse to 4.4.2 + couchdb patches

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -151,7 +151,7 @@ DepDescs = [
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-6"}},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-2"}},
+{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-2"}},
 {jaeger_passage,   "jaeger-passage",   {tag, "CouchDB-0.1.14-2"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.5-1"}},
 {local,            "local",            {tag, "0.2.1"}},

--- a/src/couch_replicator/src/couch_replicator_connection.erl
+++ b/src/couch_replicator/src/couch_replicator_connection.erl
@@ -73,7 +73,10 @@ init([]) ->
     Interval = config:get_integer("replicator", "connection_close_interval",
         ?DEFAULT_CLOSE_INTERVAL),
     Timer = erlang:send_after(Interval, self(), close_idle_connections),
-    ibrowse:add_config([{inactivity_timeout, Interval}]),
+    ibrowse:add_config([
+        {inactivity_timeout, Interval},
+        {worker_trap_exits, false}
+    ]),
     {ok, #state{close_interval=Interval, timer=Timer}}.
 
 acquire(Url) ->


### PR DESCRIPTION
Set the `worker_trap_exits = false` setting to ensure our replication worker pool properly cleans up worker processes.

Ref: https://github.com/apache/couchdb/pull/3208
