### PR TITLE
Add error propagation to couch_eval and couch_views_indexer

### DIFF
--- a/src/couch_eval/src/couch_eval.erl
+++ b/src/couch_eval/src/couch_eval.erl
@@ -86,8 +86,12 @@ acquire_map_context(DbName, DDocId, Language, Sig, Lib, MapFuns) ->
         lib => Lib,
         map_funs => MapFuns
     },
-    {ok, Ctx} = ApiMod:acquire_map_context(CtxOpts),
-    {ok, {ApiMod, Ctx}}.
+    case ApiMod:acquire_map_context(CtxOpts) of
+        {ok, Ctx} ->
+            {ok, {ApiMod, Ctx}};
+        {error, Error} ->
+            {error, Error}
+    end.
 
 
 -spec release_map_context(context()) -> ok | {error, any()}.

--- a/src/couch_eval/test/couch_eval_error_tests.erl
+++ b/src/couch_eval/test/couch_eval_error_tests.erl
@@ -10,7 +10,7 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
--module(error_tests).
+-module(couch_eval_error_tests).
 
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").

--- a/src/couch_eval/test/couch_eval_error_tests.erl
+++ b/src/couch_eval/test/couch_eval_error_tests.erl
@@ -2,7 +2,7 @@
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at
 %
-%   http://www.apache.org/licenses/LICENSE-2.0
+%     http://www.apache.org/licenses/LICENSE-2.0
 %
 % Unless required by applicable law or agreed to in writing, software
 % distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -20,34 +20,35 @@
 
 
 setup() ->
-  meck:new(mock_language_server, [non_strict]),
-  Ctx = test_util:start_couch(),
-  config:set("couch_eval.languages", ?LANG_STRING,
-    atom_to_list(mock_language_server)),
-  Ctx.
+    meck:new(mock_language_server, [non_strict]),
+    Ctx = test_util:start_couch(),
+    config:set("couch_eval.languages", ?LANG_STRING,
+        atom_to_list(mock_language_server)),
+    Ctx.
 
 
 teardown(Ctx) ->
-  test_util:stop_couch(Ctx),
-  meck:unload().
+    test_util:stop_couch(Ctx),
+    meck:unload().
 
 
 error_test_() ->
-  {
-    "Error tests",
     {
-      setup,
-      fun setup/0, fun teardown/1,
-      [
-        fun acquire_map_context_error_handled/0
-      ]
-    }
-  }.
+        "Error tests",
+        {
+            setup,
+            fun setup/0, fun teardown/1,
+            [
+                fun acquire_map_context_error_handled/0
+            ]
+        }
+    }.
+
 
 acquire_map_context_error_handled() ->
-  meck:expect(mock_language_server, acquire_map_context,
-    fun(_) -> {error, foo_error} end),
-  Result = couch_eval:acquire_map_context(<<"foo">>, <<"bar">>, ?LANG_BINARY,
-    <<"baz">>, <<"quux">>, [<<"quuz">>]),
-  ?assertEqual({error, foo_error}, Result).
-
+    meck:expect(mock_language_server, acquire_map_context, fun(_) ->
+        {error, foo_error}
+    end),
+    Result = couch_eval:acquire_map_context(<<"foo">>, <<"bar">>, ?LANG_BINARY,
+        <<"baz">>, <<"quux">>, [<<"quuz">>]),
+    ?assertEqual({error, foo_error}, Result).

--- a/src/couch_eval/test/error_tests.erl
+++ b/src/couch_eval/test/error_tests.erl
@@ -1,0 +1,53 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(error_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(LANG_BINARY, <<"foo_lang">>).
+-define(LANG_STRING, binary_to_list(?LANG_BINARY)).
+
+
+setup() ->
+  meck:new(mock_language_server, [non_strict]),
+  Ctx = test_util:start_couch(),
+  config:set("couch_eval.languages", ?LANG_STRING,
+    atom_to_list(mock_language_server)),
+  Ctx.
+
+
+teardown(Ctx) ->
+  test_util:stop_couch(Ctx),
+  meck:unload().
+
+
+error_test_() ->
+  {
+    "Error tests",
+    {
+      setup,
+      fun setup/0, fun teardown/1,
+      [
+        fun acquire_map_context_error_handled/0
+      ]
+    }
+  }.
+
+acquire_map_context_error_handled() ->
+  meck:expect(mock_language_server, acquire_map_context,
+    fun(_) -> {error, foo_error} end),
+  Result = couch_eval:acquire_map_context(<<"foo">>, <<"bar">>, ?LANG_BINARY,
+    <<"baz">>, <<"quux">>, [<<"quuz">>]),
+  ?assertEqual({error, foo_error}, Result).
+

--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -561,15 +561,19 @@ start_query_server(#mrst{qserver = nil} = Mrst) ->
         lib = Lib,
         views = Views
     } = Mrst,
-    {ok, QServer} = couch_eval:acquire_map_context(
+    case couch_eval:acquire_map_context(
             DbName,
             DDocId,
             Language,
             Sig,
             Lib,
             [View#mrview.def || View <- Views]
-        ),
-    Mrst#mrst{qserver = QServer};
+        ) of
+        {ok, QServer} ->
+            Mrst#mrst{qserver = QServer};
+        {error, Error} ->
+            throw(Error)
+    end;
 
 start_query_server(#mrst{} = Mrst) ->
     Mrst.

--- a/src/couch_views/src/couch_views_indexer.erl
+++ b/src/couch_views/src/couch_views_indexer.erl
@@ -572,7 +572,7 @@ start_query_server(#mrst{qserver = nil} = Mrst) ->
         {ok, QServer} ->
             Mrst#mrst{qserver = QServer};
         {error, Error} ->
-            throw(Error)
+            error(Error)
     end;
 
 start_query_server(#mrst{} = Mrst) ->

--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -451,7 +451,8 @@ multiple_doc_update_with_existing_rows(Db) ->
     ?assertEqual([
         row(<<"0">>, 0, 0),
         row(<<"1">>, 2, 2)
-    ], Out2).    
+    ], Out2).
+
 
 handle_db_recreated_when_running(Db) ->
     DbName = fabric2_db:name(Db),
@@ -572,7 +573,8 @@ handle_doc_updated_when_running(Db) ->
     }, couch_jobs:wait(SubId, finished, infinity)),
 
     Args = #mrargs{update = false},
-    {ok, Out2} = couch_views:query(Db, DDoc, ?MAP_FUN1, fun fold_fun/2, [], Args),
+    {ok, Out2} = couch_views:query(Db, DDoc, ?MAP_FUN1, fun fold_fun/2, [],
+        Args),
     ?assertEqual([
         row(<<"0">>, 0, 0)
     ], Out2).
@@ -617,17 +619,17 @@ handle_acquire_map_context_error(_) ->
     meck:new(mock_language_server, [non_strict]),
     config:set("couch_eval.languages", ?QUERY_SERVER_LANG_STRING,
         atom_to_list(mock_language_server)),
-    meck:expect(mock_language_server, acquire_map_context,
-        fun(_) -> {error, foo_error} end),
-    {'EXIT', {Reason, _}} = (catch couch_views_indexer:start_query_server(#mrst{
+    meck:expect(mock_language_server, acquire_map_context, fun(_) ->
+        {error, foo_error}
+    end),
+    ?assertError(foo_error, couch_views_indexer:start_query_server(#mrst{
         db_name = "DbName",
         idx_name = "DDocId",
         language = ?QUERY_SERVER_LANG_BINARY,
         sig = "Sig",
         lib = "Lib",
         views = []
-    })),
-    ?assertEqual(foo_error, Reason).
+    })).
 
 
 row(Id, Key, Value) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

When `ApiMod:acquire_map_context` returns with `{error, any()}`, the caller(s) fail with `badmatch`. This PR changes the caller hierarchy so that those `{error, _}` are propagated back and a failing `update` gets retried (up to `retry_limit` times).

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
I tested manually: `curl -XPUT -HContent-type:application/json -d'{"views": { "testView": { "map": "function(doc) {if(doc.name) {emit(doc.name)};}" } }, "language": "javascript"}'  http://adm:pass@127.0.0.1:15984/foo/_design/fooDD2` and `curl http://adm:pass@127.0.0.1:15984/foo/_design/fooDD2/_view/testView` and I watched as the `badmatch` log entries disappeared after the change.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
