### PR TITLE
Bump ibrowse to 4.4.2 + couchdb patches

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -159,7 +159,7 @@ DepDescs = [
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.3"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-6"}},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.0.1-1"}},
+{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-2"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.5-1"}},
 {mochiweb,         "mochiweb",         {tag, "v2.20.0"}},
 {meck,             "meck",             {tag, "0.8.8"}},

--- a/src/couch_replicator/src/couch_replicator_connection.erl
+++ b/src/couch_replicator/src/couch_replicator_connection.erl
@@ -72,7 +72,10 @@ init([]) ->
     Interval = config:get_integer("replicator", "connection_close_interval",
         ?DEFAULT_CLOSE_INTERVAL),
     Timer = erlang:send_after(Interval, self(), close_idle_connections),
-    ibrowse:add_config([{inactivity_timeout, Interval}]),
+    ibrowse:add_config([
+        {inactivity_timeout, Interval},
+        {worker_trap_exits, false}
+    ]),
     {ok, #state{close_interval=Interval, timer=Timer}}.
 
 acquire(Url) ->


### PR DESCRIPTION
This is a port from main https://github.com/apache/couchdb/pull/3551

Set the `worker_trap_exits = false` setting to ensure our replication worker pool properly cleans up worker processes.

Ref: https://github.com/apache/couchdb/pull/3208
