### PR TITLE
Handle disabled retries in restart_tx logic

### DIFF
--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -1879,11 +1879,13 @@ restart_fold(Tx, #fold_acc{} = Acc) ->
 
     ok = erlfdb:reset(Tx),
 
+    % During buggify test runs MaxRetries would be -1
     MaxRetries = fabric2_server:get_retry_limit(),
     case {erase(?PDICT_FOLD_ACC_STATE), Acc#fold_acc.retries} of
         {#fold_acc{db = Db} = Acc1, _} ->
             Acc1#fold_acc{db = check_db_instance(Db), retries = 0};
-        {undefined, Retries} when Retries < MaxRetries ->
+        {undefined, Retries} when Retries < MaxRetries orelse
+                MaxRetries =:= -1 ->
             Db = check_db_instance(Acc#fold_acc.db),
             Acc#fold_acc{db = Db, retries = Retries + 1};
         {undefined, _} ->


### PR DESCRIPTION
During buggify runs we disable max tx retries by setting it to -1. That's FDB's documented way of doing it. However, when we re-use that setting to handle `restart_tx` logic we don't account for -1, so we that's what this PR fixes.