### PR TITLE
Re-enable skipped ConfigTest elixir tests

### DIFF
--- a/test/elixir/test/config/skip.elixir
+++ b/test/elixir/test/config/skip.elixir
@@ -43,15 +43,6 @@
     "CoffeeScript basic functionality"
   ],
   "ConfigTest": [
-    "Atoms, binaries, and strings suffice as whitelist sections and keys.",
-    "Blacklist is functional",
-    "Keys not in the whitelist may not be modified",
-    "Non-2-tuples in the whitelist are ignored",
-    "Non-list whitelist values allow further modification of the whitelist",
-    "Non-term whitelist values allow further modification of the whitelist",
-    "Reload config",
-    "Server-side password hashing, and raw updates disabling that",
-    "Settings can be altered with undefined whitelist allowing any change"
   ],
   "CookieAuthTest": [
     "cookie auth"


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
I was walking through the skipped elixir tests and I just realized the `ConfigTest` tests are passing with no change.
Fun fact, they may have already been passing for some time: https://github.com/apache/couchdb/pull/3465#pullrequestreview-622784583
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
