### PR TITLE
Use the last commit result even when there are intermediate retries

### DIFF
--- a/src/fabric/include/fabric2.hrl
+++ b/src/fabric/include/fabric2.hrl
@@ -78,6 +78,7 @@
 -define(PDICT_CHECKED_MD_IS_CURRENT, '$fabric_checked_md_is_current').
 -define(PDICT_TX_ID_KEY, '$fabric_tx_id').
 -define(PDICT_TX_RES_KEY, '$fabric_tx_result').
+-define(PDICT_TX_RES_WAS_UNKNOWN, '$fabric_tx_res_was_unknown').
 -define(PDICT_FOLD_ACC_STATE, '$fabric_fold_acc_state').
 
 -define(DEFAULT_BINARY_CHUNK_SIZE, 100000).

--- a/src/fabric/src/fabric2_fdb.erl
+++ b/src/fabric/src/fabric2_fdb.erl
@@ -1969,7 +1969,7 @@ check_db_instance(#{} = Db) ->
 
 
 is_transaction_applied(Tx) ->
-    is_commit_unknown_result()
+    was_commit_unknown_result()
         andalso has_transaction_id()
         andalso transaction_id_exists(Tx).
 
@@ -1997,11 +1997,23 @@ clear_transaction() ->
     erase(?PDICT_CHECKED_DB_IS_CURRENT),
     erase(?PDICT_CHECKED_MD_IS_CURRENT),
     erase(?PDICT_TX_ID_KEY),
-    erase(?PDICT_TX_RES_KEY).
+    erase(?PDICT_TX_RES_KEY),
+    erase(?PDICT_TX_RES_WAS_UNKNOWN).
 
 
-is_commit_unknown_result() ->
-    erlfdb:get_last_error() == ?ERLFDB_COMMIT_UNKNOWN_RESULT.
+was_commit_unknown_result() ->
+    case get(?PDICT_TX_RES_WAS_UNKNOWN) of
+        true ->
+            true;
+        undefined ->
+            case erlfdb:get_last_error() == ?ERLFDB_COMMIT_UNKNOWN_RESULT of
+                true ->
+                    put(?PDICT_TX_RES_WAS_UNKNOWN, true),
+                    true;
+                false ->
+                    false
+            end
+    end.
 
 
 has_transaction_id() ->


### PR DESCRIPTION
Previously, if a transaction got a `commit_unknown_result`, during the next successful attempt that result would be returned to the user. However, if the next attempt was another retryable error, then the committed result was ignored
and the whole transaction would be applied again. This could result in document update transactions conflicting with themselves as described in issue https://github.com/apache/couchdb/issues/3560

To prevent that from happening we remember that there was an `commit_unknown_result` error during the course of any previous retries and try to return that result.
