### PR TITLE
Re-enable more elixir tests

### DIFF
--- a/test/elixir/test/config/skip.elixir
+++ b/test/elixir/test/config/skip.elixir
@@ -47,7 +47,6 @@
   "CookieAuthTest": [
   ],
   "CopyDocTest": [
-    "Copy doc tests"
   ],
   "DesignDocsQueryTest": [
   ],

--- a/test/elixir/test/config/skip.elixir
+++ b/test/elixir/test/config/skip.elixir
@@ -45,7 +45,6 @@
   "ConfigTest": [
   ],
   "CookieAuthTest": [
-    "cookie auth"
   ],
   "CopyDocTest": [
     "Copy doc tests"

--- a/test/elixir/test/cookie_auth_test.exs
+++ b/test/elixir/test/cookie_auth_test.exs
@@ -369,11 +369,13 @@ defmodule CookieAuthTest do
       error_message: "forbidden"
     )
 
-    session = login("jchris", "funnybone")
-    info = Couch.Session.info(session)
+    retry_until(fn ->
+      session = login("jchris", "funnybone")
+      info = Couch.Session.info(session)
 
-    assert not Enum.member?(info["userCtx"]["roles"], "_admin")
-    assert(Enum.member?(info["userCtx"]["roles"], "foo"))
+      assert not Enum.member?(info["userCtx"]["roles"], "_admin")
+      assert(Enum.member?(info["userCtx"]["roles"], "foo"))
+    end)
 
     logout(session)
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
The only test in the group is passing. This PR re-enables it.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
