### PR TITLE
Moved couch_httpd_auth options to chttpd_auth 3.x

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -232,8 +232,31 @@ socket_options = [{sndbuf, 262144}]
 [ssl]
 port = 6984
 
-; [chttpd_auth]
-; authentication_db = _users
+[chttpd_auth]
+;authentication_db = _users
+
+; These options are moved from [couch_httpd_auth]
+;authentication_redirect = /_utils/session.html
+;require_valid_user = false
+;timeout = 600 ; number of seconds before automatic logout
+;auth_cache_size = 50 ; size is number of cache entries
+;allow_persistent_cookies = true ; set to false to disallow persistent cookies
+;iterations = 10 ; iterations for password hashing
+;min_iterations = 1
+;max_iterations = 1000000000
+;password_scheme = pbkdf2
+; List of Erlang RegExp or tuples of RegExp and an optional error message.
+; Where a new password must match all RegExp.
+; Example: [{".{10,}", "Password min length is 10 characters."}, "\\d+"]
+;password_regexp = []
+;proxy_use_secret = false
+; comma-separated list of public fields, 404 if empty
+;public_fields =
+;secret =
+;users_db_public = false
+;cookie_domain = example.com
+; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
+;same_site =
 
 ; [chttpd_auth_cache]
 ; max_lifetime = 600000
@@ -281,27 +304,12 @@ port = 6984
 ; WARNING! This only affects the node-local port (5986 by default).
 ; You probably want the settings under [chttpd].
 authentication_db = _users
-authentication_redirect = /_utils/session.html
-require_valid_user = false
-timeout = 600 ; number of seconds before automatic logout
-auth_cache_size = 50 ; size is number of cache entries
-allow_persistent_cookies = true ; set to false to disallow persistent cookies
-iterations = 10 ; iterations for password hashing
-; min_iterations = 1
-; max_iterations = 1000000000
-; password_scheme = pbkdf2
-; List of Erlang RegExp or tuples of RegExp and an optional error message.
-; Where a new password must match all RegExp.
-; Example: [{".{10,}", "Password min length is 10 characters."}, "\\d+"]
-; password_regexp = []
-; proxy_use_secret = false
-; comma-separated list of public fields, 404 if empty
-; public_fields =
-; secret = 
-; users_db_public = false
-; cookie_domain = example.com
-; Set the SameSite cookie property for the auth cookie. If empty, the SameSite property is not set.
-; same_site =
+
+; These settings were moved to [chttpd_auth]
+; authentication_redirect, require_valid_user, timeout,
+; auth_cache_size, allow_persistent_cookies, iterations, min_iterations,
+; max_iterations, password_scheme, password_regexp, proxy_use_secret,
+; public_fields, secret, users_db_public, cookie_domain, same_site
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1036,14 +1036,16 @@ error_headers(#httpd{mochi_req=MochiReq}=Req, 401=Code, ErrorStr, ReasonStr) ->
             % redirect to the session page.
             case ErrorStr of
             <<"unauthorized">> ->
-                case config:get("couch_httpd_auth", "authentication_redirect", undefined) of
+                case chttpd_util:get_chttpd_auth_config(
+                    "authentication_redirect", "/_utils/session.html") of
                 undefined -> {Code, []};
                 AuthRedirect ->
-                    case config:get("couch_httpd_auth", "require_valid_user", "false") of
-                    "true" ->
+                    case chttpd_util:get_chttpd_auth_config_boolean(
+                        "require_valid_user", false) of
+                    true ->
                         % send the browser popup header no matter what if we are require_valid_user
                         {Code, [{"WWW-Authenticate", "Basic realm=\"server\""}]};
-                    _False ->
+                    false ->
                         case MochiReq:accepts_content_type("application/json") of
                         true ->
                             {Code, []};

--- a/src/chttpd/src/chttpd_util.erl
+++ b/src/chttpd/src/chttpd_util.erl
@@ -17,7 +17,11 @@
     get_chttpd_config/1,
     get_chttpd_config/2,
     get_chttpd_config_integer/2,
-    get_chttpd_config_boolean/2
+    get_chttpd_config_boolean/2,
+    get_chttpd_auth_config/1,
+    get_chttpd_auth_config/2,
+    get_chttpd_auth_config_integer/2,
+    get_chttpd_auth_config_boolean/2
 ]).
 
 
@@ -37,3 +41,22 @@ get_chttpd_config_integer(Key, Default) ->
 get_chttpd_config_boolean(Key, Default) ->
     config:get_boolean("chttpd", Key,
         config:get_boolean("httpd", Key, Default)).
+
+
+get_chttpd_auth_config(Key) ->
+    config:get("chttpd_auth", Key, config:get("couch_httpd_auth", Key)).
+
+
+get_chttpd_auth_config(Key, Default) ->
+    config:get("chttpd_auth", Key,
+        config:get("couch_httpd_auth", Key, Default)).
+
+
+get_chttpd_auth_config_integer(Key, Default) ->
+    config:get_integer("chttpd_auth", Key,
+        config:get_integer("couch_httpd_auth", Key, Default)).
+
+
+get_chttpd_auth_config_boolean(Key, Default) ->
+    config:get_boolean("chttpd_auth", Key,
+        config:get_boolean("couch_httpd_auth", Key, Default)).

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -957,14 +957,16 @@ error_headers(#httpd{mochi_req=MochiReq}=Req, Code, ErrorStr, ReasonStr) ->
                 % redirect to the session page.
                 case ErrorStr of
                 <<"unauthorized">> ->
-                    case config:get("couch_httpd_auth", "authentication_redirect", undefined) of
+                    case chttpd_util:get_chttpd_auth_config(
+                        "authentication_redirect", "/_utils/session.html") of
                     undefined -> {Code, []};
                     AuthRedirect ->
-                        case config:get("couch_httpd_auth", "require_valid_user", "false") of
-                        "true" ->
+                        case chttpd_util:get_chttpd_auth_config_boolean(
+                            "require_valid_user", false) of
+                        true ->
                             % send the browser popup header no matter what if we are require_valid_user
                             {Code, [{"WWW-Authenticate", "Basic realm=\"server\""}]};
-                        _False ->
+                        false ->
                             case MochiReq:accepts_content_type("application/json") of
                             true ->
                                 {Code, []};

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -38,10 +38,11 @@
 -compile({no_auto_import,[integer_to_binary/1, integer_to_binary/2]}).
 
 party_mode_handler(Req) ->
-    case config:get("couch_httpd_auth", "require_valid_user", "false") of
-    "true" ->
+    case chttpd_util:get_chttpd_auth_config_boolean(
+        "require_valid_user", false) of
+    true ->
         throw({unauthorized, <<"Authentication required.">>});
-    "false" ->
+    false ->
         Req#httpd{user_ctx=#user_ctx{}}
     end.
 
@@ -116,11 +117,12 @@ default_authentication_handler(Req, AuthModule) ->
         true ->
             Req;
         false ->
-            case config:get("couch_httpd_auth", "require_valid_user", "false") of
-                "true" -> Req;
+            case chttpd_util:get_chttpd_auth_config_boolean(
+                "require_valid_user", false) of
+                true -> Req;
                 % If no admins, and no user required, then everyone is admin!
                 % Yay, admin party!
-                _ -> Req#httpd{user_ctx=?ADMIN_USER}
+                false -> Req#httpd{user_ctx=?ADMIN_USER}
             end
         end
     end.
@@ -155,12 +157,12 @@ proxy_authentification_handler(Req) ->
     proxy_authentication_handler(Req).
     
 proxy_auth_user(Req) ->
-    XHeaderUserName = config:get("couch_httpd_auth", "x_auth_username",
-                                "X-Auth-CouchDB-UserName"),
-    XHeaderRoles = config:get("couch_httpd_auth", "x_auth_roles",
-                                "X-Auth-CouchDB-Roles"),
-    XHeaderToken = config:get("couch_httpd_auth", "x_auth_token",
-                                "X-Auth-CouchDB-Token"),
+    XHeaderUserName = chttpd_util:get_chttpd_auth_config(
+        "x_auth_username", "X-Auth-CouchDB-UserName"),
+    XHeaderRoles = chttpd_util:get_chttpd_auth_config(
+        "x_auth_roles", "X-Auth-CouchDB-Roles"),
+    XHeaderToken = chttpd_util:get_chttpd_auth_config(
+        "x_auth_token", "X-Auth-CouchDB-Token"),
     case header_value(Req, XHeaderUserName) of
         undefined -> nil;
         UserName ->
@@ -169,9 +171,10 @@ proxy_auth_user(Req) ->
                 Else ->
                     [?l2b(R) || R <- string:tokens(Else, ",")]
             end,
-            case config:get("couch_httpd_auth", "proxy_use_secret", "false") of
-                "true" ->
-                    case config:get("couch_httpd_auth", "secret", undefined) of
+            case chttpd_util:get_chttpd_auth_config_boolean(
+                "proxy_use_secret", false) of
+                true ->
+                    case chttpd_util:get_chttpd_auth_config("secret") of
                         undefined ->
                             Req#httpd{user_ctx=#user_ctx{name=?l2b(UserName), roles=Roles}};
                         Secret ->
@@ -183,7 +186,7 @@ proxy_auth_user(Req) ->
                                 _ -> nil
                             end
                     end;
-                _ ->
+                false ->
                     Req#httpd{user_ctx=#user_ctx{name=?l2b(UserName), roles=Roles}}
             end
     end.
@@ -244,7 +247,7 @@ cookie_authentication_handler(#httpd{mochi_req=MochiReq}=Req, AuthModule) ->
         end,
         % Verify expiry and hash
         CurrentTime = make_cookie_time(),
-        case config:get("couch_httpd_auth", "secret", undefined) of
+        case chttpd_util:get_chttpd_auth_config("secret") of
         undefined ->
             couch_log:debug("cookie auth secret is not set",[]),
             Req;
@@ -257,8 +260,8 @@ cookie_authentication_handler(#httpd{mochi_req=MochiReq}=Req, AuthModule) ->
                 FullSecret = <<Secret/binary, UserSalt/binary>>,
                 ExpectedHash = couch_util:hmac(sha, FullSecret, User ++ ":" ++ TimeStr),
                 Hash = ?l2b(HashStr),
-                Timeout = list_to_integer(
-                    config:get("couch_httpd_auth", "timeout", "600")),
+                Timeout = chttpd_util:get_chttpd_auth_config_integer(
+                    "timeout", 600),
                 couch_log:debug("timeout ~p", [Timeout]),
                 case (catch erlang:list_to_integer(TimeStr, 16)) of
                     TimeStamp when CurrentTime < TimeStamp + Timeout ->
@@ -309,7 +312,7 @@ cookie_auth_cookie(Req, User, Secret, TimeStamp) ->
         [{path, "/"}] ++ cookie_scheme(Req) ++ max_age() ++ cookie_domain() ++ same_site()).
 
 ensure_cookie_auth_secret() ->
-    case config:get("couch_httpd_auth", "secret", undefined) of
+    case chttpd_util:get_chttpd_auth_config("secret") of
         undefined ->
             NewSecret = ?b2l(couch_uuids:random()),
             config:set("couch_httpd_auth", "secret", NewSecret),
@@ -449,8 +452,8 @@ authenticate(Pass, UserProps) ->
     couch_passwords:verify(PasswordHash, ExpectedHash).
 
 verify_iterations(Iterations) when is_integer(Iterations) ->
-    Min = list_to_integer(config:get("couch_httpd_auth", "min_iterations", "1")),
-    Max = list_to_integer(config:get("couch_httpd_auth", "max_iterations", "1000000000")),
+    Min = chttpd_util:get_chttpd_auth_config_integer("min_iterations", 1),
+    Max = chttpd_util:get_chttpd_auth_config_integer("max_iterations", 1000000000),
     case Iterations < Min of
         true ->
             throw({forbidden, <<"Iteration count is too low for this server">>});
@@ -476,17 +479,18 @@ cookie_scheme(#httpd{mochi_req=MochiReq}) ->
     end.
 
 max_age() ->
-    case config:get("couch_httpd_auth", "allow_persistent_cookies", "true") of
-        "false" ->
+    case chttpd_util:get_chttpd_auth_config_boolean(
+        "allow_persistent_cookies", true) of
+        false ->
             [];
-        "true" ->
-            Timeout = list_to_integer(
-                config:get("couch_httpd_auth", "timeout", "600")),
+        true ->
+            Timeout = chttpd_util:get_chttpd_auth_config_integer(
+                "timeout", 600),
             [{max_age, Timeout}]
     end.
 
 cookie_domain() ->
-    Domain = config:get("couch_httpd_auth", "cookie_domain", ""),
+    Domain = chttpd_util:get_chttpd_auth_config("cookie_domain", ""),
     case Domain of
         "" -> [];
         _ -> [{domain, Domain}]
@@ -494,7 +498,7 @@ cookie_domain() ->
 
 
 same_site() ->
-    SameSite = config:get("couch_httpd_auth", "same_site", ""),
+    SameSite = chttpd_util:get_chttpd_auth_config("same_site", ""),
     case string:to_lower(SameSite) of
         "" -> [];
         "none" -> [{same_site, none}];

--- a/src/couch/src/couch_passwords.erl
+++ b/src/couch/src/couch_passwords.erl
@@ -37,7 +37,7 @@ hash_admin_password(ClearPassword) when is_list(ClearPassword) ->
     hash_admin_password(?l2b(ClearPassword));
 hash_admin_password(ClearPassword) when is_binary(ClearPassword) ->
     %% Support both schemes to smooth migration from legacy scheme
-    Scheme = config:get("couch_httpd_auth", "password_scheme", "pbkdf2"),
+    Scheme = chttpd_util:get_chttpd_auth_config("password_scheme", "pbkdf2"),
     hash_admin_password(Scheme, ClearPassword).
 
 hash_admin_password("simple", ClearPassword) -> % deprecated
@@ -45,10 +45,10 @@ hash_admin_password("simple", ClearPassword) -> % deprecated
     Hash = crypto:hash(sha, <<ClearPassword/binary, Salt/binary>>),
     ?l2b("-hashed-" ++ couch_util:to_hex(Hash) ++ "," ++ ?b2l(Salt));
 hash_admin_password("pbkdf2", ClearPassword) ->
-    Iterations = config:get("couch_httpd_auth", "iterations", "10000"),
+    Iterations = chttpd_util:get_chttpd_auth_config("iterations", "10"),
     Salt = couch_uuids:random(),
     DerivedKey = couch_passwords:pbkdf2(couch_util:to_binary(ClearPassword),
-                                        Salt ,list_to_integer(Iterations)),
+                                        Salt, list_to_integer(Iterations)),
     ?l2b("-pbkdf2-" ++ ?b2l(DerivedKey) ++ ","
         ++ ?b2l(Salt) ++ ","
         ++ Iterations).

--- a/src/couch/src/couch_users_db.erl
+++ b/src/couch/src/couch_users_db.erl
@@ -62,7 +62,7 @@ before_doc_update(Doc, Db, _UpdateType) ->
 %    newDoc.password = null
 save_doc(#doc{body={Body}} = Doc) ->
     %% Support both schemes to smooth migration from legacy scheme
-    Scheme = config:get("couch_httpd_auth", "password_scheme", "pbkdf2"),
+    Scheme = chttpd_util:get_chttpd_auth_config("password_scheme", "pbkdf2"),
     case {couch_util:get_value(?PASSWORD, Body), Scheme} of
     {null, _} -> % server admins don't have a user-db password entry
         Doc;
@@ -79,7 +79,8 @@ save_doc(#doc{body={Body}} = Doc) ->
         Doc#doc{body={Body3}};
     {ClearPassword, "pbkdf2"} ->
         ok = validate_password(ClearPassword),
-        Iterations = list_to_integer(config:get("couch_httpd_auth", "iterations", "1000")),
+        Iterations = chttpd_util:get_chttpd_auth_config_integer(
+            "iterations", 10),
         Salt = couch_uuids:random(),
         DerivedKey = couch_passwords:pbkdf2(ClearPassword, Salt, Iterations),
         Body0 = ?replace(Body, ?PASSWORD_SCHEME, ?PBKDF2),
@@ -97,7 +98,7 @@ save_doc(#doc{body={Body}} = Doc) ->
 % Throws if not.
 % In this function the [couch_httpd_auth] password_regexp config is parsed.
 validate_password(ClearPassword) ->
-    case config:get("couch_httpd_auth", "password_regexp", "") of
+    case chttpd_util:get_chttpd_auth_config("password_regexp", "") of
         "" ->
             ok;
         "[]" ->
@@ -210,6 +211,6 @@ get_doc_name(_) ->
     undefined.
 
 strip_non_public_fields(#doc{body={Props}}=Doc) ->
-    Public = re:split(config:get("couch_httpd_auth", "public_fields", ""),
+    Public = re:split(chttpd_util:get_chttpd_auth_config("public_fields", ""),
                       "\\s*,\\s*", [{return, binary}]),
     Doc#doc{body={[{K, V} || {K, V} <- Props, lists:member(K, Public)]}}.

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -197,8 +197,9 @@ is_public_fields_configured(Db) ->
     DbName = ?b2l(couch_db:name(Db)),
     case config:get("couch_httpd_auth", "authentication_db", "_users") of
     DbName ->
-        UsersDbPublic = config:get("couch_httpd_auth", "users_db_public", "false"),
-        PublicFields = config:get("couch_httpd_auth", "public_fields"),
+        UsersDbPublic = chttpd_util:get_chttpd_auth_config(
+            "users_db_public", "false"),
+        PublicFields = chttpd_util:get_chttpd_auth_config("public_fields"),
         case {UsersDbPublic, PublicFields} of
         {"true", PublicFields} when PublicFields =/= undefined ->
             true;

--- a/src/global_changes/test/eunit/global_changes_hooks_tests.erl
+++ b/src/global_changes/test/eunit/global_changes_hooks_tests.erl
@@ -33,8 +33,8 @@ stop({Ctx, DbName}) ->
 
 setup(default) ->
     add_admin("admin", <<"pass">>),
-    config:delete("couch_httpd_auth", "authentication_redirect", false),
-    config:set("couch_httpd_auth", "require_valid_user", "false", false),
+    config:delete("chttpd_auth", "authentication_redirect", false),
+    config:set("chttpd_auth", "require_valid_user", "false", false),
     get_host();
 setup(A) ->
     Host = setup(default),

--- a/test/elixir/test/cookie_auth_test.exs
+++ b/test/elixir/test/cookie_auth_test.exs
@@ -17,7 +17,7 @@ defmodule CookieAuthTest do
                  @users_db
                },
                {
-                 "couch_httpd_auth",
+                 "chttpd_auth",
                  "iterations",
                  "1"
                },

--- a/test/elixir/test/users_db_security_test.exs
+++ b/test/elixir/test/users_db_security_test.exs
@@ -259,7 +259,7 @@ defmodule UsersDbSecurityTest do
            "true"
          },
          {
-           "couch_httpd_auth",
+           "chttpd_auth",
            "iterations",
            "1"
          },

--- a/test/elixir/test/users_db_test.exs
+++ b/test/elixir/test/users_db_test.exs
@@ -17,7 +17,7 @@ defmodule UsersDbTest do
                  @users_db_name
                },
                {
-                 "couch_httpd_auth",
+                 "chttpd_auth",
                  "iterations",
                  "1"
                },

--- a/test/javascript/tests/replicator_db_by_doc_id.js
+++ b/test/javascript/tests/replicator_db_by_doc_id.js
@@ -83,7 +83,7 @@ couchTests.replicator_db_by_doc_id = function(debug) {
 
   /*var server_config = [
     {
-      section: "couch_httpd_auth",
+      section: "chttpd_auth",
       key: "iterations",
       value: "1"
     },


### PR DESCRIPTION
## Overview
Move configuration options from [couch_httpd_auth] to [chttpd_auth].

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
make eunit apps=chttpd suites=chttpd_util_test
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
This fixes #3472
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
