### PR TITLE
Improve basic auth credentials handling in replicator

### DIFF
--- a/src/couch_replicator/src/couch_replicator.erl
+++ b/src/couch_replicator/src/couch_replicator.erl
@@ -373,13 +373,13 @@ t_strip_local_db_creds() ->
 t_strip_http_basic_creds() ->
     ?_test(begin
         Url1 = <<"http://adm:pass@host/db">>,
-        ?assertEqual(<<"http://adm:*****@host/db/">>, strip_url_creds(Url1)),
+        ?assertEqual(<<"http://host/db/">>, strip_url_creds(Url1)),
         Url2 = <<"https://adm:pass@host/db">>,
-        ?assertEqual(<<"https://adm:*****@host/db/">>, strip_url_creds(Url2)),
+        ?assertEqual(<<"https://host/db/">>, strip_url_creds(Url2)),
         Url3 = <<"http://adm:pass@host:80/db">>,
-        ?assertEqual(<<"http://adm:*****@host:80/db/">>, strip_url_creds(Url3)),
+        ?assertEqual(<<"http://host:80/db/">>, strip_url_creds(Url3)),
         Url4 = <<"http://adm:pass@host/db?a=b&c=d">>,
-        ?assertEqual(<<"http://adm:*****@host/db?a=b&c=d">>,
+        ?assertEqual(<<"http://host/db?a=b&c=d">>,
             strip_url_creds(Url4))
     end).
 
@@ -387,7 +387,7 @@ t_strip_http_basic_creds() ->
 t_strip_http_props_creds() ->
     ?_test(begin
         Props1 = {[{<<"url">>, <<"http://adm:pass@host/db">>}]},
-        ?assertEqual(<<"http://adm:*****@host/db/">>, strip_url_creds(Props1)),
+        ?assertEqual(<<"http://host/db/">>, strip_url_creds(Props1)),
         Props2 = {[ {<<"url">>, <<"http://host/db">>},
             {<<"headers">>, {[{<<"Authorization">>, <<"Basic pa55">>}]}}
         ]},

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -408,7 +408,7 @@ parse_rep_db({Props}, Proxy, Options) ->
     {BinHeaders} = get_value(<<"headers">>, Props, {[]}),
     Headers = lists:ukeysort(1, [{?b2l(K), ?b2l(V)} || {K, V} <- BinHeaders]),
     DefaultHeaders = (#httpdb{})#httpdb.headers,
-    #httpdb{
+    HttpDb = #httpdb{
         url = Url,
         auth_props = AuthProps,
         headers = lists:ukeymerge(1, Headers, DefaultHeaders),
@@ -419,7 +419,8 @@ parse_rep_db({Props}, Proxy, Options) ->
         http_connections = get_value(http_connections, Options),
         retries = get_value(retries, Options),
         proxy_url = ProxyURL
-    };
+    },
+    couch_replicator_utils:normalize_basic_auth(HttpDb);
 
 parse_rep_db(<<"http://", _/binary>> = Url, Proxy, Options) ->
     parse_rep_db({[{<<"url">>, Url}]}, Proxy, Options);

--- a/src/couch_replicator/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc.erl
@@ -112,7 +112,13 @@ send_ibrowse_req(#httpdb{headers = BaseHeaders} = HttpDb0, Params) ->
         end
     end,
     {ok, Worker} = couch_replicator_httpc_pool:get_worker(HttpDb#httpdb.httpc_pool),
-    IbrowseOptions = [
+    BasicAuthOpts = case couch_replicator_utils:get_basic_auth_creds(HttpDb) of
+        {undefined, undefined} ->
+            [];
+        {User, Pass} when is_list(User), is_list(Pass) ->
+            [{basic_auth, {User, Pass}}]
+    end,
+    IbrowseOptions = BasicAuthOpts ++ [
         {response_format, binary}, {inactivity_timeout, HttpDb#httpdb.timeout} |
         lists:ukeymerge(1, get_value(ibrowse_options, Params, []),
             HttpDb#httpdb.ibrowse_options)

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -1072,8 +1072,8 @@ scheduler_job_format_status_test() ->
         highest_seq_done = <<"5">>
     },
     Format = format_status(opts_ignored, [pdict, State]),
-    ?assertEqual("http://u:*****@h1/d1/", proplists:get_value(source, Format)),
-    ?assertEqual("http://u:*****@h2/d2/", proplists:get_value(target, Format)),
+    ?assertEqual("http://h1/d1/", proplists:get_value(source, Format)),
+    ?assertEqual("http://h2/d2/", proplists:get_value(target, Format)),
     ?assertEqual({"base", "+ext"}, proplists:get_value(rep_id, Format)),
     ?assertEqual([{create_target, true}], proplists:get_value(options, Format)),
     ?assertEqual(<<"mydoc">>, proplists:get_value(doc_id, Format)),


### PR DESCRIPTION
Previously, there were two ways to pass in basic auth credentials for
endpoints -- using URL's userinfo part and encoding the them in an
`"Authorization": "basic ..."` header. Neither one is ideal for these reasons:

 * Passwords in userinfo doesn't allow using ":", "@" and other characters.
   However, even after switching to always unquoting them like we did recently
   [1], would break authentication for usernames or passwords previously
   containing "+" or "%HH" patterns, as "+" might now be decoded to a " ".

 * Base64 encoded headers need an extra step to encode them. Also, quite often
   these encoded headers are confused as being "encrypted" and shared in a
   clear channel.

To improve this, revert the recent commit to unquote URL userinfo parts to
restore backwards compatibility, and introduce a way to pass in basic auth
credentials in the "auth" object. The "auth" object was already added a while
back to allow authentication plugins to store their credentials in it. The
format is:

```
   "source": {
       "url": "https://host/db",
       "auth": {
           "basic": {
               "username":"myuser",
               "password":"mypassword"
           }
       }
   }
```

{"auth" : "basic" : {...}} object is checked first, and if credentials are
provided, they will be used. If they are not then userinfo and basic auth
header will be parsed.

Internally, there was a good amount duplication related to parsing credentials
from userinfo and headers in replication ID generation logic and in the auth
session plugin. As a cleanup, consolidate that logic in the
`couch_replicator_utils` module.

[1] https://github.com/apache/couchdb/commit/f672b911db19981a81d7fc6ce8ac33b150234fd7

The original idea for this scheme belongs to @jaydoane

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation (will create a docs pr after the review)
