### PR TITLE
Aegis improvements

### DIFF
--- a/src/aegis/rebar.config.script
+++ b/src/aegis/rebar.config.script
@@ -11,6 +11,11 @@
 % the License.
 
 
+CoverProps = [
+    {cover_enabled, true},
+    {cover_print_enabled, true}
+],
+
 CouchConfig = case filelib:is_file(os:getenv("COUCHDB_CONFIG")) of
     true ->
         {ok, Result} = file:consult(os:getenv("COUCHDB_CONFIG")),
@@ -31,5 +36,7 @@ CurrentOpts = case lists:keyfind(erl_opts, 1, CONFIG) of
     false -> []
 end,
 
+Config = CoverProps ++ CONFIG,
+
 AegisOpts = {d, 'AEGIS_KEY_MANAGER', AegisKeyManager},
-lists:keystore(erl_opts, 1, CONFIG, {erl_opts, [AegisOpts | CurrentOpts]}).
+lists:keystore(erl_opts, 1, Config, {erl_opts, [AegisOpts | CurrentOpts]}).

--- a/src/aegis/src/aegis.erl
+++ b/src/aegis/src/aegis.erl
@@ -18,6 +18,7 @@
 
 
 -export([
+    key_manager/0,
     init_db/2,
     open_db/1,
     get_db_info/1,
@@ -27,6 +28,10 @@
     encrypt/3,
     wrap_fold_fun/2
 ]).
+
+key_manager() ->
+    ?AEGIS_KEY_MANAGER.
+
 
 init_db(#{} = Db, Options) ->
     Db#{

--- a/src/aegis/test/aegis_server_test.erl
+++ b/src/aegis/test/aegis_server_test.erl
@@ -51,9 +51,10 @@ basic_test_() ->
 
 setup() ->
     Ctx = test_util:start_couch([fabric]),
-    meck:new([?AEGIS_KEY_MANAGER], [passthrough]),
+    meck:new([?AEGIS_KEY_MANAGER], [non_strict]),
     ok = meck:expect(?AEGIS_KEY_MANAGER, init_db, 2, {ok, <<0:256>>}),
     ok = meck:expect(?AEGIS_KEY_MANAGER, open_db, 1, {ok, <<0:256>>}),
+    ok = meck:expect(?AEGIS_KEY_MANAGER, get_db_info, 1, []),
     Ctx.
 
 

--- a/src/aegis/test/aegis_server_test.erl
+++ b/src/aegis/test/aegis_server_test.erl
@@ -139,9 +139,9 @@ disabled_test_() ->
         end,
         fun teardown/1,
         [
-            {"init_db returns false when encryptions disabled",
+            {"init_db returns false when encryption disabled",
             {timeout, ?TIMEOUT, fun test_disabled_init_db/0}},
-            {"open_db returns false when encryptions disabled",
+            {"open_db returns false when encryption disabled",
             {timeout, ?TIMEOUT, fun test_disabled_open_db/0}},
             {"pass through on encrypt when encryption disabled",
             {timeout, ?TIMEOUT, fun test_disabled_encrypt/0}},
@@ -185,6 +185,7 @@ lru_cache_with_expiration_test_() ->
                 ("aegis", "cache_limit", _) -> 5;
                 ("aegis", "cache_max_age_sec", _) -> 130;
                 ("aegis", "cache_expiration_check_sec", _) -> 1;
+                ("aegis", "cache_deletion_grace_sec", _) -> 1;
                 (_, _, Default) -> Default
             end),
             Ctx = setup(),
@@ -313,10 +314,11 @@ test_remove_expired() ->
     meck:reset(aegis_server),
     meck:wait(aegis_server, handle_info, [maybe_remove_expired, '_'], 2500),
 
-    %% 3 "oldest" entries should be removed, 2 yet to expire still in cache
+    %% 2 "oldest" entries should be removed, 2 yet to expire still in cache,
+    %% and one remaining in cache due to grace period
     lists:foreach(fun(I) ->
         Db = ?DB#{uuid => <<I:64>>},
         aegis_server:encrypt(Db, <<I:64>>, ?VALUE)
     end, lists:seq(1, 5)),
 
-    ?assertEqual(8, meck:num_calls(?AEGIS_KEY_MANAGER, open_db, 1)).
+    ?assertEqual(7, meck:num_calls(?AEGIS_KEY_MANAGER, open_db, 1)).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

- Add aegis eunit coverage
- Decrease likelihood of key expiring from cache while in use
- Fix test which breaks when aegis configured with operational key manager
- Add `aegis:key_manager/0` function

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

`make eunit apps=aegis` should pass with default `aegis_noop_key_manager` and any operational key manager you might choose.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
