### PR TITLE
Delete unused chttpd_show:apply_etag/2 function

### DIFF
--- a/src/chttpd/src/chttpd_show.erl
+++ b/src/chttpd/src/chttpd_show.erl
@@ -100,18 +100,6 @@ json_apply_field({Key, NewValue}, [], Acc) ->
     % end of list, add ours
     {[{Key, NewValue}|Acc]}.
 
-apply_etag(JsonResp, undefined) ->
-    JsonResp;
-apply_etag({ExternalResponse}, CurrentEtag) ->
-    % Here we embark on the delicate task of replacing or creating the
-    % headers on the JsonResponse object. We need to control the Etag and
-    % Vary headers. If the external function controls the Etag, we'd have to
-    % run it to check for a match, which sort of defeats the purpose.
-    apply_headers(ExternalResponse, [
-        {<<"ETag">>, CurrentEtag},
-        {<<"Vary">>, <<"Accept">>}
-    ]).
-
 apply_headers(JsonResp, []) ->
     JsonResp;
 apply_headers(JsonResp, NewHeaders) ->


### PR DESCRIPTION
This code is generating an unused function compilation warning.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
