### PR TITLE
Bump ibrowse to 4.4.2-3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -151,7 +151,7 @@ DepDescs = [
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-2"}},
+{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-3"}},
 {jaeger_passage,   "jaeger-passage",   {tag, "CouchDB-0.1.14-4"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.5-1"}},
 {local,            "local",            {tag, "0.2.1"}},


### PR DESCRIPTION
This reverts the update to ibrowse to always unquote userinfo
(username and password) in endpoint URLs, as it has issues with
compatibility since it would unqoute passwords which had a literal '+'
as ' ' for example.

There is a new recommended way of specifying passwords which may
contain '@', ':' and other such symbols in
https://github.com/apache/couchdb/commit/1860ebbf2fa1731a62f3c9b107b2e52811489c1e.

Issue: https://github.com/apache/couchdb/issues/2892
