### PR TITLE
Bump ibrowse to 4.4.2-3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -159,7 +159,7 @@ DepDescs = [
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-2"}},
+{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-3"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.5-1"}},
 {mochiweb,         "mochiweb",         {tag, "v2.20.0"}},
 {meck,             "meck",             {tag, "0.9.2"}},


### PR DESCRIPTION
This is a backport of https://github.com/apache/couchdb/commit/e349128d21212e9ab9ca35e8a72c581b9b77ebb1 from main.

