### PR TITLE
Build enc at top level

### DIFF
--- a/configure
+++ b/configure
@@ -265,6 +265,17 @@ install_local_rebar() {
     fi
 }
 
+install_local_enc() {
+    if [ ! -x "${rootdir}/bin/enc" ]; then
+        if [ ! -d "${rootdir}/src/erlang-native-compiler" ]; then
+            git clone --depth 1 https://github.com/davisp/erlang-native-compiler.git ${rootdir}/src/erlang-native-compiler
+        fi
+        make -C ${rootdir}/src/erlang-native-compiler
+        mv ${rootdir}/src/erlang-native-compiler/enc ${rootdir}/bin/enc
+        make -C ${rootdir}/src/erlang-native-compiler clean
+    fi
+}
+
 install_local_emilio() {
     if [ ! -x "${rootdir}/bin/emilio" ]; then
         if [ ! -d "${rootdir}/src/emilio" ]; then
@@ -280,6 +291,11 @@ install_local_emilio() {
 if [ -z "${REBAR}" ]; then
     install_local_rebar
     REBAR=${rootdir}/bin/rebar
+fi
+
+if [ -z "${ENC}" ]; then
+    install_local_enc
+    ENC=${rootdir}/bin/enc
 fi
 
 install_local_emilio

--- a/configure.ps1
+++ b/configure.ps1
@@ -201,6 +201,21 @@ if ((Get-Command "rebar.cmd" -ErrorAction SilentlyContinue) -eq $null)
    $env:Path += ";$rootdir\bin"
 }
 
+# check for enc; if not found, build it and add it to our path
+if ((Get-Command "enc.cmd" -ErrorAction SilentlyContinue) -eq $null)
+{
+   Write-Verbose "==> enc.cmd not found; bootstrapping..."
+   if (-Not (Test-Path "src\erlang-native-compiler"))
+   {
+      git clone --depth 1 https://github.com/davisp/erlang-native-compiler.git $rootdir\src\erlang-native-compiler
+   }
+   cmd /c "cd src\erlang-native-compiler && $rootdir\src\erlang-native-compiler\bootstrap.bat"
+   cp $rootdir\src\erlang-native-compiler\enc $rootdir\bin\enc
+   cp $rootdir\src\erlang-native-compiler\enc.cmd $rootdir\bin\enc.cmd
+   make -C $rootdir\src\erlang-native-compiler clean
+   $env:Path += ";$rootdir\bin"
+}
+
 # check for emilio; if not found, get it and build it
 if ((Get-Command "emilio.cmd" -ErrorAction SilentlyContinue) -eq $null)
 {


### PR DESCRIPTION
## Overview

Currently, the `enc` (https://github.com/davisp/erlang-native-compiler) binary is kept in the `couchdb-jiffy` repository. This is a security risk. This PR builds the `enc` binary at the top level so we can verify where it came from and have it available for dependencies.

## Testing recommendations

Follow the steps to build CouchDB. After `./configure` is run, an `enc` binary should be located in `/bin`. Following the rest of the steps should lead to a successful build.

## Related Issues or Pull Requests

Remove `enc` from `couchdb-jiffy` and build it at top-level CouchDB instead: https://github.com/apache/couchdb-jiffy/pull/5
## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
