### PR TITLE
Erlang 19 is not supported for 3.x

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -196,7 +196,7 @@ ErlOpts = case os:getenv("ERL_OPTS") of
 end.
 
 AddConfig = [
-    {require_otp_vsn, "19|20|21|22|23|24"},
+    {require_otp_vsn, "20|21|22|23|24"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},


### PR DESCRIPTION
It doesn't really work as we have functionality relying on 20.0+ features. One particular instance is in [1].

Issue: https://github.com/apache/couchdb/issues/3571

[1] https://github.com/apache/couchdb/blob/ce596c65d9d7f0bc5d9937bcaf6253b343015690/src/couch/src/couch_emsort.erl#L363-L366
