### PR TITLE
Bump ibrowse to 4.4.2-5

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -151,7 +151,7 @@ DepDescs = [
 %% Third party deps
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-4"}},
+{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
 {jaeger_passage,   "jaeger-passage",   {tag, "CouchDB-0.1.14-4"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.5-1"}},
 {local,            "local",            {tag, "0.2.1"}},


### PR DESCRIPTION
Previously, in 4.4.2-4 ibrowse upstream rebase also included the commit which
unconditionally unquoted userinfo credentials. Since we know have a better way
of handing basic auth creds bump ibrowse with a rebase which doesn't include
that commit.

