### PR TITLE
Remove attempt to download GeoTrust CA

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,10 +15,8 @@ ARG FDB_VERSION
 ARG SM_VSN
 ENV SM_VSN=${SM_VSN:-60}
 
-# Workaround for Debian's temporary lack of trust in FDB Root CA
 RUN set -ex; \
-    wget https://www.geotrust.com/resources/root_certificates/certificates/GeoTrust_Global_CA.pem; \
-    wget --ca-certificate=GeoTrust_Global_CA.pem https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
+    wget https://www.foundationdb.org/downloads/${FDB_VERSION}/ubuntu/installers/foundationdb-clients_${FDB_VERSION}-1_amd64.deb; \
     mkdir /var/lib/foundationdb; \
     dpkg -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb
 


### PR DESCRIPTION
## Overview

This URL is a 404 now, but fortunately we don't care as foundationdb.org is no longer dependent on GeoTrust at all in its root of trust.

## Testing recommendations

Open the project in VS Code using the Remote - Containers extension and check to see if the editor starts up successfully. Alternatively, just try to build the CouchDB layer container using the instructions in `.devcontainer/Dockerfile`

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
