### PR TITLE
COUCHDB_FAUXTON_DOCROOT fails on {{fauxton_root}}

### DIFF
--- a/rel/files/couchdb.in
+++ b/rel/files/couchdb.in
@@ -38,7 +38,7 @@ export PROGNAME=`echo $0 | sed 's/.*\///'`
 
 export COUCHDB_QUERY_SERVER_JAVASCRIPT="${COUCHDB_QUERY_SERVER_JAVASCRIPT:-{{prefix}}/bin/couchjs {{prefix}}/share/server/main.js}"
 export COUCHDB_QUERY_SERVER_COFFEESCRIPT="${COUCHDB_QUERY_SERVER_COFFEESCRIPT:-{{prefix}}/bin/couchjs {{prefix}}/share/server/main-coffee.js}"
-export COUCHDB_FAUXTON_DOCROOT="${COUCHDB_FAUXTON_DOCROOT:-{{fauxton_root}} }"
+export COUCHDB_FAUXTON_DOCROOT="${COUCHDB_FAUXTON_DOCROOT:-{{prefix}}/share/www}"
 
 ARGS_FILE="${COUCHDB_ARGS_FILE:-$ROOTDIR/etc/vm.args}"
 [ -n "${COUCHDB_INI_FILES:-}" ] && INI_ARGS="-couch_ini $COUCHDB_INI_FILES"


### PR DESCRIPTION
"${COUCHDB_FAUXTON_DOCROOT:-{{fauxton_root}}}" substitution fails as it gobbles the the third "}" yielding:

`./rel/couchdb/bin/couchdb: 51: Syntax error: Unterminated quoted string`

Adding a surplus white space succeeds in substitution, but then fauxton fails to locate the directory with trailing white space. 

Two alternatives: 

"${COUCHDB_FAUXTON_DOCROOT:-{{fauxton_root}}/}" removes the triple brace, succeeds in substitution, and should be a valid directory.
"${COUCHDB_FAUXTON_DOCROOT:-{{prefix}}/share/www}" works the same, avoids the doubled // and looks similar to the lines above. 

I went with the second.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
