### PR TITLE
Fix custodian default system dbs

### DIFF
--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -13,7 +13,7 @@
 -module(chttpd_auth_cache).
 -behaviour(gen_server).
 
--export([start_link/0, get_user_creds/2, update_user_creds/3]).
+-export([start_link/0, get_user_creds/2, update_user_creds/3, dbname/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
     code_change/3]).
 -export([listen_for_changes/1, changes_callback/2]).

--- a/src/custodian/src/custodian_db_checker.erl
+++ b/src/custodian/src/custodian_db_checker.erl
@@ -132,7 +132,7 @@ get_dbs() ->
 
 
 get_users_db() ->
-    UsersDb = config:get("couch_httpd_auth", "authentication_db", "users"),
+    UsersDb = chttpd_auth_cache:dbname(),
     [list_to_binary(UsersDb)].
 
 

--- a/src/custodian/src/custodian_util.erl
+++ b/src/custodian/src/custodian_util.erl
@@ -43,7 +43,7 @@ report() ->
     fold_dbs([], Fun).
 
 ensure_dbs_exists() ->
-    DbName = config:get("mem3", "shards_db", "dbs"),
+    DbName = mem3_sync:shards_db(),
     {ok, Db} = mem3_util:ensure_exists(DbName),
     ensure_custodian_ddoc_exists(Db),
     {ok, Db}.


### PR DESCRIPTION
These system db defaults were left unchanged when this code was
imported from Cloudant. This changes them to CouchDB defaults.

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
