### PR TITLE
Normalize some config options (main)

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -138,7 +138,7 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{config,           "config",           {tag, "2.1.8"}},
+{config,           "config",           {tag, "2.1.9"}},
 {b64url,           "b64url",           {tag, "1.0.2"}},
 {erlfdb,           "erlfdb",           {tag, "v1.3.4"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -4,22 +4,30 @@ name = {{package_author_name}}
 
 [couchdb]
 uuid = {{uuid}}
+
 ; util_driver_dir =
 ; plugin_dir =
-os_process_timeout = 5000 ; 5 seconds. for view servers.
-max_dbs_open = 500
+;os_process_timeout = 5000 ; 5 seconds. for view servers.
+
+;max_dbs_open = 500
+
+
+
+
 ; Default security object for databases if not explicitly set
 ; everyone - same as couchdb 1.0, everyone can read/write
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_only
+;default_security = admin_only
+
 ; maintenance_mode = false
+
 ; uri_file =
 ; The speed of processing the _changes feed with doc_ids filter can be
 ; influenced directly with this setting - increase for faster processing at the
 ; expense of more memory usage.
-changes_doc_ids_optimization_threshold = 100
+;changes_doc_ids_optimization_threshold = 100
 ;
 ; Maximum database name length. The default setting is chosen for CouchDB < 4.x
 ; compatibility, where it was determined by the maximum file name size. On most
@@ -35,7 +43,7 @@ changes_doc_ids_optimization_threshold = 100
 ; requests which update a single document as well as individual documents from
 ; a _bulk_docs request. The size limit is approximate due to the nature of JSON
 ; encoding.
-max_document_size = 8000000 ; bytes
+;max_document_size = 8000000 ; bytes
 ;
 ; Maximum number of documents in a _bulk_docs request. Anything larger
 ; returns a 413 error for the whole request
@@ -47,6 +55,7 @@ max_document_size = 8000000 ; bytes
 ;
 ; Maximum attachment size.
 ; max_attachment_size = infinity
+
 ;
 ; Enable this to only "soft-delete" databases when DELETE /{db} requests are
 ; made. This will place a .recovery directory in your data directory and
@@ -54,25 +63,29 @@ max_document_size = 8000000 ; bytes
 ; these files later, as desired.
 ;enable_database_recovery = false
 ;
+
 ; Allow edits on the _security object in the user db. By default, it's disabled.
-users_db_security_editable = false
+;users_db_security_editable = false
+
+
+
 
 [chttpd]
 ; These settings affect the main, clustered port (5984 by default).
 port = {{cluster_port}}
 bind_address = 127.0.0.1
-backlog = 512
-socket_options = [{sndbuf, 262144}, {nodelay, true}]
-server_options = [{recbuf, undefined}]
-require_valid_user = false
+;backlog = 512
+;socket_options = [{sndbuf, 262144}, {nodelay, true}]
+;server_options = [{recbuf, undefined}]
+;require_valid_user = false
 ; require_valid_user_except_for_up = false
 ; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
 ; If Server header is left out, Mochiweb will add its own one in.
-prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
 ;
 ; Limit maximum number of databases when tying to get detailed information using
 ; _dbs_info in a request
-max_db_number_for_dbs_info_req = 100
+;max_db_number_for_dbs_info_req = 100
 
 ; set to true to delay the start of a response until the end has been calculated
 ;buffer_response = false
@@ -129,24 +142,32 @@ max_db_number_for_dbs_info_req = 100
 ; rsa:foo = -----BEGIN PUBLIC KEY-----\nMIIBIjAN...IDAQAB\n-----END PUBLIC KEY-----\n
 ; ec:bar = -----BEGIN PUBLIC KEY-----\nMHYwEAYHK...AzztRs\n-----END PUBLIC KEY-----\n
 
+
+
+
+
+
+
+
 [httpd]
 port = {{backend_port}}
 bind_address = 127.0.0.1
-authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+;authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
 
 ; Options for the MochiWeb HTTP server.
 ;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
-socket_options = [{sndbuf, 262144}]
+;socket_options = [{sndbuf, 262144}]
 
 ; These settings were moved to [chttpd]
 ; secure_rewrites, allow_jsonp, enable_cors, enable_xframe_options,
 ; max_uri_length, changes_timeout, config_whitelist, rewrite_limit,
 ; x_forwarded_host, x_forwarded_proto, x_forwarded_ssl, max_http_request_size
 
+
 [ssl]
-port = 6984
+;port = 6984
 
 [chttpd_auth]
 ;authentication_db = _users
@@ -179,11 +200,13 @@ port = 6984
 ; max_objects =
 ; max_size = 104857600
 
+
 ; [fabric]
 ; Custom FDB directory prefix. All the nodes of the same CouchDB instance
 ; should have a matching directory prefix in order to read and write the same
 ; data. Changes to this value take effect only on node start-up.
 ;fdb_directory = couchdb
+
 ;
 ; Enable or disable index auto-updater
 ;index_updater_enabled = true
@@ -277,11 +300,11 @@ authentication_db = _users
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]
-enable = true
+;enable = true
 ; header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
 
 [cors]
-credentials = false
+;credentials = false
 ; List of origins separated by a comma, * means accept all
 ; Origins must include the scheme: http://example.com
 ; You can't set origins: * and credentials = true at the same time.
@@ -328,12 +351,13 @@ credentials = false
 ; please let us know on the mailing list so we can fine tune the heuristic.
 [query_server_config]
 ; commit_freq = 5
-reduce_limit = true
-os_process_limit = 100
+;reduce_limit = true
+;os_process_limit = 100
 ; os_process_idle_limit = 300
 ; os_process_soft_limit = 100
 ; Timeout for how long a response from a busy view group server can take.
 ; "infinity" is also a valid configuration value.
+
 ;query_limit = 268435456
 ;partition_query_limit = 268435456
 
@@ -355,6 +379,7 @@ query = mango_eval
 ; the warning.
 ;index_scan_warning_threshold = 10
 
+
 [feature_flags]
 ; This enables any database to be created as a partitioned databases (except system db's).
 ; Setting this to false will stop the creation of paritioned databases.
@@ -374,16 +399,16 @@ query = mango_eval
 ;     First 14 characters are the time in hex. Last 18 are random.
 ;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
 ;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
-algorithm = sequential
+;algorithm = sequential
 ; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
 ; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
-utc_id_suffix =
+;utc_id_suffix =
 # Maximum number of UUIDs retrievable from /_uuids in a single request
-max_count = 1000
+;max_count = 1000
 
 [attachments]
-compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
-compressible_types = text/*, application/javascript, application/json, application/xml
+;compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+;compressible_types = text/*, application/javascript, application/json, application/xml
 
 [replicator]
 ; Number of actively running replications per replication backend node
@@ -489,6 +514,7 @@ compressible_types = text/*, application/javascript, application/json, applicati
 ; and add log noise.
 ;missing_doc_retry_msec = 2000
 
+
 ; List of replicator client authentication plugins to try. Plugins will be
 ; tried in order. The first to initialize successfully will be used for that
 ; particular endpoint (source or target). Normally couch_replicator_auth_noop
@@ -512,6 +538,7 @@ compressible_types = text/*, application/javascript, application/json, applicati
 ; or 403 response this setting is not needed.
 ;session_refresh_interval_sec = 550
 
+
 [log]
 ; Possible log levels:
 ;  debug
@@ -524,7 +551,7 @@ compressible_types = text/*, application/javascript, application/json, applicati
 ;  emergency, emerg
 ;  none
 ;
-level = info
+;level = info
 ;
 ; Set the maximum log message length in bytes that will be
 ; passed through the writer
@@ -547,7 +574,7 @@ level = info
 ; over the network, and a journald writer that's more suitable
 ; when using systemd journald.
 ;
-writer = stderr
+;writer = stderr
 ; Journald Writer notes:
 ;
 ; The journald writer doesn't have any options. It still writes
@@ -599,6 +626,7 @@ writer = stderr
 ; notifications more performant, however, it would also increase notification
 ; latency.
 ;type_monitor_holdoff_msec = 50
+
 ;
 ; Timeout used when waiting for the job type notification watches. The default
 ; value of "infinity" should work well in most cases.
@@ -606,9 +634,12 @@ writer = stderr
 ;
 ; How often to check for the presense of new job types.
 ;type_check_period_msec = 15000
+
 ;
 ; Jitter applied when checking for new job types.
 ;type_check_max_jitter_msec = 5000
+
+
 
 [tracing]
 ;
@@ -716,9 +747,11 @@ writer = stderr
 ; The interval in seconds of how often the expiration check runs.
 ;cache_expiration_check_sec = 10
 
+
 ; The period in seconds that an expired key remains in the cache.
 ; Lowering this too much might expose races.
 ;cache_deletion_grace_sec = 5
+
 
 [prometheus]
 additional_port = false

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -58,6 +58,9 @@
     buffer_response=false
 }).
 
+-define(DEFAULT_SERVER_OPTIONS, "[{recbuf, undefined}]").
+-define(DEFAULT_SOCKET_OPTIONS, "[{sndbuf, 262144}, {nodelay, true}]").
+
 start_link() ->
     start_link(http).
 start_link(http) ->
@@ -148,7 +151,12 @@ start_link(Name, Options) ->
     end.
 
 get_server_options(Module) ->
-    ServerOptsCfg = config:get(Module, "server_options", "[]"),
+    ServerOptsCfg =
+        case Module of
+            "chttpd" -> config:get(Module,
+                "server_options", ?DEFAULT_SERVER_OPTIONS);
+            _ -> config:get(Module, "server_options", "[]")
+        end,
     {ok, ServerOpts} = couch_util:parse_term(ServerOptsCfg),
     ServerOpts.
 
@@ -165,13 +173,10 @@ handle_request(MochiReq0) ->
 
 handle_request_int(MochiReq) ->
     Begin = os:timestamp(),
-    case config:get("chttpd", "socket_options") of
-    undefined ->
-        ok;
-    SocketOptsCfg ->
-        {ok, SocketOpts} = couch_util:parse_term(SocketOptsCfg),
-        ok = mochiweb_socket:setopts(MochiReq:get(socket), SocketOpts)
-    end,
+    SocketOptsCfg = config:get(
+        "chttpd", "socket_options", ?DEFAULT_SOCKET_OPTIONS),
+    {ok, SocketOpts} = couch_util:parse_term(SocketOptsCfg),
+    ok = mochiweb_socket:setopts(MochiReq:get(socket), SocketOpts),
 
     % for the path, use the raw path with the query string and fragment
     % removed, but URL quoting left intact

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -89,7 +89,7 @@ handle_utils_dir_req(#httpd{method='GET'}=Req, DocumentRoot) ->
     {_ActionKey, "/", RelativePath} ->
         % GET /_utils/path or GET /_utils/
         CachingHeaders = [{"Cache-Control", "private, must-revalidate"}],
-        EnableCsp = config:get("csp", "enable", "false"),
+        EnableCsp = config:get("csp", "enable", "true"),
         Headers = maybe_add_csp_headers(CachingHeaders, EnableCsp),
         chttpd:serve_file(Req, RelativePath, DocumentRoot, Headers);
     {_ActionKey, "", _RelativePath} ->

--- a/src/chttpd/src/chttpd_prefer_header.erl
+++ b/src/chttpd/src/chttpd_prefer_header.erl
@@ -22,6 +22,11 @@
 -include_lib("couch/include/couch_db.hrl").
 
 
+-define(DEFAULT_PREFER_MINIMAL,
+    "Cache-Control, Content-Length, Content-Range, "
+    "Content-Type, ETag, Server, Transfer-Encoding, Vary").
+
+
 maybe_return_minimal(#httpd{mochi_req = MochiReq}, Headers) ->
     case get_prefer_header(MochiReq) of
         "return=minimal" -> 
@@ -47,7 +52,8 @@ filter_headers(Headers, IncludeList) ->
 
 
 get_header_list() ->
-    SectionStr = config:get("chttpd", "prefer_minimal", ""),
+    SectionStr = config:get("chttpd",
+        "prefer_minimal", ?DEFAULT_PREFER_MINIMAL),
     split_list(SectionStr).
 
 

--- a/src/chttpd/src/chttpd_sup.erl
+++ b/src/chttpd/src/chttpd_sup.erl
@@ -26,6 +26,8 @@
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 100, Type, [I]}).
+-define(DEFAULT_BACKLOG, 512).
+-define(DEFAULT_SERVER_OPTIONS, "[{recbuf, undefined}]").
 
 start_link() ->
     Arg = case fabric2_node_types:is_type(api_frontend) of
@@ -77,8 +79,9 @@ settings() ->
     [
         {bind_address, config:get("chttpd", "bind_address")},
         {port, config:get("chttpd", "port")},
-        {backlog, config:get("chttpd", "backlog")},
-        {server_options, config:get("chttpd", "server_options")}
+        {backlog, config:get_integer("chttpd", "backlog", ?DEFAULT_BACKLOG)},
+        {server_options, config:get("chttpd",
+            "server_options", ?DEFAULT_SERVER_OPTIONS)}
     ].
 
 maybe_replace(Key, Value, Settings) ->

--- a/src/chttpd/test/eunit/chttpd_util_test.erl
+++ b/src/chttpd/test/eunit/chttpd_util_test.erl
@@ -51,25 +51,17 @@ chttpd_util_config_test_() ->
                 fun setup/0,
                 fun teardown/1,
                 [
-                    ?TDEF_FE(test_behavior),
+                    ?TDEF_FE(test_chttpd_behavior),
                     ?TDEF_FE(test_with_undefined_option),
-                    ?TDEF_FE(test_with_httpd_option),
-                    ?TDEF_FE(test_with_chttpd_option),
-                    ?TDEF_FE(test_with_chttpd_option_which_moved_from_httpd),
-                    ?TDEF_FE(test_get_chttpd_config_integer),
-                    ?TDEF_FE(test_get_chttpd_config_boolean),
                     ?TDEF_FE(test_auth_behavior),
-                    ?TDEF_FE(test_auth_with_undefined_option),
-                    ?TDEF_FE(test_auth_with_moved_options),
-                    ?TDEF_FE(test_get_chttpd_auth_config_integer),
-                    ?TDEF_FE(test_get_chttpd_auth_config_boolean)
+                    ?TDEF_FE(test_auth_with_undefined_option)
                 ]
             }
         }
     }.
 
 
-test_behavior(_) ->
+test_chttpd_behavior(_) ->
     ?assertEqual("get_in_chttpd", chttpd_util:get_chttpd_config("both_exist")),
     ?assertEqual(1, chttpd_util:get_chttpd_config_integer("chttpd_only", 0)),
     ?assert(chttpd_util:get_chttpd_config_boolean("httpd_only", false)).
@@ -84,40 +76,6 @@ test_with_undefined_option(_) ->
     ?assertEqual("", chttpd_util:get_chttpd_config("undefined_option", "")),
     ?assert(chttpd_util:get_chttpd_config("undefined_option", true)),
     ?assertNot(chttpd_util:get_chttpd_config("undefined_option", false)).
-
-
-test_with_httpd_option(_) ->
-    ?assertEqual("{couch_httpd_auth, cookie_authentication_handler}, " ++
-            "{couch_httpd_auth, default_authentication_handler}",
-                    chttpd_util:get_chttpd_config("authentication_handlers")).
-
-
-test_with_chttpd_option(_) ->
-    ?assertEqual("512", chttpd_util:get_chttpd_config("backlog")),
-    ?assertEqual("512", chttpd_util:get_chttpd_config("backlog", 123)),
-    ?assertEqual(512, chttpd_util:get_chttpd_config_integer("backlog", 123)),
-    ?assertEqual("false",
-        chttpd_util:get_chttpd_config("require_valid_user")),
-    ?assertEqual("false",
-        chttpd_util:get_chttpd_config("require_valid_user", "true")),
-    ?assertEqual(false,
-        chttpd_util:get_chttpd_config_boolean("require_valid_user", true)).
-
-
-test_with_chttpd_option_which_moved_from_httpd(_) ->
-    ?assertEqual(undefined, chttpd_util:get_chttpd_config("max_uri_length")),
-    ?assertEqual(8000, chttpd_util:get_chttpd_config("max_uri_length", 8000)),
-    ?assertEqual(undefined, chttpd_util:get_chttpd_config("WWW-Authenticate")),
-    ?assert(chttpd_util:get_chttpd_config("enable_cors", true)).
-
-
-test_get_chttpd_config_integer(_) ->
-    ?assertEqual(123,
-        chttpd_util:get_chttpd_config_integer("max_http_request_size", 123)).
-
-
-test_get_chttpd_config_boolean(_) ->
-    ?assert(chttpd_util:get_chttpd_config_boolean("allow_jsonp", true)).
 
 
 test_auth_behavior(_) ->
@@ -135,22 +93,3 @@ test_auth_with_undefined_option(_) ->
     ?assertEqual("", chttpd_util:get_chttpd_auth_config("undefine", "")),
     ?assert(chttpd_util:get_chttpd_auth_config("undefine", true)),
     ?assertNot(chttpd_util:get_chttpd_auth_config("undefine", false)).
-
-
-test_auth_with_moved_options(_) ->
-    ?assertEqual("/_utils/session.html", chttpd_util:get_chttpd_auth_config(
-        "authentication_redirect", "/_utils/session.html")),
-    ?assert(chttpd_util:get_chttpd_auth_config("require_valid_user", true)),
-    ?assertEqual(10, chttpd_util:get_chttpd_auth_config("iterations", 10)).
-
-
-test_get_chttpd_auth_config_integer(_) ->
-    ?assertEqual(123, chttpd_util:get_chttpd_auth_config_integer(
-        "timeout", 123)).
-
-
-test_get_chttpd_auth_config_boolean(_) ->
-    ?assertNot(chttpd_util:get_chttpd_auth_config_boolean(
-        "require_valid_user", false)),
-    ?assert(chttpd_util:get_chttpd_auth_config_boolean(
-        "allow_persistent_cookies", true)).

--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -130,7 +130,7 @@ from_json_obj_validate(EJson) ->
     from_json_obj_validate(EJson, undefined).
 
 from_json_obj_validate(EJson, DbName) ->
-    MaxSize = config:get_integer("couchdb", "max_document_size", 4294967296),
+    MaxSize = config:get_integer("couchdb", "max_document_size", 8000000),
     Doc = from_json_obj(EJson, DbName),
     case couch_ejson_size:encoded_size(Doc#doc.body) =< MaxSize of
         true ->

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -16,6 +16,7 @@
 
 -include_lib("couch/include/couch_db.hrl").
 
+
 -export([header_value/2,header_value/3,qs_value/2,qs_value/3,qs/1,qs_json_value/3]).
 -export([path/1,absolute_uri/2,body_length/1]).
 -export([verify_is_server_admin/1,unquote/1,quote/1,recv/2,recv_chunked/4,error_info/1]).
@@ -35,11 +36,22 @@
 -export([validate_host/1]).
 -export([validate_bind_address/1]).
 -export([check_max_request_length/1]).
+
 -export([maybe_decompress/2]).
 
 -define(HANDLER_NAME_IN_MODULE_POS, 6).
 -define(MAX_DRAIN_BYTES, 1048576).
 -define(MAX_DRAIN_TIME_MSEC, 1000).
+-define(DEFAULT_SOCKET_OPTIONS, "[{sndbuf, 262144}]").
+-define(DEFAULT_AUTHENTICATION_HANDLERS,
+    "{couch_httpd_auth, cookie_authentication_handler}, "
+    "{couch_httpd_auth, default_authentication_handler}").
+
+
+
+
+
+            ?DEFAULT_AUTHENTICATION_HANDLERS)),
 
 
 % SpecStr is a string like "{my_module, my_fun}"
@@ -72,6 +84,7 @@ make_arity_3_fun(SpecStr) ->
 make_fun_spec_strs(SpecStr) ->
     re:split(SpecStr, "(?<=})\\s*,\\s*(?={)", [{return, list}]).
 
+
 validate_host(#httpd{} = Req) ->
     case chttpd_util:get_chttpd_config_boolean("validate_host", false) of
         true ->
@@ -99,6 +112,7 @@ hostname(#httpd{} = Req) ->
 valid_hosts() ->
     List = chttpd_util:get_chttpd_config("valid_hosts", ""),
     re:split(List, ",", [{return, list}]).
+
 
 validate_referer(Req) ->
     Host = host_for_request(Req),
@@ -894,6 +908,7 @@ http_respond_(#httpd{mochi_req = MochiReq}, 413, Headers, Args, Type) ->
     Result;
 http_respond_(#httpd{mochi_req = MochiReq}, Code, Headers, Args, Type) ->
     MochiReq:Type({Code, Headers, Args}).
+
 
 
 %%%%%%%% module tests below %%%%%%%%

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -598,11 +598,11 @@ can_spawn(#state{hard_limit = HardLimit, counts = Counts}, Lang) ->
 
 
 get_proc_config() ->
-    Limit = config:get("query_server_config", "reduce_limit", "true"),
-    Timeout = config:get("couchdb", "os_process_timeout", "5000"),
+    Limit = config:get_boolean("query_server_config", "reduce_limit", true),
+    Timeout = config:get_integer("couchdb", "os_process_timeout", 5000),
     {[
-        {<<"reduce_limit">>, list_to_atom(Limit)},
-        {<<"timeout">>, list_to_integer(Timeout)}
+        {<<"reduce_limit">>, Limit},
+        {<<"timeout">>, Timeout}
     ]}.
 
 
@@ -612,5 +612,4 @@ get_hard_limit() ->
 
 
 get_soft_limit() ->
-    LimStr = config:get("query_server_config", "os_process_soft_limit", "100"),
-    list_to_integer(LimStr).
+    config:get_integer("query_server_config", "os_process_soft_limit", 100).

--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -545,7 +545,7 @@ proc_set_timeout(Proc, Timeout) ->
     apply(Mod, Func, [Proc#proc.pid, Timeout]).
 
 get_os_process_timeout() ->
-    list_to_integer(config:get("couchdb", "os_process_timeout", "5000")).
+    config:get_integer("couchdb", "os_process_timeout", 5000).
 
 get_ddoc_process(#doc{} = DDoc, DDocKey) ->
     % remove this case statement

--- a/src/couch/src/couch_uuids.erl
+++ b/src/couch/src/couch_uuids.erl
@@ -98,7 +98,7 @@ inc() ->
     couch_rand:uniform(16#ffd).
 
 state() ->
-    AlgoStr = config:get("uuids", "algorithm", "random"),
+    AlgoStr = config:get("uuids", "algorithm", "sequential"),
     case couch_util:to_existing_atom(AlgoStr) of
         random ->
             random;

--- a/src/couch/test/eunit/couch_doc_json_tests.erl
+++ b/src/couch/test/eunit/couch_doc_json_tests.erl
@@ -39,7 +39,7 @@ mock(couch_log) ->
 mock(config) ->
     meck:new(config, [passthrough]),
     meck:expect(config, get_integer,
-        fun("couchdb", "max_document_size", 4294967296) -> 1024 end),
+        fun("couchdb", "max_document_size", 8000000) -> 1024 end),
     meck:expect(config, get, fun(_, _) -> undefined end),
     meck:expect(config, get, fun(_, _, Default) -> Default end),
     ok.

--- a/src/couch_replicator/src/couch_replicator_ids.erl
+++ b/src/couch_replicator/src/couch_replicator_ids.erl
@@ -67,7 +67,7 @@ base_id(#{?SOURCE := Src0, ?TARGET := Tgt0} = Rep, 2) ->
         % TODO: we might be under an SSL socket server only, or both under
         % SSL and a non-SSL socket.
         % ... mochiweb_socket_server:get(https, port)
-        list_to_integer(config:get("httpd", "port", "5984"))
+        config:get_integer("httpd", "port", 5984)
     end,
     Src = get_rep_endpoint(Src0),
     Tgt = get_rep_endpoint(Tgt0),

--- a/src/couch_replicator/test/eunit/couch_replicator_create_target_with_options_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_create_target_with_options_tests.erl
@@ -19,6 +19,7 @@
 -include_lib("fabric/test/fabric2_test.hrl").
 
 
+
 create_target_with_options_replication_test_() ->
     {
         "Create target with range partitions tests",
@@ -90,6 +91,7 @@ should_create_target_with_q_2_n_1({Source, Target}) ->
     ?assertEqual(0, couch_util:get_value(n, ClusterInfo)).
 
 
+
 should_create_target_with_default({Source, Target}) ->
     RepObject = {[
         {<<"source">>, Source},
@@ -102,6 +104,7 @@ should_create_target_with_default({Source, Target}) ->
 
     TargetInfo = db_info(Target),
     {ClusterInfo} = couch_util:get_value(cluster, TargetInfo),
+
     delete_db(Source),
     delete_db(Target),
     ?assertEqual(0, couch_util:get_value(q, ClusterInfo)).

--- a/test/elixir/test/config_test.exs
+++ b/test/elixir/test/config_test.exs
@@ -11,6 +11,7 @@ defmodule ConfigTest do
 
   setup do
     config_url = "/_node/_local/_config"
+
     resp = Couch.get(config_url)
     assert resp.status_code == 200
     {:ok, config: resp.body, config_url: config_url}
@@ -71,8 +72,10 @@ defmodule ConfigTest do
   end
 
 
+
   test "Standard config options are present", context do
     assert context[:config]["chttpd"]["port"]
+
   end
 
   test "Settings can be altered with undefined whitelist allowing any change", context do
@@ -94,6 +97,7 @@ defmodule ConfigTest do
     delete_config(context, "admins", "administrator")
     assert Couch.delete("/_session").body["ok"]
   end
+
 
   test "Non-term whitelist values allow further modification of the whitelist", context do
     val = "!This is an invalid Erlang term!"


### PR DESCRIPTION
## Overview
Normalize some configuration options to comment out the default.ini file.
Solved conflicts from "cherry-pick" 3.x commit with kdiff3 merge tool.

## Testing recommendations


## Related Issues or Pull Requests
fixes #3473 

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
