### PR TITLE
Normalize config options main

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -138,7 +138,7 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{config,           "config",           {tag, "2.1.8"}},
+{config,           "config",           {tag, "2.1.9"}},
 {b64url,           "b64url",           {tag, "1.0.2"}},
 {erlfdb,           "erlfdb",           {tag, "v1.3.4"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -6,20 +6,20 @@ name = {{package_author_name}}
 uuid = {{uuid}}
 ; util_driver_dir =
 ; plugin_dir =
-os_process_timeout = 5000 ; 5 seconds. for view servers.
-max_dbs_open = 500
+;os_process_timeout = 5000 ; 5 seconds. for view servers.
+;max_dbs_open = 500
 ; Default security object for databases if not explicitly set
 ; everyone - same as couchdb 1.0, everyone can read/write
 ; admin_only - only admins can read/write
 ; admin_local - sharded dbs on :5984 are read/write for everyone,
 ;               local dbs on :5986 are read/write for admins only
-default_security = admin_only
+;default_security = admin_only
 ; maintenance_mode = false
 ; uri_file =
 ; The speed of processing the _changes feed with doc_ids filter can be
 ; influenced directly with this setting - increase for faster processing at the
 ; expense of more memory usage.
-changes_doc_ids_optimization_threshold = 100
+;changes_doc_ids_optimization_threshold = 100
 ;
 ; Maximum database name length. The default setting is chosen for CouchDB < 4.x
 ; compatibility, where it was determined by the maximum file name size. On most
@@ -55,24 +55,24 @@ max_document_size = 8000000 ; bytes
 ;enable_database_recovery = false
 ;
 ; Allow edits on the _security object in the user db. By default, it's disabled.
-users_db_security_editable = false
+;users_db_security_editable = false
 
 [chttpd]
 ; These settings affect the main, clustered port (5984 by default).
 port = {{cluster_port}}
 bind_address = 127.0.0.1
-backlog = 512
-socket_options = [{sndbuf, 262144}, {nodelay, true}]
-server_options = [{recbuf, undefined}]
-require_valid_user = false
+;backlog = 512
+;socket_options = [{sndbuf, 262144}, {nodelay, true}]
+;server_options = [{recbuf, undefined}]
+;require_valid_user = false
 ; require_valid_user_except_for_up = false
 ; List of headers that will be kept when the header Prefer: return=minimal is included in a request.
 ; If Server header is left out, Mochiweb will add its own one in.
-prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
+;prefer_minimal = Cache-Control, Content-Length, Content-Range, Content-Type, ETag, Server, Transfer-Encoding, Vary
 ;
 ; Limit maximum number of databases when tying to get detailed information using
 ; _dbs_info in a request
-max_db_number_for_dbs_info_req = 100
+;max_db_number_for_dbs_info_req = 100
 
 ; set to true to delay the start of a response until the end has been calculated
 ;buffer_response = false
@@ -132,13 +132,13 @@ max_db_number_for_dbs_info_req = 100
 [httpd]
 port = {{backend_port}}
 bind_address = 127.0.0.1
-authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
+;authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
 
 ; Options for the MochiWeb HTTP server.
 ;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
 ; For more socket options, consult Erlang's module 'inet' man page.
 ;socket_options = [{recbuf, undefined}, {sndbuf, 262144}, {nodelay, true}]
-socket_options = [{sndbuf, 262144}]
+;socket_options = [{sndbuf, 262144}]
 
 ; These settings were moved to [chttpd]
 ; secure_rewrites, allow_jsonp, enable_cors, enable_xframe_options,
@@ -146,7 +146,7 @@ socket_options = [{sndbuf, 262144}]
 ; x_forwarded_host, x_forwarded_proto, x_forwarded_ssl, max_http_request_size
 
 [ssl]
-port = 6984
+;port = 6984
 
 [chttpd_auth]
 ;authentication_db = _users
@@ -207,7 +207,7 @@ port = 6984
 [couch_httpd_auth]
 ; WARNING! This only affects the node-local port (5986 by default).
 ; You probably want the settings under [chttpd].
-authentication_db = _users
+;authentication_db = _users
 
 ; These settings were moved to [chttpd_auth]
 ; authentication_redirect, require_valid_user, timeout,
@@ -277,11 +277,11 @@ authentication_db = _users
 
 ; CSP (Content Security Policy) Support for _utils
 [csp]
-enable = true
+;enable = true
 ; header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
 
 [cors]
-credentials = false
+;credentials = false
 ; List of origins separated by a comma, * means accept all
 ; Origins must include the scheme: http://example.com
 ; You can't set origins: * and credentials = true at the same time.
@@ -328,8 +328,8 @@ credentials = false
 ; please let us know on the mailing list so we can fine tune the heuristic.
 [query_server_config]
 ; commit_freq = 5
-reduce_limit = true
-os_process_limit = 100
+;reduce_limit = true
+;os_process_limit = 100
 ; os_process_idle_limit = 300
 ; os_process_soft_limit = 100
 ; Timeout for how long a response from a busy view group server can take.
@@ -341,8 +341,8 @@ os_process_limit = 100
 ; The list of modules that implement the couch_eval
 ; beahvior for executing provided code in design
 ; documents.
-javascript = couch_js
-query = mango_eval
+;javascript = couch_js
+;query = mango_eval
 
 [mango]
 ; Set to true to disable the "index all fields" text index, which can lead
@@ -374,16 +374,16 @@ query = mango_eval
 ;     First 14 characters are the time in hex. Last 18 are random.
 ;   utc_id - Time since Jan 1, 1970 UTC with microseconds, plus utc_id_suffix string
 ;     First 14 characters are the time in hex. uuids/utc_id_suffix string value is appended to these.
-algorithm = sequential
+;algorithm = sequential
 ; The utc_id_suffix value will be appended to uuids generated by the utc_id algorithm.
 ; Replicating instances should have unique utc_id_suffix values to ensure uniqueness of utc_id ids.
-utc_id_suffix =
+;utc_id_suffix =
 # Maximum number of UUIDs retrievable from /_uuids in a single request
-max_count = 1000
+;max_count = 1000
 
 [attachments]
-compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
-compressible_types = text/*, application/javascript, application/json, application/xml
+;compression_level = 8 ; from 1 (lowest, fastest) to 9 (highest, slowest), 0 to disable compression
+;compressible_types = text/*, application/javascript, application/json, application/xml
 
 [replicator]
 ; Number of actively running replications per replication backend node
@@ -524,7 +524,7 @@ compressible_types = text/*, application/javascript, application/json, applicati
 ;  emergency, emerg
 ;  none
 ;
-level = info
+;level = info
 ;
 ; Set the maximum log message length in bytes that will be
 ; passed through the writer
@@ -547,7 +547,7 @@ level = info
 ; over the network, and a journald writer that's more suitable
 ; when using systemd journald.
 ;
-writer = stderr
+;writer = stderr
 ; Journald Writer notes:
 ;
 ; The journald writer doesn't have any options. It still writes
@@ -721,6 +721,6 @@ writer = stderr
 ;cache_deletion_grace_sec = 5
 
 [prometheus]
-additional_port = false
+;additional_port = false
 bind_address = 127.0.0.1
 port = {{prometheus_port}}

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -89,7 +89,7 @@ handle_utils_dir_req(#httpd{method='GET'}=Req, DocumentRoot) ->
     {_ActionKey, "/", RelativePath} ->
         % GET /_utils/path or GET /_utils/
         CachingHeaders = [{"Cache-Control", "private, must-revalidate"}],
-        EnableCsp = config:get("csp", "enable", "false"),
+        EnableCsp = config:get("csp", "enable", "true"),
         Headers = maybe_add_csp_headers(CachingHeaders, EnableCsp),
         chttpd:serve_file(Req, RelativePath, DocumentRoot, Headers);
     {_ActionKey, "", _RelativePath} ->
@@ -330,7 +330,7 @@ handle_reload_query_servers_req(Req) ->
     send_method_not_allowed(Req, "POST").
 
 handle_uuids_req(#httpd{method='GET'}=Req) ->
-    Max = list_to_integer(config:get("uuids","max_count","1000")),
+    Max = config:get_integer("uuids", "max_count", 1000),
     Count = try list_to_integer(couch_httpd:qs_value(Req, "count", "1")) of
         N when N > Max ->
             throw({bad_request, <<"count parameter too large">>});

--- a/src/chttpd/src/chttpd_prefer_header.erl
+++ b/src/chttpd/src/chttpd_prefer_header.erl
@@ -22,6 +22,11 @@
 -include_lib("couch/include/couch_db.hrl").
 
 
+-define(DEFAULT_PREFER_MINIMAL,
+    "Cache-Control, Content-Length, Content-Range, "
+    "Content-Type, ETag, Server, Transfer-Encoding, Vary").
+
+
 maybe_return_minimal(#httpd{mochi_req = MochiReq}, Headers) ->
     case get_prefer_header(MochiReq) of
         "return=minimal" -> 
@@ -47,8 +52,7 @@ filter_headers(Headers, IncludeList) ->
 
 
 get_header_list() ->
-    SectionStr = config:get("chttpd", "prefer_minimal", ""),
-    split_list(SectionStr).
+    split_list(config:get("chttpd", "prefer_minimal", ?DEFAULT_PREFER_MINIMAL)).
 
 
 split_list(S) ->

--- a/src/chttpd/src/chttpd_sup.erl
+++ b/src/chttpd/src/chttpd_sup.erl
@@ -26,6 +26,8 @@
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 100, Type, [I]}).
+-define(DEFAULT_BACKLOG, 512).
+-define(DEFAULT_SERVER_OPTIONS, "[{recbuf, undefined}]").
 
 start_link() ->
     Arg = case fabric2_node_types:is_type(api_frontend) of
@@ -77,8 +79,9 @@ settings() ->
     [
         {bind_address, config:get("chttpd", "bind_address")},
         {port, config:get("chttpd", "port")},
-        {backlog, config:get("chttpd", "backlog")},
-        {server_options, config:get("chttpd", "server_options")}
+        {backlog, config:get_integer("chttpd", "backlog", ?DEFAULT_BACKLOG)},
+        {server_options, config:get("chttpd",
+            "server_options", ?DEFAULT_SERVER_OPTIONS)}
     ].
 
 maybe_replace(Key, Value, Settings) ->

--- a/src/chttpd/test/eunit/chttpd_util_test.erl
+++ b/src/chttpd/test/eunit/chttpd_util_test.erl
@@ -51,25 +51,17 @@ chttpd_util_config_test_() ->
                 fun setup/0,
                 fun teardown/1,
                 [
-                    ?TDEF_FE(test_behavior),
+                    ?TDEF_FE(test_chttpd_behavior),
                     ?TDEF_FE(test_with_undefined_option),
-                    ?TDEF_FE(test_with_httpd_option),
-                    ?TDEF_FE(test_with_chttpd_option),
-                    ?TDEF_FE(test_with_chttpd_option_which_moved_from_httpd),
-                    ?TDEF_FE(test_get_chttpd_config_integer),
-                    ?TDEF_FE(test_get_chttpd_config_boolean),
                     ?TDEF_FE(test_auth_behavior),
-                    ?TDEF_FE(test_auth_with_undefined_option),
-                    ?TDEF_FE(test_auth_with_moved_options),
-                    ?TDEF_FE(test_get_chttpd_auth_config_integer),
-                    ?TDEF_FE(test_get_chttpd_auth_config_boolean)
+                    ?TDEF_FE(test_auth_with_undefined_option)
                 ]
             }
         }
     }.
 
 
-test_behavior(_) ->
+test_chttpd_behavior(_) ->
     ?assertEqual("get_in_chttpd", chttpd_util:get_chttpd_config("both_exist")),
     ?assertEqual(1, chttpd_util:get_chttpd_config_integer("chttpd_only", 0)),
     ?assert(chttpd_util:get_chttpd_config_boolean("httpd_only", false)).
@@ -84,40 +76,6 @@ test_with_undefined_option(_) ->
     ?assertEqual("", chttpd_util:get_chttpd_config("undefined_option", "")),
     ?assert(chttpd_util:get_chttpd_config("undefined_option", true)),
     ?assertNot(chttpd_util:get_chttpd_config("undefined_option", false)).
-
-
-test_with_httpd_option(_) ->
-    ?assertEqual("{couch_httpd_auth, cookie_authentication_handler}, " ++
-            "{couch_httpd_auth, default_authentication_handler}",
-                    chttpd_util:get_chttpd_config("authentication_handlers")).
-
-
-test_with_chttpd_option(_) ->
-    ?assertEqual("512", chttpd_util:get_chttpd_config("backlog")),
-    ?assertEqual("512", chttpd_util:get_chttpd_config("backlog", 123)),
-    ?assertEqual(512, chttpd_util:get_chttpd_config_integer("backlog", 123)),
-    ?assertEqual("false",
-        chttpd_util:get_chttpd_config("require_valid_user")),
-    ?assertEqual("false",
-        chttpd_util:get_chttpd_config("require_valid_user", "true")),
-    ?assertEqual(false,
-        chttpd_util:get_chttpd_config_boolean("require_valid_user", true)).
-
-
-test_with_chttpd_option_which_moved_from_httpd(_) ->
-    ?assertEqual(undefined, chttpd_util:get_chttpd_config("max_uri_length")),
-    ?assertEqual(8000, chttpd_util:get_chttpd_config("max_uri_length", 8000)),
-    ?assertEqual(undefined, chttpd_util:get_chttpd_config("WWW-Authenticate")),
-    ?assert(chttpd_util:get_chttpd_config("enable_cors", true)).
-
-
-test_get_chttpd_config_integer(_) ->
-    ?assertEqual(123,
-        chttpd_util:get_chttpd_config_integer("max_http_request_size", 123)).
-
-
-test_get_chttpd_config_boolean(_) ->
-    ?assert(chttpd_util:get_chttpd_config_boolean("allow_jsonp", true)).
 
 
 test_auth_behavior(_) ->
@@ -135,22 +93,3 @@ test_auth_with_undefined_option(_) ->
     ?assertEqual("", chttpd_util:get_chttpd_auth_config("undefine", "")),
     ?assert(chttpd_util:get_chttpd_auth_config("undefine", true)),
     ?assertNot(chttpd_util:get_chttpd_auth_config("undefine", false)).
-
-
-test_auth_with_moved_options(_) ->
-    ?assertEqual("/_utils/session.html", chttpd_util:get_chttpd_auth_config(
-        "authentication_redirect", "/_utils/session.html")),
-    ?assert(chttpd_util:get_chttpd_auth_config("require_valid_user", true)),
-    ?assertEqual(10, chttpd_util:get_chttpd_auth_config("iterations", 10)).
-
-
-test_get_chttpd_auth_config_integer(_) ->
-    ?assertEqual(123, chttpd_util:get_chttpd_auth_config_integer(
-        "timeout", 123)).
-
-
-test_get_chttpd_auth_config_boolean(_) ->
-    ?assertNot(chttpd_util:get_chttpd_auth_config_boolean(
-        "require_valid_user", false)),
-    ?assert(chttpd_util:get_chttpd_auth_config_boolean(
-        "allow_persistent_cookies", true)).

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -60,6 +60,8 @@
 
 
 -define(CURRENT_ATT_FORMAT, 0).
+-define(DEFAULT_COMPRESSIBLE_TYPES,
+    "text/*, application/javascript, application/json, application/xml").
 
 
 -type prop_name() ::
@@ -633,7 +635,7 @@ fold_streamed_data(RcvFun, LenLeft, Fun, Acc) when LenLeft > 0->
 maybe_compress(Att) ->
     [Encoding, Type] = fetch([encoding, type], Att),
     IsCompressible = is_compressible(Type),
-    CompLevel = config:get_integer("attachments", "compression_level", 0),
+    CompLevel = config:get_integer("attachments", "compression_level", 8),
     case Encoding of
         identity when IsCompressible, CompLevel >= 1, CompLevel =< 9 ->
             compress(Att, CompLevel);
@@ -665,7 +667,8 @@ is_compressible(Type) when is_binary(Type) ->
     is_compressible(binary_to_list(Type));
 is_compressible(Type) ->
     TypeExpList = re:split(
-        config:get("attachments", "compressible_types", ""),
+        config:get("attachments", "compressible_types",
+            ?DEFAULT_COMPRESSIBLE_TYPES),
         "\\s*,\\s*",
         [{return, list}]
     ),

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -40,6 +40,7 @@
 -define(HANDLER_NAME_IN_MODULE_POS, 6).
 -define(MAX_DRAIN_BYTES, 1048576).
 -define(MAX_DRAIN_TIME_MSEC, 1000).
+-define(DEFAULT_MAX_HTTP_REQUEST_SIZE, 4294967296).
 
 
 % SpecStr is a string like "{my_module, my_fun}"
@@ -131,7 +132,7 @@ validate_ctype(Req, Ctype) ->
 check_max_request_length(Req) ->
     Len = list_to_integer(header_value(Req, "Content-Length", "0")),
     MaxLen = chttpd_util:get_chttpd_config_integer(
-        "max_http_request_size", 4294967296),
+        "max_http_request_size", ?DEFAULT_MAX_HTTP_REQUEST_SIZE),
     case Len > MaxLen of
         true ->
             exit({body_too_large, Len});
@@ -256,14 +257,14 @@ recv_chunked(#httpd{mochi_req=MochiReq}, MaxChunkSize, ChunkFun, InitState) ->
     % called with Length == 0 on the last time.
     MochiReq:stream_body(MaxChunkSize, ChunkFun, InitState,
         chttpd_util:get_chttpd_config_integer(
-            "max_http_request_size", 4294967296)).
+            "max_http_request_size", ?DEFAULT_MAX_HTTP_REQUEST_SIZE)).
 
 body_length(#httpd{mochi_req=MochiReq}) ->
     MochiReq:get(body_length).
 
 body(#httpd{mochi_req=MochiReq, req_body=undefined}) ->
     MaxSize = chttpd_util:get_chttpd_config_integer(
-        "max_http_request_size", 4294967296),
+        "max_http_request_size", ?DEFAULT_MAX_HTTP_REQUEST_SIZE),
     MochiReq:recv_body(MaxSize);
 body(#httpd{req_body=ReqBody}) ->
     ReqBody.

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -598,19 +598,17 @@ can_spawn(#state{hard_limit = HardLimit, counts = Counts}, Lang) ->
 
 
 get_proc_config() ->
-    Limit = config:get("query_server_config", "reduce_limit", "true"),
-    Timeout = config:get("couchdb", "os_process_timeout", "5000"),
+    Limit = config:get_boolean("query_server_config", "reduce_limit", true),
+    Timeout = config:get_integer("couchdb", "os_process_timeout", 5000),
     {[
-        {<<"reduce_limit">>, list_to_atom(Limit)},
-        {<<"timeout">>, list_to_integer(Timeout)}
+        {<<"reduce_limit">>, Limit},
+        {<<"timeout">>, Timeout}
     ]}.
 
 
 get_hard_limit() ->
-    LimStr = config:get("query_server_config", "os_process_limit", "100"),
-    list_to_integer(LimStr).
+    config:get_integer("query_server_config", "os_process_limit", 100).
 
 
 get_soft_limit() ->
-    LimStr = config:get("query_server_config", "os_process_soft_limit", "100"),
-    list_to_integer(LimStr).
+    config:get_integer("query_server_config", "os_process_soft_limit", 100).

--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -545,7 +545,7 @@ proc_set_timeout(Proc, Timeout) ->
     apply(Mod, Func, [Proc#proc.pid, Timeout]).
 
 get_os_process_timeout() ->
-    list_to_integer(config:get("couchdb", "os_process_timeout", "5000")).
+    config:get_integer("couchdb", "os_process_timeout", 5000).
 
 get_ddoc_process(#doc{} = DDoc, DDocKey) ->
     % remove this case statement

--- a/src/couch/src/couch_uuids.erl
+++ b/src/couch/src/couch_uuids.erl
@@ -98,7 +98,7 @@ inc() ->
     couch_rand:uniform(16#ffd).
 
 state() ->
-    AlgoStr = config:get("uuids", "algorithm", "random"),
+    AlgoStr = config:get("uuids", "algorithm", "sequential"),
     case couch_util:to_existing_atom(AlgoStr) of
         random ->
             random;

--- a/src/couch_eval/src/couch_eval.erl
+++ b/src/couch_eval/src/couch_eval.erl
@@ -145,11 +145,19 @@ release_context({ApiMod, Ctx}) ->
 get_api_mod(Language) when is_binary(Language) ->
     try
         LangStr = binary_to_list(Language),
-        ModStr = config:get("couch_eval.languages", LangStr),
-        if ModStr /= undefined -> ok; true ->
-            erlang:error({unknown_eval_api_language, Language})
-        end,
-        list_to_existing_atom(ModStr)
+        ModStr =
+            case LangStr of
+                "javascript" ->
+                    config:get("couch_eval.languages", LangStr, "couch_js");
+                "query" ->
+                    config:get("couch_eval.languages", LangStr, "mango_eval");
+                _ ->
+                    config:get("couch_eval.languages", LangStr)
+            end,
+        case ModStr of
+            _ -> list_to_existing_atom(ModStr);
+            undefined -> erlang:error({unknown_eval_api_language, Language})
+        end
     catch error:badarg ->
         erlang:error({invalid_eval_api_mod, Language})
     end.

--- a/src/couch_js/src/couch_js_proc_manager.erl
+++ b/src/couch_js/src/couch_js_proc_manager.erl
@@ -604,19 +604,17 @@ can_spawn(#state{hard_limit = HardLimit, counts = Counts}, Lang) ->
 
 
 get_proc_config() ->
-    Limit = config:get("query_server_config", "reduce_limit", "true"),
-    Timeout = config:get("couchdb", "os_process_timeout", "5000"),
+    Limit = config:get_boolean("query_server_config", "reduce_limit", true),
+    Timeout = config:get_integer("couchdb", "os_process_timeout", 5000),
     {[
-        {<<"reduce_limit">>, list_to_atom(Limit)},
-        {<<"timeout">>, list_to_integer(Timeout)}
+        {<<"reduce_limit">>, Limit},
+        {<<"timeout">>, Timeout}
     ]}.
 
 
 get_hard_limit() ->
-    LimStr = config:get("query_server_config", "os_process_limit", "100"),
-    list_to_integer(LimStr).
+    config:get_integer("query_server_config", "os_process_limit", 100).
 
 
 get_soft_limit() ->
-    LimStr = config:get("query_server_config", "os_process_soft_limit", "100"),
-    list_to_integer(LimStr).
+    config:get_integer("query_server_config", "os_process_soft_limit", 100).

--- a/src/couch_js/src/couch_js_query_servers.erl
+++ b/src/couch_js/src/couch_js_query_servers.erl
@@ -468,7 +468,7 @@ proc_set_timeout(Proc, Timeout) ->
     apply(Mod, Func, [Proc#proc.pid, Timeout]).
 
 get_os_process_timeout() ->
-    list_to_integer(config:get("couchdb", "os_process_timeout", "5000")).
+    config:get_integer("couchdb", "os_process_timeout", 5000).
 
 get_ddoc_process(#doc{} = DDoc, DDocKey) ->
     % remove this case statement

--- a/src/couch_prometheus/src/couch_prometheus_sup.erl
+++ b/src/couch_prometheus/src/couch_prometheus_sup.erl
@@ -32,8 +32,7 @@ init([]) ->
     }}.
 
 maybe_start_prometheus_http() ->
-    case config:get("prometheus", "additional_port", "false") of
-        "false" -> [];
-        "true" -> [?CHILD(couch_prometheus_http, worker)];
-        _ -> []
+    case config:get_boolean("prometheus", "additional_port", false) of
+        false -> [];
+        true -> [?CHILD(couch_prometheus_http, worker)]
     end.

--- a/src/couch_replicator/test/eunit/couch_replicator_large_atts_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_large_atts_tests.erl
@@ -21,6 +21,8 @@
 -define(ATT_SIZE_2, round(6.6 * 1024 * 1024)).
 -define(DOCS_COUNT, 11).
 -define(TIMEOUT_EUNIT, 120).
+-define(DEFAULT_COMPRESSIBLE_TYPES,
+    "text/*, application/javascript, application/json, application/xml").
 
 
 large_atts_test_() ->
@@ -43,7 +45,8 @@ large_atts_test_() ->
 
 
 setup() ->
-    AttCfg = config:get("attachments", "compressible_types"),
+    AttCfg = config:get("attachments",
+        "compressible_types", ?DEFAULT_COMPRESSIBLE_TYPES),
     config:set("attachments", "compressible_types", "text/*", false),
     Source = couch_replicator_test_helper:create_db(),
     ok = populate_db(Source, ?DOCS_COUNT),


### PR DESCRIPTION
## Overview
Normalize some configuration options to comment out the default.ini file in the main branch.

## Testing recommendations


## Related Issues or Pull Requests
This fixes #3473

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
