### PR TITLE
Fix formatter python compatibility

### DIFF
--- a/dev/format_check.py
+++ b/dev/format_check.py
@@ -45,7 +45,8 @@ if __name__ == "__main__":
                     item["raw_path"],
                 ],
                 encoding="utf-8",
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
             if run_result.returncode != 0:
                 # erlfmt sometimes returns a non-zero status code with no

--- a/dev/format_lib.py
+++ b/dev/format_lib.py
@@ -23,7 +23,10 @@ import subprocess
 
 def get_source_paths():
     for item in subprocess.run(
-        ["git", "ls-files"], encoding="utf-8", capture_output=True
+        ["git", "ls-files"],
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     ).stdout.split("\n"):
         item_path = pathlib.Path(item)
         if item_path.suffix != ".erl":


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
https://github.com/apache/couchdb/pull/3568 [broke CI on main](https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FFullPlatformMatrix/detail/main/175/pipeline) by using current python features. 
This PR fixes that by applying a [workaround](https://stackoverflow.com/a/53209196) to make the formatter scripts compatible.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
