### PR TITLE
Add rebar3 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ src/parse_trans/
 src/passage/
 src/proper/
 src/rebar/
+src/rebar3/
 src/recon/
 src/smoosh/
 src/snappy/


### PR DESCRIPTION
## Overview

Rebar3 is now cloned after the merge of https://github.com/apache/couchdb/pull/3637/commits/dd0b666e743f6466910b278000a865bb087da451 but is not added to the `.gitignore`.

## Testing recommendations

N/A

## Related Issues or Pull Requests

Rebar3 is now cloned after the merge of https://github.com/apache/couchdb/pull/3637/commits/dd0b666e743f6466910b278000a865bb087da451.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
