### PR TITLE
Comment out [couchdb]: max_document_size

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -35,7 +35,7 @@ uuid = {{uuid}}
 ; requests which update a single document as well as individual documents from
 ; a _bulk_docs request. The size limit is approximate due to the nature of JSON
 ; encoding. The size limit must be less than or equal to 8000000 bytes.
-max_document_size = 8000000 ; bytes
+;max_document_size = 8000000 ; bytes
 ;
 ; Maximum number of documents in a _bulk_docs request. Anything larger
 ; returns a 413 error for the whole request

--- a/test/elixir/test/bulk_docs_test.exs
+++ b/test/elixir/test/bulk_docs_test.exs
@@ -132,11 +132,9 @@ defmodule BulkDocsTest do
 
   @tag :with_db
   test "bulk docs raises error for transaction larger than 10MB", ctx do
-    docs = [%{_id: "0", a: random_string(16_000_000)}]
-    old_size = Couch.get("/_node/node1@127.0.0.1/_config/couchdb/max_document_size").body
-    set_config_raw("couchdb", "max_document_size", "67108864") # 64M
+    # the default value for max_document_size is 8_000_000
+    docs = [%{_id: "0", a: random_string(9_000_000)}]
     resp = Couch.post("/#{ctx[:db_name]}/_bulk_docs", body: %{docs: docs})
-    set_config_raw("couchdb", "max_document_size", old_size) # set back
     assert resp.status_code == 413
     assert resp.body["error"] == "document_too_large"
     assert resp.body["reason"] == "0" # DocID


### PR DESCRIPTION
## Overview
Normalize config options, comment out `[couchdb]: max_document_size`.

## Testing recommendations

## Related Issues or Pull Requests
https://github.com/apache/couchdb/pull/3636

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
