### PR TITLE
Fix __MODULE__ compiler variable warning

### DIFF
--- a/test/elixir/lib/step/start.ex
+++ b/test/elixir/lib/step/start.ex
@@ -59,7 +59,7 @@ defmodule Couch.Test.Setup.Step.Start do
     }
   end
 
-  def teardown(_setup, %___MODULE__{test_ctx: test_ctx}) do
+  def teardown(_setup, %__MODULE__{test_ctx: test_ctx}) do
     :test_util.stop_couch(test_ctx)
   end
 


### PR DESCRIPTION
Fixes:
```
warning: unknown compiler variable "___MODULE__" (expected one of __MODULE__, __ENV__, __DIR__, __CALLER__, __STACKTRACE__)
  src/couchdb/test/elixir/lib/step/start.ex:62: Couch.Test.Setup.Step.Start.teardown/2
```

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
