### PR TITLE
Fix COUCHDB_FAUXTON_DOCROOT in couchdb script

### DIFF
--- a/rel/files/couchdb.in
+++ b/rel/files/couchdb.in
@@ -38,7 +38,7 @@ export PROGNAME=`echo $0 | sed 's/.*\///'`
 
 export COUCHDB_QUERY_SERVER_JAVASCRIPT="${COUCHDB_QUERY_SERVER_JAVASCRIPT:-{{prefix}}/bin/couchjs {{prefix}}/share/server/main.js}"
 export COUCHDB_QUERY_SERVER_COFFEESCRIPT="${COUCHDB_QUERY_SERVER_COFFEESCRIPT:-{{prefix}}/bin/couchjs {{prefix}}/share/server/main-coffee.js}"
-export COUCHDB_FAUXTON_DOCROOT="${COUCHDB_FAUXTON_DOCROOT:-{{fauxton_root}} }"
+export COUCHDB_FAUXTON_DOCROOT="${COUCHDB_FAUXTON_DOCROOT:-{{fauxton_root}}}"
 
 ARGS_FILE="${COUCHDB_ARGS_FILE:-$ROOTDIR/etc/vm.args}"
 [ -n "${COUCHDB_INI_FILES:-}" ] && INI_ARGS="-couch_ini $COUCHDB_INI_FILES"


### PR DESCRIPTION
## Overview

Currently, the couchdb script generated by `make release` will 404 when trying to access `fauxton` under `/_utils/`. After investigation, it occurs because the `COUCHDB_FAUXTON_DOCROOT` is set to `"./share/www "` (with a space).

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
