### PR TITLE
Fix "error":"case_clause" using latest=true

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1076,7 +1076,7 @@ db_doc_req(#httpd{method = 'DELETE'} = Req, Db, DocId) ->
     send_updated_doc(Req, Db, DocId, Doc);
 db_doc_req(#httpd{method = 'GET', mochi_req = MochiReq} = Req, Db, DocId) ->
     #doc_query_args{
-        rev = Rev,
+        rev = Rev0,
         open_revs = Revs,
         options = Options,
         atts_since = AttsSince
@@ -1089,6 +1089,13 @@ db_doc_req(#httpd{method = 'GET', mochi_req = MochiReq} = Req, Db, DocId) ->
                         [{atts_since, AttsSince}, attachments | Options];
                     true ->
                         Options
+                end,
+            Rev =
+                case lists:member(latest, Options) of
+                    % couch_doc_open will open the winning rev despite of a rev passed
+                    % https://docs.couchdb.org/en/stable/api/document/common.html?highlight=latest#get--db-docid
+                    true -> nil;
+                    false -> Rev0
                 end,
             Doc = couch_doc_open(Db, DocId, Rev, Options2),
             send_doc(Req, Doc, Options2);


### PR DESCRIPTION
This is a port of https://github.com/apache/couchdb/pull/3424/commits/a8622f0cca40d8f2338ec24b40f14d013a0f69d4 to main

Issue #3424
