### PR TITLE
Fix response code for nonexistent attachment

### DIFF
--- a/test/elixir/test/attachments_test.exs
+++ b/test/elixir/test/attachments_test.exs
@@ -109,6 +109,11 @@ defmodule AttachmentsTest do
     resp = Couch.delete("/#{db_name}/bin_doc/foo.txt", query: %{w: 3})
 
     assert resp.status_code == 409
+    
+    resp = Couch.delete("/#{db_name}/bin_doc/notexisting.txt", query: %{w: 3, rev: rev})
+    assert resp.status_code == 404
+    assert resp.body["error"] == "not_found"
+    assert resp.body["reason"] == "Document is missing attachment"
 
     resp = Couch.delete("/#{db_name}/bin_doc/foo.txt", query: %{w: 3, rev: rev})
     assert resp.status_code == 200


### PR DESCRIPTION
## Overview

Currently, a DELETE request for a non existent attachment responds with a 200 OK even if the attachment is missing. This PR changes the response code for nonexistent attachments to a 404 NOT FOUND `{"error":"not_found","reason":"Document is missing attachment"}`

## Testing recommendations

```
% curl -X PUT http://localhost:15984/demo/38 -H 'Authorization: Basic YWRtOnBhc3M=' -d '{"name": "whatever"}'
{"ok":true,"id":"38","rev":"1-a0f595984a7c4cf1dafc4cf4c04081d6"}
% curl -X DELETE 'http://adm:pass@localhost:15984/demo/38/notexisting.txt?rev=1-a0f595984a7c4cf1dafc4cf4c04081d6'
{"error":"not_found","reason":"Document is missing attachment"}
```

## Related Issues or Pull Requests

Deleting not existing attachment responds 200 instead of 404: https://github.com/apache/couchdb/issues/2146

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
