### PR TITLE
Run the validate doc update function through couch_eval

### DIFF
--- a/src/chttpd/src/chttpd_test_util.erl
+++ b/src/chttpd/src/chttpd_test_util.erl
@@ -20,7 +20,7 @@ start_couch() ->
     start_couch(?CONFIG_CHAIN).
 
 start_couch(IniFiles) ->
-    test_util:start_couch(IniFiles, [couch_js, couch_views, chttpd]).
+    test_util:start_couch(IniFiles, [js_engine, couch_views, chttpd]).
 
 stop_couch(Ctx) ->
     test_util:stop_couch(Ctx).

--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -27,7 +27,6 @@
 
 -include_lib("couch/include/couch_db.hrl").
 
-
 -spec to_path(#doc{}) -> path().
 to_path(#doc{revs = {Start, RevIds}} = Doc) ->
     [Branch] = to_branch(Doc, lists:reverse(RevIds)),
@@ -431,7 +430,7 @@ get_validate_doc_fun(#doc{body = {Props}} = DDoc) ->
             nil;
         _Else ->
             fun(EditDoc, DiskDoc, Ctx, SecObj) ->
-                couch_query_servers:validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj)
+                couch_eval:validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj)
             end
     end.
 

--- a/src/couch_js/src/couch_js.erl
+++ b/src/couch_js/src/couch_js.erl
@@ -19,7 +19,8 @@
     map_docs/2,
     acquire_context/0,
     release_context/1,
-    try_compile/4
+    try_compile/4,
+    validate_doc_update/5
 ]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -62,3 +63,6 @@ release_context(Proc) ->
 
 try_compile(Proc, FunctionType, FunName, FunSrc) ->
     couch_query_servers:try_compile(Proc, FunctionType, FunName, FunSrc).
+
+validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
+    couch_query_servers:validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj).

--- a/src/couch_replicator/test/eunit/couch_replicator_test_helper.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_test_helper.erl
@@ -52,7 +52,7 @@
 -define(PASSWORD, "rep_eunit_password").
 
 start_couch() ->
-    Ctx = test_util:start_couch([fabric, chttpd, couch_replicator, couch_js]),
+    Ctx = test_util:start_couch([fabric, chttpd, couch_replicator, js_engine]),
     Hashed = couch_passwords:hash_admin_password(?PASSWORD),
     ok = config:set("admins", ?USERNAME, ?b2l(Hashed), _Persist = false),
     Ctx.

--- a/src/couch_views/test/couch_views_active_tasks_test.erl
+++ b/src/couch_views/test/couch_views_active_tasks_test.erl
@@ -27,7 +27,7 @@ setup() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     Ctx.

--- a/src/couch_views/test/couch_views_cleanup_test.erl
+++ b/src/couch_views/test/couch_views_cleanup_test.erl
@@ -53,7 +53,7 @@ setup_all() ->
     test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]).
 

--- a/src/couch_views/test/couch_views_custom_red_test.erl
+++ b/src/couch_views/test/couch_views_custom_red_test.erl
@@ -70,7 +70,7 @@ setup_common(Enabled) ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     config:set_boolean("couch_views", "custom_reduce_enabled", Enabled, false),

--- a/src/couch_views/test/couch_views_error_test.erl
+++ b/src/couch_views/test/couch_views_error_test.erl
@@ -45,7 +45,7 @@ setup() ->
         fabric,
         chttpd,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     Hashed = couch_passwords:hash_admin_password(?PASS),

--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -64,7 +64,7 @@ setup() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     Ctx.

--- a/src/couch_views/test/couch_views_info_test.erl
+++ b/src/couch_views/test/couch_views_info_test.erl
@@ -23,7 +23,7 @@ setup() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     Ctx.

--- a/src/couch_views/test/couch_views_map_test.erl
+++ b/src/couch_views/test/couch_views_map_test.erl
@@ -22,7 +22,7 @@ setup() ->
     test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]).
 

--- a/src/couch_views/test/couch_views_red_test.erl
+++ b/src/couch_views/test/couch_views_red_test.erl
@@ -88,7 +88,7 @@ setup_db() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),

--- a/src/couch_views/test/couch_views_server_test.erl
+++ b/src/couch_views/test/couch_views_server_test.erl
@@ -43,7 +43,7 @@ setup() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_eval,
         couch_lib
     ]),

--- a/src/couch_views/test/couch_views_size_test.erl
+++ b/src/couch_views/test/couch_views_size_test.erl
@@ -52,7 +52,7 @@ setup() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     Ctx.

--- a/src/couch_views/test/couch_views_trace_index_test.erl
+++ b/src/couch_views/test/couch_views_trace_index_test.erl
@@ -45,7 +45,7 @@ indexer_test_() ->
     }.
 
 setup() ->
-    test_util:start_couch([fabric, couch_js]).
+    test_util:start_couch([fabric, js_engine]).
 
 cleanup(Ctx) ->
     test_util:stop_couch(Ctx).

--- a/src/couch_views/test/couch_views_updater_test.erl
+++ b/src/couch_views/test/couch_views_updater_test.erl
@@ -44,7 +44,7 @@ setup() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views,
         mango
     ]),

--- a/src/couch_views/test/couch_views_upgrade_test.erl
+++ b/src/couch_views/test/couch_views_upgrade_test.erl
@@ -49,7 +49,7 @@ setup() ->
     Ctx = test_util:start_couch([
         fabric,
         couch_jobs,
-        couch_js,
+        js_engine,
         couch_views
     ]),
     Ctx.

--- a/src/fabric/test/fabric2_doc_crud_tests.erl
+++ b/src/fabric/test/fabric2_doc_crud_tests.erl
@@ -72,7 +72,7 @@ doc_crud_test_() ->
     }.
 
 setup() ->
-    Ctx = test_util:start_couch([fabric, couch_js]),
+    Ctx = test_util:start_couch([fabric, js_engine]),
     {ok, Db} = fabric2_db:create(?tempdb(), [{user_ctx, ?ADMIN_USER}]),
     {Db, Ctx}.
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

With Couchdb on fdb, we want all javascript and language specific functionality to run through `couch_eval`. 
This moves the `validate_doc_update` check to run through `couch_eval` instead of going directly through `couch_query_servers`. 


## Testing recommendations

All existing tests should pass. 

## Related Issues or Pull Requests

https://github.com/cloudant-labs/ateles/pull/29


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
