### PR TITLE
Fix typo for Spidermonkey 78

### DIFF
--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -155,7 +155,7 @@ CouchJSSrc = case SMVsn of
     "1.8.5" -> ["priv/couch_js/1.8.5/*.c"];
     "60" -> ["priv/couch_js/60/*.cpp"];
     "68" -> ["priv/couch_js/68/*.cpp"];
-    "78" -> ["priv/couch_js/86/*.cpp"];
+    "78" -> ["priv/couch_js/78/*.cpp"];
     "86" -> ["priv/couch_js/86/*.cpp"]
 end.
 


### PR DESCRIPTION
## Overview

While review current state of Spidermonkey support for packaging purposes, I’ve realized what seems to me like a typo.

## Testing recommendations

Not sure, I don’t exactly know what this code does, but it did not look right.

## Related Issues or Pull Requests

Was added in https://github.com/apache/couchdb/pull/3500

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
