### PR TITLE
Contribute Custom Erlang Network Protocol to CouchDB main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ dev/*.beam
 dev/devnode.*
 dev/lib/
 dev/logs/
+dev/erlserver.pem
+dev/couch_ssl_dist.conf
 ebin/
 erl_crash.dump
 erln8.config

--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,7 @@ clean:
 	@rm -f src/couch/priv/couchspawnkillable
 	@rm -f src/couch/priv/couch_js/config.h
 	@rm -f dev/*.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
+	@rm -f dev/erlserver.pem dev/couch_ssl_dist.conf
 
 
 .PHONY: distclean

--- a/configure
+++ b/configure
@@ -55,7 +55,27 @@ Options:
   --rebar=PATH                use rebar by specified path (version >=2.6.0 && <3.0 required)
   --rebar3=PATH               use rebar3 by specified path
   --erlfmt=PATH               use erlfmt by specified path
+  --generate-tls-dev-cert     generate a cert for TLS distribution (To enable TLS, change the vm.args file.)
 EOF
+}
+
+# This is just an example to generate a certfile for TLS distribution.
+# This is not an endorsement of specific expiration limits, key sizes, or algorithms.
+generate_tls_dev_cert() {
+    if [ ! -e "${rootdir}/dev/erlserver.pem" ]; then
+        openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem
+        cat key.pem cert.pem > dev/erlserver.pem && rm key.pem cert.pem
+    fi
+
+    if [ ! -e "${rootdir}/dev/couch_ssl_dist.conf" ]; then
+        cat > "${rootdir}/dev/couch_ssl_dist.conf" << EOF
+[{server,
+  [{certfile, "${rootdir}/dev/erlserver.pem"},
+   {secure_renegotiate, true}]},
+ {client,
+  [{secure_renegotiate, true}]}].
+EOF
+    fi
 }
 
 parse_opts() {
@@ -194,6 +214,14 @@ parse_opts() {
                 printf 'ERROR: "--spidermonkey-version" requires a non-empty argument.\n' >&2
                 exit 1
                 ;;
+
+            --generate-tls-dev-cert)
+                echo "WARNING: To enable TLS distribution, don't forget to customize \033[31mvm.args\033[0m file."
+                generate_tls_dev_cert
+                shift
+                continue
+                ;;
+
             --) # End of options
                 shift
                 break
@@ -282,6 +310,7 @@ install_local_rebar() {
     if [ ! -x "${rootdir}/bin/rebar" ]; then
         if [ ! -d "${rootdir}/src/rebar" ]; then
             git clone --depth 1 https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
+
         fi
         make -C ${rootdir}/src/rebar
         mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar

--- a/dev/remsh.tls
+++ b/dev/remsh.tls
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+if [ -z $NODE ]; then
+    if [ -z $1 ]; then
+        NODE=1
+    else
+        NODE=$1
+    fi
+fi
+
+if [ -z $HOST ]; then
+    HOST="127.0.0.1"
+fi
+
+NAME="remsh$$@$HOST"
+NODE="node$NODE@$HOST"
+COOKIE=monster
+rootdir="$(cd "${0%/*}" 2>/dev/null; echo "$PWD")"
+erl -name $NAME -remsh $NODE -setcookie $COOKIE -hidden -proto_dist inet_tls -ssl_dist_optfile "${rootdir}/couch_ssl_dist.conf"

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -120,18 +120,25 @@ SubDirs = [
     "src/couch_eval",
     "src/couch_js",
     "src/couch_lib",
+
     "src/couch_replicator",
+
     "src/couch_stats",
+
     "src/couch_tests",
     "src/couch_views",
+    "src/couch_dist",
     "src/ctrace",
+
     "src/fabric",
     "src/aegis",
     "src/couch_jobs",
     "src/couch_expiring_cache",
     "src/jwtf",
+
     "src/mango",
     "src/ebtree",
+
     "src/couch_prometheus",
     "rel"
 ].
@@ -142,6 +149,7 @@ DepDescs = [
 {b64url,           "b64url",           {tag, "1.0.2"}},
 {erlfdb,           "erlfdb",           {tag, "v1.3.4"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
+
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},

--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -59,16 +59,17 @@ COOKIE="${COOKIE:-monster}"
 
 printHelpAndExit() {
   echo "Usage: ${PROGNAME} [OPTION]... [-- <additional Erlang cli options>]"
-  echo "  -c cookie     specify shared Erlang cookie (default: monster)"
-  echo "  -l HOST       specify remsh's host name (default: 127.0.0.1)"
-  echo "  -m            use output of \`hostname -f\` as remsh's host name"
-  echo "  -n NAME@HOST  specify couchdb's Erlang node name (-name in vm.args)"
-  echo "  -v            verbose; print invocation line"
-  echo "  -h            this help message"
+  echo "  -c cookie         specify shared Erlang cookie (default: monster)"
+  echo "  -l HOST           specify remsh's host name (default: 127.0.0.1)"
+  echo "  -m                use output of \`hostname -f\` as remsh's host name"
+  echo "  -n NAME@HOST      specify couchdb's Erlang node name (-name in vm.args)"
+  echo "  -v                verbose; print invocation line"
+  echo "  -t path/to/conf   enable TLS distribution (customize in vm.args)"
+  echo "  -h                this help message"
   exit
 }
 
-while getopts ":hn:c:l:mv" optionName; do
+while getopts ":hn:c:l:mvt:" optionName; do
   case "$optionName" in
     h)
       printHelpAndExit 0
@@ -88,6 +89,9 @@ while getopts ":hn:c:l:mv" optionName; do
     v)
       VERBOSE=0
       ;;
+    t)
+      TLSCONF=$OPTARG
+      ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       printHelpAndExit 0
@@ -106,6 +110,13 @@ fi
 # to avoid conflicts with the cli parameters
 ERL_FLAGS_CLEAN=$(echo "$ERL_FLAGS" | sed 's/-setcookie \([^ ][^ ]*\)//g' | sed 's/-name \([^ ][^ ]*\)//g')
 
-exec env ERL_FLAGS="$ERL_FLAGS_CLEAN" "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
-    -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie $COOKIE \
-    "$@"
+if [ -z "$TLSCONF" ]; then
+  exec env ERL_FLAGS="$ERL_FLAGS_CLEAN" "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
+      -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie $COOKIE \
+      "$@"
+else
+  exec env ERL_FLAGS="$ERL_FLAGS_CLEAN" "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
+      -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie $COOKIE \
+      -proto_dist inet_tls -ssl_dist_optfile $TLSCONF \
+      "$@"
+fi

--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -60,3 +60,36 @@
 
 # Set maximum SSL session lifetime to reap terminated replication readers
 -ssl session_lifetime 300
+
+## TLS Distribution
+## Use TLS for connections between Erlang cluster members.
+## http://erlang.org/doc/apps/ssl/ssl_distribution.html
+##
+## Generate Cert(PEM) File
+## This is just an example command to generate a certfile (PEM).
+## This is not an endorsement of specific expiration limits, key sizes, or algorithms.
+##    $ openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem
+##    $ cat key.pem cert.pem > dev/erlserver.pem && rm key.pem cert.pem
+##
+## Generate a Config File (couch_ssl_dist.conf)
+##    [{server,
+##      [{certfile, "</path/to/erlserver.pem>"},
+##       {secure_renegotiate, true}]},
+##     {client,
+##      [{secure_renegotiate, true}]}].
+##
+## CouchDB recommends the following values for no_tls flag:
+## 1. Use TCP only, set to true, such as:
+##      -couch_dist no_tls true
+## 2. Use TLS only, set to false, such as:
+##      -couch_dist no_tls false
+## 3. Specify which node to use TCP, such as:
+##      -couch_dist no_tls \"*@127.0.0.1\"
+##
+## To ensure search works, make sure to set 'no_tls' option for the clouseau node.
+## By default that would be "clouseau@127.0.0.1".
+## Don't forget to override the paths to point to your certificate(s) and key(s)!
+##
+#-proto_dist couch
+#-couch_dist no_tls \"clouseau@127.0.0.1\"
+#-ssl_dist_optfile <path/to/couch_ssl_dist.conf>

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -37,27 +37,35 @@
         couch_jobs,
         couch_lib,
         couch_log,
+
         couch_replicator,
         couch_stats,
         couch_eval,
         couch_js,
         couch_views,
+        couch_dist,
         ebtree,
         erlfdb,
+
         ets_lru,
         fabric,
         folsom,
+
         hyper,
         ibrowse,
         jaeger_passage,
         jiffy,
         jwtf,
         local,
+
         mango,
+
         mochiweb,
         passage,
         thrift_protocol,
+
         couch_prometheus,
+
         %% extra
         recon
     ]},
@@ -96,24 +104,31 @@
     {app, couch_jobs, [{incl_cond, include}]},
     {app, couch_lib, [{incl_cond, include}]},
     {app, couch_log, [{incl_cond, include}]},
+
     {app, couch_replicator, [{incl_cond, include}]},
     {app, couch_stats, [{incl_cond, include}]},
     {app, couch_views, [{incl_cond, include}]},
     {app, erlfdb, [{incl_cond, include}]},
     {app, ebtree, [{incl_cond, include}]},
+    {app, couch_dist ,[{incl_cond, include}]},
+
     {app, ets_lru, [{incl_cond, include}]},
     {app, fabric, [{incl_cond, include}]},
     {app, folsom, [{incl_cond, include}]},
+
     {app, hyper, [{incl_cond, include}]},
     {app, ibrowse, [{incl_cond, include}]},
     {app, jaeger_passage, [{incl_cond, include}]},
     {app, jiffy, [{incl_cond, include}]},
     {app, jwtf, [{incl_cond, include}]},
     {app, local, [{incl_cond, include}]},
+
     {app, mango, [{incl_cond, include}]},
+
     {app, mochiweb, [{incl_cond, include}]},
     {app, passage, [{incl_cond, include}]},
     {app, thrift_protocol, [{incl_cond, include}]},
+
     {app, couch_prometheus, [{incl_cond, include}]},
 
     %% extra
@@ -129,6 +144,7 @@
     {copy, "../src/couch/priv/couchjs", "bin/couchjs"},
     {copy, "../share/server/main.js", "share/server/main.js"},
     {copy, "../share/server/main-coffee.js", "share/server/main-coffee.js"},
+
     {copy, "files/sys.config", "releases/\{\{rel_vsn\}\}/sys.config"},
     {copy, "files/vm.args", "releases/\{\{rel_vsn\}\}/vm.args"},
     {template, "overlay/etc/default.ini", "etc/default.ini"},

--- a/src/couch/src/couch.app.src
+++ b/src/couch/src/couch.app.src
@@ -14,12 +14,14 @@
     {description, "Apache CouchDB"},
     {vsn, git},
     {registered, [
+
         couch_httpd,
         couch_primary_services,
         couch_proc_manager,
         couch_secondary_services,
         couch_server,
         couch_sup
+
     ]},
     {mod, {couch_app, []}},
     {applications, [
@@ -39,8 +41,11 @@
         couch_epi,
         b64url,
         couch_log,
+
         couch_stats,
         hyper,
-        couch_prometheus
+        couch_prometheus,
+        couch_dist
+
     ]}
 ]}.

--- a/src/couch_dist/LICENSE
+++ b/src/couch_dist/LICENSE
@@ -1,0 +1,177 @@
+
+                                Apache License
+                          Version 2.0, January 2004
+                       http://www.apache.org/licenses/
+
+  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+  1. Definitions.
+
+     "License" shall mean the terms and conditions for use, reproduction,
+     and distribution as defined by Sections 1 through 9 of this document.
+
+     "Licensor" shall mean the copyright owner or entity authorized by
+     the copyright owner that is granting the License.
+
+     "Legal Entity" shall mean the union of the acting entity and all
+     other entities that control, are controlled by, or are under common
+     control with that entity. For the purposes of this definition,
+     "control" means (i) the power, direct or indirect, to cause the
+     direction or management of such entity, whether by contract or
+     otherwise, or (ii) ownership of fifty percent (50%) or more of the
+     outstanding shares, or (iii) beneficial ownership of such entity.
+
+     "You" (or "Your") shall mean an individual or Legal Entity
+     exercising permissions granted by this License.
+
+     "Source" form shall mean the preferred form for making modifications,
+     including but not limited to software source code, documentation
+     source, and configuration files.
+
+     "Object" form shall mean any form resulting from mechanical
+     transformation or translation of a Source form, including but
+     not limited to compiled object code, generated documentation,
+     and conversions to other media types.
+
+     "Work" shall mean the work of authorship, whether in Source or
+     Object form, made available under the License, as indicated by a
+     copyright notice that is included in or attached to the work
+     (an example is provided in the Appendix below).
+
+     "Derivative Works" shall mean any work, whether in Source or Object
+     form, that is based on (or derived from) the Work and for which the
+     editorial revisions, annotations, elaborations, or other modifications
+     represent, as a whole, an original work of authorship. For the purposes
+     of this License, Derivative Works shall not include works that remain
+     separable from, or merely link (or bind by name) to the interfaces of,
+     the Work and Derivative Works thereof.
+
+     "Contribution" shall mean any work of authorship, including
+     the original version of the Work and any modifications or additions
+     to that Work or Derivative Works thereof, that is intentionally
+     submitted to Licensor for inclusion in the Work by the copyright owner
+     or by an individual or Legal Entity authorized to submit on behalf of
+     the copyright owner. For the purposes of this definition, "submitted"
+     means any form of electronic, verbal, or written communication sent
+     to the Licensor or its representatives, including but not limited to
+     communication on electronic mailing lists, source code control systems,
+     and issue tracking systems that are managed by, or on behalf of, the
+     Licensor for the purpose of discussing and improving the Work, but
+     excluding communication that is conspicuously marked or otherwise
+     designated in writing by the copyright owner as "Not a Contribution."
+
+     "Contributor" shall mean Licensor and any individual or Legal Entity
+     on behalf of whom a Contribution has been received by Licensor and
+     subsequently incorporated within the Work.
+
+  2. Grant of Copyright License. Subject to the terms and conditions of
+     this License, each Contributor hereby grants to You a perpetual,
+     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+     copyright license to reproduce, prepare Derivative Works of,
+     publicly display, publicly perform, sublicense, and distribute the
+     Work and such Derivative Works in Source or Object form.
+
+  3. Grant of Patent License. Subject to the terms and conditions of
+     this License, each Contributor hereby grants to You a perpetual,
+     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+     (except as stated in this section) patent license to make, have made,
+     use, offer to sell, sell, import, and otherwise transfer the Work,
+     where such license applies only to those patent claims licensable
+     by such Contributor that are necessarily infringed by their
+     Contribution(s) alone or by combination of their Contribution(s)
+     with the Work to which such Contribution(s) was submitted. If You
+     institute patent litigation against any entity (including a
+     cross-claim or counterclaim in a lawsuit) alleging that the Work
+     or a Contribution incorporated within the Work constitutes direct
+     or contributory patent infringement, then any patent licenses
+     granted to You under this License for that Work shall terminate
+     as of the date such litigation is filed.
+
+  4. Redistribution. You may reproduce and distribute copies of the
+     Work or Derivative Works thereof in any medium, with or without
+     modifications, and in Source or Object form, provided that You
+     meet the following conditions:
+
+     (a) You must give any other recipients of the Work or
+         Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices
+         stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works
+         that You distribute, all copyright, patent, trademark, and
+         attribution notices from the Source form of the Work,
+         excluding those notices that do not pertain to any part of
+         the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its
+         distribution, then any Derivative Works that You distribute must
+         include a readable copy of the attribution notices contained
+         within such NOTICE file, excluding those notices that do not
+         pertain to any part of the Derivative Works, in at least one
+         of the following places: within a NOTICE text file distributed
+         as part of the Derivative Works; within the Source form or
+         documentation, if provided along with the Derivative Works; or,
+         within a display generated by the Derivative Works, if and
+         wherever such third-party notices normally appear. The contents
+         of the NOTICE file are for informational purposes only and
+         do not modify the License. You may add Your own attribution
+         notices within Derivative Works that You distribute, alongside
+         or as an addendum to the NOTICE text from the Work, provided
+         that such additional attribution notices cannot be construed
+         as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and
+     may provide additional or different license terms and conditions
+     for use, reproduction, or distribution of Your modifications, or
+     for any such Derivative Works as a whole, provided Your use,
+     reproduction, and distribution of the Work otherwise complies with
+     the conditions stated in this License.
+
+  5. Submission of Contributions. Unless You explicitly state otherwise,
+     any Contribution intentionally submitted for inclusion in the Work
+     by You to the Licensor shall be under the terms and conditions of
+     this License, without any additional terms or conditions.
+     Notwithstanding the above, nothing herein shall supersede or modify
+     the terms of any separate license agreement you may have executed
+     with Licensor regarding such Contributions.
+
+  6. Trademarks. This License does not grant permission to use the trade
+     names, trademarks, service marks, or product names of the Licensor,
+     except as required for reasonable and customary use in describing the
+     origin of the Work and reproducing the content of the NOTICE file.
+
+  7. Disclaimer of Warranty. Unless required by applicable law or
+     agreed to in writing, Licensor provides the Work (and each
+     Contributor provides its Contributions) on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied, including, without limitation, any warranties or conditions
+     of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+     PARTICULAR PURPOSE. You are solely responsible for determining the
+     appropriateness of using or redistributing the Work and assume any
+     risks associated with Your exercise of permissions under this License.
+
+  8. Limitation of Liability. In no event and under no legal theory,
+     whether in tort (including negligence), contract, or otherwise,
+     unless required by applicable law (such as deliberate and grossly
+     negligent acts) or agreed to in writing, shall any Contributor be
+     liable to You for damages, including any direct, indirect, special,
+     incidental, or consequential damages of any character arising as a
+     result of this License or out of the use or inability to use the
+     Work (including but not limited to damages for loss of goodwill,
+     work stoppage, computer failure or malfunction, or any and all
+     other commercial damages or losses), even if such Contributor
+     has been advised of the possibility of such damages.
+
+  9. Accepting Warranty or Additional Liability. While redistributing
+     the Work or Derivative Works thereof, You may choose to offer,
+     and charge a fee for, acceptance of support, warranty, indemnity,
+     or other liability obligations and/or rights consistent with this
+     License. However, in accepting such obligations, You may act only
+     on Your own behalf and on Your sole responsibility, not on behalf
+     of any other Contributor, and only if You agree to indemnify,
+     defend, and hold each Contributor harmless for any liability
+     incurred by, or claims asserted against, such Contributor by reason
+     of your accepting any such warranty or additional liability.
+
+  END OF TERMS AND CONDITIONS

--- a/src/couch_dist/rebar.config
+++ b/src/couch_dist/rebar.config
@@ -1,0 +1,2 @@
+{cover_enabled, true}.
+{cover_print_enabled, true}.

--- a/src/couch_dist/src/couch_dist.app.src
+++ b/src/couch_dist/src/couch_dist.app.src
@@ -1,0 +1,19 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+{application, couch_dist,
+    [{description, "A Custom Erlang network protocol for CouchDB"},
+    {vsn, git},
+    {modules, [couch_dist]},
+    {registered, [couch_dist]},
+    {applications, [kernel, stdlib, ssl]}
+]}.

--- a/src/couch_dist/src/couch_dist.erl
+++ b/src/couch_dist/src/couch_dist.erl
@@ -1,0 +1,114 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_dist).
+
+-export([childspecs/0, listen/2, accept/1, accept_connection/5,
+    setup/5, close/1, select/1, is_node_name/1]).
+
+% Just for tests
+-export([no_tls/1, get_init_args/0]).
+
+
+childspecs() ->
+    {ok, [{ssl_dist_sup, {ssl_dist_sup, start_link, []},
+        permanent, infinity, supervisor, [ssl_dist_sup]}]}.
+
+
+listen(Name, Host) ->
+    NodeName =
+        case is_atom(Name) of
+            true -> atom_to_list(Name);
+            false -> Name
+        end,
+    case no_tls(NodeName ++ "@" ++ Host) of
+        true -> inet_tcp_dist:listen(NodeName, Host);
+        false -> inet_tls_dist:listen(NodeName, Host)
+    end.
+
+
+accept(Listen) ->
+    case no_tls(node()) of
+        true -> inet_tcp_dist:accept(Listen);
+        false -> inet_tls_dist:accept(Listen)
+    end.
+
+
+accept_connection(AcceptPid, DistCtrl, MyNode, Allowed, SetupTime) ->
+    case no_tls(MyNode) of
+        true -> inet_tcp_dist:accept_connection(
+            AcceptPid, DistCtrl, MyNode, Allowed, SetupTime);
+        false -> inet_tls_dist:accept_connection(
+            AcceptPid, DistCtrl, MyNode, Allowed, SetupTime)
+    end.
+
+
+setup(Node, Type, MyNode, LongOrShortNames, SetupTime) ->
+    case no_tls(Node) of
+        true -> inet_tcp_dist:setup(
+            Node, Type, MyNode, LongOrShortNames, SetupTime);
+        false -> inet_tls_dist:setup(
+            Node, Type, MyNode, LongOrShortNames, SetupTime)
+    end.
+
+
+close(Socket) ->
+    inet_tls_dist:close(Socket).
+
+
+select(Node) ->
+    inet_tls_dist:select(Node).
+
+
+is_node_name(Node) ->
+    inet_tls_dist:is_node_name(Node).
+
+
+no_tls(NodeName) when is_atom(NodeName) ->
+    no_tls(atom_to_list(NodeName));
+
+no_tls(NodeName) when is_list(NodeName) ->
+    case ?MODULE:get_init_args() of
+        {ok, Args} ->
+            GlobPatterns = [V || [K, V] <- Args, K == "no_tls"],
+            lists:any(fun(P) -> match(NodeName, P) end, GlobPatterns);
+        error -> false
+    end.
+
+
+get_init_args() ->
+    init:get_argument(couch_dist).
+
+
+match(_NodeName, "true") ->
+    true;
+match(_NodeName, "false") ->
+    false;
+match(NodeName, Pattern) ->
+    {ok, RE} =
+        case string:split(Pattern, [$"], all) of
+            ["", GlobPattern, ""] -> to_re(GlobPattern);
+            _ -> to_re(Pattern)
+        end,
+    re:run(NodeName, RE) /= nomatch.
+
+
+to_re(GlobPattern) ->
+    re:compile([$^, lists:flatmap(fun glob_re/1, GlobPattern), $$]).
+
+
+glob_re($*) ->
+    ".*";
+glob_re($?) ->
+    ".";
+glob_re(C) ->
+    [C].

--- a/src/couch_dist/test/eunit/couch_dist_tests.erl
+++ b/src/couch_dist/test/eunit/couch_dist_tests.erl
@@ -1,0 +1,97 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_dist_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+no_tls_test_() ->
+    {
+        "test couch_dist no_tls/1",
+        {
+            setup,
+            fun() -> meck:new(couch_dist, [passthrough]) end,
+            fun(_) -> meck:unload() end,
+            [
+                no_tls_test_with_true(),
+                no_tls_test_with_false(),
+                no_tls_test_with_character(),
+                no_tls_test_with_wildcard(),
+                no_tls_test_with_question_mark(),
+                no_tls_test_with_error()
+            ]
+        }
+    }.
+
+
+mock_get_init_args(Reply) ->
+    meck:expect(couch_dist, get_init_args, fun() -> Reply end).
+
+
+no_tls_test_with_true() ->
+    ?_test(
+        begin
+            mock_get_init_args({ok, [["no_tls", "true"]]}),
+            ?assert(couch_dist:no_tls('abc123')),
+            ?assert(couch_dist:no_tls("123abd"))
+        end).
+
+
+no_tls_test_with_false() ->
+    ?_test(
+        begin
+            mock_get_init_args({ok, [["no_tls", "false"]]}),
+            ?assertNot(couch_dist:no_tls('abc123')),
+            ?assertNot(couch_dist:no_tls("123abc"))
+        end).
+
+
+no_tls_test_with_character() ->
+    ?_test(
+        begin
+            mock_get_init_args({ok, [["no_tls", "node@127.0.0.1"]]}),
+            ?assert(couch_dist:no_tls('node@127.0.0.1')),
+            ?assert(couch_dist:no_tls("node@127.0.0.1"))
+        end).
+
+
+no_tls_test_with_wildcard() ->
+    ?_test(
+        begin
+            mock_get_init_args({ok, [["no_tls", "\"a*2\""]]}),
+            ?assert(couch_dist:no_tls('ab12')),
+            ?assert(couch_dist:no_tls("a12")),
+            ?assert(couch_dist:no_tls("a2")),
+            ?assertNot(couch_dist:no_tls('a')),
+            ?assertNot(couch_dist:no_tls("2"))
+        end).
+
+
+no_tls_test_with_question_mark() ->
+    ?_test(
+        begin
+            mock_get_init_args({ok, [["no_tls", "\"a?2\""]]}),
+            ?assert(couch_dist:no_tls('a12')),
+            ?assert(couch_dist:no_tls("ab2")),
+            ?assertNot(couch_dist:no_tls('a2')),
+            ?assertNot(couch_dist:no_tls("a"))
+        end).
+
+
+no_tls_test_with_error() ->
+    ?_test(
+        begin
+            mock_get_init_args(error),
+            ?assertNot(couch_dist:no_tls('abc123')),
+            ?assertNot(couch_dist:no_tls("123abc"))
+        end).


### PR DESCRIPTION
## Overview
Enable Custom Erlang Network Protocol for CouchDB Classic.
- Add the `couch_dist.erl` app with tests.
- Update the `vm.args` config lines with documentation.
- Update`remsh.tls` script, `configure` for development, and release script `remsh`


## Testing recommendations
make eunit apps=couch_dist suites=couch_dist_tests

## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
