### PR TITLE
Fix response code for existing att and wrong rev

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1568,12 +1568,7 @@ db_attachment_req(#httpd{method=Method, user_ctx=Ctx}=Req, Db, DocId, FileNamePa
 
     NewAtt = case Method of
         'DELETE' ->
-            case get_attachment(Req, Db, DocId, FileName) of
-                {error, missing} ->
-                    throw({not_found, "Document is missing attachment"});
-                {ok, _, _} ->
-                    []
-            end;
+            [];
         _ ->
             MimeType = case couch_httpd:header_value(Req,"Content-Type") of
                 % We could throw an error here or guess by the FileName.
@@ -1631,6 +1626,17 @@ db_attachment_req(#httpd{method=Method, user_ctx=Ctx}=Req, Db, DocId, FileNamePa
     end,
 
     #doc{atts=Atts} = Doc,
+    case Method of
+        'DELETE' ->
+            case get_attachment(Req, Db, DocId, FileName) of
+                {error, missing} ->
+                    throw({not_found, "Document is missing attachment"});
+                {ok, _, _} ->
+                    []
+            end;
+        _ ->
+            nil
+    end,
     DocEdited = Doc#doc{
         atts = NewAtt ++ [A || A <- Atts, couch_att:fetch(name, A) /= FileName]
     },

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1628,14 +1628,11 @@ db_attachment_req(#httpd{method=Method, user_ctx=Ctx}=Req, Db, DocId, FileNamePa
     #doc{atts=Atts} = Doc,
     case Method of
         'DELETE' ->
-            case get_attachment(Req, Db, DocId, FileName) of
-                {error, missing} ->
-                    throw({not_found, "Document is missing attachment"});
-                {ok, _, _} ->
-                    []
+            case [A || A <- Atts, couch_att:fetch(name, A) == FileName] of
+                [] -> throw({not_found, "Document is missing attachment"});
+                _ ->  ok
             end;
-        _ ->
-            nil
+        _ -> ok
     end,
     DocEdited = Doc#doc{
         atts = NewAtt ++ [A || A <- Atts, couch_att:fetch(name, A) /= FileName]

--- a/test/elixir/test/attachments_test.exs
+++ b/test/elixir/test/attachments_test.exs
@@ -106,8 +106,12 @@ defmodule AttachmentsTest do
     rev = resp.body["rev"]
 
     resp = Couch.delete("/#{db_name}/bin_doc/foo.txt", query: %{w: 3})
-
     assert resp.status_code == 409
+
+    resp = Couch.delete("/#{db_name}/bin_doc/foo.txt", query: %{w: 3, rev: "4-garbage"})
+    assert resp.status_code == 409
+    assert resp.body["error"] == "not_found"
+    assert resp.body["reason"] == "missing_rev"
 
     resp = Couch.delete("/#{db_name}/bin_doc/notexisting.txt", query: %{w: 3, rev: rev})
     assert resp.status_code == 404


### PR DESCRIPTION
## Overview

https://github.com/apache/couchdb/pull/3673 created a bug where trying to delete an existing attachment using the wrong rev would return a 404. This PR changes the response code to be a 409 as intended.

## Testing recommendations

Assuming you have a database `test` and doc `25` and att `recipe.txt`,

Deletion of existing attachment using incorrect rev:

```
% curl -X DELETE 'http://localhost:15984/test/25/recipe.txt?rev=4-garbage' -H 'Authorization: Basic YWRtOnBhc3M='
{"error":"not_found","reason":"missing_rev"}
```

409 error in this case.

Deletion of non-existing attachment using correct rev:

```
% curl -X DELETE 'http://localhost:15984/test/notexisting.txt?rev=2-e6eeb3fa3da4088ff5dac56b7c34a732' -H 'Authorization: Basic YWRtOnBhc3M='
{"error":"not_found","reason":"Document is missing attachment"}
```
404 error in this case.

## Related Issues or Pull Requests

404 at deletion of an existing attachment when using wrong rev: https://github.com/apache/couchdb/issues/3684
Fix response code for nonexistent attachment: https://github.com/apache/couchdb/pull/3673

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
