### PR TITLE
Port attachment deletion fix from 3.x

### DIFF
--- a/test/elixir/test/attachments_test.exs
+++ b/test/elixir/test/attachments_test.exs
@@ -107,9 +107,13 @@ defmodule AttachmentsTest do
     rev = resp.body["rev"]
 
     resp = Couch.delete("/#{db_name}/bin_doc/foo.txt", query: %{w: 3})
-
     assert resp.status_code == 409
-    
+
+    resp = Couch.delete("/#{db_name}/bin_doc/foo.txt", query: %{w: 3, rev: "4-garbage"})
+    assert resp.status_code == 409
+    assert resp.body["error"] == "not_found"
+    assert resp.body["reason"] == "missing_rev"
+
     resp = Couch.delete("/#{db_name}/bin_doc/notexisting.txt", query: %{w: 3, rev: rev})
     assert resp.status_code == 404
     assert resp.body["error"] == "not_found"


### PR DESCRIPTION
## Overview

Port ba638783b5d87b855939dae69fd63ffd41cb5ed7 from 3.x

This should fix the edge case where deletion with a bad rev was returning a
404. Now it should return a 409.

Issue: https://github.com/apache/couchdb/issues/2146

## Testing recommendations

     make && make elixir tests=test/elixir/test/attachments_test.exs:102

