### PR TITLE
Disable running ibrowse tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ DESTDIR=
 
 # Rebar options
 apps=
-skip_deps=folsom,meck,mochiweb,triq,proper,snappy,bcrypt,hyper
+skip_deps=folsom,meck,mochiweb,triq,proper,snappy,bcrypt,hyper,ibrowse
 suites=
 tests=
 


### PR DESCRIPTION
They used to be disabled before the last major ibrowse upgrade.

On MacOS and FreeBSD the following tests fails periodically:

```
    ibrowse_tests: running_server_fixture_test_ (Pipeline too small signals retries)...*failed*
in function ibrowse_tests:'-small_pipeline/0-fun-5-'/1 (test/ibrowse_tests.erl, line 150)
in call from ibrowse_tests:small_pipeline/0 (test/ibrowse_tests.erl, line 150)
**error:{assertEqual,[{module,ibrowse_tests},
              {line,150},
              {expression,"Counts"},
              {expected,"\n\n\n\n\n\n\n\n\n\n"},
              {value,"\t\n\n\n\n\t\t\n\n\t"}]}
  output:<<"Load Balancer Pid     : <0.494.0>
```

But seems to pass more reliable on Linux for some reason. It would be nice to run the tests of course but having a passing full platform suite is more important.
