### PR TITLE
Fix fauxton_root templating in bin/couchdb script

### DIFF
--- a/rel/files/couchdb.in
+++ b/rel/files/couchdb.in
@@ -38,7 +38,9 @@ export PROGNAME=`echo $0 | sed 's/.*\///'`
 
 export COUCHDB_QUERY_SERVER_JAVASCRIPT="${COUCHDB_QUERY_SERVER_JAVASCRIPT:-{{prefix}}/bin/couchjs {{prefix}}/share/server/main.js}"
 export COUCHDB_QUERY_SERVER_COFFEESCRIPT="${COUCHDB_QUERY_SERVER_COFFEESCRIPT:-{{prefix}}/bin/couchjs {{prefix}}/share/server/main-coffee.js}"
-export COUCHDB_FAUXTON_DOCROOT="${COUCHDB_FAUXTON_DOCROOT:-{{fauxton_root}} }"
+# Use a separate var to work around rebar's mustache template bug
+DEFAULT_FAUXTON_ROOT={{fauxton_root}}
+export COUCHDB_FAUXTON_DOCROOT="${COUCHDB_FAUXTON_DOCROOT:-${DEFAULT_FAUXTON_ROOT}}"
 
 ARGS_FILE="${COUCHDB_ARGS_FILE:-$ROOTDIR/etc/vm.args}"
 [ -n "${COUCHDB_INI_FILES:-}" ] && INI_ARGS="-couch_ini $COUCHDB_INI_FILES"


### PR DESCRIPTION
Rebar mustache templating engine has a bug when handling the `}}}` brackets in a case like `{...{{var}}}`. So we work around the issue by using a separate variable.

This is an alternate fix for issue: https://github.com/apache/couchdb/pull/3617