### PR TITLE
Fix 'clause cannot match' compiler warning

### DIFF
--- a/src/couch_eval/src/couch_eval.erl
+++ b/src/couch_eval/src/couch_eval.erl
@@ -164,8 +164,8 @@ get_api_mod(Language) when is_binary(Language) ->
                     config:get("couch_eval.languages", LangStr)
             end,
         case ModStr of
-            _ -> list_to_existing_atom(ModStr);
-            undefined -> erlang:error({unknown_eval_api_language, Language})
+            undefined -> erlang:error({unknown_eval_api_language, Language});
+            _ -> list_to_existing_atom(ModStr)
         end
     catch
         error:badarg ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Fixes this warning:

```
couchdb/src/couch_eval/src/couch_eval.erl:168: Warning: this clause cannot match because a previous clause at line 167 always matches
```

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=couch_eval
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
