### PR TITLE
Increase timeout for multiple ddoc indexer test

### DIFF
--- a/src/couch_views/test/couch_views_indexer_test.erl
+++ b/src/couch_views/test/couch_views_indexer_test.erl
@@ -45,7 +45,7 @@ indexer_test_() ->
                     ?TDEF_FE(multiple_keys_from_same_doc),
                     ?TDEF_FE(multiple_identical_keys_from_same_doc),
                     ?TDEF_FE(fewer_multiple_identical_keys_from_same_doc),
-                    ?TDEF_FE(multiple_design_docs),
+                    ?TDEF_FE(multiple_design_docs, 10),
                     ?TDEF_FE(multiple_doc_update_with_existing_rows),
                     ?TDEF_FE(handle_size_key_limits),
                     ?TDEF_FE(handle_size_value_limits),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Increase timeout for multiple ddoc indexer test to help prevent:
```
 couch_views_indexer_test:48: indexer_test_ (multiple_design_docs)...*timed out*
```

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
