### PR TITLE
Improve fabric_util get_db timeout logic

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -276,6 +276,7 @@ bind_address = 127.0.0.1
 ; all_docs_concurrency = 10
 ; changes_duration = 
 ; shard_timeout_factor = 2
+; shard_timeout_min_msec = 100
 ; uuid_prefix_len = 7
 ; request_timeout = 60000
 ; all_docs_timeout = 10000


### PR DESCRIPTION
Previously, users with low {Q, N} dbs often got the `"No DB shards could be opened."` error when the cluster is overloaded. The hard-coded 100 msec timeout was too low to open the few available shards and the whole request would crash with a 500 error.

Attempt to calculate an optimal timeout value based on the number of shards and the max fabric request timeout limit.

The sequence of doubling (by default) timeouts forms a geometric progression. Use the well known closed form formula for the sum [0], and the maximum request timeout, to calculate the initial timeout. The test case illustrates a few examples with some default Q and N values.

Because we don't want the timeout value to be too low, since it takes time to open shards, and we don't want to quickly cycle through a few initial shards and discard the results, the minimum initial timeout is clipped to the
previously hard-coded 100 msec timeout. Unlike previously however, this minimum value can now also be configured.

[0] https://en.wikipedia.org/wiki/Geometric_series

Fixes: https://github.com/apache/couchdb/issues/3733

