### PR TITLE
Improve views tests

### DIFF
--- a/src/couch_views/src/couch_views_batch_impl.erl
+++ b/src/couch_views/src/couch_views_batch_impl.erl
@@ -150,8 +150,8 @@ good_config_test() ->
         )
     end).
 
-bad_config_test() ->
-    Fields = [
+bad_config_test_() ->
+    FieldErrors = [
         {batch_initial_size, invalid_non_neg_integer},
         {batch_search_increment, invalid_non_neg_integer},
         {batch_sense_increment, invalid_non_neg_integer},
@@ -159,16 +159,17 @@ bad_config_test() ->
         {batch_max_tx_time_msec, invalid_non_neg_integer},
         {batch_threshold_penalty, invalid_float}
     ],
-    lists:foreach(
+    lists:map(
         fun({Field, Error}) ->
-            with_bad_config(atom_to_list(Field), fun() ->
-                ?assertError(
-                    {Error, {couch_views, Field, _}},
+            FieldName = atom_to_list(Field),
+            {FieldName, ?_assertError(
+                {Error, {couch_views, Field, _}},
+                with_bad_config(FieldName, fun() ->
                     start(#mrst{}, undefined)
-                )
-            end)
+                end))
+            }
         end,
-        Fields
+        FieldErrors
     ).
 
 float_range_test() ->

--- a/src/couch_views/test/couch_views_active_tasks_test.erl
+++ b/src/couch_views/test/couch_views_active_tasks_test.erl
@@ -66,8 +66,8 @@ active_tasks_test_() ->
                 fun foreach_setup/0,
                 fun foreach_teardown/1,
                 [
-                    ?TDEF_FE(verify_basic_active_tasks),
-                    ?TDEF_FE(verify_muliple_active_tasks)
+                    ?TDEF_FE(verify_basic_active_tasks, 10),
+                    ?TDEF_FE(verify_muliple_active_tasks, 10)
                 ]
             }
         }


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Several couch_views eunit tests are prone to timeouts when run on resource constrained build systems. This improves the robustness of those tests by either increasing the timeout, in the case of active tasks tests, or by separating the monolithic "bad config" test into several smaller tests.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=couch_views
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
