### PR TITLE
Fix meta result for views when limit = 0

### DIFF
--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -146,10 +146,11 @@ handle_message({meta, Meta0}, {Worker, From}, State) ->
         }}
     end;
 
-handle_message(#view_row{}, {_, _}, #collector{limit=0} = State) ->
-    #collector{callback=Callback} = State,
-    {_, Acc} = Callback(complete, State#collector.user_acc),
-    {stop, State#collector{user_acc=Acc}};
+handle_message(#view_row{}, {_, From}, #collector{limit=0} = State) ->
+    rexi:stream_ack(From),
+    % Rely on limit=0 clause in maybe_send_row/1 to wait until all
+    % shard ranges reply with meta
+    fabric_view:maybe_send_row(State);
 
 handle_message(#view_row{} = Row, {_,From}, #collector{sorted=false} = St) ->
     #collector{callback=Callback, user_acc=AccIn, limit=Limit} = St,


### PR DESCRIPTION
Previously, as soon as one row returned, we immediately stopped, erroneously
assuming that meta for all ranges have already been received. However, it was
possible that we'd get meta from range `00-7f`, then a row from `00-7f` before
getting meta from `7f-ff` and thus we'd return an empty result.

To fix the issue we simply re-use the already existing limit=0 clause from the
[fabric_view:maybe_send_row/1](https://github.com/apache/couchdb/blob/9f081914fe1fd7f31c2c1c7b3ead89427cf342f3/src/fabric/src/fabric_view.erl#L124-L134) function which will wait until there is a complete
ring before returning. That relies on updating the counters (the ring) only
with meta return and not with view rows, so if the ring is complete, we know we
only completed with meta.

The other issue with limit=0 clause was that it wasn't properly ack-ing the
received row. Rows are ack-ed for [sorted=false](https://github.com/apache/couchdb/blob/9f081914fe1fd7f31c2c1c7b3ead89427cf342f3/src/fabric/src/fabric_view_map.erl#L157) case below and for the regular
limit>0, sorted=true case in [fabric_view:get_next_row/1](https://github.com/apache/couchdb/blob/9f081914fe1fd7f31c2c1c7b3ead89427cf342f3/src/fabric/src/fabric_view.erl#L268)

To test run the reproducer script from https://github.com/apache/couchdb/issues/3750 with limit =0