### PR TITLE
Fix logic in ensure_exunit_started

### DIFF
--- a/test/elixir/lib/suite.ex
+++ b/test/elixir/lib/suite.ex
@@ -153,7 +153,7 @@ defmodule Couch.Test.Suite do
 
       if not started? do
         ExUnit.start(autorun: false)
-        Process.get(EXUNIT_STARTED, true)
+        Process.put(EXUNIT_STARTED, true)
       end
     end
   end


### PR DESCRIPTION
## Overview

The state management logic in ensure_exunit_started is incorrect. It doesn't store the fact that exunit is already started.

## Testing recommendations

```
make elixir-suite
```

## Related Issues or Pull Requests

The problem was introduced in https://github.com/apache/couchdb/pull/3286

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
