### PR TITLE
Fix limit0 for views again

### DIFF
--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -146,7 +146,7 @@ handle_message({meta, Meta0}, {Worker, From}, State) ->
         }}
     end;
 
-handle_message(#view_row{}, {_, _}, #collector{limit=0} = State) ->
+handle_message(#view_row{}, {_, _}, #collector{sorted=false, limit=0} = State) ->
     #collector{callback=Callback} = State,
     {_, Acc} = Callback(complete, State#collector.user_acc),
     {stop, State#collector{user_acc=Acc}};


### PR DESCRIPTION
## Overview

    Restrict the limit=0 clause to the sorted=false case as originally intended

    The limit=0 clause was introduced in commit 4e0c97bf which added
    sorted=false support. It accidentally matches when the user specifies
    limit=0 and causes us not to apply the logic that ensures we collect a
    {meta, Meta} message from each shard range and then send the
    total_rows and offset fields.

## Testing recommendations

repro steps described in https://github.com/apache/couchdb/issues/3750

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/3750

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
