### PR TITLE
Make view merge row aggregation in fabric stable

### DIFF
--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -298,7 +298,6 @@ transform_row(#view_row{key=Key, id=_Id, value=_Value, doc={error,Reason}}) ->
 transform_row(#view_row{key=Key, id=Id, value=Value, doc=Doc}) ->
     {row, [{id,Id}, {key,Key}, {value,Value}, {doc,Doc}]}.
 
-compare(_, _, A, A) -> true;
 compare(fwd, <<"raw">>, A, B) -> A < B;
 compare(rev, <<"raw">>, A, B) -> B < A;
 compare(fwd, _, A, B) -> couch_ejson_compare:less_json(A, B);

--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -241,7 +241,6 @@ merge_row(Dir, Collation, KeyDict0, Row, Rows0) ->
             {Rows1, KeyDict1}
     end.
 
-compare(_, _, A, A) -> true;
 compare(fwd, <<"raw">>, A, B) -> A < B;
 compare(rev, <<"raw">>, A, B) -> B < A;
 compare(fwd, _, A, B) -> couch_ejson_compare:less_json_ids(A, B);


### PR DESCRIPTION
We do that by matching the comparator function behavior used during row [merging](https://github.com/apache/couchdb/blob/3.x/src/fabric/src/fabric_view_map.erl#L244-L248) with the comparison function used when sorting the rows on view [shards](https://github.com/apache/couchdb/blob/3.x/src/couch_mrview/src/couch_mrview_util.erl#L1103-L1107). This goes along with the constraint in the `lists:merge/3` docs which indicates that the input lists should be sorted according to the same [comparator](https://erlang.org/doc/man/lists.html#merge-3) as the one passed to the `lists:merge/3` call.

The stability of returned rows results from the case when both keys match as equal. Now `lists:merge/3` will favor the element in the existing rows list instead of always [replacing](https://github.com/erlang/otp/blob/master/lib/stdlib/src/lists.erl#L2668-L2675) the older matching row with the last arriving row, since now `less(A, A)` will be `false`, while previously it was `true`.

The fix was found by Adam when discussing issue [3750](https://github.com/apache/couchdb/issues/3750#issuecomment-920947424)

Co-author: Adam Kocoloski <kocolosk@apache.org>