### PR TITLE
support maximum changes_duration configuration option

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -208,6 +208,11 @@ bind_address = 127.0.0.1
 ;
 ; Bulk docs transaction batch size in bytes
 ;update_docs_batch_size = 2500000
+;
+; The upper bound, in milliseconds, that a continuous changes feed will return
+; database results for. The response ends on receipt of the first change to occur
+; after the duration period has lapsed.
+;changes_duration = infinity
 
 [couch_httpd_auth]
 ; WARNING! This only affects the node-local port (5986 by default).


### PR DESCRIPTION
## Overview

Restores the ability for a couchdb administrator to set an upper limit to the duration of a continuous changes feed originally introduced in https://github.com/apache/couchdb/commit/c6ad114ec797874a7eccf741fecb7139b117948b but lost in the FDB work.

## Testing recommendations

Set up a continuous changes feed with a heartbeat, observe that it does not terminate naturally. Set the [fabric] changes_duration parameter to some positive integer value and retest. The changes feed should not return any new updates after that duration and the response will _end_ when the database is next updated (but will not return that update in the response).

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
