### PR TITLE
Add search to list of features in welcome response

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -689,7 +689,7 @@ partitioned||* = true
 ; The default number of results returned from a search on a partition
 ; of a database.
 ; limit_partitions = 2000
- 
+
 ; The maximum number of results that can be returned from a global
 ; search query (or any search query on a database without user-defined
 ; partitions). Attempts to set ?limit=N higher than this value will
@@ -702,6 +702,13 @@ partitioned||* = true
 ; CouchDB will use the value of `max_limit` instead. If neither is
 ; defined, the default is 2000 as stated here.
 ; max_limit_partitions = 2000
+
+; Enable or Disable the Search Functionality
+; To use the "search" function, clouseau needs to be run locally
+; The command is as follows:
+; mvn install
+; mvn scala:run -Dlauncher=clouseau
+;enable = false
 
 [reshard]
 ;max_jobs = 48

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -36,6 +36,7 @@
     send_chunk/2,start_chunked_response/3]).
 
 -define(MAX_DB_NUM_FOR_DBS_INFO, 100).
+-define(DEFAULT_ENABLE_SEARCH, false).
 
 % httpd global handlers
 
@@ -60,7 +61,8 @@ handle_welcome_req(Req, _) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
 get_features() ->
-    case clouseau_rpc:connected() of
+    case clouseau_rpc:connected() andalso config:get_boolean(
+        "dreyfus", "enable", ?DEFAULT_ENABLE_SEARCH) of
         true ->
             [search | config:features()];
         false ->


### PR DESCRIPTION
## Overview
Return `search` in the `features` list from the welcome endpoint. Something like:
```
curl http://adm:pass@127.0.0.1:15984 | jq '.'

  "couchdb": "Welcome",
  "version": "3.1.1-9f08191",
  "git_sha": "9f08191",
  "uuid": "fake_uuid_for_dev",
  "features": [
    "access-ready",
    "partitioned",
    "pluggable-storage-engines",
    "reshard",
    "scheduler",
    "search"
  ],
  "vendor": {
    "name": "The Apache Software Foundation"
  }
}
```
To make it configurable, a configuration option has been added.
```
[dreyfus]
enable = false
```
## Testing recommendations

## Related Issues or Pull Requests
Issue [#70](https://github.ibm.com/cloudant/dbcore/issues/70)


## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
