### PR TITLE
Remove redundant CSP tests

### DIFF
--- a/src/chttpd/test/eunit/chttpd_db_test.erl
+++ b/src/chttpd/test/eunit/chttpd_db_test.erl
@@ -69,8 +69,6 @@ all_test_() ->
                     fun should_return_404_for_delete_att_on_notadoc/1,
                     fun should_return_409_for_del_att_without_rev/1,
                     fun should_return_200_for_del_att_with_rev/1,
-                    fun should_send_csp_header_with_att/1,
-                    fun should_send_not_csp_header_with_att_when_no_config/1,
                     fun should_return_409_for_put_att_nonexistent_rev/1,
                     fun should_return_update_seq_when_set_on_all_docs/1,
                     fun should_not_return_update_seq_when_unset_on_all_docs/1,
@@ -208,49 +206,6 @@ should_return_200_for_del_att_with_rev(Url) ->
           []
       ),
       ?assertEqual(200, RC1)
-    end)}.
-
-
-should_send_csp_header_with_att(Url) ->
-  {timeout, ?TIMEOUT, ?_test(begin
-      {ok, RC, _, _} = test_request:put(
-          Url ++ "/testdoc5",
-          [?CONTENT_JSON, ?AUTH],
-          jiffy:encode(attachment_doc())
-      ),
-      ?assertEqual(201, RC),
-
-      {ok, _, Headers, _} = test_request:get(
-          Url ++ "/testdoc5/file.erl",
-          [?AUTH],
-          []
-      ),
-      CSPHeader = couch_util:get_value("Content-Security-Policy", Headers),
-      ?assertEqual("sandbox", CSPHeader)
-    end)}.
-
-
-should_send_not_csp_header_with_att_when_no_config(Url) ->
-  {timeout, ?TIMEOUT, ?_test(begin
-      {ok, RC, _, _} = test_request:put(
-          Url ++ "/testdoc6",
-          [?CONTENT_JSON, ?AUTH],
-          jiffy:encode(attachment_doc())
-      ),
-      ?assertEqual(201, RC),
-
-      config:set_boolean("csp", "attachments_enable", false, _Persist=false),
-
-      {ok, _, Headers, _} = test_request:get(
-          Url ++ "/testdoc6/file.erl",
-          [?AUTH],
-          []
-      ),
-      CSPHeader = couch_util:get_value("Content-Security-Policy", Headers),
-      ?assertEqual(undefined, CSPHeader),
-
-      config:delete("csp", "attachments_enable", _Persist=false)
-
     end)}.
 
 

--- a/src/chttpd/test/eunit/chttpd_db_test.erl
+++ b/src/chttpd/test/eunit/chttpd_db_test.erl
@@ -259,7 +259,7 @@ should_return_correct_id_on_doc_copy(Url) ->
             [?CONTENT_JSON, ?AUTH, ?DESTHEADER1]),
         {ResultJson1} = ?JSON_DECODE(ResultBody1),
         Id1 = couch_util:get_value(<<"id">>, ResultJson1),
-        
+
         {_, _, _, ResultBody2} = test_request:copy(Url ++ "/testdoc/",
             [?CONTENT_JSON, ?AUTH, ?DESTHEADER2]),
         {ResultJson2} = ?JSON_DECODE(ResultBody2),
@@ -276,7 +276,7 @@ should_return_only_one_ok_on_doc_copy(Url) ->
        {_, _, _, ResultBody} = test_request:copy(Url ++ "/testdoc",
            [?CONTENT_JSON, ?AUTH, ?DESTHEADER1]),
        {ResultJson} = jiffy:decode(ResultBody),
-       NumOks = length(lists:filter(fun({Key, Value}) -> Key == <<"ok">> end, ResultJson)),
+       NumOks = length(lists:filter(fun({Key, _Value}) -> Key == <<"ok">> end, ResultJson)),
        [
            ?assertEqual(1, NumOks)
        ]
@@ -311,7 +311,6 @@ should_not_change_db_proper_after_rewriting_shardmap(_) ->
         TmpDb = ?tempdb(),
         Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
         Port = mochiweb_socket_server:get(chttpd, port),
-        AdmPort = mochiweb_socket_server:get(couch_httpd, port),
 
         BaseUrl = lists:concat(["http://", Addr, ":", Port, "/", ?b2l(TmpDb)]),
         Url = BaseUrl ++ "?partitioned=true&q=1",


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Remove redundant CSP tests, and cleanup unused variables, extra whitespace.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=chttpd
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
