### PR TITLE
align spidermonkey cflags across couch_js settings

### DIFF
--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -141,8 +141,8 @@ end.
         };
     {unix, _} when SMVsn == "78" ->
         {
-            "-DXP_UNIX -I/usr/include/mozjs-78 -I/usr/local/include/mozjs-78 -std=c++20 -Wno-invalid-offsetof",
-            "-L/usr/local/lib -std=c++20 -lmozjs-78 -lm"
+            "-DXP_UNIX -I/usr/include/mozjs-78 -I/usr/local/include/mozjs-78 -std=c++17 -Wno-invalid-offsetof",
+            "-L/usr/local/lib -std=c++17 -lmozjs-78 -lm"
         };
     {unix, _} when SMVsn == "86" ->
         {


### PR DESCRIPTION
## Overview

Patch fixes couch_js + SM78 compilation on FreeBSD 13.0-RELEASE amd64.

during 3.2.0-rc.1 testing, with FreeBSD SpiderMonkey 78 (which will be only supported SpiderMonkey after the Great Python 2 Deprecation at end of September), following error occurs:

```
Compiled src/couch_changes.erl
Compiling /tmp/couch/3.2.0/rc.1/apache-couchdb-3.2.0/src/couch/priv/couch_js/86/main.cpp
In file included from /tmp/couch/3.2.0/rc.1/apache-couchdb-3.2.0/src/couch/priv/couch_js/86/main.cpp:24:
In file included from /usr/local/include/mozjs-78/jsapi.h:31:
In file included from /usr/local/include/mozjs-78/js/CallArgs.h:74:
/usr/local/include/mozjs-78/js/Value.h:164:55: warning: bitwise operation between different enumeration types ('JSValueTag' and 'JSValueType') is deprecated [-Wdeprecated-enum-enum-conversion]
  return static_cast<JSValueTag>(JSVAL_TAG_MAX_DOUBLE | type);
                                 ~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
In file included from /tmp/couch/3.2.0/rc.1/apache-couchdb-3.2.0/src/couch/priv/couch_js/86/main.cpp:24:
In file included from /usr/local/include/mozjs-78/jsapi.h:31:
In file included from /usr/local/include/mozjs-78/js/CallArgs.h:73:
In file included from /usr/local/include/mozjs-78/js/RootingAPI.h:24:
/usr/local/include/mozjs-78/js/GCPolicyAPI.h:70:3: error: static_assert failed due to requirement '!std::is_pointer_v<void *>' "Pointer type not allowed for StructGCPolicy"
  static_assert(!std::is_pointer_v<T>,
  ^             ~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/mozjs-78/js/GCPolicyAPI.h:89:26: note: in instantiation of template class 'JS::StructGCPolicy<void *>' requested here
struct GCPolicy : public StructGCPolicy<T> {};
                         ^
/usr/local/include/mozjs-78/js/RootingAPI.h:896:9: note: in instantiation of template class 'JS::GCPolicy<void *>' requested here
    JS::GCPolicy<T>::trace(trc, &ptr, name);
        ^
/usr/local/include/mozjs-78/js/RootingAPI.h:883:8: note: in instantiation of member function 'js::RootedTraceable<void *>::trace' requested here
struct RootedTraceable final : public VirtualTraceable {
       ^
/usr/local/include/mozjs-78/js/RootingAPI.h:896:20: error: incomplete definition of type 'JS::GCPolicy<void *>'
```

## Testing recommendations

see release test procedure

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation

If this breaks other platforms I can carry it downstream as a local patch.
