### PR TITLE
Bump jiffy to CouchDB-1.0.9-1

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -161,7 +161,7 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
-{jiffy,            "jiffy",            {tag, "CouchDB-1.0.5-1"}},
+{jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-1"}},
 {mochiweb,         "mochiweb",         {tag, "CouchDB-v2.21.0-1"}},
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.2"}}


### PR DESCRIPTION
Based off of the upstream 1.0.9 + CouchDB clone changes

https://github.com/apache/couchdb-jiffy/releases/tag/CouchDB-1.0.9-1

