### PR TITLE
Fix Windows makefile for Fauxton

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -425,7 +425,7 @@ endif
 share\www:
 ifeq ($(with_fauxton), 1)
 	@echo 'Building Fauxton'
-	@cd src\fauxton && npm install --production && .\node_modules\.bin\grunt couchdb
+	@cd src\fauxton && npm install && .\node_modules\.bin\grunt couchdb
 endif
 
 derived:


### PR DESCRIPTION
Missed file in f85cff669f20cee0a54da7bb8c645dfc4d2de5c9

12:29 <+vatamane> Wohali: +1 to merge the fix to 3.x for windows