### PR TITLE
Return empty list from fabric:inactive_index_files/1 when database doesn't exist

### DIFF
--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -504,9 +504,13 @@ cleanup_index_files() ->
 %% @doc clean up index files for a specific db
 -spec cleanup_index_files(dbname()) -> ok.
 cleanup_index_files(DbName) ->
-    lists:foreach(fun(File) ->
-        file:delete(File)
-    end, inactive_index_files(DbName)).
+    try lists:foreach(
+        fun(File) ->
+            file:delete(File)
+        end, inactive_index_files(DbName))
+    catch
+        error:database_does_not_exist -> ok
+    end.
 
 %% @doc inactive index files for a specific db
 -spec inactive_index_files(dbname()) -> ok.

--- a/src/fabric/test/eunit/fabric_tests.erl
+++ b/src/fabric/test/eunit/fabric_tests.erl
@@ -1,0 +1,60 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric_tests).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+
+cleanup_index_files_test_() ->
+    {
+        setup,
+        fun setup/0,
+        fun teardown/1,
+        fun(Ctx) -> [
+            t_cleanup_index_files(),
+            t_cleanup_index_files_with_existing_db(Ctx),
+            t_cleanup_index_files_with_deleted_db(Ctx)
+        ] end
+    }.
+
+
+setup() ->
+    Ctx = test_util:start_couch([fabric]),
+    % TempDb is deleted in the test "t_cleanup_index_files_with_deleted_db".
+    TempDb = ?tempdb(),
+    fabric:create_db(TempDb),
+    {Ctx, TempDb}.
+
+
+teardown({Ctx, _TempDb}) ->
+    test_util:stop_couch(Ctx).
+
+
+t_cleanup_index_files() ->
+    ?_assert(
+        lists:all(fun(Res) -> Res =:= ok end, fabric:cleanup_index_files())).
+
+
+t_cleanup_index_files_with_existing_db({_Ctx, TempDb}) ->
+    ?_assertEqual(ok, fabric:cleanup_index_files(TempDb)).
+
+
+t_cleanup_index_files_with_deleted_db({_Ctx, TempDb}) ->
+    ?_test(
+        begin
+            fabric:delete_db(TempDb, []),
+            ?assertError(database_does_not_exist,
+                fabric:inactive_index_files(TempDb)),
+            ?assertEqual(ok, fabric:cleanup_index_files(TempDb))
+        end).


### PR DESCRIPTION
## Overview

The fabric:cleanup_index_files/1 is crashing when database is deleted between execution start and completion.

```
(node1@127.0.0.1)1> fabric:cleanup_index_files().
** exception error: database_does_not_exist
     in function  mem3_shards:load_shards_from_db/89
        called as mem3_shards:load_shards_from_db(53,51,54,99,100,102,98,56,45,102,57,54,53,45,52,54,49,97,
                                                  45,56,49,55,49,45,52,100,56,101,55|...)
     in call from mem3_shards:load_shards_from_disk/1 (src/mem3_shards.erl, line 368)
     in call from mem3_shards:for_db/2 (src/mem3_shards.erl, line 54)
     in call from fabric_util:is_partitioned/1 (src/fabric_util.erl, line 253)
     in call from fabric_view_all_docs:shards/2 (src/fabric_view_all_docs.erl, line 145)
     in call from fabric_view_all_docs:go/5 (src/fabric_view_all_docs.erl, line 26)
     in call from fabric:inactive_index_files/1 (src/fabric.erl, line 514)
     in call from fabric:cleanup_index_files/1 (src/fabric.erl, line 509)
```

This problem can be easily solved by wrapping the function body in a try/catch block and checking database_does_not_exist. In this case, we will return an empty list.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
`make eunit apps=fabric suites=fabric_tests`

## Related Issues or Pull Requests
Issue [#69](https://github.ibm.com/cloudant/dbcore/issues/69)

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
