### PR TITLE
Avoid badmatch for fabric:cleanup_index_files

### DIFF
--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -509,7 +509,11 @@ cleanup_index_files(DbName) ->
             file:delete(File)
         end, inactive_index_files(DbName))
     catch
-        error:database_does_not_exist -> ok
+        error:Error ->
+            couch_log:error(
+                "~p:cleanup_index_files. Error: ~p",
+                [?MODULE, Error]),
+            ok
     end.
 
 %% @doc inactive index files for a specific db


### PR DESCRIPTION
## Overview

Avoid badmatch for `fabric:cleanup_index_files`.

## Testing recommendations
`make eunit apps=fabric suites=fabric_tests`

## Related Issues or Pull Requests
https://github.com/apache/couchdb/pull/3779

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
