### PR TITLE
Add libicu version fetching and emit it in the _node/_local/_versions

### DIFF
--- a/src/couch/priv/couch_ejson_compare/couch_ejson_compare.c
+++ b/src/couch/priv/couch_ejson_compare/couch_ejson_compare.c
@@ -166,6 +166,40 @@ compare_strings_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 }
 
 
+ERL_NIF_TERM
+get_icu_version(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UVersionInfo ver = {0};
+    ERL_NIF_TERM tup[U_MAX_VERSION_LENGTH] = {0};
+    int i;
+
+    u_getVersion(ver);
+
+    for (i = 0; i < U_MAX_VERSION_LENGTH; i++) {
+        tup[i] = enif_make_int(env, ver[i]);
+    }
+
+    return enif_make_tuple_from_array(env, tup, U_MAX_VERSION_LENGTH);
+}
+
+
+ERL_NIF_TERM
+get_uca_version(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UVersionInfo ver = {0};
+    ERL_NIF_TERM tup[U_MAX_VERSION_LENGTH] = {0};
+    int i;
+
+    ucol_getUCAVersion(get_collator(), ver);
+
+    for (i = 0; i < U_MAX_VERSION_LENGTH; i++) {
+        tup[i] = enif_make_int(env, ver[i]);
+    }
+
+    return enif_make_tuple_from_array(env, tup, U_MAX_VERSION_LENGTH);
+}
+
+
 int
 less_json(int depth, ctx_t* ctx, ERL_NIF_TERM a, ERL_NIF_TERM b)
 {
@@ -531,7 +565,9 @@ on_unload(ErlNifEnv* env, void* priv_data)
 
 static ErlNifFunc nif_functions[] = {
     {"less_nif", 2, less_json_nif},
-    {"compare_strings_nif", 2, compare_strings_nif}
+    {"compare_strings_nif", 2, compare_strings_nif},
+    {"get_icu_version", 0, get_icu_version},
+    {"get_uca_version", 0, get_uca_version}
 };
 
 

--- a/src/couch/src/couch_ejson_compare.erl
+++ b/src/couch/src/couch_ejson_compare.erl
@@ -12,10 +12,20 @@
 
 -module(couch_ejson_compare).
 
--export([less/2, less_json_ids/2, less_json/2]).
+-export([
+    less/2,
+    less_json_ids/2,
+    less_json/2,
+    get_icu_version/0,
+    get_uca_version/0
+]).
 
 % For testing
--export([less_nif/2, less_erl/2, compare_strings_nif/2]).
+-export([
+    less_nif/2,
+    less_erl/2,
+    compare_strings_nif/2
+]).
 
 
 -on_load(init/0).
@@ -49,6 +59,14 @@ less_json_ids({JsonA, IdA}, {JsonB, IdB}) ->
 
 less_json(A,B) ->
     less(A, B) < 0.
+
+
+get_icu_version() ->
+    erlang:nif_error(get_icu_version).
+
+
+get_uca_version() ->
+    erlang:nif_error(get_uca_version).
 
 
 less_nif(A, B) ->

--- a/src/couch/test/eunit/couch_ejson_compare_tests.erl
+++ b/src/couch/test/eunit/couch_ejson_compare_tests.erl
@@ -183,6 +183,26 @@ zero_width_chars() ->
 
 % Regular EUnit tests
 
+get_icu_version_test() ->
+    Ver = couch_ejson_compare:get_icu_version(),
+    ?assertMatch({_, _, _, _}, Ver),
+    {V1, V2, V3, V4} = Ver,
+    ?assert(is_integer(V1) andalso V1 > 0),
+    ?assert(is_integer(V2) andalso V2 >= 0),
+    ?assert(is_integer(V3) andalso V3 >= 0),
+    ?assert(is_integer(V4) andalso V4 >= 0).
+
+
+get_uca_version_test() ->
+    Ver = couch_ejson_compare:get_uca_version(),
+    ?assertMatch({_, _, _, _}, Ver),
+    {V1, V2, V3, V4} = Ver,
+    ?assert(is_integer(V1) andalso V1 > 0),
+    ?assert(is_integer(V2) andalso V2 >= 0),
+    ?assert(is_integer(V3) andalso V3 >= 0),
+    ?assert(is_integer(V4) andalso V4 >= 0).
+
+
 max_depth_error_list_test() ->
     % NIF can handle terms with depth <= 9
     Nested9 = nest_list(<<"val">>, 9),


### PR DESCRIPTION
Fetch the libicu base version as well as the collator version. The base version may be used to determine which libicu library CouchDB is using. The collator version may be used to debug view behavior in case when collation order had changed from one version to the next.
