### PR TITLE
Eliminate eunit compiler warnings

### DIFF
--- a/src/couch/test/eunit/couch_util_tests.erl
+++ b/src/couch/test/eunit/couch_util_tests.erl
@@ -15,24 +15,6 @@
 -include_lib("couch/include/couch_eunit.hrl").
 
 
-setup() ->
-    %% We cannot start driver from here since it becomes bounded to eunit
-    %% master process and the next couch_server_sup:start_link call will
-    %% fail because server couldn't load driver since it already is.
-    %%
-    %% On other hand, we cannot unload driver here due to
-    %% {error, not_loaded_by_this_process} while it is. Any ideas is welcome.
-    %%
-    Ctx = test_util:start_couch(),
-    %% config:start_link(?CONFIG_CHAIN),
-    Ctx.
-
-teardown(Ctx) ->
-    ok = test_util:stop_couch(Ctx),
-    %% config:stop(),
-    ok.
-
-
 validate_callback_exists_test_() ->
     {
         "validate_callback_exists tests",

--- a/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
+++ b/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
@@ -85,17 +85,15 @@ node_call_prometheus_http(_) ->
     Url = construct_url(?PROM_PORT),
     {ok, RC1, _, _} = test_request:get(
             Url,
-            [?CONTENT_JSON, ?AUTH],
-            []
+            [?CONTENT_JSON, ?AUTH]
         ),
     % since this port doesn't require auth, this should work
     {ok, RC2, _, _} = test_request:get(
             Url,
-            [?CONTENT_JSON],
-            []
+            [?CONTENT_JSON]
         ),
     delete_db(Url),
-    ?_assertEqual(200, RC2).
+    ?_assertEqual({200, 200}, {RC1, RC2}).
 
 % we don't start the http server
 deny_prometheus_http(_) ->
@@ -121,8 +119,6 @@ construct_url(Port) ->
     lists:concat(["http://", Addr, ":", Port, "/_node/_local/_prometheus"]).
 
 create_db(Url) ->
-    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
-    Port = mochiweb_socket_server:get(chttpd, port),
     {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),
     ?assert(Status =:= 201 orelse Status =:= 202).
 

--- a/src/dreyfus/test/dreyfus_blacklist_await_test.erl
+++ b/src/dreyfus/test/dreyfus_blacklist_await_test.erl
@@ -62,8 +62,8 @@ do_not_await_1() ->
     State = create_state(?DBNAME, Index, nil, nil, []),
     Msg = "Index Blocked from Updating - db: ~p, ddocid: ~p name: ~p",
     Return = wait_log_message(Msg, fun() ->
-        {noreply, NewState} = dreyfus_index:handle_call({await, 1},
-        self(), State)
+        {noreply, _NewState} = dreyfus_index:handle_call({await, 1},
+            self(), State)
     end),
     ?assertEqual(Return, ok).
 

--- a/src/dreyfus/test/dreyfus_purge_test.erl
+++ b/src/dreyfus/test/dreyfus_purge_test.erl
@@ -27,6 +27,8 @@
         test_local_doc/0, test_delete_local_doc/0, test_purge_search/0]).
 
 -compile(export_all).
+-compile(nowarn_export_all).
+
 
 test_all() ->
     test_purge_single(),
@@ -703,10 +705,14 @@ test_purge_search() ->
 
 %private API
 db_name() ->
-    Nums = tuple_to_list(erlang:now()),
-    Prefix = "test-db",
-    Suffix = lists:concat([integer_to_list(Num) || Num <- Nums]),
-    list_to_binary(Prefix ++ "-" ++ Suffix).
+    iolist_to_binary([
+        "dreyfus-test-db-", [
+            integer_to_list(I) || I <- [
+                erlang:unique_integer([positive]),
+                rand:uniform(10000)
+            ]
+        ]
+    ]).
 
 purge_docs(DBName, DocIds) ->
     IdsRevs = [{DocId, [get_rev(DBName, DocId)]} || DocId <- DocIds],

--- a/src/dreyfus/test/dreyfus_test_util.erl
+++ b/src/dreyfus/test/dreyfus_test_util.erl
@@ -1,6 +1,8 @@
 -module(dreyfus_test_util).
 
--compile(export_all).
+-export([
+    wait_config_change/2
+]).
 
 -include_lib("couch/include/couch_db.hrl").
 

--- a/src/mem3/test/eunit/mem3_reshard_test.erl
+++ b/src/mem3/test/eunit/mem3_reshard_test.erl
@@ -519,7 +519,6 @@ target_reset_in_initial_copy(#{db1 := Db}) ->
 
 split_an_incomplete_shard_map(#{db1 := Db}) ->
     {timeout, ?TIMEOUT, ?_test(begin
-        [#shard{} = Src] = lists:sort(mem3:local_shards(Db)),
         [#shard{name=Shard}] = lists:sort(mem3:local_shards(Db)),
         meck:expect(mem3_util, calculate_max_n, 1, 0),
         ?assertMatch({error, {not_enough_shard_copies, _}},


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

- Unused functions in `couch_util_tests`
- Unused variables in `couch_prometheus_e2e_tests`
- Unused variable in `dreyfus_blacklist_await_test`
- Deprecated BIF `erlang:now/0` in `dreyfus_purge_test`
- `export_all` flag in dreyfus tests
- Unused variable in `mem3_reshard_test`

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit
```
There should be fewer compilation warnings.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are in tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
