### PR TITLE
Fix flaky mem3_bdu test

### DIFF
--- a/src/mem3/test/eunit/mem3_bdu_test.erl
+++ b/src/mem3/test/eunit/mem3_bdu_test.erl
@@ -89,8 +89,7 @@ t_can_insert_shard_map_doc({Top, Db}) ->
     },
     {Code, Res} = req(post, Top ++ ?DBS, ShardMap),
     ?assertEqual(201, Code),
-    ?assertMatch(#{<<"ok">> := true}, Res),
-    ?assertMatch({200, _}, req(get, Top ++ Db)).
+    ?assertMatch(#{<<"ok">> := true}, Res).
 
 
 t_missing_by_node_section({Top, Db}) ->
@@ -236,7 +235,6 @@ t_replicated_changes_not_validated({Top, Db}) ->
     {Code, Res} = req(post, Top ++ ?DBS ++ "/_bulk_docs", Docs),
     ?assertEqual(201, Code),
     ?assertEqual([], Res),
-    ?assertMatch({200, _}, req(get, Top ++ Db)),
     Deleted = #{
         <<"id">> => Db,
         <<"_rev">> => <<"1-abc">>,
@@ -267,12 +265,6 @@ sync_delete_db(Top, Db) when is_binary(Db) ->
         error:database_does_not_exist ->
             ok
     end.
-
-
-req(Method, Url) ->
-    Headers = [?AUTH],
-    {ok, Code, _, Res} = test_request:request(Method, Url, Headers),
-    {Code, jiffy:decode(Res, [return_maps])}.
 
 
 req(Method, Url, #{} = Body) ->


### PR DESCRIPTION
The test only checks that we can update the shard doc so we just verify that. Apparently, it doesn't mean we can synchronously access the newly created db info right away so we just skip that part to avoid a flaky failure.

