### PR TITLE
fix(local.ini): straggling s/couch_httpd_auth/chttpd_auth/

### DIFF
--- a/rel/overlay/etc/local.ini
+++ b/rel/overlay/etc/local.ini
@@ -43,7 +43,7 @@
 ; the whitelist.
 ;config_whitelist = [{httpd,config_whitelist}, {log,level}, {etc,etc}]
 
-[couch_httpd_auth]
+[chttpd_auth]
 ; If you set this to true, you should also uncomment the WWW-Authenticate line
 ; above. If you don't configure a WWW-Authenticate header, CouchDB will send
 ; Basic realm="server" in order to prevent you getting logged out.


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The appropriately named `hack_local_ini` function in dev/run lives up
to its name by adding a random `secret` to the end of whichever
section contains the line `"; require_valid_user = false\n"`.

[Recent commits](https://github.com/apache/couchdb/pull/3808) updated the `setup` application from
`couch_httpd_auth` to `chttpd_auth` without also changing this line
in local.ini, which had the fun effect of causing `setup` to fail with
this error:

```
[error] 2021-10-30T18:50:15.019274Z node1@127.0.0.1 <0.817.0> 85d0421b9c setup sync_admin results [{badrpc,{'EXIT',{function_clause,[{config,set,["chttpd_auth","secret",undefined,true,nil],[{file,"src/config.erl"},{line,189}]},{rpc,'-handle_call_call/6-fun-0-',5,[{file,"rpc.erl"},{line,197}]}]}}},{badrpc,{'EXIT',{function_clause,[{config,set,["chttpd_auth","secret",undefined,true,nil],[{file,"src/config.erl"},{line,189}]},{rpc,'-handle_call_call/6-fun-0-',5,[{file,"rpc.erl"},{line,197}]}]}}}] errors []
[notice] 2021-10-30T18:50:15.019530Z node1@127.0.0.1 <0.817.0> 85d0421b9c 127.0.0.1:15984 127.0.0.1 adm POST /_cluster_setup 500 ok 12
```

This change "fixes" dev/run by also updating the straggling section
name in local.ini.


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Running e.g.
```
dev/run -a adm:pass --no-eval 'dev/remsh'
```
should result in a formed cluster and a remsh on node1 instead of a crash:
```
[ * ] Running cluster setup ... failed: b'{"error":"setup_error","reason":"Cluster setup unable to sync admin passwords"}\n'
Traceback (most recent call last):
  File "dev/run", line 857, in <module>
    main()
  File "dev/run", line 91, in main
    startup(ctx)
  File "dev/run", line 519, in startup
    cluster_setup(ctx)
  File "dev/run", line 71, in wrapper
    res = func(*args, **kwargs)
  File "dev/run", line 666, in cluster_setup
    finish_cluster(lead_port, *ctx["admin"])
  File "dev/run", line 752, in finish_cluster
    assert resp.status in (201, 400), resp.read()
AssertionError: b'{"error":"setup_error","reason":"Cluster setup unable to sync admin passwords"}\n'
returned 1
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
