### PR TITLE
Using _bulk_docs with new_edits false and without _rev should responds 400 Bad Request

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -569,16 +569,26 @@ db_req(#httpd{method='POST',path_parts=[_,<<"_bulk_docs">>], user_ctx=Ctx}=Req, 
             send_json(Req, 417, ErrorsJson)
         end;
     false ->
-        case fabric:update_docs(Db, Docs, [replicated_changes|Options]) of
-        {ok, Errors} ->
-            chttpd_stats:incr_writes(length(Docs)),
-            ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
-            send_json(Req, 201, ErrorsJson);
-        {accepted, Errors} ->
-            chttpd_stats:incr_writes(length(Docs)),
-            ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
-            send_json(Req, 202, ErrorsJson)
-        end;
+        lists:map(fun(JsonObj) ->
+            Doc = couch_db:doc_from_json_obj_validate(Db, JsonObj),
+            case Doc#doc.revs of
+            {0, []} ->
+                send_json(Req, 400, {[{missing_revs,
+                    ?l2b("If `new_edits` is false, a well-formed "
+                    "`_rev` must be included in the document.")}]});
+            _ ->
+                case fabric:update_docs(Db, Docs, [replicated_changes|Options]) of
+                {ok, Errors} ->
+                    chttpd_stats:incr_writes(length(Docs)),
+                    ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
+                    send_json(Req, 201, ErrorsJson);
+                {accepted, Errors} ->
+                    chttpd_stats:incr_writes(length(Docs)),
+                    ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
+                    send_json(Req, 202, ErrorsJson)
+                end
+            end
+        end, DocsArray);
     _ ->
         throw({bad_request, <<"`new_edits` parameter must be a boolean.">>})
     end;


### PR DESCRIPTION
## Overview
Using _bulk_docs with "new_edits": false and without _rev responds with 500 Server Error. I understand I should always include _rev into the document, but if I don't, it is a bad request, isn't it?

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
Related Issues: https://github.com/apache/couchdb/issues/2242

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
