### PR TITLE
Using _bulk_docs with new_edits false and without _rev should respond 400 Bad Request

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -569,26 +569,17 @@ db_req(#httpd{method='POST',path_parts=[_,<<"_bulk_docs">>], user_ctx=Ctx}=Req, 
             send_json(Req, 417, ErrorsJson)
         end;
     false ->
-        lists:map(fun(JsonObj) ->
-            Doc = couch_db:doc_from_json_obj_validate(Db, JsonObj),
-            case Doc#doc.revs of
-            {0, []} ->
-                send_json(Req, 400, {[{missing_revs,
-                    ?l2b("If `new_edits` is false, a well-formed "
-                    "`_rev` must be included in the document.")}]});
-            _ ->
-                case fabric:update_docs(Db, Docs, [replicated_changes | Options]) of
-                {ok, Errors} ->
-                    chttpd_stats:incr_writes(length(Docs)),
-                    ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
-                    send_json(Req, 201, ErrorsJson);
-                {accepted, Errors} ->
-                    chttpd_stats:incr_writes(length(Docs)),
-                    ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
-                    send_json(Req, 202, ErrorsJson)
-                end
-            end
-        end, DocsArray);
+        Docs2 = [Doc || Doc <- Docs, element(3, Doc) =/= {0, []}],
+        case fabric:update_docs(Db, Docs2, [replicated_changes | Options]) of
+        {ok, Errors} ->
+            chttpd_stats:incr_writes(length(Docs)),
+            ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
+            send_json(Req, 201, ErrorsJson);
+        {accepted, Errors} ->
+            chttpd_stats:incr_writes(length(Docs)),
+            ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
+            send_json(Req, 202, ErrorsJson)
+        end;
     _ ->
         throw({bad_request, <<"`new_edits` parameter must be a boolean.">>})
     end;


### PR DESCRIPTION
## Overview
Use `_bulk_docs` with "new_edits": false and without `_rev` should respond with 400 Bad Request instead of 500 Server Error.
When "new_edits": false, the request should always include the value of `_rev`.
Ref: https://docs.couchdb.org/en/stable/api/database/bulk-api.html?highlight=bulk_docs#db-bulk-docs

## Testing recommendations
**Manual testing:**

1. If all documents don't have `_rev`, raise **400 Bad Request**.
```
$ curl -X POST http://adm:pass@127.0.0.1:15984/demo/_bulk_docs \
  -H 'Content-Type: application/json' \
  -d '{
       "docs": [{"_id": "FishStew", "value": 1},
                {"_id": "LambStew", "value": 2}],
       "new_edits": false
  }'
{"missing_revs":"If `new_edits` is false, a well-formed `_rev` must be included in the document."}
```


2. If the document does not exist and the request contains `_rev`, it will be created.
```
$ curl -X POST http://adm:pass@127.0.0.1:15984/demo/_bulk_docs \
  -H 'Content-Type: application/json' \
  -d '{
       "docs": [{"_id": "BeefStew", "_rev": "1-1", "value": 0},
                {"_id": "FishStew", "_rev": "2-1", "value": 1},
                {"_id": "LambStew", "value": 2}],
       "new_edits": false
  }'
[]

$ curl "http://adm:pass@127.0.0.1:15984/demo/_all_docs?include_docs=true"
{"total_rows":2,"offset":0,"rows":[
{"id":"BeefStew","key":"BeefStew","value":{"rev":"1-1"},"doc":{"_id":"BeefStew","_rev":"1-1","value":0}},
{"id":"FishStew","key":"FishStew","value":{"rev":"2-1"},"doc":{"_id":"FishStew","_rev":"2-1","value":1}}]}
```


3. If the document exists and the new `_rev` is greater than the original `_rev`, it will be updated.
4. If the document exists but the new `_rev` is smaller than the original `_rev`, it will do nothing.
```
$ curl -X POST http://adm:pass@127.0.0.1:15984/demo/_bulk_docs \
  -H 'Content-Type: application/json' \
  -d '{
       "docs": [{"_id": "BeefStew", "_rev": "2-1", "value": 100},
                {"_id": "FishStew", "_rev": "1-2", "value": 200},
                {"_id": "LambStew", "value": 300}],
       "new_edits": false
  }'
[]

$ curl "http://adm:pass@127.0.0.1:15984/demo/_all_docs?include_docs=true"
{"total_rows":2,"offset":0,"rows":[
{"id":"BeefStew","key":"BeefStew","value":{"rev":"2-1"},"doc":{"_id":"BeefStew","_rev":"2-1","value":100}},
{"id":"FishStew","key":"FishStew","value":{"rev":"2-1"},"doc":{"_id":"FishStew","_rev":"2-1","value":1}}]}
```

## Related Issues or Pull Requests
https://github.com/apache/couchdb/issues/2242

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
