### PR TITLE
feat(couchjs): add support for SpiderMonkey 91esr

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,92 @@
+name: Ubuntu build CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: update
+      run: sudo apt-get update
+    - name: install
+      run: sudo apt-get --no-install-recommends -y install autoconf2.13 build-essential pkg-config libcurl4-openssl-dev erlang-dev rebar elixir
+
+    - name: couch checkout
+      uses: actions/checkout@v2
+      with:
+        path: couch
+
+    - name: ICU checkout
+      uses: actions/checkout@v2
+      with:
+        repository: unicode-org/icu
+        path: icubuild
+        
+    - name: ICU4C with gcc     
+      env: 
+        PREFIX: /usr/local
+      run: |
+        cd icubuild
+        mkdir build;
+        cd build;
+        ../icu4c/source/runConfigureICU --enable-debug --disable-release Linux/gcc --prefix=$PREFIX --enable-tracing;
+        make -j2;
+        make -j2 check;
+        ( cd ../icu4c/source/test/depstest && ./depstest.py ../../../../build/ );
+        sudo make install;
+
+    - name: Cache packages
+      uses: actions/cache@v2
+      id: wgetcache
+      with:
+        key: wgetcache
+        path: |
+          firefox-91.3.0esr.source.tar.xz
+          foundationdb-clients_6.3.22-1_amd64.deb
+          foundationdb-server_6.3.22-1_amd64.deb
+
+    - name: wget moz
+      if: steps.wgetcache.outputs.cache-hit != 'true'
+      run: wget -q https://www.foundationdb.org/downloads/6.3.22/ubuntu/installers/foundationdb-server_6.3.22-1_amd64.deb https://www.foundationdb.org/downloads/6.3.22/ubuntu/installers/foundationdb-clients_6.3.22-1_amd64.deb https://download.cdn.mozilla.net/pub/firefox/releases/91.3.0esr/source/firefox-91.3.0esr.source.tar.xz
+
+    - name: build spidermonkeycheckout
+      run: |
+        tar xf firefox-91.3.0esr.source.tar.xz
+        export PKG_CONFIG_PATH=${{github.workspace}}/icu/lib/pkgconfig:$PKG_CONFIG_PATH
+        export AC_MACRODIR=${{github.workspace}}/firefox-91.3.0/build/autoconf/
+        cd firefox-91.3.0
+        export PYTHON=python3
+        export M4=m4
+        export AWK=awk
+        export CFLAGS="-I/usr/local/include"
+        export LDFLAGS="-L/usr/local/lib"
+        cd js/src
+        sh ../../build/autoconf/autoconf.sh --localdir=$PWD configure.in > configure
+        chmod +x configure
+        mkdir ${{github.workspace}}/build_OPT.OBJ
+        cd ${{github.workspace}}/build_OPT.OBJ
+        ${{github.workspace}}/firefox-91.3.0/js/src/configure --prefix=/usr/local --disable-ctypes --disable-jit --disable-jemalloc --enable-optimize --enable-hardening --with-intl-api --build-backends=RecursiveMake --with-system-icu --disable-debug --enable-gczeal
+        make
+        sudo make install
+            
+    - name: install
+      run: sudo apt-get --no-install-recommends -y install ./foundationdb-clients_6.3.22-1_amd64.deb ./foundationdb-server_6.3.22-1_amd64.deb
+        
+    - name: configure
+      run: |
+        cd couch
+        sed -i -e "s@DRV_CFLAGS -DPIC@DRV_CFLAGS -I/usr/local/include -DPIC@" src/couch/rebar.config.script
+        sed -i -e "s@DRV_LDFLAGS -lm@DRV_LDFLAGS -L/usr/local/lib -lm@" src/couch/rebar.config.script
+        sh ./configure --spidermonkey-version=91 --disable-docs
+    - name: Compile
+      run: |
+        cd couch
+        make release
+    - name: Run tests
+      run: |
+        cd couch
+        make check

--- a/src/couch/priv/couch_js/86/util.cpp
+++ b/src/couch/priv/couch_js/86/util.cpp
@@ -330,7 +330,7 @@ void
 couch_oom(JSContext* cx, void* data)
 {
     fprintf(stderr, "out of memory\n");
-    exit(1);
+    _Exit(1);
 }
 
 

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -65,6 +65,8 @@ SMVsn = case lists:keyfind(spidermonkey_version, 1, CouchConfig) of
         "78";
     {_, "86"} ->
         "86";
+    {_, "91"} ->
+        "91";
     undefined ->
         "1.8.5";
     {_, Unsupported} ->
@@ -88,6 +90,8 @@ ConfigH = [
 
 CouchJSConfig = case SMVsn of
     "78" ->
+        "priv/couch_js/86/config.h";
+    "91" ->
         "priv/couch_js/86/config.h";
     _ ->
         "priv/couch_js/" ++ SMVsn ++ "/config.h"
@@ -148,6 +152,11 @@ end.
         {
             "-DXP_UNIX -I/usr/include/mozjs-86 -I/usr/local/include/mozjs-86 -I/opt/homebrew/include/mozjs-86/ -std=c++17 -Wno-invalid-offsetof",
             "-L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-86 -lm"
+        };
+    {unix, _} when SMVsn == "91" ->
+        {
+            "-DXP_UNIX -I/usr/include/mozjs-91 -I/usr/local/include/mozjs-91 -I/opt/homebrew/include/mozjs-91/ -std=c++17 -Wno-invalid-offsetof",
+            "-L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-91 -lm"
         }
 end.
 
@@ -156,7 +165,8 @@ CouchJSSrc = case SMVsn of
     "60" -> ["priv/couch_js/60/*.cpp"];
     "68" -> ["priv/couch_js/68/*.cpp"];
     "78" -> ["priv/couch_js/86/*.cpp"];
-    "86" -> ["priv/couch_js/86/*.cpp"]
+    "86" -> ["priv/couch_js/86/*.cpp"];
+    "91" -> ["priv/couch_js/86/*.cpp"]
 end.
 
 CouchJSEnv = case SMVsn of


### PR DESCRIPTION
## Overview

This PR introduces spidermonkey 91esr. As with 78 and 86 there are no relevant API changes but it became necessary in practice as well as in theory to destroy the context and shutdown JS before any proper exit to prevent assertions in destructors. (For more information, the issue tracking the esr91 migration guide is [here](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples/issues/41.)

## Testing recommendations

Since many distributions don't ship with moz-js 91 yet, I've included a github workflow to test couchdb in ubuntu with the latest spidermonkey, foundationdb 6.x, and icu. It is set to be manually run on a branch from the actions menu.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X]  Any new configurable parameters are documented in `rel/overlay/etc/default.ini` [^1]
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation [^2]
[^1]: no configurable parameters for runtime
[^2]: spidermonkey versions are only referenced in whatsnew for release branches.