### PR TITLE
Fix Jenkins email quoting failures

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -54,7 +54,6 @@ pipeline {
 
   environment {
     COUCHAUTH = credentials('couchdb_vm2_couchdb')
-    recipient = 'notifications@couchdb.apache.org'
     COUCHDB_IO_LOG_DIR = '/tmp/couchjslogs'
     // Following fix an issue with git <= 2.6.5 where no committer
     // name or email are present for reflog, required for git clone
@@ -754,20 +753,20 @@ pipeline {
 
   post {
     success {
-      mail to: "${env.recipient}",
-        replyTo: "${env.recipient}",
+      mail to: 'notifications@couchdb.apache.org',
+        replyTo: 'notifications@couchdb.apache.org',
         subject: "[Jenkins] SUCCESS: ${currentBuild.fullDisplayName}",
         body: "Yay, we passed. ${env.RUN_DISPLAY_URL}"
     }
     unstable {
-      mail to: "${env.recipient}",
-        replyTo: "${env.recipient}",
+      mail to: 'notifications@couchdb.apache.org',
+        replyTo: 'notifications@couchdb.apache.org',
         subject: "[Jenkins] SUCCESS: ${currentBuild.fullDisplayName}",
         body: "Eep! Build is unstable... ${env.RUN_DISPLAY_URL}"
     }
     failure {
-      mail to: "${env.recipient}",
-        replyTo: "${env.recipient}",
+      mail to: 'notifications@couchdb.apache.org',
+        replyTo: 'notifications@couchdb.apache.org',
         subject: "[Jenkins] FAILURE: ${currentBuild.fullDisplayName}",
         body: "Boo, we failed. ${env.RUN_DISPLAY_URL}"
     }


### PR DESCRIPTION
Should fix:
```
Warning: A secret was passed to "mail" using Groovy String interpolation, which is insecure.
```

This ports the fix from 3.x