### PR TITLE
Add SameSite setting when clearing session cookie

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -548,7 +548,7 @@ handle_session_req(#httpd{method = 'DELETE'} = Req, _AuthModule) ->
         "AuthSession",
         "",
         [{path, "/"}] ++
-            cookie_domain() ++ cookie_scheme(Req)
+            cookie_domain() ++ cookie_scheme(Req) ++ same_site()
     ),
     {Code, Headers} =
         case couch_httpd:qs_value(Req, "next", nil) of


### PR DESCRIPTION
## Overview

DELETE /_session does not work if the SameSite attribute is enabled when using browsers that enforce it because we forgot to add the property when deleting the cookie. This PR adds the SameSite attribute if enabled.

## Testing recommendations

Enable SameSite, login via the dashboard, then log out. Observe that the AuthSession cookie has a value before log out but not after.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
