### PR TITLE
Fix TLS custom (couch) dist for Erlang 20

### DIFF
--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -91,5 +91,5 @@
 ## Don't forget to override the paths to point to your certificate(s) and key(s)!
 ##
 #-proto_dist couch
-#-couch_dist no_tls \"clouseau@127.0.0.1\"
+#-couch_dist no_tls '"clouseau@127.0.0.1"'
 #-ssl_dist_optfile <path/to/couch_ssl_dist.conf>


### PR DESCRIPTION
### Summary

 * Fix quoting so that it works with all OTP versions 20 through 24 [1].

 * Dist API in 20 [2] did not have a `listen/2` [3] callback. Implement
   `listen/1` so we're compatible with all the supported OTP versions.

[1] https://github.com/apache/couchdb/issues/3821#issuecomment-985089867
[2] https://github.com/erlang/otp/blob/maint-20/lib/kernel/src/inet_tcp_dist.erl#L71-L72
[3] https://github.com/erlang/otp/blob/master/lib/kernel/src/inet_tcp_dist.erl#L79-L80

### Testing

 * Follow the nice instructions by @jiahuili430 [here](https://github.com/apache/couchdb/issues/3821#issuecomment-985089867). Try with Erlang 20 and then 23, for example.

My setup with 20 looked like:

vm.args:
```
-proto_dist couch
-couch_dist no_tls '"clouseau@127.0.0.1"'
-couch_dist no_tls '"node1@127.0.0.1"'
-ssl_dist_optfile "/...../asf-3/dev/couch_ssl_dist.conf"
```

remsh to node 2
```
./dev/remsh-tls 2
(node2@127.0.0.1)1> net_kernel:nodes_info().
{ok,[{'node3@127.0.0.1',
         [{owner,<0.399.0>},
          {state,up},
          {address,{net_address,{{127,0,0,1},53431},"xxxx",proxy,inet}},
          {type,normal},
          {in,123},
          {out,137}]},
     {'node1@127.0.0.1',
         [{owner,<0.369.0>},
          {state,up},
          {address,
              {net_address,{{127,0,0,1},53429},"127.0.0.1",tcp,inet}},
          {type,normal},
          {in,177},
          {out,145}]},
     {'remsh29344@127.0.0.1',
         [{owner,<0.1095.0>},
          {state,up},
          {address,{net_address,{{127,0,0,1},53431},"xxxx",proxy,inet}},
          {type,hidden},
          {in,8},
          {out,10}]}]}
```

There are two minor things to watch out for when testing:

 * In Erlang 20 TLS dist works a bit differently -- there is a `proxy` driver module, so TLS connections in `net_kernel:nodes_info/0` show up as `proxy` instead of `tls`. That's expected.
 
 * Because connections between nodes are bi-directional, when we set `node1` to be TCP, we're not guaranteed to always get a TCP connection to it, as, for example, `node1` could first connect to `node2`  and node2 doesn't have a `no_tls` flag so it will be a TLS connection. But after a few tries we should get a TCP connection.





