### PR TITLE
Add SameSite setting when clearing session cookie (2)

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -486,7 +486,7 @@ handle_session_req(#httpd{method = 'POST', mochi_req = MochiReq} = Req, AuthModu
             authentication_warning(Req, UserName),
             % clear the session
             Cookie = mochiweb_cookies:cookie(
-                "AuthSession", "", [{path, "/"}] ++ cookie_scheme(Req)
+                "AuthSession", "", [{path, "/"}] ++ cookie_scheme(Req) ++ same_site()
             ),
             {Code, Headers} =
                 case couch_httpd:qs_value(Req, "fail", nil) of


### PR DESCRIPTION
## Overview

Deleting the session cookie on auth failure does not work if the SameSite attribute is enabled when using browsers that enforce it because we forgot to add the property. This PR adds the SameSite attribute if enabled.

## Testing recommendations

Enable SameSite, login via the dashboard, then attempt authentication again with the wrong password. Observe that the AuthSession cookie has a value before that attempt but not after.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
