### PR TITLE
Ubuntu CI: wget pull cleanup and downgrade fdb to workaround a cdn problem

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,6 +3,10 @@ name: Ubuntu build CI
 on:
   workflow_dispatch:
 
+env:
+  FIREFOX_VERSION: 91.4.0
+  FDB_VERSION: 6.3.18
+
 jobs:
 
   build:
@@ -14,6 +18,23 @@ jobs:
       run: sudo apt-get update
     - name: install
       run: sudo apt-get --no-install-recommends -y install autoconf2.13 build-essential pkg-config libcurl4-openssl-dev erlang-dev rebar elixir
+
+    - name: Cache packages
+      uses: actions/cache@v2
+      id: wgetcache
+      with:
+        key: wgetcache-${{env.FIREFOX_VERSION}}-${{env.FDB_VERSION}}
+        path: |
+          firefox-${{env.FIREFOX_VERSION}}esr.source.tar.xz
+          foundationdb-clients_${{env.FDB_VERSION}}-1_amd64.deb
+          foundationdb-server_${{env.FDB_VERSION}}-1_amd64.deb
+
+    - name: wget moz
+      if: steps.wgetcache.outputs.cache-hit != 'true'
+      run: |
+        wget -nv -S https://www.foundationdb.org/downloads/${{env.FDB_VERSION}}/ubuntu/installers/foundationdb-clients_${{env.FDB_VERSION}}-1_amd64.deb
+        wget -nv -S https://www.foundationdb.org/downloads/${{env.FDB_VERSION}}/ubuntu/installers/foundationdb-server_${{env.FDB_VERSION}}-1_amd64.deb
+        wget -nv https://download.cdn.mozilla.net/pub/firefox/releases/${{env.FIREFOX_VERSION}}esr/source/firefox-${{env.FIREFOX_VERSION}}esr.source.tar.xz
 
     - name: couch checkout
       uses: actions/checkout@v2
@@ -39,26 +60,12 @@ jobs:
         ( cd ../icu4c/source/test/depstest && ./depstest.py ../../../../build/ );
         sudo make install;
 
-    - name: Cache packages
-      uses: actions/cache@v2
-      id: wgetcache
-      with:
-        key: wgetcache
-        path: |
-          firefox-91.3.0esr.source.tar.xz
-          foundationdb-clients_6.3.22-1_amd64.deb
-          foundationdb-server_6.3.22-1_amd64.deb
-
-    - name: wget moz
-      if: steps.wgetcache.outputs.cache-hit != 'true'
-      run: wget -q https://www.foundationdb.org/downloads/6.3.22/ubuntu/installers/foundationdb-server_6.3.22-1_amd64.deb https://www.foundationdb.org/downloads/6.3.22/ubuntu/installers/foundationdb-clients_6.3.22-1_amd64.deb https://download.cdn.mozilla.net/pub/firefox/releases/91.3.0esr/source/firefox-91.3.0esr.source.tar.xz
-
     - name: build spidermonkeycheckout
       run: |
-        tar xf firefox-91.3.0esr.source.tar.xz
+        tar xf firefox-${{env.FIREFOX_VERSION}}esr.source.tar.xz
         export PKG_CONFIG_PATH=${{github.workspace}}/icu/lib/pkgconfig:$PKG_CONFIG_PATH
-        export AC_MACRODIR=${{github.workspace}}/firefox-91.3.0/build/autoconf/
-        cd firefox-91.3.0
+        export AC_MACRODIR=${{github.workspace}}/firefox-${{env.FIREFOX_VERSION}}/build/autoconf/
+        cd firefox-${{env.FIREFOX_VERSION}}
         export PYTHON=python3
         export M4=m4
         export AWK=awk
@@ -69,12 +76,12 @@ jobs:
         chmod +x configure
         mkdir ${{github.workspace}}/build_OPT.OBJ
         cd ${{github.workspace}}/build_OPT.OBJ
-        ${{github.workspace}}/firefox-91.3.0/js/src/configure --prefix=/usr/local --disable-ctypes --disable-jit --disable-jemalloc --enable-optimize --enable-hardening --with-intl-api --build-backends=RecursiveMake --with-system-icu --disable-debug --enable-gczeal
+        ${{github.workspace}}/firefox-${{env.FIREFOX_VERSION}}/js/src/configure --prefix=/usr/local --disable-ctypes --disable-jit --disable-jemalloc --enable-optimize --enable-hardening --with-intl-api --build-backends=RecursiveMake --with-system-icu --disable-debug --enable-gczeal
         make
         sudo make install
             
     - name: install
-      run: sudo apt-get --no-install-recommends -y install ./foundationdb-clients_6.3.22-1_amd64.deb ./foundationdb-server_6.3.22-1_amd64.deb
+      run: sudo apt-get --no-install-recommends -y install ./foundationdb-clients_${{env.FDB_VERSION}}-1_amd64.deb ./foundationdb-server_${{env.FDB_VERSION}}-1_amd64.deb
         
     - name: configure
       run: |


### PR DESCRIPTION
## Overview

Setup Ubuntu manual CI to accept variables for fdb and mozjs packages; downgrade fdb and upgrade mozjs.

## Testing recommendations

The CI can be triggered manually in actions on a clone of this branch.

## Related Issues or Pull Requests

There have been recurrent issues fetching fdb 6.3.22 that will probably resolve soon, but the need to raise these versions will come up regularly,

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
