### PR TITLE
Always send all cookie attributes

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -371,8 +371,17 @@ cookie_auth_cookie(Req, User, Secret, TimeStamp) ->
     mochiweb_cookies:cookie(
         "AuthSession",
         couch_util:encodeBase64Url(SessionData ++ ":" ++ ?b2l(Hash)),
-        [{path, "/"}] ++ cookie_scheme(Req) ++ max_age() ++ cookie_domain() ++ same_site()
+        cookie_attributes(Req)
     ).
+
+clear_auth_cookie(Req) ->
+    mochiweb_cookies:cookie(
+        "AuthSession", "", cookie_attributes(Req)
+    ).
+
+cookie_attributes(Req) ->
+    Attributes = [path(), http_only(), max_age(), cookie_scheme(Req), cookie_domain(), same_site()],
+    lists:flatten(Attributes).
 
 ensure_cookie_auth_secret() ->
     case chttpd_util:get_chttpd_auth_config("secret") of
@@ -446,9 +455,7 @@ handle_session_req(#httpd{method = 'POST', mochi_req = MochiReq} = Req, AuthModu
         false ->
             authentication_warning(Req, UserName),
             % clear the session
-            Cookie = mochiweb_cookies:cookie(
-                "AuthSession", "", [{path, "/"}] ++ cookie_scheme(Req)
-            ),
+            Cookie = clear_auth_cookie(Req),
             {Code, Headers} =
                 case couch_httpd:qs_value(Req, "fail", nil) of
                     nil ->
@@ -505,12 +512,7 @@ handle_session_req(#httpd{method = 'GET', user_ctx = UserCtx} = Req, _AuthModule
     end;
 % logout by deleting the session
 handle_session_req(#httpd{method = 'DELETE'} = Req, _AuthModule) ->
-    Cookie = mochiweb_cookies:cookie(
-        "AuthSession",
-        "",
-        [{path, "/"}] ++
-            cookie_domain() ++ cookie_scheme(Req) ++ same_site()
-    ),
+    Cookie = clear_auth_cookie(Req),
     {Code, Headers} =
         case couch_httpd:qs_value(Req, "next", nil) of
             nil ->
@@ -577,12 +579,17 @@ make_cookie_time() ->
     {NowMS, NowS, _} = os:timestamp(),
     NowMS * 1000000 + NowS.
 
+path() ->
+    {path, "/"}.
+
+http_only() ->
+    {http_only, true}.
+
 cookie_scheme(#httpd{mochi_req = MochiReq}) ->
-    [{http_only, true}] ++
-        case MochiReq:get(scheme) of
-            http -> [];
-            https -> [{secure, true}]
-        end.
+    case MochiReq:get(scheme) of
+        http -> [];
+        https -> [{secure, true}]
+    end.
 
 max_age() ->
     case


### PR DESCRIPTION
## Overview

Send all the cookie attributes whenever we send a cookie. Only the value of AuthSession varies.

## Testing recommendations

Configure the same-site and/or domain attribute in the nodes config.

1) Acquire a session cookie successfully then log out. Confirm AuthSession is the empty string.
2) Acquire a session cookie successfully then attempt to acquire a session cookie with the wrong password. Confirm AuthSession is the empty string.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
