### PR TITLE
Run erlfmt-check in a separate stage

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -94,7 +94,6 @@ pipeline {
           set
           rm -rf apache-couchdb-*
           ./configure
-          make erlfmt-check
           make dist
           chmod -R a+w * .
         '''

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -51,6 +51,10 @@ pipeline {
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
     LOW_ERLANG_VER = '20.3.8.26'
+
+    // erlfmt doesn't run with the lowest erlang version so we run it in a
+    // separate stage with a higher erlang version.
+    ERLFMT_ERLANG_VER = '23.3.1'
   }
 
   options {
@@ -63,6 +67,38 @@ pipeline {
   }
 
   stages {
+
+    stage('erlfmt') {
+      agent {
+        docker {
+          image "${DOCKER_IMAGE}"
+          label 'docker'
+          args "${DOCKER_ARGS}"
+          registryUrl 'https://docker.io/'
+          registryCredentialsId 'dockerhub_creds'
+        }
+      }
+      options {
+        timeout(time: 15, unit: "MINUTES")
+      }
+      steps {
+        sh '''
+          set
+          rm -rf apache-couchdb-*
+          . /usr/local/kerl/${ERLFMT_ERLANG_VER}/activate
+          ./configure --skip-deps
+          make erlfmt-check
+        '''
+      }
+      post {
+        cleanup {
+          // UGH see https://issues.jenkins-ci.org/browse/JENKINS-41894
+          sh 'rm -rf ${WORKSPACE}/*'
+        }
+      }
+    } // stage erlfmt
+
+
     stage('Build Release Tarball') {
       agent {
         docker {
@@ -82,7 +118,6 @@ pipeline {
           rm -rf apache-couchdb-*
           . /usr/local/kerl/${LOW_ERLANG_VER}/activate
           ./configure
-          make erlfmt-check
           make dist
           chmod -R a+w * .
         '''

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -140,8 +140,9 @@ handle_all_dbs_info_req(Req) ->
 all_dbs_info_callback({meta, _Meta}, #vacc{resp = Resp0} = Acc) ->
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp0, "["),
     {ok, Acc#vacc{resp = Resp1}};
-all_dbs_info_callback({row, Row}, #vacc{resp = Resp0} = Acc)
-  when Acc#vacc.req#httpd.path_parts =:= [<<"_all_dbs">>] ->
+all_dbs_info_callback({row, Row}, #vacc{resp = Resp0} = Acc) when
+    Acc#vacc.req#httpd.path_parts =:= [<<"_all_dbs">>]
+->
     Prepend = couch_mrview_http:prepend_val(Acc),
     case couch_util:get_value(id, Row) of
         <<"_design", _/binary>> ->
@@ -150,8 +151,9 @@ all_dbs_info_callback({row, Row}, #vacc{resp = Resp0} = Acc)
             {ok, Resp1} = chttpd:send_delayed_chunk(Resp0, [Prepend, ?JSON_ENCODE(DbName)]),
             {ok, Acc#vacc{prepend = ",", resp = Resp1}}
     end;
-all_dbs_info_callback({row, Row}, #vacc{resp = Resp0} = Acc)
-  when Acc#vacc.req#httpd.path_parts =:= [<<"_dbs_info">>] ->
+all_dbs_info_callback({row, Row}, #vacc{resp = Resp0} = Acc) when
+    Acc#vacc.req#httpd.path_parts =:= [<<"_dbs_info">>]
+->
     Prepend = couch_mrview_http:prepend_val(Acc),
     DbName = couch_util:get_value(id, Row),
     case chttpd_util:get_db_info(DbName) of
@@ -173,7 +175,7 @@ all_dbs_info_callback({error, Reason}, #vacc{resp = Resp0} = Acc) ->
     {ok, Resp1} = chttpd:send_delayed_error(Resp0, Reason),
     {ok, Acc#vacc{resp = Resp1}}.
 
-handle_dbs_info_req(#httpd{method='GET'}=Req) ->
+handle_dbs_info_req(#httpd{method = 'GET'} = Req) ->
     handle_all_dbs_info_req(Req);
 handle_dbs_info_req(#httpd{method = 'POST'} = Req) ->
     chttpd:validate_ctype(Req, "application/json"),

--- a/src/chttpd/test/eunit/chttpd_dbs_info_test.erl
+++ b/src/chttpd/test/eunit/chttpd_dbs_info_test.erl
@@ -56,8 +56,11 @@ mock_timeout() ->
     meck:expect(fabric_util, request_timeout, fun() -> 0 end).
 
 mock_db_not_exist() ->
-    meck:expect(chttpd_util, get_db_info,
-        fun(_) -> {error, database_does_not_exist} end).
+    meck:expect(
+        chttpd_util,
+        get_db_info,
+        fun(_) -> {error, database_does_not_exist} end
+    ).
 
 dbs_info_test_() ->
     {
@@ -93,132 +96,162 @@ dbs_info_test_() ->
         }
     }.
 
-
 get_db_info_should_return_db_info(_) ->
     DbInfo = fabric:get_db_info("db1"),
     ?_assertEqual(DbInfo, chttpd_util:get_db_info("db1")).
 
-
 get_db_info_should_return_error_when_db_not_exist(_) ->
-    ?_assertEqual({error, database_does_not_exist},
-        chttpd_util:get_db_info("db_not_exist")).
-
+    ?_assertEqual(
+        {error, database_does_not_exist},
+        chttpd_util:get_db_info("db_not_exist")
+    ).
 
 get_db_info_should_return_error_when_time_out(_) ->
     ?_test(
         begin
             mock_timeout(),
             ?assertEqual({error, timeout}, chttpd_util:get_db_info("db1"))
-        end).
-
+        end
+    ).
 
 should_return_error_for_put_dbs_info(Url) ->
     ?_test(
         begin
-            {ok, Code, _, ResultBody} = test_request:put(Url
-            ++ "_dbs_info", [?CONTENT_JSON, ?AUTH], ""),
+            {ok, Code, _, ResultBody} = test_request:put(
+                Url ++
+                    "_dbs_info",
+                [?CONTENT_JSON, ?AUTH],
+                ""
+            ),
             {Body} = jiffy:decode(ResultBody),
             ?assertEqual(405, Code),
-            ?assertEqual(<<"method_not_allowed">>,
-                couch_util:get_value(<<"error">>, Body))
-        end).
-
+            ?assertEqual(
+                <<"method_not_allowed">>,
+                couch_util:get_value(<<"error">>, Body)
+            )
+        end
+    ).
 
 should_return_dbs_info_for_get_dbs_info(Url) ->
     ?_test(
         begin
-            {ok, _, _, ResultBody} = test_request:get(Url
-            ++ "_dbs_info", [?CONTENT_JSON, ?AUTH]),
+            {ok, _, _, ResultBody} = test_request:get(
+                Url ++
+                    "_dbs_info",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             BodyJson = jiffy:decode(ResultBody),
             {Db1Data} = lists:nth(1, BodyJson),
             {Db2Data} = lists:nth(2, BodyJson),
             ?assertEqual(2, length(BodyJson)),
             ?assertEqual(<<"db1">>, couch_util:get_value(<<"key">>, Db1Data)),
             ?assertEqual(<<"db2">>, couch_util:get_value(<<"key">>, Db2Data))
-        end).
-
+        end
+    ).
 
 should_return_nothing_when_db_not_exist_for_get_dbs_info(Url) ->
     ?_test(
         begin
             mock_db_not_exist(),
-            {ok, Code, _, ResultBody} = test_request:get(Url
-            ++ "_dbs_info", [?CONTENT_JSON, ?AUTH]),
+            {ok, Code, _, ResultBody} = test_request:get(
+                Url ++
+                    "_dbs_info",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             BodyJson = jiffy:decode(ResultBody),
             ?assertEqual(200, Code),
             ?assertEqual([], BodyJson)
-        end).
-
+        end
+    ).
 
 should_return_500_time_out_when_time_is_not_enough_for_get_dbs_info(Url) ->
     ?_test(
         begin
             mock_timeout(),
-            {ok, Code, _, ResultBody} = test_request:get(Url ++ "_dbs_info"
-                ++ "?buffer_response=true", [?CONTENT_JSON, ?AUTH]),
+            {ok, Code, _, ResultBody} = test_request:get(
+                Url ++ "_dbs_info" ++
+                    "?buffer_response=true",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             {Body} = jiffy:decode(ResultBody),
             ?assertEqual(500, Code),
             ?assertEqual(<<"timeout">>, couch_util:get_value(<<"error">>, Body))
-        end).
-
+        end
+    ).
 
 should_return_db2_for_get_dbs_info_with_descending(Url) ->
     ?_test(
         begin
-            {ok, _, _, ResultBody} = test_request:get(Url ++ "_dbs_info"
-                ++ "?descending=true", [?CONTENT_JSON, ?AUTH]),
+            {ok, _, _, ResultBody} = test_request:get(
+                Url ++ "_dbs_info" ++
+                    "?descending=true",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             BodyJson = jiffy:decode(ResultBody),
             {Db1Data} = lists:nth(1, BodyJson),
             {Db2Data} = lists:nth(2, BodyJson),
             ?assertEqual(2, length(BodyJson)),
             ?assertEqual(<<"db2">>, couch_util:get_value(<<"key">>, Db1Data)),
             ?assertEqual(<<"db1">>, couch_util:get_value(<<"key">>, Db2Data))
-        end).
-
+        end
+    ).
 
 should_return_db1_for_get_dbs_info_with_limit_1(Url) ->
     ?_test(
         begin
-            {ok, _, _, ResultBody} = test_request:get(Url ++ "_dbs_info"
-                ++ "?limit=1", [?CONTENT_JSON, ?AUTH]),
+            {ok, _, _, ResultBody} = test_request:get(
+                Url ++ "_dbs_info" ++
+                    "?limit=1",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             BodyJson = jiffy:decode(ResultBody),
             {DbData} = lists:nth(1, BodyJson),
             ?assertEqual(1, length(BodyJson)),
             ?assertEqual(<<"db1">>, couch_util:get_value(<<"key">>, DbData))
-        end).
-
+        end
+    ).
 
 should_return_db2_for_get_dbs_info_with_skip_1(Url) ->
     ?_test(
         begin
-            {ok, _, _, ResultBody} = test_request:get(Url ++ "_dbs_info"
-                ++ "?skip=1", [?CONTENT_JSON, ?AUTH]),
+            {ok, _, _, ResultBody} = test_request:get(
+                Url ++ "_dbs_info" ++
+                    "?skip=1",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             BodyJson = jiffy:decode(ResultBody),
             {DbData} = lists:nth(1, BodyJson),
             ?assertEqual(1, length(BodyJson)),
             ?assertEqual(<<"db2">>, couch_util:get_value(<<"key">>, DbData))
-        end).
-
+        end
+    ).
 
 should_return_dbs_info_with_correct_start_end_key(Url) ->
     ?_test(
         begin
-            {ok, _, _, ResultBody} = test_request:get(Url ++ "_dbs_info"
-                ++ "?startkey=\"db1\"&endkey=\"db2\"", [?CONTENT_JSON, ?AUTH]),
+            {ok, _, _, ResultBody} = test_request:get(
+                Url ++ "_dbs_info" ++
+                    "?startkey=\"db1\"&endkey=\"db2\"",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             BodyJson = jiffy:decode(ResultBody),
             {DbData} = lists:nth(1, BodyJson),
             ?assertEqual(2, length(BodyJson)),
             ?assertEqual(<<"db1">>, couch_util:get_value(<<"key">>, DbData))
-        end).
-
+        end
+    ).
 
 should_return_empty_list_with_wrong_start_end_key(Url) ->
     ?_test(
         begin
-            {ok, _, _, ResultBody} = test_request:get(Url ++ "_dbs_info"
-                ++ "?startkey=\"db3\"&endkey=\"db4\"", [?CONTENT_JSON, ?AUTH]),
+            {ok, _, _, ResultBody} = test_request:get(
+                Url ++ "_dbs_info" ++
+                    "?startkey=\"db3\"&endkey=\"db4\"",
+                [?CONTENT_JSON, ?AUTH]
+            ),
             ?assertEqual([], jiffy:decode(ResultBody))
-        end).
+        end
+    ).
 
 should_return_dbs_info_for_single_db(Url) ->
     ?_test(begin

--- a/src/couch/test/eunit/couchdb_vhosts_tests.erl
+++ b/src/couch/test/eunit/couchdb_vhosts_tests.erl
@@ -33,11 +33,12 @@ setup() ->
             {<<"_id">>, <<"_design/doc1">>},
             {<<"shows">>,
                 {[
-                    {<<"test">>,
-                        <<"function(doc, req) {\n"
+                    {<<"test">>, <<
+                        "function(doc, req) {\n"
                         "            return { json: {\n"
                         "                    requested_path: '/' + req.requested_path.join('/'),\n"
-                        "                    path: '/' + req.path.join('/')}};}">>}
+                        "                    path: '/' + req.path.join('/')}};}"
+                    >>}
                 ]}},
             {<<"rewrites">>, [
                 {[

--- a/src/couch_replicator/test/eunit/couch_replicator_filtered_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_filtered_tests.erl
@@ -21,12 +21,13 @@
         {<<"_id">>, <<"_design/filter_ddoc">>},
         {<<"filters">>,
             {[
-                {<<"testfilter">>,
-                    <<"\n"
+                {<<"testfilter">>, <<
+                    "\n"
                     "            function(doc, req){if (doc.class == 'mammal') return true;}\n"
-                    "        ">>},
-                {<<"queryfilter">>,
-                    <<"\n"
+                    "        "
+                >>},
+                {<<"queryfilter">>, <<
+                    "\n"
                     "            function(doc, req) {\n"
                     "                if (doc.class && req.query.starts) {\n"
                     "                    return doc.class.indexOf(req.query.starts) === 0;\n"
@@ -35,20 +36,22 @@
                     "                    return false;\n"
                     "                }\n"
                     "            }\n"
-                    "        ">>}
+                    "        "
+                >>}
             ]}},
         {<<"views">>,
             {[
                 {<<"mammals">>,
                     {[
-                        {<<"map">>,
-                            <<"\n"
+                        {<<"map">>, <<
+                            "\n"
                             "                function(doc) {\n"
                             "                    if (doc.class == 'mammal') {\n"
                             "                        emit(doc._id, null);\n"
                             "                    }\n"
                             "                }\n"
-                            "            ">>}
+                            "            "
+                        >>}
                     ]}}
             ]}}
     ]}

--- a/src/couch_replicator/test/eunit/couch_replicator_retain_stats_between_job_runs.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_retain_stats_between_job_runs.erl
@@ -262,13 +262,15 @@ scheduler_jobs() ->
     maps:get(<<"jobs">>, Json).
 
 vdu() ->
-    <<"function(newDoc, oldDoc, userCtx) {\n"
-    "        if(newDoc.nope === true) {\n"
-    "            throw({forbidden: 'nope'});\n"
-    "        } else {\n"
-    "            return;\n"
-    "        }\n"
-    "    }">>.
+    <<
+        "function(newDoc, oldDoc, userCtx) {\n"
+        "        if(newDoc.nope === true) {\n"
+        "            throw({forbidden: 'nope'});\n"
+        "        } else {\n"
+        "            return;\n"
+        "        }\n"
+        "    }"
+    >>.
 
 add_vdu(DbName) ->
     DocProps = [


### PR DESCRIPTION
Previously, we ran it in the dist building stage. However, unlike in main, in 3.x that stage is run with Erlang 20 where erlfmt check is skipped. To fix that we run erlfmt in a separate stage with Erlang 23.

The second commit re-runs erlfmt and fixes a few  more files which slipped through the cracks one set of files is from a recent PR, the others are some test modules which had been skipped during the initial reformatting.

This is the output and failure without the second commit to prove that erlfmt-check would fail:
```
[2021-12-13T05:01:59.058Z] + make erlfmt-check
[2021-12-13T05:01:59.058Z] ERLFMT_PATH=/home/****/workspace/****-cm1_PullRequests_PR-3872/bin/erlfmt python3 dev/format_check.py
[2021-12-13T05:02:15.195Z]   > Checking formatting...
[2021-12-13T05:02:15.195Z]   > src/chttpd/src/chttpd_stats.erl:52:9: syntax error before: Fmt
[2021-12-13T05:02:15.195Z]   > [warn] src/chttpd/src/chttpd_misc.erl
[2021-12-13T05:02:15.195Z]   > src/chttpd/src/chttpd.erl:353:9: syntax error before: '{'
[2021-12-13T05:02:15.195Z]   > src/chttpd/src/chttpd.erl:361:13: syntax error before: send_error
[2021-12-13T05:02:15.195Z]   > src/chttpd/src/chttpd.erl:394:9: syntax error before: '{'
[2021-12-13T05:02:15.195Z]   > src/chttpd/src/chttpd.erl:405:9: syntax error before: '{'
[2021-12-13T05:02:15.195Z]   > [warn] Code style issues found in the above file(s). Forgot to run erlfmt?
[2021-12-13T05:02:15.195Z]   > 
[2021-12-13T05:02:15.195Z]   > Checking formatting...
[2021-12-13T05:02:15.195Z]   > [warn] src/chttpd/test/eunit/chttpd_dbs_info_test.erl
[2021-12-13T05:02:15.195Z]   > [warn] Code style issues found in the above file(s). Forgot to run erlfmt?
[2021-12-13T05:02:15.195Z]   > 
[2021-12-13T05:02:15.195Z]   > Checking formatting...
[2021-12-13T05:02:15.195Z]   > [warn] src/couch/test/eunit/couchdb_vhosts_tests.erl
[2021-12-13T05:02:15.195Z]   > [warn] Code style issues found in the above file(s). Forgot to run erlfmt?
[2021-12-13T05:02:15.195Z]   > 
[2021-12-13T05:02:15.195Z]   > Checking formatting...
[2021-12-13T05:02:15.195Z]   > [warn] src/couch_replicator/test/eunit/couch_replicator_filtered_tests.erl
[2021-12-13T05:02:15.195Z]   > [warn] src/couch_replicator/test/eunit/couch_replicator_retain_stats_between_job_runs.erl
[2021-12-13T05:02:15.195Z]   > [warn] Code style issues found in the above file(s). Forgot to run erlfmt?
[2021-12-13T05:02:15.195Z]   > 
[2021-12-13T05:02:15.195Z] 
[2021-12-13T05:02:15.195Z]  1 error for src/chttpd/src/*.erl
[2021-12-13T05:02:15.195Z] 
[2021-12-13T05:02:15.195Z]  1 error for src/chttpd/test/eunit/*.erl
[2021-12-13T05:02:15.195Z] 
[2021-12-13T05:02:15.195Z]  1 error for src/couch/test/eunit/*.erl
[2021-12-13T05:02:15.195Z] 
[2021-12-13T05:02:15.195Z]  1 error for src/couch_replicator/test/eunit/*.erl
[2021-12-13T05:02:15.195Z] make: *** [Makefile:207: erlfmt-check] Error 1
```

Closes: https://github.com/apache/couchdb/issues/3871
