### PR TITLE
Remove ERL_OPTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ help:
 
 
 .PHONY: couch
-# target: couch - Build CouchDB core, use ERL_OPTS to provide custom compiler's options
+# target: couch - Build CouchDB core, use ERL_COMPILER_OPTIONS to provide custom compiler's options
 couch: config.erl
 	@COUCHDB_VERSION=$(COUCHDB_VERSION) COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) $(REBAR) compile $(COMPILE_OPTS)
 	@cp src/couch/priv/couchjs bin/

--- a/Makefile.win
+++ b/Makefile.win
@@ -105,7 +105,7 @@ all: couch fauxton docs
 
 
 .PHONY: couch
-# target: couch - Build CouchDB core, use ERL_OPTS to provide custom compiler's options
+# target: couch - Build CouchDB core, use ERL_COMPILER_OPTIONS to provide custom compiler's options
 couch: config.erl
 	@set COUCHDB_VERSION=$(COUCHDB_VERSION) && set COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) && $(REBAR) compile $(COMPILE_OPTS)
 	@copy src\couch\priv\couchjs.exe bin

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -191,18 +191,13 @@ MakeDep = fun
         {AppName, ".*", {git, Url, Version}, Options}
 end.
 
-ErlOpts = case os:getenv("ERL_OPTS") of
-    false -> [];
-    Opts -> [list_to_atom(O) || O <- string:tokens(Opts, ",")]
-end.
-
 AddConfig = [
     {require_otp_vsn, "20|21|22|23|24"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},
     {lib_dirs, ["src"]},
-    {erl_opts, [{i, "../"}] ++ [{d, 'COUCHDB_ERLANG_VERSION', VerString}] ++ ErlOpts},
+    {erl_opts, [{i, "../"}, {d, 'COUCHDB_ERLANG_VERSION', VerString}]},
     {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]},
     {plugins, [eunit_plugin]},
     {dialyzer, [


### PR DESCRIPTION
## Overview

Since Erlang 19.0 there is an [ERL_COMPILER_OPTIONS](https://www.erlang.org/doc/man/compile.html#env_compiler_options-0) environment variable which the compiler will consult.

## Testing recommendations

Run `make clean && ERL_COMPILER_OPTIONS='[no_line_info,deterministic,no_debug_info]' make`.
Capture module-info from some module (something like `couch_db:module_info(compile).` perhaps). Then, run `make clean && make` and see if the changes took effect. With `no_debug_info` there should be almost no extra info shown.

## Related Issues or Pull Requests

Remove ERL_OPTS handling from rebar.config* scripts: https://github.com/apache/couchdb/issues/3841

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
