### PR TITLE
Enforce row limit in mango

### DIFF
--- a/src/mango/src/mango_cursor_special.erl
+++ b/src/mango/src/mango_cursor_special.erl
@@ -36,7 +36,8 @@ create(Db, Indexes, Selector, Opts) ->
     Composited = mango_cursor_view:composite_indexes(Indexes, FieldRanges),
     {Index, IndexRanges} = mango_cursor_view:choose_best_index(Db, Composited),
 
-    Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
+    MRLimit = mango_opts:mr_limit(couch_db:is_partitioned(Db)),
+    Limit = erlang:min(MRLimit, couch_util:get_value(limit, Opts, mango_opts:default_limit())),
     Skip = couch_util:get_value(skip, Opts, 0),
     Fields = couch_util:get_value(fields, Opts, all_fields),
     Bookmark = couch_util:get_value(bookmark, Opts),

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -120,7 +120,7 @@ base_args(#cursor{index = Idx, selector = Selector} = Cursor) ->
         extra = [
             {callback, {?MODULE, view_cb}},
             {selector, Selector},
-            {ignore_partition_query_limit, true}
+            {is_mango_query, true}
         ]
     }.
 

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -40,7 +40,8 @@ create(Db, Indexes, Selector, Opts) ->
     Composited = composite_indexes(Indexes, FieldRanges),
     {Index, IndexRanges} = choose_best_index(Db, Composited),
 
-    Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
+    MRLimit = mango_opts:mr_limit(couch_db:is_partitioned(Db)),
+    Limit = erlang:min(MRLimit, couch_util:get_value(limit, Opts, mango_opts:default_limit())),
     Skip = couch_util:get_value(skip, Opts, 0),
     Fields = couch_util:get_value(fields, Opts, all_fields),
     Bookmark = couch_util:get_value(bookmark, Opts),

--- a/src/mango/src/mango_opts.erl
+++ b/src/mango/src/mango_opts.erl
@@ -36,10 +36,12 @@
     validate_bulk_delete/1,
     validate_partitioned/1,
 
-    default_limit/0
+    default_limit/0,
+    mr_limit/1
 ]).
 
 -include("mango.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl").
 
 validate_idx_create({Props}) ->
     Opts = [
@@ -356,3 +358,8 @@ validate_opt(Name, [{validator, Fun} | Rest], Value) ->
 
 default_limit() ->
     config:get_integer("mango", "default_limit", 25).
+
+mr_limit(true) ->
+    config:get_integer("query_server_config", "partition_query_limit", ?MAX_VIEW_LIMIT);
+mr_limit(false) ->
+    config:get_integer("query_server_config", "query_limit", ?MAX_VIEW_LIMIT).

--- a/test/elixir/test/partition_mango_test.exs
+++ b/test/elixir/test/partition_mango_test.exs
@@ -552,7 +552,7 @@ defmodule PartitionMangoTest do
     create_partition_docs(db_name)
     create_index(db_name, ["value"])
 
-    # this is to test that we bypass partition_query_limit for mango
+    # this is to test that we enforce partition_query_limit for mango
     set_config({"query_server_config", "partition_query_limit", "1"})
 
     url = "/#{db_name}/_partition/foo/_find"
@@ -573,7 +573,7 @@ defmodule PartitionMangoTest do
 
     assert resp.status_code == 200
     partitions = get_partitions(resp)
-    assert length(partitions) == 3
+    assert length(partitions) == 1
     assert_correct_partition(partitions, "foo")
 
     %{:body => %{"bookmark" => bookmark}} = resp
@@ -595,7 +595,7 @@ defmodule PartitionMangoTest do
 
     assert resp.status_code == 200
     partitions = get_partitions(resp)
-    assert length(partitions) == 2
+    assert length(partitions) == 1
     assert_correct_partition(partitions, "foo")
   end
 


### PR DESCRIPTION
## Overview

We specify two config variables under query_server_config called partition_query_limit and query_limit. These are not enforced in the code since https://github.com/apache/couchdb/commit/b2f9cfaceb121bf391f25e5edc51ad75b71967b4 was merged in response to issue https://github.com/apache/couchdb/issues/2795.

The right fix is to move the enforcement to later in the mango execution sequence.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

 https://github.com/apache/couchdb/issues/2795

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
