### PR TITLE
Feat/support sm91 3.x from lostnet

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -158,18 +158,18 @@ eunit: couch
 exunit: export BUILDDIR = $(shell echo %cd%)
 exunit: export MIX_ENV=test
 exunit: export ERL_LIBS = $(shell echo %cd%)\src
-exunit: export ERL_AFLAGS = -config $(shell echo %cd%)/rel/files/eunit.config
+exunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 exunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 exunit: couch elixir-init setup-eunit elixir-check-formatted elixir-credo
 	@mix test --cover --trace $(EXUNIT_OPTS)
 
 setup-eunit: export BUILDDIR = $(shell pwd)
-setup-eunit: export ERL_AFLAGS = "-config $(shell echo %cd%)/rel/files/eunit.config")
+setup-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 setup-eunit:
 	@$(REBAR) setup_eunit 2> nul
 
 just-eunit: export BUILDDIR = $(shell pwd)
-just-eunit: export ERL_AFLAGS = "-config $(shell echo %cd%)/rel/files/eunit.config")
+just-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -17,8 +17,9 @@
 include version.mk
 
 SHELL=cmd.exe
-REBAR=bin\rebar.cmd
-ERLFMT=bin\erlfmt
+REBAR?=$(CURDIR)\bin\rebar.cmd
+PYTHON=python.exe
+ERLFMT?=$(CURDIR)\bin\erlfmt.cmd
 MAKE=make -f Makefile.win
 # REBAR?=$(shell where rebar.cmd)
 
@@ -77,7 +78,7 @@ DESTDIR=
 
 # Rebar options
 apps=
-skip_deps=folsom,meck,mochiweb,triq,proper,snappy,bcrypt,hyper
+skip_deps=folsom,meck,mochiweb,triq,proper,snappy,bcrypt,hyper,ibrowse,local
 suites=
 tests=
 
@@ -172,29 +173,31 @@ just-eunit: export ERL_AFLAGS = "-config $(shell echo %cd%)/rel/files/eunit.conf
 just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 
+erlfmt-check: export ERLFMT_PATH := $(ERLFMT)
 erlfmt-check:
-	ERLFMT_PATH=bin\erlfmt python3 dev\format_check.py
+	@$(PYTHON) dev\format_check.py
 
+erlfmt-format: export ERLFMT_PATH := $(ERLFMT)
 erlfmt-format:
-	ERLFMT_PATH=bin\erlfmt python3 dev\format_all.py
+	@$(PYTHON) dev\format_all.py
 
 .venv/bin/black:
-	@python.exe -m venv .venv
+	@$(PYTHON) -m venv .venv
 	@.venv\Scripts\pip3.exe install black || copy /b .venv\Scripts\black.exe +,,
 
 # Python code formatter - only runs if we're on Python 3.6 or greater
 python-black: .venv/bin/black
-	@python.exe -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
+	@$(PYTHON) -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
 		echo 'Python formatter not supported on Python < 3.6; check results on a newer platform'
-	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
+	@$(PYTHON) -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe --check \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/erlfmt|src/rebar/pr2relnotes.py|src/fauxton" \
 		build-aux dev\run dev\format_*.py src\mango\test src\docs\src\conf.py src\docs\ext .
 
 python-black-update: .venv/bin/black
-	@python.exe -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
+	@$(PYTHON) -c "import sys; exit(1 if sys.version_info < (3,6) else 0)" || \
 		echo 'Python formatter not supported on Python < 3.6; check results on a newer platform'
-	@python.exe -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
+	@$(PYTHON) -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		.venv\Scripts\black.exe \
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/erlfmt|src/rebar/pr2relnotes.py|src/fauxton" \
 		build-aux dev\run dev\format_*.py src\mango\test src\docs\src\conf.py src\docs\ext .

--- a/configure
+++ b/configure
@@ -224,9 +224,9 @@ parse_opts() {
 
 parse_opts $@
 
-if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" != "1.8.5" ]
+if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" = "60" ]
 then
-  echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use 1.8.5 instead."
+  echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use another version instead."
   exit 1
 fi
 

--- a/src/couch/priv/couch_js/86/main.cpp
+++ b/src/couch/priv/couch_js/86/main.cpp
@@ -287,17 +287,9 @@ int runWithContext(JSContext* cx, couch_args* args) {
 
         // Compile and run
         JS::CompileOptions options(cx);
-        options.setFileAndLine(filename, 1);
         JS::RootedScript script(cx);
-        FILE* fp;
 
-        fp = fopen(args->scripts[i], "r");
-        if(fp == NULL) {
-            fprintf(stderr, "Failed to read file: %s\n", filename);
-            return 3;
-        }
-        script = JS::CompileUtf8File(cx, options, fp);
-        fclose(fp);
+        script = JS::CompileUtf8Path(cx, options, filename);
         if (!script) {
             JS::RootedValue exc(cx);
             if(!JS_GetPendingException(cx, &exc)) {

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -155,8 +155,13 @@ end.
         };
     {unix, _} when SMVsn == "91" ->
         {
-            "-DXP_UNIX -I/usr/include/mozjs-91 -I/usr/local/include/mozjs-91 -I/opt/homebrew/include/mozjs-91/ -std=c++17 -Wno-invalid-offsetof",
-            "-L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-91 -lm"
+            "$CFLAGS -DXP_UNIX -I/usr/include/mozjs-91 -I/usr/local/include/mozjs-91 -I/opt/homebrew/include/mozjs-91/ -std=c++17 -Wno-invalid-offsetof",
+            "$LDFLAGS -L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-91 -lm"
+        };
+    {win32, _} when SMVsn == "91" ->
+        {
+            "/std:c++17 /DXP_WIN",
+            "$LDFLAGS mozjs-91.lib"
         }
 end.
 
@@ -189,7 +194,7 @@ IcuDarwinEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/opt/icu4c/include -I/opt/home
 IcuBsdEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/include"},
              {"LDFLAGS", "-L/usr/local/lib"}].
 IcuWinEnv = [{"CFLAGS", "$DRV_CFLAGS /DXP_WIN"},
-             {"LDFLAGS", "icuin.lib icudt.lib icuuc.lib"}].
+             {"LDFLAGS", "$LDFLAGS icuin.lib icudt.lib icuuc.lib"}].
 
 ComparePath = "priv/couch_ejson_compare.so".
 CompareSrc = ["priv/couch_ejson_compare/*.c"].


### PR DESCRIPTION
## Overview

  Supporting changes necessary to build/test spidermonkey 91esr on windows and linux/arm64 for the 3.x.

## Testing recommendations

  - Linux/AMD_64: normal CI Tests
  - Windows I am using the following:
https://github.com/lostnet/couchdb-glazier/blob/main/.github/workflows/ci.yml
  - Linux/Arm64: I previously [tested 68/78](https://github.com/lostnet/couchdb-nix-debug) and yocto seems to be using 60, hopefully with arm specific patches.

## Related Issues or Pull Requests

 - #3873
 - #3149
 - Passing the fopen'ed JS file to mozjs was fragile due to [MS Boundaries](https://docs.microsoft.com/en-us/cpp/c-runtime-library/potential-errors-passing-crt-objects-across-dll-boundaries?view=msvc-170). I have moved JS::CompileUtf8File to JS::CompileUtf8Path which implements the logic within mozjs, but will result in lumping failures to fopen with other compile errors that return error 1 instead of error 3.

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
