### PR TITLE
Feat/support sm91 4.x from lostnet

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/cache@v2
       id: wgetcache
       with:
-        key: wgetcache-${{env.FIREFOX_VERSION}}-${{env.FDB_VERSION}}
+        key: wgetcache-${{env.FIREFOX_VERSION}}-${{env.FDB_VERSION}}-${{ runner.os }}
         path: |
           firefox-${{env.FIREFOX_VERSION}}esr.source.tar.xz
           foundationdb-clients_${{env.FDB_VERSION}}-1_amd64.deb
@@ -32,8 +32,8 @@ jobs:
     - name: wget moz
       if: steps.wgetcache.outputs.cache-hit != 'true'
       run: |
-        wget -nv -S https://www.foundationdb.org/downloads/${{env.FDB_VERSION}}/ubuntu/installers/foundationdb-clients_${{env.FDB_VERSION}}-1_amd64.deb
-        wget -nv -S https://www.foundationdb.org/downloads/${{env.FDB_VERSION}}/ubuntu/installers/foundationdb-server_${{env.FDB_VERSION}}-1_amd64.deb
+        wget -nv -S https://github.com/apple/foundationdb/releases/download/${{env.FDB_VERSION}}/foundationdb-clients_${{env.FDB_VERSION}}-1_amd64.deb
+        wget -nv -S https://github.com/apple/foundationdb/releases/download/${{env.FDB_VERSION}}/foundationdb-server_${{env.FDB_VERSION}}-1_amd64.deb
         wget -nv https://download.cdn.mozilla.net/pub/firefox/releases/${{env.FIREFOX_VERSION}}esr/source/firefox-${{env.FIREFOX_VERSION}}esr.source.tar.xz
 
     - name: couch checkout

--- a/Makefile.win
+++ b/Makefile.win
@@ -147,7 +147,7 @@ endif
 .PHONY: eunit
 # target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
 eunit: export BUILDDIR = $(shell echo %cd%)
-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
+eunit: export ERL_AFLAGS = -config rel/files/eunit.config
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 eunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 eunit: couch
@@ -159,7 +159,7 @@ eunit: couch
 exunit: export BUILDDIR = $(shell echo %cd%)
 exunit: export MIX_ENV=test
 exunit: export ERL_LIBS = $(shell echo %cd%)\src
-exunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
+exunit: export ERL_AFLAGS = -config rel/files/eunit.config
 exunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 exunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 exunit: couch elixir-init setup-eunit elixir-check-formatted elixir-credo
@@ -171,7 +171,7 @@ setup-eunit:
 	@$(REBAR) setup_eunit 2> nul
 
 just-eunit: export BUILDDIR = $(shell pwd)
-just-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
+just-eunit: export ERL_AFLAGS = -config rel/files/eunit.config
 just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -159,19 +159,19 @@ eunit: couch
 exunit: export BUILDDIR = $(shell echo %cd%)
 exunit: export MIX_ENV=test
 exunit: export ERL_LIBS = $(shell echo %cd%)\src
-exunit: export ERL_AFLAGS = -config $(shell echo %cd%)/rel/files/eunit.config
+exunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 exunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 exunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 exunit: couch elixir-init setup-eunit elixir-check-formatted elixir-credo
 	@mix test --cover --trace $(EXUNIT_OPTS)
 
 setup-eunit: export BUILDDIR = $(shell pwd)
-setup-eunit: export ERL_AFLAGS = "-config $(shell echo %cd%)/rel/files/eunit.config")
+setup-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 setup-eunit:
 	@$(REBAR) setup_eunit 2> nul
 
 just-eunit: export BUILDDIR = $(shell pwd)
-just-eunit: export ERL_AFLAGS = "-config $(shell echo %cd%)/rel/files/eunit.config")
+just-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
 just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -147,7 +147,7 @@ endif
 .PHONY: eunit
 # target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
 eunit: export BUILDDIR = $(shell echo %cd%)
-eunit: export ERL_AFLAGS = -config rel/files/eunit.config
+eunit: export ERL_AFLAGS = "-config rel/files/eunit.config"
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 eunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 eunit: couch
@@ -159,19 +159,19 @@ eunit: couch
 exunit: export BUILDDIR = $(shell echo %cd%)
 exunit: export MIX_ENV=test
 exunit: export ERL_LIBS = $(shell echo %cd%)\src
-exunit: export ERL_AFLAGS = -config rel/files/eunit.config
+exunit: export ERL_AFLAGS = "-config rel/files/eunit.config"
 exunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 exunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 exunit: couch elixir-init setup-eunit elixir-check-formatted elixir-credo
 	@mix test --cover --trace $(EXUNIT_OPTS)
 
-setup-eunit: export BUILDDIR = $(shell pwd)
-setup-eunit: export ERL_AFLAGS = $(shell echo "-config rel/files/eunit.config")
+setup-eunit: export BUILDDIR = $(shell echo %cd%)
+setup-eunit: export ERL_AFLAGS = "-config rel/files/eunit.config"
 setup-eunit:
 	@$(REBAR) setup_eunit 2> nul
 
-just-eunit: export BUILDDIR = $(shell pwd)
-just-eunit: export ERL_AFLAGS = -config rel/files/eunit.config
+just-eunit: export BUILDDIR = $(shell echo %cd%)
+just-eunit: export ERL_AFLAGS = "-config rel/files/eunit.config"
 just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 

--- a/configure
+++ b/configure
@@ -211,9 +211,9 @@ parse_opts() {
 
 parse_opts $@
 
-if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" != "1.8.5" ]
+if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" = "60" ]
 then
-  echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use 1.8.5 instead."
+  echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use another version instead."
   exit 1
 fi
 

--- a/src/couch/priv/couch_js/86/main.cpp
+++ b/src/couch/priv/couch_js/86/main.cpp
@@ -287,17 +287,9 @@ int runWithContext(JSContext* cx, couch_args* args) {
 
         // Compile and run
         JS::CompileOptions options(cx);
-        options.setFileAndLine(filename, 1);
         JS::RootedScript script(cx);
-        FILE* fp;
 
-        fp = fopen(args->scripts[i], "r");
-        if(fp == NULL) {
-            fprintf(stderr, "Failed to read file: %s\n", filename);
-            return 3;
-        }
-        script = JS::CompileUtf8File(cx, options, fp);
-        fclose(fp);
+        script = JS::CompileUtf8Path(cx, options, filename);
         if (!script) {
             JS::RootedValue exc(cx);
             if(!JS_GetPendingException(cx, &exc)) {

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -155,8 +155,13 @@ end.
         };
     {unix, _} when SMVsn == "91" ->
         {
-            "-DXP_UNIX -I/usr/include/mozjs-91 -I/usr/local/include/mozjs-91 -I/opt/homebrew/include/mozjs-91/ -std=c++17 -Wno-invalid-offsetof",
-            "-L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-91 -lm"
+            "$CFLAGS -DXP_UNIX -I/usr/include/mozjs-91 -I/usr/local/include/mozjs-91 -I/opt/homebrew/include/mozjs-91/ -std=c++17 -Wno-invalid-offsetof",
+            "$LDFLAGS -L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-91 -lm"
+        };
+    {win32, _} when SMVsn == "91" ->
+        {
+            "/std:c++17 /DXP_WIN",
+            "$LDFLAGS mozjs-91.lib"
         }
 end.
 
@@ -191,7 +196,7 @@ IcuDarwinEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/opt/icu4c/include -I/opt/home
 IcuBsdEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/include"},
              {"LDFLAGS", "-L/usr/local/lib"}].
 IcuWinEnv = [{"CFLAGS", "$DRV_CFLAGS /DXP_WIN"},
-             {"LDFLAGS", "icuin.lib icudt.lib icuuc.lib"}].
+             {"LDFLAGS", "$LDFLAGS icuin.lib icudt.lib icuuc.lib"}].
 
 ComparePath = "priv/couch_ejson_compare.so".
 CompareSrc = ["priv/couch_ejson_compare/*.c"].


### PR DESCRIPTION
## Overview

Changes to couchdb4 with spidermonkey 91 to function on windows and hopefully linux/arm64 (I do not yet have a build of a recent enough fdb in my distribution to test on arm).

## Testing recommendations

For Windows it is necessary to install foundationdb and then edit the \bin\couchdb.cmd to add foundationdb's bin folder, then fauxton verify should pass.
[Reference binaries](https://github.com/lostnet/couchdb-glazier/releases/tag/msdeps7)

## Related Issues or Pull Requests

#3883 #3149

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
