### PR TITLE
Fix changes feed rewinds after a shard move with no subsequent db updates

### DIFF
--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ basename=`basename $0`
 
 PACKAGE_AUTHOR_NAME="The Apache Software Foundation"
 
-REBAR3_BRANCH="master"
+REBAR3_BRANCH="main"
 
 # TEST=0
 WITH_PROPER="true"


### PR DESCRIPTION
Previously, when a database shard is moved to a new node, and there are no subsequent updates, the changes feed sequence rewound to the previous epoch. In case of a first shard move, it would rewind to 0.

To fix the issue, update `owner_of/2` and `start_seq/3` functions to account for the case when epoch sequence can exactly match the current db update sequence.

Fixes #3885
