### PR TITLE
Fix stats endpoint

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -358,8 +358,25 @@ format_pid_stats(Mailboxes) ->
 get_distribution_stats() ->
     lists:map(
         fun({Node, Socket}) ->
-            {ok, Stats} = inet:getstat(Socket),
-            {Node, {Stats}}
+            try inet:getstat(Socket) of
+                {ok, Stats} ->
+                    {Node, {Stats}}
+            catch
+                _:_ ->
+                    {Node,
+                        {[
+                            {recv_oct, 0},
+                            {recv_cnt, 0},
+                            {recv_max, 0},
+                            {recv_avg, 0},
+                            {recv_dvi, 0},
+                            {send_oct, 0},
+                            {send_cnt, 0},
+                            {send_max, 0},
+                            {send_avg, 0},
+                            {send_pend, 0}
+                        ]}}
+            end
         end,
         erlang:system_info(dist_ctrl)
     ).


### PR DESCRIPTION
## Overview

When getting the distribution stats, we get a list of all the connected nodes that we then loop over to get the statistics. While looping, one of the nodes can become unresponsive or offline during that check which results in `{error, einval}`. This will be more of an issue on larger clusters as there is more of a time window for the initial acquisition of open sockets and the iteration of checking each.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
