### PR TITLE
Update Jenkins Erlang versions, add 24

### DIFF
--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -39,7 +39,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'Jenkins User'
     GIT_COMMITTER_EMAIL = 'couchdb@apache.org'
     // Parameters for the matrix build
-    DOCKER_IMAGE = 'apache/couchdbci-debian:bullseye-erlang-all'
+    DOCKER_IMAGE = 'apache/couchdbci-debian:bullseye-erlang-all-1'
     // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -39,7 +39,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'Jenkins User'
     GIT_COMMITTER_EMAIL = 'couchdb@apache.org'
     // Parameters for the matrix build
-    DOCKER_IMAGE = 'apache/couchdbci-debian:buster-erlang-all'
+    DOCKER_IMAGE = 'apache/couchdbci-debian:bullseye-erlang-all'
     // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -50,7 +50,7 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    LOW_ERLANG_VER = '21.3.8.22'
+    LOW_ERLANG_VER = '21.3.8.24'
   }
 
   options {
@@ -108,8 +108,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            // kerl can't build 24 yet
-            values '21.3.8.22', '22.3.4.17', '23.3.1'
+            values '21.3.8.24', '22.3.4.24', '23.3.4.10', '24.2'
           }
         }
 

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -21,7 +21,7 @@ cd build
 tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz
 cd apache-couchdb-*
 . /usr/local/kerl/${ERLANG_VERSION}/activate
-./configure --spidermonkey-version 60
+./configure
 make check || (make build-report && false)
 '''
 
@@ -51,6 +51,9 @@ pipeline {
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
     LOW_ERLANG_VER = '21.3.8.24'
+
+    // Ensure that the SpiderMonkey version is appropriate for the $DOCKER_IMAGE
+    SM_VSN = '78'
   }
 
   options {


### PR DESCRIPTION
## Overview

Just bumping the patch releases we use to test PRs against, and adding Erlang 24 to the mix.

## Testing recommendations

Jenkins