### PR TITLE
Use Debian Stable, add Erlang 24 to CI

### DIFF
--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -20,7 +20,6 @@ mkdir build
 cd build
 tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz
 cd apache-couchdb-*
-. /usr/local/kerl/${ERLANG_VERSION}/activate
 ./configure
 make check || (make build-report && false)
 '''
@@ -39,7 +38,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'Jenkins User'
     GIT_COMMITTER_EMAIL = 'couchdb@apache.org'
     // Parameters for the matrix build
-    DOCKER_IMAGE = 'apache/couchdbci-debian:bullseye-erlang-all-1'
+    DOCKER_IMAGE_BASE = 'apache/couchdbci-debian:erlang'
     // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly
@@ -50,14 +49,11 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    LOW_ERLANG_VER = '20.3.8.26'
+    LOW_ERLANG_VER = '20'
 
     // erlfmt doesn't run with the lowest erlang version so we run it in a
     // separate stage with a higher erlang version.
-    ERLFMT_ERLANG_VER = '23.3.4.10'
-
-    // Ensure that the SpiderMonkey version is appropriate for the $DOCKER_IMAGE
-     SM_VSN = '78'
+    ERLFMT_ERLANG_VER = '23'
   }
 
   options {
@@ -74,7 +70,7 @@ pipeline {
     stage('erlfmt') {
       agent {
         docker {
-          image "${DOCKER_IMAGE}"
+          image "${DOCKER_IMAGE_BASE}-${ERLFMT_ERLANG_VER}"
           label 'docker'
           args "${DOCKER_ARGS}"
           registryUrl 'https://docker.io/'
@@ -88,7 +84,6 @@ pipeline {
         sh '''
           set
           rm -rf apache-couchdb-*
-          . /usr/local/kerl/${ERLFMT_ERLANG_VER}/activate
           ./configure --skip-deps
           make erlfmt-check
         '''
@@ -105,7 +100,7 @@ pipeline {
     stage('Build Release Tarball') {
       agent {
         docker {
-          image "${DOCKER_IMAGE}"
+          image "${DOCKER_IMAGE_BASE}-${LOW_ERLANG_VER}"
           label 'docker'
           args "${DOCKER_ARGS}"
           registryUrl 'https://docker.io/'
@@ -119,7 +114,6 @@ pipeline {
         sh '''
           set
           rm -rf apache-couchdb-*
-          . /usr/local/kerl/${LOW_ERLANG_VER}/activate
           ./configure
           make dist
           chmod -R a+w * .
@@ -146,7 +140,33 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '20.3.8.26', '21.3.8.24', '22.3.4.24', '23.3.4.10', '24.2'
+            values '20', '21', '22', '23', '24'
+          }
+          axis {
+            name 'SM_VSN'
+            values '60', '78'
+          }
+        }
+        excludes {
+          exclude {
+            axis {
+              name 'ERLANG_VERSION'
+              values '20'
+            }
+            axis {
+              name 'SM_VSN'
+              notValues '60'
+            }
+          }
+          exclude {
+            axis {
+              name 'ERLANG_VERSION'
+              values '21', '22', '23', '24'
+            }
+            axis {
+              name 'SM_VSN'
+              notValues '78'
+            }
           }
         }
 
@@ -154,7 +174,7 @@ pipeline {
           stage('Build and Test') {
             agent {
               docker {
-                image "${DOCKER_IMAGE}"
+                image "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}"
                 label 'docker'
                 args "${DOCKER_ARGS}"
               }

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -21,7 +21,7 @@ cd build
 tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz
 cd apache-couchdb-*
 . /usr/local/kerl/${ERLANG_VERSION}/activate
-./configure --spidermonkey-version 60
+./configure
 make check || (make build-report && false)
 '''
 
@@ -39,7 +39,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'Jenkins User'
     GIT_COMMITTER_EMAIL = 'couchdb@apache.org'
     // Parameters for the matrix build
-    DOCKER_IMAGE = 'apache/couchdbci-debian:buster-erlang-all'
+    DOCKER_IMAGE = 'apache/couchdbci-debian:bullseye-erlang-all-1'
     // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly
@@ -54,7 +54,10 @@ pipeline {
 
     // erlfmt doesn't run with the lowest erlang version so we run it in a
     // separate stage with a higher erlang version.
-    ERLFMT_ERLANG_VER = '23.3.1'
+    ERLFMT_ERLANG_VER = '23.3.4.10'
+
+    // Ensure that the SpiderMonkey version is appropriate for the $DOCKER_IMAGE
+     SM_VSN = '78'
   }
 
   options {
@@ -143,7 +146,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '20.3.8.26', '21.3.8.22', '22.3.4.17', '23.3.1'
+            values '20.3.8.26', '21.3.8.24', '22.3.4.24', '23.3.4.10', '24.2'
           }
         }
 

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule CouchDBTest.Mixfile do
       {:jwtf, path: Path.expand("src/jwtf", __DIR__)},
       {:ibrowse,
        path: Path.expand("src/ibrowse", __DIR__), override: true, compile: false},
-      {:credo, "~> 1.5.4", only: [:dev, :test, :integration], runtime: false}
+      {:credo, "~> 1.5.6", only: [:dev, :test, :integration], runtime: false}
     ]
   end
 


### PR DESCRIPTION
## Overview

This PR switches away from using a single container image with multiple Erlang versions installed via kerl and instead uses specific images for each version of Erlang against which we want to test a PR.

It also relies on tags like '20', '21' ... '24' instead of specific Erlang versions, so we can push updated images with new patch releases without needing to also file a PR to modify the Jenkinsfile configuration. The "Update Docker Containers" Jenkins job may need a small tweak to ensure that we can pick up the updated images behind those tags.

The matrix we are testing PRs against after this change looks like

| Erlang | OS | Elixir | JS |
|-------|-------|-----| ------ |
| 20.3.8.26 | Debian 10 (Buster) | v1.9.4 | 60 |
| 21.3.8.24 | Debian 11 (Bullseye) | v1.11.4 | 78 |
| 22.3.4.24 | Debian 11 (Bullseye) | v1.12.3 | 78 | 
| 23.3.4.10 | Debian 11 (Bullseye) | v1.12.3 | 78 |
| 24.2 | Debian 11 (Bullseye) | v1.12.3 | 78 |

I _could_ hack in better support for Erlang 20 on Debian 11 but didn't bother. I encountered linker errors out of the box on Erlang 20 with gcc 10, and figured this was just one more reason to move towards dropping support for it rather than hacking in conditional usage of gcc 9 and/or putting in special linker flags (`-fcommon` probably would have done it).

## Testing recommendations

Jenkins
