### PR TITLE
Back port: Do not start test name with "test "

### DIFF
--- a/test/elixir/test/attachments_test.exs
+++ b/test/elixir/test/attachments_test.exs
@@ -313,7 +313,7 @@ defmodule AttachmentsTest do
   end
 
   @tag :with_db
-  test "test COUCHDB-497 - empty attachments", context do
+  test "COUCHDB-497 - empty attachments", context do
     db_name = context[:db_name]
 
     lorem_att = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "

--- a/test/elixir/test/design_docs_test.exs
+++ b/test/elixir/test/design_docs_test.exs
@@ -251,7 +251,7 @@ defmodule DesignDocsTest do
   end
 
   @tag :with_db
-  test "test that we get correct design doc info back", context do
+  test "that we get correct design doc info back", context do
     db_name = context[:db_name]
     {:ok, _} = create_doc(db_name, @design_doc)
 


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This is a back port of @kocolosk's work on main:

The code that generates suite.elixir will repreatedly strip the "test "
from the name of the test when writing the file, resulting in a mismatch
between the actual test name and what's in suite.elixir. You can see
this by searching for e.g. COUCHDB-497 in the suite file.

I tried using String.replace_prefix instead of String.replace_leading in
test_name() but that function seems to get called multiple times during
the test grouping. Simpler to just avoid naming the tests that way for
now.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

https://github.com/apache/couchdb/commit/e91779cbf122f5a822c884d89c1c55a44a548ee4

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
