### PR TITLE
Remove CI support for Ubuntu 16.04

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -288,51 +288,6 @@ pipeline {
           } // post
         } // stage
 
-        stage('Ubuntu Xenial') {
-          agent {
-            docker {
-              image 'apache/couchdbci-ubuntu:xenial-erlang-21.3.8.17-1'
-              label 'docker'
-              args "${DOCKER_ARGS}"
-              registryUrl 'https://docker.io/'
-              registryCredentialsId 'dockerhub_creds'
-            }
-          }
-          environment {
-            platform = 'xenial'
-            sm_ver = '1.8.5'
-          }
-          stages {
-            stage('Build from tarball & test') {
-              steps {
-                unstash 'tarball'
-                sh( script: build_and_test )
-              }
-              post {
-                always {
-                  junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
-                }
-              }
-            }
-            stage('Build CouchDB packages') {
-              steps {
-                sh( script: make_packages )
-                sh( script: cleanup_and_save )
-              }
-              post {
-                success {
-                  archiveArtifacts artifacts: 'pkgs/**', fingerprint: true
-                }
-              }
-            }
-          } // stages
-          post {
-            cleanup {
-              sh 'rm -rf ${WORKSPACE}/*'
-            }
-          } // post
-        } // stage
-
         stage('Ubuntu Bionic') {
           agent {
             docker {
@@ -714,8 +669,6 @@ pipeline {
             reprepro -b couchdb-pkg/repo includedeb stretch pkgs/stretch/*.deb
             cp js/debian-buster/*.deb pkgs/stretch
             reprepro -b couchdb-pkg/repo includedeb buster pkgs/buster/*.deb
-            cp js/ubuntu-xenial/*.deb pkgs/xenial
-            reprepro -b couchdb-pkg/repo includedeb xenial pkgs/xenial/*.deb
             cp js/ubuntu-bionic/*.deb pkgs/bionic
             reprepro -b couchdb-pkg/repo includedeb bionic pkgs/bionic/*.deb
             reprepro -b couchdb-pkg/repo includedeb focal pkgs/focal/*.deb


### PR DESCRIPTION
## Overview

Remove Ubuntu Xenial from the CI matrix as discussed on the ML.
