### PR TITLE
Improve CI pipeline for PRs

### DIFF
--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -12,17 +12,6 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-build_and_test = '''
-mkdir -p ${COUCHDB_IO_LOG_DIR} ${ERLANG_VERSION}
-cd ${ERLANG_VERSION}
-rm -rf build
-mkdir build
-cd build
-tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz
-cd apache-couchdb-*
-./configure
-make check || (make build-report && false)
-'''
 
 pipeline {
 
@@ -49,7 +38,10 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    MIN_ERLANG_VERSION = '21'
+    MINIMUM_ERLANG_VERSION = '21'
+
+    // Ensure that the SpiderMonkey version is appropriate for the $DOCKER_IMAGE
+    SM_VSN = '78'
   }
 
   options {
@@ -65,7 +57,7 @@ pipeline {
     stage('Build Release Tarball') {
       agent {
         docker {
-          image "${DOCKER_IMAGE_BASE}-${MIN_ERLANG_VERSION}"
+          image "${DOCKER_IMAGE_BASE}-${MINIMUM_ERLANG_VERSION}"
           label 'docker'
           args "${DOCKER_ARGS}"
           registryUrl 'https://docker.io/'
@@ -74,33 +66,25 @@ pipeline {
       }
       steps {
         timeout(time: 15, unit: "MINUTES") {
-          sh '''
-            set
-            rm -rf apache-couchdb-*
-            ./configure
-            make erlfmt-check
-            make dist
-            chmod -R a+w * .
-          '''
+          sh( script: 'rm -rf apache-couchdb-*', label: 'Clean out workspace' )
+          sh( script: './configure', label: 'Retrieve dependencies and configure build system' )
+          sh( script: 'make erlfmt-check', label: 'Verify Erlang coding style' )
+          sh( script: 'make elixir-check-formatted', label: 'Verify Elixir coding style' )
+          sh( script: 'make dist', label: 'Build self-contained release' )
         }
       }
       post {
         success {
-          stash includes: 'apache-couchdb-*.tar.gz', name: 'tarball'
+          stash includes: 'apache-couchdb-*.tar.gz', name: 'release-tarball'
         }
         cleanup {
           // UGH see https://issues.jenkins-ci.org/browse/JENKINS-41894
-          sh 'rm -rf ${WORKSPACE}/*'
+          sh( script: 'rm -rf ${WORKSPACE}/*', label: 'Clean up after ourselves' )
         }
       }
     } // stage Build Release Tarball
 
-    // TODO Rework once Improved Docker Pipeline Engine is released
-    // https://issues.jenkins-ci.org/browse/JENKINS-47962
-    // https://issues.jenkins-ci.org/browse/JENKINS-48050
-
     stage('Make Check') {
-
       matrix {
         axes {
           axis {
@@ -123,19 +107,36 @@ pipeline {
             }
             steps {
               timeout(time: 90, unit: "MINUTES") {
-                unstash 'tarball'
-                sh( script: build_and_test )
+                echo "Building CouchDB PR using Erlang ${ERLANG_VERSION} and SpiderMonkey ${SM_VSN}"
+                sh( script: "rm -rf build-${ERLANG_VERSION} apache-couchdb-*", label: 'Clean out workspace' )
+                unstash 'release-tarball'
+                sh( script: "mkdir -p ${COUCHDB_IO_LOG_DIR} build-${ERLANG_VERSION}" )
+                sh( script: "tar -xf apache-couchdb-*.tar.gz -C build-${ERLANG_VERSION} --strip-components=1", label: 'Unpack release' )
+                dir( "build-${ERLANG_VERSION}" ) {
+                  sh( script: './configure --skip-deps', label: 'Configure CouchDB build system' )
+                  sh( script: 'make', label: 'Build CouchDB' )
+                  sh( script: 'make eunit', label: 'EUnit test suite' )
+                  sh( script: 'make elixir-suite', label: 'ExUnit unit test suite' )
+                  sh( script: 'make exunit', label: 'ExUnit integration test suite' )
+                  sh( script: 'make mango-test', label: 'Python-based Mango query test suite' )
+                }
               }
             }
             post {
               always {
                 junit '**/.eunit/*.xml, **/_build/*/lib/couchdbtest/*.xml, **/src/mango/nosetests.xml, **/test/javascript/junit.xml'
               }
+              failure {
+                dir( "build-${ERLANG_VERSION}" ) {
+                  sh 'ls -l'
+                  sh 'make build-report'
+                }
+              }
               cleanup {
                 sh 'rm -rf ${WORKSPACE}/* ${COUCHDB_IO_LOG_DIR}'
               }
             }
-          } // stage
+          } // stage "Build and Test"
         } // stages
       } // matrix
     } // stage "Make Check"

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -20,7 +20,6 @@ mkdir build
 cd build
 tar -xf ${WORKSPACE}/apache-couchdb-*.tar.gz
 cd apache-couchdb-*
-. /usr/local/kerl/${ERLANG_VERSION}/activate
 ./configure
 make check || (make build-report && false)
 '''
@@ -39,7 +38,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'Jenkins User'
     GIT_COMMITTER_EMAIL = 'couchdb@apache.org'
     // Parameters for the matrix build
-    DOCKER_IMAGE = 'apache/couchdbci-debian:bullseye-erlang-all-1'
+    DOCKER_IMAGE_BASE = 'apache/couchdbci-debian:erlang'
     // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly
@@ -50,10 +49,7 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    LOW_ERLANG_VER = '21.3.8.24'
-
-    // Ensure that the SpiderMonkey version is appropriate for the $DOCKER_IMAGE
-    SM_VSN = '78'
+    MIN_ERLANG_VERSION = '21'
   }
 
   options {
@@ -69,7 +65,7 @@ pipeline {
     stage('Build Release Tarball') {
       agent {
         docker {
-          image "${DOCKER_IMAGE}"
+          image "${DOCKER_IMAGE_BASE}-${MIN_ERLANG_VERSION}"
           label 'docker'
           args "${DOCKER_ARGS}"
           registryUrl 'https://docker.io/'
@@ -83,7 +79,6 @@ pipeline {
         sh '''
           set
           rm -rf apache-couchdb-*
-          . /usr/local/kerl/${LOW_ERLANG_VER}/activate
           ./configure
           make erlfmt-check
           make dist
@@ -111,7 +106,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '21.3.8.24', '22.3.4.24', '23.3.4.10', '24.2'
+            values '21', '22', '23', '24'
           }
         }
 
@@ -119,7 +114,7 @@ pipeline {
           stage('Build and Test') {
             agent {
               docker {
-                image "${DOCKER_IMAGE}"
+                image "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}"
                 label 'docker'
                 args "${DOCKER_ARGS}"
               }

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -72,18 +72,17 @@ pipeline {
           registryCredentialsId 'dockerhub_creds'
         }
       }
-      options {
-        timeout(time: 15, unit: "MINUTES")
-      }
       steps {
-        sh '''
-          set
-          rm -rf apache-couchdb-*
-          ./configure
-          make erlfmt-check
-          make dist
-          chmod -R a+w * .
-        '''
+        timeout(time: 15, unit: "MINUTES") {
+          sh '''
+            set
+            rm -rf apache-couchdb-*
+            ./configure
+            make erlfmt-check
+            make dist
+            chmod -R a+w * .
+          '''
+        }
       }
       post {
         success {
@@ -121,11 +120,12 @@ pipeline {
             }
             options {
               skipDefaultCheckout()
-              timeout(time: 90, unit: "MINUTES")
             }
             steps {
-              unstash 'tarball'
-              sh( script: build_and_test )
+              timeout(time: 90, unit: "MINUTES") {
+                unstash 'tarball'
+                sh( script: build_and_test )
+              }
             }
             post {
               always {

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule CouchDBTest.Mixfile do
       {:jwtf, path: Path.expand("src/jwtf", __DIR__)},
       {:ibrowse,
        path: Path.expand("src/ibrowse", __DIR__), override: true, compile: false},
-      {:credo, "~> 1.5.4", only: [:dev, :test, :integration], runtime: false}
+      {:credo, "~> 1.5.6", only: [:dev, :test, :integration], runtime: false}
     ]
   end
 

--- a/src/chttpd/test/exunit/pagination_test.exs
+++ b/src/chttpd/test/exunit/pagination_test.exs
@@ -580,9 +580,8 @@ defmodule Couch.Test.Pagination do
 
   for descending <- [false, true] do
     for n <- [4, 9] do
-      describe "Pagination API (10 docs) : _all_docs?page_size=#{n}&descending=#{
-                 descending
-               }" do
+      describe "Pagination API (10 docs) : _all_docs" <>
+                 "?page_size=#{n}&descending=#{descending}" do
         @describetag n_docs: 10
         @describetag descending: descending
         @describetag page_size: n
@@ -613,9 +612,8 @@ defmodule Couch.Test.Pagination do
         end
       end
 
-      describe "Pagination API (10 docs) : _all_docs?page_size=#{n}&descending=#{
-                 descending
-               } : range" do
+      describe "Pagination API (10 docs) : _all_docs" <>
+                 "?page_size=#{n}&descending=#{descending} : range" do
         @describetag n_docs: 10
         @describetag descending: descending
         @describetag page_size: n
@@ -706,9 +704,8 @@ defmodule Couch.Test.Pagination do
 
   for descending <- [false, true] do
     for n <- [4, 9] do
-      describe "Pagination API (10 docs) : _all_docs?page_size=#{n}&descending=#{
-                 descending
-               } : pages" do
+      describe "Pagination API (10 docs) : _all_docs" <>
+                 "?page_size=#{n}&descending=#{descending} : pages" do
         @describetag n_docs: 10
         @describetag descending: descending
         @describetag page_size: n
@@ -752,7 +749,8 @@ defmodule Couch.Test.Pagination do
   end
 
   for n <- 10..11 do
-    describe "Pagination API (10 docs) : _all_docs?page_size=#{n}" do
+    describe "Pagination API (10 docs) : _all_docs" <>
+               "?page_size=#{n}" do
       @describetag n_docs: 10
       @describetag descending: false
       @describetag page_size: n
@@ -772,9 +770,8 @@ defmodule Couch.Test.Pagination do
 
   for descending <- [false, true] do
     for n <- [4, 9] do
-      describe "Pagination API (10 docs) : _all_docs/queries?page_size=#{n}&descending=#{
-                 descending
-               } : pages" do
+      describe "Pagination API (10 docs) : _all_docs/queries" <>
+                 "?page_size=#{n}&descending=#{descending} : pages" do
         @describetag n_docs: 10
         @describetag descending: descending
         @describetag page_size: n
@@ -908,9 +905,8 @@ defmodule Couch.Test.Pagination do
 
   for descending <- [false, true] do
     for n <- [4, 9] do
-      describe "Pagination API (10 docs) : /{db}/_design/{ddoc}/_view?page_size=#{n}&descending=#{
-                 descending
-               }" do
+      describe "Pagination API (10 docs) : /{db}/_design/{ddoc}/_view" <>
+                 "?page_size=#{n}&descending=#{descending}" do
         @describetag n_docs: 10
         @describetag descending: descending
         @describetag page_size: n
@@ -1015,7 +1011,8 @@ defmodule Couch.Test.Pagination do
   end
 
   for n <- 10..11 do
-    describe "Pagination API (10 docs) :  /{db}/_design/{ddoc}/_view?page_size=#{n}" do
+    describe "Pagination API (10 docs) :  /{db}/_design/{ddoc}/_view" <>
+               "?page_size=#{n}" do
       @describetag n_docs: 10
       @describetag descending: false
       @describetag page_size: n
@@ -1062,9 +1059,8 @@ defmodule Couch.Test.Pagination do
 
   for descending <- [false, true] do
     for n <- [4, 9] do
-      describe "Pagination API (10 docs) : /{db}/_design/{ddoc}/_view/queries?page_size=#{
-                 n
-               }&descending=#{descending} : pages" do
+      describe "Pagination API (10 docs) : /{db}/_design/{ddoc}/_view/queries" <>
+                 "?page_size=#{n}&descending=#{descending} : pages" do
         @describetag n_docs: 10
         @describetag descending: descending
         @describetag page_size: n
@@ -1224,14 +1220,12 @@ defmodule Couch.Test.Pagination do
           expected_ids_order = :ascending
 
           assert expected_key_order == ordering?(results, "key"),
-                 "expecting keys in #{expected_key_order} order, got: #{
-                   inspect(field(results, "key"))
-                 }"
+                 "expecting keys in #{expected_key_order} order, " <>
+                   "got: #{inspect(field(results, "key"))}"
 
           assert expected_ids_order == ordering?(results, "id"),
-                 "expecting ids in #{expected_ids_order} order, got: #{
-                   inspect(field(results, "id"))
-                 }"
+                 "expecting ids in #{expected_ids_order} order, " <>
+                   "got: #{inspect(field(results, "id"))}"
 
           results = List.flatten(limit_query)
           [_descendiing_query, query] = ctx.queries[:queries]
@@ -1253,14 +1247,12 @@ defmodule Couch.Test.Pagination do
             end
 
           assert expected_key_order == ordering?(results, "key"),
-                 ~s(expecting keys in #{expected_key_order} order, got: #{
-                   inspect(field(results, "key"))
-                 })
+                 "expecting keys in #{expected_key_order} order, " <>
+                   "got: #{inspect(field(results, "key"))}"
 
           assert expected_ids_order == ordering?(results, "id"),
-                 ~s(expecting keys in #{expected_ids_order} order, got: #{
-                   inspect(field(results, "id"))
-                 })
+                 "expecting keys in #{expected_ids_order} order, " <>
+                   "got: #{inspect(field(results, "id"))}"
 
           _keys = Enum.map(results, &Map.get(&1, "key"))
         end
@@ -1270,9 +1262,8 @@ defmodule Couch.Test.Pagination do
 
   for descending <- [false, true] do
     for n <- [4, 9] do
-      describe "Pagination API (10 docs) : /{db}/_design/{ddoc}/_view/queries?page_size=#{
-                 n
-               }&descending=#{descending} : pages with same key" do
+      describe "Pagination API (10 docs) : /{db}/_design/{ddoc}/_view/queries" <>
+                 "?page_size=#{n}&descending=#{descending} : pages with same key" do
         @describetag descending: descending
         @describetag n_docs: 10
         @describetag page_size: n


### PR DESCRIPTION
## Overview

This PR has a small improvement to the Elixir test suite, and adds the `credo` style check earlier in the pipeline. It also reconfigures the per-stage timeouts so that they ignore time spent in the build queue waiting for a docker-based agent to free up.

Finally, it refactors the pipeline to use a larger number of explicit steps in each stage. This improves the developer experience navigating the Jenkins UI, as we can see timings for each phase of the build, and if a step fails the logs that are displayed will be scoped just to that step.

## Testing recommendations

Jenkins

## Related PRs

#3895 was the first PR to convert the Jenkinsfile to use specific images for each Erlang version.