### PR TITLE
Execute fabric_rpc_tests in clean database_dir

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -29,6 +29,7 @@
 -export([db_updated/1]).
 -export([num_servers/0, couch_server/1, couch_dbs_pid_to_name/1, couch_dbs/1]).
 -export([aggregate_queue_len/0, get_spidermonkey_version/0]).
+-export([names/0]).
 
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
@@ -994,6 +995,10 @@ aggregate_queue_len() ->
      || Name <- Names
     ],
     lists:sum([X || {_, X} <- MQs]).
+
+names() ->
+    N = couch_server:num_servers(),
+    [couch_server:couch_server(I) || I <- lists:seq(1, N)].
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/fabric/test/eunit/fabric_rpc_tests.erl
+++ b/src/fabric/test/eunit/fabric_rpc_tests.erl
@@ -54,9 +54,16 @@ main_test_() ->
     }.
 
 setup_all() ->
-    test_util:start_couch([rexi, mem3, fabric]).
+    Ctx = test_util:start_couch([rexi, mem3, fabric]),
+    DatabaseDir = config:get("couchdb", "database_dir"),
+    Suffix = ?b2l(couch_uuids:random()),
+    test_util:with_couch_server_restart(fun() ->
+        config:set("couchdb", "database_dir", DatabaseDir ++ "/" ++ Suffix, _Persist = false)
+    end),
+    Ctx.
 
 teardown_all(Ctx) ->
+    config:delete("couchdb", "database_dir", false),
     test_util:stop_couch(Ctx).
 
 setup_no_db_or_config() ->


### PR DESCRIPTION
## Overview

The `fabric_rpc_tests` pollutes the state of `shards_db` which causes flakiness
of other tests. This PR fixes the problem by configuring temporary `database_dir`.

The important implementation detail is that we need to wait for all `couch_server`
processes to restart. Before initroduction of sharded couch server in the
https://github.com/apache/couchdb/pull/3366 this could be done as:

```erlang
test_util:with_process_restart(couch_server, fun() ->
  config:set("couchdb", "database_dir", NewDatabaseDir)
end),
```

This method has to be updated to support sharded `couch_server`. Following auxiliary
functions where added:

- `couch_server:names/0` - returns list of registered names of each
  `couch_server` process
- `test_util:with_processes_restart/{2,4}` - waits all process to be restarted
  returns `{Pids :: #{} | timeout, Res :: term()}`
- `test_util:with_couch_server_restart/1` - waits for all `couch_server` processes
to finish restart

The new way of configuring `database_dir` in test suites is:

```erlang
test_util:with_couch_server_restart(fun() ->
  config:set("couchdb", "database_dir", NewDatabaseDir)
end),
```


## Testing recommendations

`make eunit`

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/pull/3366

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
