### PR TITLE
Bump docs to 3.2.1-1

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -154,7 +154,7 @@ DepDescs = [
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
-                   {tag, "3.2.1-RC1"}, [raw]},
+                   {tag, "3.2.1-1"}, [raw]},
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.2.8"}, [raw]},
 %% Third party deps


### PR DESCRIPTION
In order to fix formatting issue outlined in https://github.com/apache/couchdb-documentation/pull/704

