### PR TITLE
Fix publication of nightly packages

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -381,7 +381,7 @@ pipeline {
     stage('Publish') {
 
       when {
-        expression { return env.BRANCH_NAME ==~ /master|2.*.x|3.*.x|4.*.x|jenkins-.*/ }
+        expression { return env.BRANCH_NAME ==~ /main|2.*.x|3.*.x|4.*.x|jenkins-.*/ }
       }
 
       agent {

--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -404,16 +404,14 @@ pipeline {
           unstash 'tarball'
           unarchive mapping: ['pkgs/' : '.']
 
-          echo 'Retrieving & cleaning current repo-nightly tree...'
-          sh '''
+          sh( label: 'Retrieve & clean current repo-nightly tree', script: '''
             rsync -avz -e "ssh -o StrictHostKeyChecking=no -i $KEY" jenkins@repo-nightly.couchdb.org:/var/www/html/$BRANCH_NAME . || mkdir -p $BRANCH_NAME
             rm -rf $BRANCH_NAME/debian/* $BRANCH_NAME/el6 $BRANCH_NAME/el7/* $BRANCH_NAME/el8/*
             mkdir -p $BRANCH_NAME/debian $BRANCH_NAME/el7 $BRANCH_NAME/el8 $BRANCH_NAME/source
             rsync -avz -e "ssh -o StrictHostKeyChecking=no -i $KEY" jenkins@repo-nightly.couchdb.org:/var/www/html/js .
-          '''
+          ''' )
 
-          echo 'Building Debian repo...'
-          sh '''
+          sh( label: 'Build Debian repo', script: '''
             git clone https://github.com/apache/couchdb-pkg
             cp js/debian-stretch/*.deb pkgs/stretch
             cp js/ubuntu-bionic/*.deb pkgs/bionic
@@ -421,18 +419,16 @@ pipeline {
             do
               reprepro -b couchdb-pkg/repo includedeb $plat pkgs/$plat/*.deb
             done
-          '''
+          ''' )
 
-          echo 'Building CentOS repos...'
-          sh '''
+          sh( label: 'Build CentOS repos', script: '''
             cp js/centos-7/*rpm pkgs/centos7
             cp js/centos-8/*rpm pkgs/centos8
             cd pkgs/centos7 && createrepo_c --database .
             cd ../centos8 && createrepo_c --database .
-          '''
+          ''' )
 
-          echo 'Building tree to upload...'
-          sh '''
+          sh( label: 'Build tree to upload', script: '''
             mv couchdb-pkg/repo/pool $BRANCH_NAME/debian
             mv couchdb-pkg/repo/dists $BRANCH_NAME/debian
             mv pkgs/centos7/* $BRANCH_NAME/el7
@@ -441,13 +437,12 @@ pipeline {
             cd $BRANCH_NAME/source
             ls -1tr | head -n -10 | xargs -d '\n' rm -f --
             cd ../..
-          '''
+          ''' )
 
-          echo 'rsyncing tree to repo-nightly...'
-          sh '''
+          sh( label: 'Sync tree back to repo-nightly', script: '''
             rsync -avz --delete -e "ssh -o StrictHostKeyChecking=no -i $KEY" $BRANCH_NAME jenkins@repo-nightly.couchdb.org:/var/www/html
             rm -rf $BRANCH_NAME couchdb-pkg *.tar.gz
-          '''
+          ''' )
         } // withCredentials
       } // steps
     } // stage

--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -407,8 +407,8 @@ pipeline {
           echo 'Retrieving & cleaning current repo-nightly tree...'
           sh '''
             rsync -avz -e "ssh -o StrictHostKeyChecking=no -i $KEY" jenkins@repo-nightly.couchdb.org:/var/www/html/$BRANCH_NAME . || mkdir -p $BRANCH_NAME
-            rm -rf $BRANCH_NAME/debian/* $BRANCH_NAME/el6/* $BRANCH_NAME/el7/* $BRANCH_NAME/el8/*
-            mkdir -p $BRANCH_NAME/debian $BRANCH_NAME/el6 $BRANCH_NAME/el7 $BRANCH_NAME/el8 $BRANCH_NAME/source
+            rm -rf $BRANCH_NAME/debian/* $BRANCH_NAME/el6 $BRANCH_NAME/el7/* $BRANCH_NAME/el8/*
+            mkdir -p $BRANCH_NAME/debian $BRANCH_NAME/el7 $BRANCH_NAME/el8 $BRANCH_NAME/source
             rsync -avz -e "ssh -o StrictHostKeyChecking=no -i $KEY" jenkins@repo-nightly.couchdb.org:/var/www/html/js .
           '''
 

--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -416,11 +416,11 @@ pipeline {
           sh '''
             git clone https://github.com/apache/couchdb-pkg
             cp js/debian-stretch/*.deb pkgs/stretch
-            reprepro -b couchdb-pkg/repo includedeb stretch pkgs/stretch/*.deb
-            reprepro -b couchdb-pkg/repo includedeb buster pkgs/buster/*.deb
             cp js/ubuntu-bionic/*.deb pkgs/bionic
-            reprepro -b couchdb-pkg/repo includedeb bionic pkgs/bionic/*.deb
-            reprepro -b couchdb-pkg/repo includedeb focal pkgs/focal/*.deb
+            for plat in stretch buster bullseye bionic focal
+            do
+              reprepro -b couchdb-pkg/repo includedeb $plat pkgs/$plat/*.deb
+            done
           '''
 
           echo 'Building CentOS repos...'

--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -417,7 +417,6 @@ pipeline {
             git clone https://github.com/apache/couchdb-pkg
             cp js/debian-stretch/*.deb pkgs/stretch
             reprepro -b couchdb-pkg/repo includedeb stretch pkgs/stretch/*.deb
-            cp js/debian-buster/*.deb pkgs/stretch
             reprepro -b couchdb-pkg/repo includedeb buster pkgs/buster/*.deb
             cp js/ubuntu-bionic/*.deb pkgs/bionic
             reprepro -b couchdb-pkg/repo includedeb bionic pkgs/bionic/*.deb


### PR DESCRIPTION
## Overview

Som miscellaneous fixes with the ultimate goal of ensuring that Debian 11 packages get published to http://repo-nightly.couchdb.org.

## Related Issues or Pull Requests

apache/couchdb-pkg#89 is required as well.
