### PR TITLE
Include index sig in _search_info response

### DIFF
--- a/src/dreyfus/src/dreyfus_fabric_info.erl
+++ b/src/dreyfus/src/dreyfus_fabric_info.erl
@@ -102,6 +102,8 @@ merge_results(Info) ->
                 [{committed_seq, lists:sum(X)} | Acc];
             (pending_seq, X, Acc) ->
                 [{pending_seq, lists:sum(X)} | Acc];
+            (signature, [X | _], Acc) ->
+                [{signature, X} | Acc];
             (_, _, Acc) ->
                 Acc
         end,

--- a/src/dreyfus/src/dreyfus_rpc.erl
+++ b/src/dreyfus/src/dreyfus_rpc.erl
@@ -80,8 +80,13 @@ info_int(DbName, DDoc, IndexName) ->
         {ok, Index} ->
             case dreyfus_index_manager:get_index(DbName, Index) of
                 {ok, Pid} ->
-                    Result = dreyfus_index:info(Pid),
-                    rexi:reply(Result);
+                    case dreyfus_index:info(Pid) of
+                        {ok, Fields} ->
+                            Info = [{signature, Index#index.sig} | Fields],
+                            rexi:reply({ok, Info});
+                        Else ->
+                            rexi:reply(Else)
+                    end;
                 Error ->
                     rexi:reply(Error)
             end;


### PR DESCRIPTION
## Overview

Include the index signature in _search_info output (to match _info for views)

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
