### PR TITLE
Ensure the multipart parser always learns about the workers

### DIFF
--- a/src/couch/src/couch_httpd_multipart.erl
+++ b/src/couch/src/couch_httpd_multipart.erl
@@ -217,8 +217,13 @@ maybe_send_data({Ref, Chunks, Offset, Counters, Waiting}) ->
     end.
 
 update_writer(WriterPid, Counters) ->
-    UpdateFun = fun({WriterRef, Count}) -> {WriterRef, Count + 1} end,
-    orddict:update(WriterPid, UpdateFun, Counters).
+    case orddict:find(WriterPid, Counters) of
+        {ok, {WriterRef, Count}} ->
+            orddict:store(WriterPid, {WriterRef, Count + 1}, Counters);
+        error ->
+            WriterRef = erlang:monitor(process, WriterPid),
+            orddict:store(WriterPid, {WriterRef, 1}, Counters)
+    end.
 
 remove_writer(WriterPid, WriterRef, Counters) ->
     case orddict:find(WriterPid, Counters) of

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -10,7 +10,8 @@
   ],
   "AttachmentMultipartTest": [
     "manages attachments multipart requests successfully",
-    "manages compressed attachments successfully"
+    "manages compressed attachments successfully",
+    "multipart attachments with new_edits=false"
   ],
   "AttachmentNamesTest": [
     "saves attachment names successfully"


### PR DESCRIPTION
## Overview

This PR adds an extra `hello_from_writer` message into the handshake between the process that reads the multipart attachment data from the socket and the writer processes (potentially on remote nodes) that persist the data into each shard file. This ensures that even in the case where a writer does not end up asking for the data (e.g. because the revision already exists in the tree), the parser will monitor the writer and therefore know when the writer has exited.
    
The patch makes some assumptions that the attachment flush function is executed in the same process as the initial one that is spawned to handle the fabric_rpc work request. That's true today, but if it changed in the future it would be a non-obvious breakage to debug.

I'm not crazy about this solution to be quite honest, but I figured I could put it up for review anyway and see what others think.

## Testing recommendations

I added an extra test to the `elixir-suite` target. Without this patch you should find that the test eventually causes some other part of the suite to hang, because the Erlang process handling one of the open TCP connections is stuck waiting for the attachment parser to exit. Again, I wish the test failed in a more obvious way, but I guess it's better than nothing.

## Related Issues or Pull Requests

Fixes #3939

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
