### PR TITLE
Prevent users from modifying the special _replication fields

### DIFF
--- a/src/couch_replicator/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator/src/couch_replicator_js_functions.hrl
@@ -58,6 +58,21 @@
             return;
         }
 
+        // Only the replicator may change these fields, though any authorised
+        // user may delete them.
+        if (oldDoc) {
+            var keys = Object.keys(newDoc)
+            for (var i = 0; i < keys.length; i++) {
+                var key = keys[i];
+                if (key.indexOf('_replication_') === 0 &&
+                    typeof(oldDoc[key]) === 'string' &&
+                    typeof(newDoc[key]) === 'string' &&
+                    oldDoc[key] != newDoc[key]) {
+                    reportError('Only the replicator may modify the ' + key + ' field.');
+                }
+            }
+        }
+
         if (newDoc._replication_state === 'failed') {
             // Skip validation in case when we update the document with the
             // failed state. In this case it might be malformed. However,


### PR DESCRIPTION
## Overview

The `_replication_* `fields are reserved for couchdb internal usage (indicated by the underscore prefix). Nonetheless the replicator docs are still editable by local admins. In order not to mislead them into thinking that editing these fields has any intentional effect, this PR prevents them from saving an update that changes any of these fields.

## Testing recommendations

Try to change these fields as an admin (one without the reserved `_replicator` role) and confirm it fails.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
