### PR TITLE
Fix function clause in couch_replicator_scheduler_job

### DIFF
--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -344,7 +344,13 @@ handle_info(timeout, InitArgs) ->
             % Shutdown state is used to pass extra info about why start failed.
             ShutdownState = {error, Class, StackTop2, InitArgs},
             {stop, {shutdown, ShutdownReason}, ShutdownState}
-    end.
+        end;
+
+handle_info({Ref, Tuple}, State) when is_reference(Ref), is_tuple(Tuple) ->
+    % Ignore responses from timed-out or retried ibrowse calls. Aliases in
+    % Erlang 24 should help with this problem, so we should revisit this clause
+    % when we update our minimum Erlang version to >= 24.
+    {noreply, State}.
 
 terminate(
     normal,


### PR DESCRIPTION
`ibrowse` responses may crash the job process with a function clause in `handle_info/2`. Ignore those with a note that aliases should hopefully fix this issue in the future.
