### PR TITLE
Make the timeout for receiving requests from attachment writers configurable

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -80,6 +80,10 @@ view_index_dir = {{view_index_dir}}
 ; Allow edits on the _security object in the user db. By default, it's disabled.
 ;users_db_security_editable = false
 
+; Sets the maximum time that the coordinator node will wait for cluster members
+; to request attachment data before returning a response to the client.
+;attachment_writer_timeout = 300000
+
 [purge]
 ; Allowed maximum number of documents in one purge request
 ;max_document_id_number = 100

--- a/src/couch/src/couch_httpd_multipart.erl
+++ b/src/couch/src/couch_httpd_multipart.erl
@@ -122,7 +122,7 @@ mp_parse_atts(eof, {Ref, Chunks, Offset, Counters, Waiting}) ->
                             NewAcc = {Ref, Chunks, Offset, C2, Waiting -- [WriterPid]},
                             mp_parse_atts(eof, NewAcc)
                     end
-            after 300000 ->
+            after att_writer_timeout() ->
                 ok
             end
     end.
@@ -198,7 +198,7 @@ maybe_send_data({Ref, Chunks, Offset, Counters, Waiting}) ->
                     {get_bytes, Ref, X} ->
                         C2 = update_writer(X, Counters),
                         maybe_send_data({Ref, NewChunks, NewOffset, C2, [X | NewWaiting]})
-                after 300000 ->
+                after att_writer_timeout() ->
                     abort_parsing
                 end
         end
@@ -242,6 +242,9 @@ num_mp_writers() ->
         undefined -> 1;
         Count -> Count
     end.
+
+att_writer_timeout() ->
+    config:get_integer("couchdb", "attachment_writer_timeout", 300000).
 
 encode_multipart_stream(_Boundary, JsonBytes, [], WriteFun, _AttFun) ->
     WriteFun(JsonBytes);


### PR DESCRIPTION
## Overview

The code that forwards attachment data to cluster nodes via fabric has a
hard-coded timeout of five minutes for nodes to request the data. Making
this configurable lets us mitigate the impact of issue #3939, which
causes requests to block if one of the nodes already has the given
attachment and doesn't end up requesting the data for it.

## Related Issues or Pull Requests

- https://github.com/apache/couchdb/issues/3939
- https://github.com/apache/couchdb/pull/3940

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
