### PR TITLE
Opimtize key tree stemming by using maps instead of sets

### DIFF
--- a/src/couch/src/couch_key_tree.erl
+++ b/src/couch/src/couch_key_tree.erl
@@ -496,7 +496,7 @@ stem(Trees, Limit) ->
                 {NewSeen, NewBranches} = stem_tree(Tree, Limit, Seen),
                 {NewSeen, NewBranches ++ TreeAcc}
             end,
-            {sets:new(), []},
+            {#{}, []},
             Trees
         ),
         lists:sort(Branches)
@@ -553,11 +553,11 @@ stem_tree(Depth, {Key, Val, Children}, Limit, Seen0) ->
     end.
 
 check_key(Key, Seen) ->
-    case sets:is_element(Key, Seen) of
-        true ->
+    case Seen of
+        #{Key := true} ->
             throw(dupe_keys);
-        false ->
-            sets:add_element(Key, Seen)
+        _ ->
+            Seen#{Key => true}
     end.
 
 repair_tree(Trees, Limit) ->


### PR DESCRIPTION
sets to due to a compiler bug in 22 consumes too much memory and is slower on Erlang 22+

Reproducer: https://gist.github.com/nickva/ddc499e6e05678faf20d344c6e11daaa

With sets:
```
couch_key_tree:gen_and_stem().
{8,6848.812683105469}
```

With maps:
```
couch_key_tree:gen_and_stem().
{0,544.000732421875}
```
