### PR TITLE
Remove include couch_db_int

### DIFF
--- a/src/smoosh/test/smoosh_tests.erl
+++ b/src/smoosh/test/smoosh_tests.erl
@@ -3,8 +3,6 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
--include("couch/src/couch_db_int.hrl").
-
 -define(KILOBYTE, binary:copy(<<"x">>, 1024)).
 
 %% ==========
@@ -96,7 +94,8 @@ should_persist_queue(ChannelType, DbName) ->
     end).
 
 grow_db_file(DbName, SizeInKb) ->
-    {ok, #db{filepath = FilePath} = Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),
+    {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),
+    FilePath = couch_db:get_filepath(Db),
     {ok, Fd} = file:open(FilePath, [append]),
     Bytes = binary:copy(?KILOBYTE, SizeInKb),
     file:write(Fd, Bytes),


### PR DESCRIPTION
## Overview

Remove `-include` so that downstream integrations will continue to work and the internal header file remains internal.

## Testing recommendations

`make eunit apps=smoosh`

## Related Issues or Pull Requests

Prefer `include_lib` for downstream integration: https://github.com/apache/couchdb/pull/3965

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
