### PR TITLE
Fix skip and limit parameters

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -120,7 +120,8 @@ handle_all_dbs_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
 handle_all_dbs_info_req(Req) ->
-    Args = couch_mrview_http:parse_params(Req, undefined),
+    Args0 = couch_mrview_http:parse_params(Req, undefined),
+    Args1 = couch_mrview_util:set_extra(Args0, namespace, <<"_non_design">>),
     ShardDbName = config:get("mem3", "shards_db", "_dbs"),
     %% shard_db is not sharded but mem3:shards treats it as an edge case
     %% so it can be pushed thru fabric
@@ -130,7 +131,7 @@ handle_all_dbs_info_req(Req) ->
     {ok, Resp} = chttpd:etag_respond(Req, Etag, fun() ->
         {ok, Resp} = chttpd:start_delayed_json_response(Req, 200, [{"ETag", Etag}]),
         VAcc = #vacc{req = Req, resp = Resp},
-        fabric:all_docs(ShardDbName, Options, fun all_dbs_info_callback/2, VAcc, Args)
+        fabric:all_docs(ShardDbName, Options, fun all_dbs_info_callback/2, VAcc, Args1)
     end),
     case is_record(Resp, vacc) of
         true -> {ok, Resp#vacc.resp};
@@ -144,32 +145,24 @@ all_dbs_info_callback({row, Row}, #vacc{resp = Resp0} = Acc) when
     Acc#vacc.req#httpd.path_parts =:= [<<"_all_dbs">>]
 ->
     Prepend = couch_mrview_http:prepend_val(Acc),
-    case couch_util:get_value(id, Row) of
-        <<"_design", _/binary>> ->
-            {ok, Acc};
-        DbName ->
-            {ok, Resp1} = chttpd:send_delayed_chunk(Resp0, [Prepend, ?JSON_ENCODE(DbName)]),
-            {ok, Acc#vacc{prepend = ",", resp = Resp1}}
-    end;
+    DbName = couch_util:get_value(id, Row),
+    {ok, Resp1} = chttpd:send_delayed_chunk(Resp0, [Prepend, ?JSON_ENCODE(DbName)]),
+    {ok, Acc#vacc{prepend = ",", resp = Resp1}};
 all_dbs_info_callback({row, Row}, #vacc{resp = Resp0} = Acc) when
     Acc#vacc.req#httpd.path_parts =:= [<<"_dbs_info">>]
 ->
     Prepend = couch_mrview_http:prepend_val(Acc),
-    case couch_util:get_value(id, Row) of
-        <<"_design", _/binary>> ->
-            {ok, Acc};
-        DbName ->
-            case chttpd_util:get_db_info(DbName) of
-                {ok, DbInfo} ->
-                    Chunk = [Prepend, ?JSON_ENCODE({[{key, DbName}, {info, {DbInfo}}]})],
-                    {ok, Resp1} = chttpd:send_delayed_chunk(Resp0, Chunk),
-                    {ok, Acc#vacc{prepend = ",", resp = Resp1}};
-                {error, database_does_not_exist} ->
-                    {ok, Acc#vacc{resp = Resp0}};
-                {error, Reason} ->
-                    {ok, Resp1} = chttpd:send_delayed_error(Resp0, Reason),
-                    {stop, Acc#vacc{resp = Resp1}}
-            end
+    DbName = couch_util:get_value(id, Row),
+    case chttpd_util:get_db_info(DbName) of
+        {ok, DbInfo} ->
+            Chunk = [Prepend, ?JSON_ENCODE({[{key, DbName}, {info, {DbInfo}}]})],
+            {ok, Resp1} = chttpd:send_delayed_chunk(Resp0, Chunk),
+            {ok, Acc#vacc{prepend = ",", resp = Resp1}};
+        {error, database_does_not_exist} ->
+            {ok, Acc#vacc{resp = Resp0}};
+        {error, Reason} ->
+            {ok, Resp1} = chttpd:send_delayed_error(Resp0, Reason),
+            {stop, Acc#vacc{resp = Resp1}}
     end;
 all_dbs_info_callback(complete, #vacc{resp = Resp0} = Acc) ->
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp0, "]"),

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -93,6 +93,7 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
         case couch_util:get_value(namespace, Extra) of
             <<"_all_docs">> -> <<"_all_docs">>;
             <<"_design">> -> <<"_design">>;
+            <<"_non_design">> -> <<"_non_design">>;
             <<"_local">> -> <<"_local">>;
             _ -> <<"_all_docs">>
         end,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Previously, the `skip` and `limit` parameters of GET `_all_dbs` and `_dbs_info` did not work correctly. If we have 2 _design/* docs and 2 dbs (db1, db2), and we set skip=2, it will return db1 and db2, which is incorrect. Same as the `limit`. This PR will fix it.


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
make eunit apps=chttpd suites=chttpd_dbs_info_test
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
https://github.com/apache/couchdb/pull/3832
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
