### PR TITLE
Fix smoosh enqueueing not found dbs and typo

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -19,6 +19,7 @@
     incref/1,
     reopen/1,
     close/1,
+    exists/1,
 
     clustered_db/2,
     clustered_db/3,
@@ -230,6 +231,9 @@ close(#db{} = Db) ->
     ok = couch_db_engine:decref(Db);
 close(?OLD_DB_REC) ->
     ok.
+
+exists(DbName) ->
+    couch_server:exists(DbName).
 
 is_idle(#db{compactor_pid = nil} = Db) ->
     monitored_by(Db) == [];


### PR DESCRIPTION
## Overview

Currently, smoosh can recover compaction jobs for databases that do not exist. This PR ensures that the database file exists before recovering the compaction job plus a minor typo fix.

## Testing recommendations

`make eunit apps=smoosh`

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
