### PR TITLE
use undefined for timed out responses

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -637,7 +637,7 @@ db_req(#httpd{method = 'POST', path_parts = [_, <<"_bulk_docs">>], user_ctx = Ct
                     % output the results
                     chttpd_stats:incr_writes(length(Results)),
                     DocResults = lists:zipwith(
-                    fun update_doc_result_to_json/2,
+                        fun update_doc_result_to_json/2,
                         Docs,
                         Results
                     ),

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -534,14 +534,13 @@ reorder_results(Keys, SortedResults, Default) when length(Keys) < 100 ->
     [couch_util:get_value(Key, SortedResults, Default) || Key <- Keys];
 reorder_results(Keys, SortedResults, Default) ->
     KeyDict = dict:from_list(SortedResults),
-    DefaultFunc = fun ({Key, Dict}) ->
+    DefaultFunc = fun({Key, Dict}) ->
         case dict:is_key(Key, Dict) of
             true -> dict:fetch(Key, Dict);
             false -> Default
         end
     end,
     [DefaultFunc({Key, KeyDict}) || Key <- Keys].
-
 
 url_strip_password(Url) ->
     re:replace(

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -24,7 +24,7 @@
 -export([json_encode/1, json_decode/1, json_decode/2]).
 -export([verify/2, simple_call/2, shutdown_sync/1]).
 -export([get_value/2, get_value/3]).
--export([reorder_results/2]).
+-export([reorder_results/2, reorder_results/3]).
 -export([url_strip_password/1]).
 -export([encode_doc_id/1]).
 -export([normalize_ddoc_id/1]).
@@ -529,6 +529,19 @@ reorder_results(Keys, SortedResults) when length(Keys) < 100 ->
 reorder_results(Keys, SortedResults) ->
     KeyDict = dict:from_list(SortedResults),
     [dict:fetch(Key, KeyDict) || Key <- Keys].
+
+reorder_results(Keys, SortedResults, Default) when length(Keys) < 100 ->
+    [couch_util:get_value(Key, SortedResults, Default) || Key <- Keys];
+reorder_results(Keys, SortedResults, Default) ->
+    KeyDict = dict:from_list(SortedResults),
+    DefaultFunc = fun ({Key, Dict}) ->
+        case dict:is_key(Key, Dict) of
+            true -> dict:fetch(Key, Dict);
+            false -> Default
+        end
+    end,
+    [DefaultFunc({Key, KeyDict}) || Key <- Keys].
+
 
 url_strip_password(Url) ->
     re:replace(

--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -827,7 +827,7 @@ setup() ->
     ok = meck:expect(
         couch_util,
         reorder_results,
-        fun(_, [{_, Res}]) ->
+        fun(_, [{_, Res}], _) ->
             [Res]
         end
     ),

--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -193,14 +193,16 @@ maybe_reply(Doc, Replies, {stop, W, Acc}) ->
             continue
     end.
 
+reorder_results(_, []) ->
+    erlang:error({internal_server_error, "No Responses For Document Update"});
 reorder_results(AllDocs, Resp) when length(AllDocs) < 100 ->
-    couch_util:reorder_results(AllDocs, Resp);
+    [couch_util:get_value(Doc, Resp, timeout) || Doc <- AllDocs];
 reorder_results(AllDocs, Resp) ->
     KeyDict = dict:from_list(Resp),
     Default = fun ({Key, Dict}) ->
         case dict:is_key(Key, Dict) of
             true -> dict:fetch(Key, Dict);
-            false -> undefined
+            false -> timeout
         end
     end,
     [Default({Key, KeyDict}) || Key <- AllDocs].

--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -44,7 +44,10 @@ go(DbName, AllDocs0, Opts) ->
         {ok, {Health, Results}} when
             Health =:= ok; Health =:= accepted; Health =:= error
         ->
-            {Health, [R || R <- couch_util:reorder_results(AllDocs, Results, timeout), R =/= noreply]};
+            {Health, [
+                R
+             || R <- couch_util:reorder_results(AllDocs, Results, timeout), R =/= noreply
+            ]};
         {timeout, Acc} ->
             {_, _, W1, GroupedDocs1, DocReplDict} = Acc,
             {DefunctWorkers, _} = lists:unzip(GroupedDocs1),

--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -195,8 +195,15 @@ maybe_reply(Doc, Replies, {stop, W, Acc}) ->
 
 % this ensures that we got some response for all documents being updated
 ensure_all_responses(Health, AllDocs, Resp) ->
-    Results = [R || R <- couch_util:reorder_results(AllDocs, Resp,
-        {error, internal_server_error}), R =/= noreply],
+    Results = [
+        R
+     || R <- couch_util:reorder_results(
+            AllDocs,
+            Resp,
+            {error, internal_server_error}
+        ),
+        R =/= noreply
+    ],
     case lists:member({error, internal_server_error}, Results) of
         true ->
             {error, Results};


### PR DESCRIPTION
## Overview

Under heavy load, fabric_update_doc workers will return `timeout` via
rexi. Therefore no responses will populate the response dictionary.
This leads to `badargs` when we do `dict:fetch` for keys that do not exist.
This checks for the existence of the key and then returns undefined
if it does not exist, which aligns with the same code path of when we
the number of docs < 100.

In this solution, we're masking the fact that workers failed their updates. `handle_message`
is never called since no workers return. The returned `Health` value is actually `ok`. It solves
the badargs but we need to consider a correct response. I don't think 200 is correct.

1) We can return `{error,...}` and also change it for < 100 docs. Possible Breaking change.
2) We can return `{error,...}` for only > 100 docs. But this could lead to different results.
3) We can return `{accepted...}` when Results are not empty, and `error` only when results is 
completely empty.


## Testing recommendations

Run https://gist.github.com/nickva/bde7d3cfa8c9df0dd18700c661fec4ab
with
```
python stampede.py -x 100 -w 5
```
should not create badargs.

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/3948


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
