### PR TITLE
Window test suite difficulties (nose2, timestamps)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ mango-test: devclean all
 	@cd src/mango && \
 		python3 -m venv .venv && \
 		.venv/bin/python3 -m pip install -r requirements.txt
-	@cd src/mango && ../../dev/run "$(TEST_OPTS)" -n 1 --admin=testuser:testpass '.venv/bin/python3 -m nose --with-xunit'
+	@cd src/mango && ../../dev/run "$(TEST_OPTS)" -n 1 --admin=testuser:testpass '.venv/bin/python3 -m nose2'
 
 
 .PHONY: weatherreport-test

--- a/Makefile.win
+++ b/Makefile.win
@@ -262,7 +262,7 @@ mango-test: devclean all
 	@cd src\mango && \
 		python.exe -m venv .venv && \
 		.venv\Scripts\pip.exe install -r requirements.txt
-	@cd src\mango && .venv\Scripts\python.exe ..\..\dev\run -n 1 --admin=testuser:testpass .venv\Scripts\nosetests
+	@cd src\mango && .venv\Scripts\python.exe ..\..\dev\run -n 1 --admin=testuser:testpass .venv\Scripts\nose2
 
 
 ################################################################################

--- a/src/mango/requirements.txt
+++ b/src/mango/requirements.txt
@@ -1,4 +1,4 @@
-nose==1.3.7
-requests==2.20.1
-hypothesis==5.5.1
+nose2==0.11.0
+requests==2.27.1
+hypothesis==6.39.4
 

--- a/src/mango/test/README.md
+++ b/src/mango/test/README.md
@@ -8,13 +8,13 @@ To run these, do this in the Mango top level directory:
     $ python3 -m venv venv
     $ . venv/bin/activate
     $ pip3 install -r requirements.txt
-    $ venv/bin/nosetests
+    $ venv/bin/nose2
 
 To run an individual test suite:
-    nosetests --nocapture test/12-use-correct-index.py 
+    nose2 12-use-correct-index-test
 
 To run the tests with text index support:
-    MANGO_TEXT_INDEXES=1 nosetests --nocapture test
+    MANGO_TEXT_INDEXES=1 nose2 test
 
 
 Test configuration

--- a/src/mango/unittest.cfg
+++ b/src/mango/unittest.cfg
@@ -1,0 +1,3 @@
+[unittest]
+start-dir=test
+test-file-pattern=[0-9]*.py

--- a/test/elixir/test/view_errors_test.exs
+++ b/test/elixir/test/view_errors_test.exs
@@ -274,7 +274,7 @@ defmodule ViewErrorsTest do
   end
 
   defp create_view(db_name, map_fun) do
-    ddoc_name = "_design/temp_#{now(:ms)}"
+    ddoc_name = "_design/temp_#{System.unique_integer([:positive])}"
 
     ddoc = %{
       _id: ddoc_name,
@@ -286,9 +286,5 @@ defmodule ViewErrorsTest do
 
     {:ok, _} = create_doc(db_name, ddoc)
     ddoc_name
-  end
-
-  defp now(:ms) do
-    :erlang.unique_integer([:positive])
   end
 end

--- a/test/elixir/test/view_errors_test.exs
+++ b/test/elixir/test/view_errors_test.exs
@@ -289,12 +289,6 @@ defmodule ViewErrorsTest do
   end
 
   defp now(:ms) do
-    case elem(:os.type(), 0) do
-      :win32 ->
-        div(:erlang.system_time(), 1_000)
-
-      _ ->
-        div(:erlang.system_time(), 1_000_000)
-    end
+    :erlang.unique_integer([:positive])
   end
 end


### PR DESCRIPTION
## Overview

Issues that came up testing on windows.
 - nose->nose2 due to python2to3 adding code that no longer works in python 3.10 and nose1's general state.
 - replacing now() timestamp usages with a random variable to get around a clock miscalculation on windows causing transient 409 errors.

## Testing recommendations

The normal test suite runs should catch any issues.

## Related Issues or Pull Requests

These changes relate to testing of the windows glazier building process on new build systems/CI.

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
