### PR TITLE
Do not git ignore src/ioq subfolder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ src/hqueue/
 src/hyper/
 src/ibrowse/
 src/idna/
-src/ioq/
 src/jiffy/
 src/khash/
 src/meck/


### PR DESCRIPTION
We include ioq in the main repo currently so it doesn't make sense to ignore it.
