### PR TITLE
fix: consistent use of new config sections makes tests less flakey

### DIFF
--- a/test/elixir/test/config/skip.elixir
+++ b/test/elixir/test/config/skip.elixir
@@ -3,8 +3,6 @@
     "cookie auth"
   ],
   "ProxyAuthTest": [
-    "proxy auth with secret",
-    "proxy auth without secret"
   ],
   "ReaderACLTest": [
     "unrestricted db can be read"

--- a/test/elixir/test/proxyauth_test.exs
+++ b/test/elixir/test/proxyauth_test.exs
@@ -38,12 +38,12 @@ defmodule ProxyAuthTest do
         :value => users_db_name
       },
       %{
-        :section => "couch_httpd_auth",
+        :section => "chttpd_auth",
         :key => "proxy_use_secret",
         :value => "true"
       },
       %{
-        :section => "couch_httpd_auth",
+        :section => "chttpd_auth",
         :key => "secret",
         :value => secret
       }


### PR DESCRIPTION
What happens is that CouchDB starts without a secret, auto-gens one as per usual and stores it at `[chttpd_auth] secret` as per relatively recently, previously this was `[couch_http_auth] secret`.

When that change happened, we added a [utility fun](https://github.com/apache/couchdb/blob/3.x/src/chttpd/src/chttpd_util.erl#L48-L49) reads `[chttpd_auth]` and only falls back to `[couch_http_auth]` if no value exists.

So when the test set `[couch_http_auth] secret` it didn’t get picked up by CouchDB because the util function already found `[chttpd_auth] secret`.

