### PR TITLE
Creating index with empty "name"/"ddoc" should return 400

### DIFF
--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -266,11 +266,11 @@ info(mango_opts, {invalid_selector_json, BadSel}) ->
         <<"invalid_selector_json">>,
         fmt("Selector must be a JSON object, not: ~w", [BadSel])
     };
-info(mango_opts, {invalid_index_name, BadName}) ->
+info(mango_opts, invalid_empty_string) ->
     {
         400,
-        <<"invalid_index_name">>,
-        fmt("Invalid index name: ~w", [BadName])
+        <<"invalid_empty_string">>,
+        <<"Index name or ddoc cannot be empty string">>
     };
 info(mango_opts, {multiple_text_operator, {invalid_selector, BadSel}}) ->
     {

--- a/src/mango/src/mango_opts.erl
+++ b/src/mango/src/mango_opts.erl
@@ -27,7 +27,7 @@
     is_object/1,
     is_ok_or_false/1,
 
-    validate_idx_name/1,
+    validate_non_empty_string/1,
     validate_selector/1,
     validate_use_index/1,
     validate_bookmark/1,
@@ -56,13 +56,13 @@ validate_idx_create({Props}) ->
             {tag, name},
             {optional, true},
             {default, auto_name},
-            {validator, fun validate_idx_name/1}
+            {validator, fun validate_non_empty_string/1}
         ]},
         {<<"ddoc">>, [
             {tag, ddoc},
             {optional, true},
             {default, auto_name},
-            {validator, fun validate_idx_name/1}
+            {validator, fun validate_non_empty_string/1}
         ]},
         {<<"w">>, [
             {tag, w},
@@ -235,9 +235,11 @@ is_ok_or_false(false) ->
 is_ok_or_false(Else) ->
     ?MANGO_ERROR({invalid_ok_or_false_value, Else}).
 
-validate_idx_name(auto_name) ->
+validate_non_empty_string(<<>>) ->
+    ?MANGO_ERROR(invalid_empty_string);
+validate_non_empty_string(auto_name) ->
     {ok, auto_name};
-validate_idx_name(Else) ->
+validate_non_empty_string(Else) ->
     is_string(Else).
 
 validate_selector({Props}) ->

--- a/src/mango/test/01-index-crud-test.py
+++ b/src/mango/test/01-index-crud-test.py
@@ -69,7 +69,7 @@ class IndexCrudTests(mango.DbPerClass):
                 raise AssertionError("bad create index")
 
     def test_bad_names(self):
-        bad_names = [True, False, 1.5, {"foo": "bar"}, [None, False]]
+        bad_names = ["", True, False, 1.5, {"foo": "bar"}, [None, False]]
         for bn in bad_names:
             try:
                 self.db.create_index(["foo"], name=bn)
@@ -77,8 +77,12 @@ class IndexCrudTests(mango.DbPerClass):
                 self.assertEqual(e.response.status_code, 400)
             else:
                 raise AssertionError("bad create index")
+
+    def test_bad_ddocs(self):
+        bad_ddocs = ["", True, False, 1.5, {"foo": "bar"}, [None, False]]
+        for bd in bad_ddocs:
             try:
-                self.db.create_index(["foo"], ddoc=bn)
+                self.db.create_index(["foo"], ddoc=bd)
             except Exception as e:
                 self.assertEqual(e.response.status_code, 400)
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Creating an index with `"ddoc":""` or `"name":""` should return a `400 Bad Request`.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```bash
curl -X DELETE $db/abc && curl -X PUT $db/abc
curl -X POST $db/abc/_index -H 'Content-Type: application/json' -d '{"ddoc": "", "index": {"fields": ["foo"]}}'
curl -X POST $db/abc/_index -H 'Content-Type: application/json' -d '{"name": "", "index": {"fields": ["bar"]}}'

{"error":"invalid_empty_string","reason":"Index name/ddoc cannot be empty"}
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
https://github.com/apache/couchdb/issues/1472
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
