### PR TITLE
Search is available if it was ever available since start

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -68,7 +68,7 @@ handle_welcome_req(Req, _) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
 get_features() ->
-    case clouseau_rpc:connected() of
+    case dreyfus:available() of
         true ->
             [search | config:features()];
         false ->

--- a/src/dreyfus/src/dreyfus.erl
+++ b/src/dreyfus/src/dreyfus.erl
@@ -1,0 +1,31 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+
+-module(dreyfus).
+
+-export([available/0]).
+
+available() ->
+    case application:get_env(dreyfus, available) of
+        {ok, Val} ->
+            Val;
+        undefined ->
+            case clouseau_rpc:connected() of
+                true ->
+                    ok = application:set_env(dreyfus, available, true),
+                    true;
+                false ->
+                    false
+            end
+    end.

--- a/src/mango/src/mango_idx.erl
+++ b/src/mango/src/mango_idx.erl
@@ -175,7 +175,7 @@ from_ddoc(Db, {Props}) ->
         _ -> ?MANGO_ERROR(invalid_query_ddoc_language)
     end,
     IdxMods =
-        case clouseau_rpc:connected() of
+        case dreyfus:available() of
             true ->
                 [mango_idx_view, mango_idx_text];
             false ->
@@ -250,7 +250,7 @@ cursor_mod(#idx{type = <<"json">>}) ->
 cursor_mod(#idx{def = all_docs, type = <<"special">>}) ->
     mango_cursor_special;
 cursor_mod(#idx{type = <<"text">>}) ->
-    case clouseau_rpc:connected() of
+    case dreyfus:available() of
         true ->
             mango_cursor_text;
         false ->
@@ -262,7 +262,7 @@ idx_mod(#idx{type = <<"json">>}) ->
 idx_mod(#idx{type = <<"special">>}) ->
     mango_idx_special;
 idx_mod(#idx{type = <<"text">>}) ->
-    case clouseau_rpc:connected() of
+    case dreyfus:available() of
         true ->
             mango_idx_text;
         false ->
@@ -289,7 +289,7 @@ get_idx_type(Opts) ->
         <<"json">> ->
             <<"json">>;
         <<"text">> ->
-            case clouseau_rpc:connected() of
+            case dreyfus:available() of
                 true ->
                     <<"text">>;
                 false ->

--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -309,7 +309,7 @@ make_text_field_name([P | Rest], Type) ->
 
 validate_index_info(IndexInfo) ->
     IdxTypes =
-        case clouseau_rpc:connected() of
+        case dreyfus:available() of
             true ->
                 [mango_idx_view, mango_idx_text];
             false ->


### PR DESCRIPTION
calling connected() every time causes spurious 503's when clouseau
is temporarily unavailable, which is usually masked by retry logic.
