### PR TITLE
Cause a 400 Bad Request if decoding JWT token fails

### DIFF
--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -310,8 +310,8 @@ decode_b64url_json(B64UrlEncoded) ->
                 jiffy:decode(JsonEncoded)
         end
     catch
-        error:Error ->
-            throw({bad_request, Error})
+        _:_ ->
+            throw({bad_request, <<"Malformed token">>})
     end.
 
 props({Props}) ->

--- a/src/jwtf/test/jwtf_tests.erl
+++ b/src/jwtf/test/jwtf_tests.erl
@@ -39,28 +39,28 @@ jwt_io_pubkey() ->
 b64_badarg_test() ->
     Encoded = <<"0.0.0">>,
     ?assertEqual(
-        {error, {bad_request, badarg}},
+        {error, {bad_request, <<"Malformed token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 
 b64_bad_block_test() ->
     Encoded = <<" aGVsbG8. aGVsbG8. aGVsbG8">>,
     ?assertEqual(
-        {error, {bad_request, {bad_block, 0}}},
+        {error, {bad_request, <<"Malformed token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 
 invalid_json_test() ->
     Encoded = <<"fQ.fQ.fQ">>,
     ?assertEqual(
-        {error, {bad_request, {1, invalid_json}}},
+        {error, {bad_request, <<"Malformed token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 
 truncated_json_test() ->
     Encoded = <<"ew.ew.ew">>,
     ?assertEqual(
-        {error, {bad_request, {2, truncated_json}}},
+        {error, {bad_request, <<"Malformed token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 


### PR DESCRIPTION
## Overview

Jiffy throws exceptions with a descriptive reason that is not JSON-encodable. We attempt to construct a 400 Bad Request and fail, causing the request handling process to crash and no response to the client. Improve on this.

## Testing recommendations

with jwtf authenticator handler enabled;

curl -v http://localhost:15984/test -Hcontent-type:application/json -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImZvbyJ9.eyJraWQiOiJmb28iLCJzdWIiOiJhZG1pbiIsIm5hbWUiOiJhZG1pbiIsInJvbGVzIjpbInRlc3QxIiwidGVzdDIiXX0=.xftH2byj7LV9/YqqacmyZfcxQt+/h0etsgtRj6aL4AE="


## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/3976

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
