### PR TITLE
Convert DbName to list before cons

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -144,7 +144,7 @@ delete_compaction_files(RootDir, FilePath, DelOpts) ->
 is_compacting(DbName) ->
     lists:any(
         fun(Ext) ->
-            filelib:is_regular(DbName ++ Ext)
+            filelib:is_regular(?b2l(DbName) ++ Ext)
         end,
         [".compact", ".compact.data", ".compact.meta"]
     ).


### PR DESCRIPTION
## Overview

Smoosh was broken in 5ed8d54bd834a43a41eba11524171217f141e0cb with the introduction of is_compacting which attempts to cons (`++`) a binary with a list.

## Testing recommendations

Run couchdb for a few seconds with databases and observe the absence of smoosh_server crashing with a `badarg`

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/3766

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
