### PR TITLE
Ensure Object.prototype.toSource is always available

### DIFF
--- a/share/server/filter.js
+++ b/share/server/filter.js
@@ -30,7 +30,7 @@ var Filter = (function() {
       filter_view : function(fun, ddoc, args) {
         // recompile
         var sandbox = create_filter_sandbox();
-        var source = fun.toSource ? fun.toSource() : '(' + fun.toString() + ')';
+        var source = fun.toSource();
         fun = evalcx(source, sandbox);
 
         var results = [];

--- a/share/server/loop.js
+++ b/share/server/loop.js
@@ -133,7 +133,7 @@ var Loop = function() {
     } else if (e.name) {
       respond(["error", e.name, e]);
     } else {
-      respond(["error","unnamed_error",e.toSource ? e.toSource() : e.stack]);
+      respond(["error","unnamed_error", e.toSource()]);
     }
   };
   while (line = readline()) {

--- a/share/server/render.js
+++ b/share/server/render.js
@@ -347,7 +347,7 @@ var Render = (function() {
       throw(e);
     } else {
       var logMessage = "function raised error: " +
-                       (e.toSource ? e.toSource() : e.toString()) + " \n" +
+                        e.toSource() + " \n" +
                        "stacktrace: " + e.stack;
       log(logMessage);
       throw(["error", errType || "render_error", logMessage]);

--- a/share/server/util.js
+++ b/share/server/util.js
@@ -81,8 +81,7 @@ var Couch = {
           throw [
             "error",
             "compilation_error",
-            "Module require('" +name+ "') raised error " +
-            (e.toSource ? e.toSource() : e.stack)
+            "Module require('" +name+ "') raised error " + e.toSource()
           ];
         }
         ddoc._module_cache[newModule.id] = newModule.exports;
@@ -107,7 +106,7 @@ var Couch = {
       throw([
         "error",
         "compilation_error",
-        (err.toSource ? err.toSource() : err.stack) + " (" + source + ")"
+        err.toSource() + " (" + source + ")"
       ]);
     };
     if (typeof(functionObject) == "function") {
@@ -139,7 +138,7 @@ function respond(obj) {
     print(JSON.stringify(obj));
   } catch(e) {
     log("Error converting object to JSON: " + e.toString());
-    log("error on obj: "+ (obj.toSource ? obj.toSource() : obj.toString()));
+    log("error on obj: "+ obj.toSource());
   }
 };
 

--- a/share/server/views.js
+++ b/share/server/views.js
@@ -74,8 +74,7 @@ var Views = (function() {
       // will kill the OS process. This is not normally what you want.
       throw(err);
     }
-    var message = "function raised exception " +
-                  (err.toSource ? err.toSource() : err.stack);
+    var message = "function raised exception " + err.toSource();
     if (doc) message += " with doc._id " + doc._id;
     log(message);
   };

--- a/src/couch/priv/couch_js/86/main.cpp
+++ b/src/couch/priv/couch_js/86/main.cpp
@@ -269,6 +269,8 @@ int runWithContext(JSContext* cx, couch_args* args) {
     JS_SetSecurityCallbacks(cx, &security_callbacks);
 
     JS::RealmOptions options;
+    // we need this in the query server error handling
+    options.creationOptions().setToSourceEnabled(enableToSource);
     JS::RootedObject global(cx, JS_NewGlobalObject(cx, &global_class, nullptr,
                                                    JS::FireOnNewGlobalHook, options));
     if (!global)


### PR DESCRIPTION
Object.prototype.toSource() is available in all versions of spidermonkey that we support but, in later versions, must be explicitly enabled. The value of the result of toSource() is significant and we'd like to keep it.

We missed a spot when enabling the flag, which this PR corrects.

Since toSource() will always work, I have removed all the guarding added in commit aaa3921cb1cc1c96052630ac8a53ec2471e638d8 that would call toString() (with its unhelpful output) as a fallback.

