### PR TITLE
Improve index building during shard splitting

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -719,13 +719,19 @@ state_dir = {{state_dir}}
 [reshard]
 ;max_jobs = 48
 ;max_history = 20
-;max_retries = 1
+;max_retries = 5
 ;retry_interval_sec = 10
 ;delete_source = true
 ;update_shard_map_timeout_sec = 60
 ;source_close_timeout_sec = 600
 ;require_node_param = false
 ;require_range_param = false
+
+; How many times to retry building an individual index
+;index_max_retries = 5
+
+; How many seconds to wait between retries for an individual index
+;index_retry_interval_sec = 10
 
 [prometheus]
 additional_port = false


### PR DESCRIPTION
Previously we didn't check responses from get_state/2 or await/2 functions when building indices. If an index updater crashed, and the index never finished building, the get_state/2 call would simply return an error and the process would exit normally. Then, the shard splitting job would count that as a success and continue to make progress.

To fix that, make sure to check the response to all the supported indexing types and wait until they return an `ok` result.

Additionally, increase the index building resilience to allow for more retries on failure, and for configurable retries for individual index builders.
