### PR TITLE
mango_tests: revert hypothesis back for python3.6 compat

### DIFF
--- a/src/mango/requirements.txt
+++ b/src/mango/requirements.txt
@@ -1,4 +1,4 @@
 nose2==0.11.0
 requests==2.27.1
-hypothesis==6.39.4
+hypothesis==6.31.6
 


### PR DESCRIPTION
## Overview

Updating hypothesis to a recent version broke on older linux releases because it removed python 3.6 support as soon as it was EOLed.

## Testing recommendations

This needs to pass standard jenkins CI runs and should also work on python 3.10+. 

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/3980

## Checklist

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
