### PR TITLE
Remove CI support for Debian 9 (stretch)

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -47,12 +47,6 @@ meta = [
     image: "apache/couchdbci-ubuntu:focal-erlang-${ERLANG_VERSION}"
   ],
 
-  'stretch': [
-    name: 'Debian 9',
-    spidermonkey_vsn: '1.8.5',
-    image: "apache/couchdbci-debian:stretch-erlang-${ERLANG_VERSION}"
-  ],
-
   'buster': [
     name: 'Debian 10',
     spidermonkey_vsn: '60',
@@ -413,9 +407,8 @@ pipeline {
 
           sh( label: 'Build Debian repo', script: '''
             git clone https://github.com/apache/couchdb-pkg
-            cp js/debian-stretch/*.deb pkgs/stretch
             cp js/ubuntu-bionic/*.deb pkgs/bionic
-            for plat in stretch buster bullseye bionic focal
+            for plat in buster bullseye bionic focal
             do
               reprepro -b couchdb-pkg/repo includedeb $plat pkgs/$plat/*.deb
             done


### PR DESCRIPTION
## Overview

Debian Stretch is out of official support and uses python 3.5 which is EOL so this blocks using recent versions of nose2, hypothesis, etc.

## Testing recommendations

This hopefully drops stretch in the pipeline. I do not know how to test it in advance.

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/3980
https://github.com/apache/couchdb-documentation/pull/714

## Checklist

- [X] Code is written and works correctly (visual review only)
- [X] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
