### PR TITLE
Handle request processes exiting with `{shutdown, Error}`

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -162,7 +162,7 @@ DepDescs = [
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-1"}},
-{mochiweb,         "mochiweb",         {tag, "CouchDB-v2.21.0-1"}},
+{mochiweb,         "mochiweb",         {tag, "CouchDB-v2.22.0-1"}},
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.2"}}
 ].

--- a/src/chttpd/src/chttpd_external.erl
+++ b/src/chttpd/src/chttpd_external.erl
@@ -79,6 +79,8 @@ json_req_obj_field(<<"body">>, #httpd{req_body = undefined, mochi_req = Req}, _D
     try
         Req:recv_body(MaxSize)
     catch
+        exit:{shutdown, _} ->
+            exit({bad_request, <<"Invalid request body">>});
         exit:normal ->
             exit({bad_request, <<"Invalid request body">>})
     end;

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -411,6 +411,8 @@ handle_request_int(MochiReq, DefaultFun,
         throw:bad_accept_encoding_value ->
             couch_log:error("received invalid Accept-Encoding header", []),
             send_error(HttpReq, bad_request);
+        exit:{shutdown, Error} ->
+            exit({shutdown, Error});
         exit:normal ->
             exit(normal);
         exit:snappy_nif_not_loaded ->


### PR DESCRIPTION
Previously on error they exited `normal`, and now exit with the `{shutdown, Error}` reason.

See: https://github.com/mochi/mochiweb/commit/e56a4dce6b360c5c5d037e8de33dd267790092e4