### PR TITLE
Bump mochiweb to include the {shutdown, Error} in acceptor recycler

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -162,7 +162,7 @@ DepDescs = [
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-1"}},
-{mochiweb,         "mochiweb",         {tag, "CouchDB-v2.21.0-1"}},
+{mochiweb,         "mochiweb",         {tag, "CouchDB-v2.22.0-2"}},
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.2"}}
 ].


### PR DESCRIPTION
https://github.com/apache/couchdb-mochiweb/commit/077b4f801ba8f853a9649a9c0f055b8e4f33dcca

