### PR TITLE
Bump jiffy to 1.1.1 and b64url to 1.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ python-black: .venv/bin/black
 	       echo "Python formatter not supported on Python < 3.6; check results on a newer platform"
 	@python3 -c "import sys; exit(1 if sys.version_info >= (3,6) else 0)" || \
 		LC_ALL=C.UTF-8 LANG=C.UTF-8 .venv/bin/black --check \
-		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/erlfmt|src/rebar/pr2relnotes.py|src/fauxton" \
+		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/erlfmt|src/jiffy|src/rebar/pr2relnotes.py|src/fauxton" \
 		build-aux/*.py dev/run dev/format_*.py src/mango/test/*.py src/docs/src/conf.py src/docs/ext/*.py .
 
 python-black-update: .venv/bin/black

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -147,7 +147,7 @@ SubDirs = [
 DepDescs = [
 %% Independent Apps
 {config,           "config",           {tag, "2.1.9"}},
-{b64url,           "b64url",           {tag, "1.0.2"}},
+{b64url,           "b64url",           {tag, "1.0.3"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},
 {snappy,           "snappy",           {tag, "CouchDB-1.0.7"}},
@@ -161,7 +161,7 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
-{jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-1"}},
+{jiffy,            "jiffy",            {tag, "1.1.1"}},
 {mochiweb,         "mochiweb",         {tag, "v3.0.0"}},
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.2"}}


### PR DESCRIPTION
jiffy changelog: https://github.com/davisp/jiffy/compare/1.0.9...1.1.1
b64url changelog: https://github.com/apache/couchdb-b64url/compare/1.0.2...1.0.3