### PR TITLE
Fix maybe_handle_error clauses

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1134,14 +1134,14 @@ maybe_handle_error(Error) ->
     case chttpd_plugin:handle_error(Error) of
         {_Code, _Reason, _Description} = Result ->
             Result;
+        {shutdown, Err} ->
+            exit({shutdown, Err});
         {Err, Reason} ->
             {500, couch_util:to_binary(Err), couch_util:to_binary(Reason)};
         normal ->
             exit(normal);
-        {shutdown, Err} ->
-            exit({shutdown, Err});
-        Error ->
-            {500, <<"unknown_error">>, couch_util:to_binary(Error)}
+        Err ->
+            {500, <<"unknown_error">>, couch_util:to_binary(Err)}
     end.
 
 error_headers(#httpd{mochi_req = MochiReq} = Req, 401 = Code, ErrorStr, ReasonStr) ->


### PR DESCRIPTION
`{shutdown, Err}` should come before `{Err Reason}`, otherwise `{Err, Reason}` will always match.

Also, plugin `handle_error/1` response was forced to match initial `Error`, which doesn't have to always be the case based on https://github.com/apache/couchdb/blob/42f2c1c534ed5c210b45ffcd9a621a31b781b5ae/src/chttpd/src/chttpd_plugin.erl#L39-L41

