### PR TITLE
Reduce smoosh compaction log level to debug

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -651,7 +651,7 @@ partitioned||* = true
 state_dir = {{state_dir}}
 
 ; Sets the log level for informational compaction related entries.
-;compaction_log_level = notice
+;compaction_log_level = debug
 
 [ioq]
 ; The maximum number of concurrent in-flight IO requests that

--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -148,7 +148,7 @@ handle_cast({enqueue, _Object, 0}, #state{} = State) ->
 handle_cast({enqueue, Object, Priority}, #state{activated = true} = State) ->
     {noreply, maybe_start_compaction(add_to_queue(Object, Priority, State))};
 handle_cast({enqueue, Object, Priority}, #state{activated = false, requests = Requests} = State0) ->
-    Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+    Level = smoosh_utils:log_level("compaction_log_level", "debug"),
     couch_log:Level(
         "~p Channel is not activated yet. Adding ~p to requests with priority ~p.", [
             ?MODULE,
@@ -254,7 +254,7 @@ handle_info(start_recovery, #state{name = Name, waiting = Waiting0} = State0) ->
         RecActive
     ),
     State1 = maybe_start_compaction(State0#state{paused = false, waiting = Waiting1}),
-    Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+    Level = smoosh_utils:log_level("compaction_log_level", "debug"),
     couch_log:Level(
         "~p Previously active compaction jobs (if any) have been successfully recovered and restarted.",
         [?MODULE]
@@ -292,7 +292,7 @@ do_recover(FilePath) ->
             <<Vsn, Binary/binary>> = Content,
             try parse_state(Vsn, ?VSN, Binary) of
                 Term ->
-                    Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+                    Level = smoosh_utils:log_level("compaction_log_level", "debug"),
                     couch_log:Level(
                         "~p Successfully restored state file ~s", [?MODULE, FilePath]
                     ),
@@ -306,7 +306,7 @@ do_recover(FilePath) ->
                     error
             end;
         {error, enoent} ->
-            Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+            Level = smoosh_utils:log_level("compaction_log_level", "debug"),
             couch_log:Level(
                 "~p (~p) State file ~s does not exist. Not restoring.", [?MODULE, enoent, FilePath]
             ),

--- a/src/smoosh/src/smoosh_priority_queue.erl
+++ b/src/smoosh/src/smoosh_priority_queue.erl
@@ -144,7 +144,7 @@ do_recover(FilePath) ->
             <<Vsn, Binary/binary>> = Content,
             try parse_queue(Vsn, ?VSN, Binary) of
                 Bin ->
-                    Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+                    Level = smoosh_utils:log_level("compaction_log_level", "debug"),
                     couch_log:Level(
                         "~p Successfully restored state file ~s", [?MODULE, FilePath]
                     ),
@@ -158,7 +158,7 @@ do_recover(FilePath) ->
                     error
             end;
         {error, enoent} ->
-            Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+            Level = smoosh_utils:log_level("compaction_log_level", "debug"),
             couch_log:Level(
                 "~p (~p) Queue file ~s does not exist. Not restoring.", [?MODULE, enoent, FilePath]
             ),

--- a/src/smoosh/src/smoosh_server.erl
+++ b/src/smoosh/src/smoosh_server.erl
@@ -173,7 +173,7 @@ handle_call({enqueue, Object}, _From, State) ->
 handle_call(suspend, _From, State) ->
     ets:foldl(
         fun(#channel{name = Name, pid = P}, _) ->
-            Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+            Level = smoosh_utils:log_level("compaction_log_level", "debug"),
             couch_log:Level("Suspending ~p", [Name]),
             smoosh_channel:suspend(P)
         end,
@@ -184,7 +184,7 @@ handle_call(suspend, _From, State) ->
 handle_call(resume, _From, State) ->
     ets:foldl(
         fun(#channel{name = Name, pid = P}, _) ->
-            Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+            Level = smoosh_utils:log_level("compaction_log_level", "debug"),
             couch_log:Level("Resuming ~p", [Name]),
             smoosh_channel:resume(P)
         end,

--- a/src/smoosh/src/smoosh_utils.erl
+++ b/src/smoosh/src/smoosh_utils.erl
@@ -88,7 +88,7 @@ throw_on_error(Args, {error, Reason}) ->
     throw({error, {Reason, Args}}).
 
 write_to_file(Content, FileName, VSN) ->
-    Level = log_level("compaction_log_level", "notice"),
+    Level = log_level("compaction_log_level", "debug"),
     couch_log:Level("~p Writing state ~s", [?MODULE, FileName]),
     OnDisk = <<VSN, (erlang:term_to_binary(Content, [compressed, {minor_version, 1}]))/binary>>,
     TmpFileName = FileName ++ ".tmp",


### PR DESCRIPTION
With a few channels around these add up and make local development not as ergonomic. Let's turn them to `debug` and users can always toggle them to info or error if needed.
