### PR TITLE
Default rexi use_kill_all to true

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -296,11 +296,11 @@ bind_address = 127.0.0.1
 ; server_per_node = true
 ; stream_limit = 5
 ;
-; Use a single message to kill a group of remote workers This is
-; mostly is an upgrade clause to allow operating in a mixed cluster of
-; 2.x and 3.x nodes. After upgrading switch to true to save some
-; network bandwidth
-;use_kill_all = false
+; Use a single message to kill a group of remote workers. This feature is
+; available starting with 3.0. When performing a rolling upgrade from 2.x to
+; 3.x, set this value to false, then after all nodes were upgraded delete it so
+; it can use the default true value.
+;use_kill_all = true
 
 ; [global_changes]
 ; max_event_delay = 25

--- a/src/rexi/src/rexi.erl
+++ b/src/rexi/src/rexi.erl
@@ -80,11 +80,10 @@ kill(Node, Ref) ->
 %% No rexi_EXIT message will be sent.
 -spec kill_all([{node(), reference()}]) -> ok.
 kill_all(NodeRefs) when is_list(NodeRefs) ->
-    %% Upgrade clause. Since kill_all is a new message, nodes in a mixed
-    %% cluster won't know how to process it. In that case, the default is to send
-    %% the individual kill messages. Once all the nodes have been upgraded, can
-    %% configure the cluster to send kill_all messages.
-    case config:get_boolean("rexi", "use_kill_all", false) of
+    %% use_kill_all is available since version 3.0. When performing a rolling
+    %% cluster upgrade from 2.x, set this value to false, then revert it back
+    %% to default (true) after all nodes have been upgraded.
+    case config:get_boolean("rexi", "use_kill_all", true) of
         true ->
             PerNodeMap = lists:foldl(
                 fun({Node, Ref}, Acc) ->


### PR DESCRIPTION
It should save some dist bandwidth when workers are canceled at the end of fabric requests. The feature has been available since 3.0.x (3 years ago) so opt to enable it by default.

Users who do a rolling upgrade from 2.x could still set it to `false` and then, after the upgrade completes, delete it to return it to default (true).
