### PR TITLE
Dead code cleanup

### DIFF
--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -39,11 +39,11 @@
 % public API
 -export([open/1, open/2, close/1, bytes/1, sync/1, truncate/2, set_db_pid/2]).
 -export([pread_term/2, pread_iolist/2, pread_binary/2]).
--export([append_binary/2, append_binary_md5/2]).
--export([append_raw_chunk/2, assemble_file_chunk/1, assemble_file_chunk/2]).
--export([append_term/2, append_term/3, append_term_md5/2, append_term_md5/3]).
--export([pread_terms/2, pread_binaries/2, pread_iolists/2]).
--export([append_terms/2, append_terms/3, append_binaries/2]).
+-export([append_binary/2]).
+-export([append_raw_chunk/2, assemble_file_chunk/2]).
+-export([append_term/2, append_term/3]).
+-export([pread_terms/2]).
+-export([append_terms/2, append_terms/3]).
 -export([write_header/2, read_header/1]).
 -export([delete/2, delete/3, nuke_dir/2, init_delete_dir/1]).
 -export([last_read/1]).
@@ -124,13 +124,6 @@ append_term(Fd, Term, Options) ->
     Comp = couch_util:get_value(compression, Options, ?DEFAULT_COMPRESSION),
     append_binary(Fd, couch_compress:compress(Term, Comp)).
 
-append_term_md5(Fd, Term) ->
-    append_term_md5(Fd, Term, []).
-
-append_term_md5(Fd, Term, Options) ->
-    Comp = couch_util:get_value(compression, Options, ?DEFAULT_COMPRESSION),
-    append_binary_md5(Fd, couch_compress:compress(Term, Comp)).
-
 %%----------------------------------------------------------------------
 %% Purpose: To append an Erlang binary to the end of the file.
 %% Args:    Erlang term to serialize and append to the file.
@@ -141,13 +134,6 @@ append_term_md5(Fd, Term, Options) ->
 
 append_binary(Fd, Bin) ->
     ioq:call(Fd, {append_bin, assemble_file_chunk(Bin)}, erlang:get(io_priority)).
-
-append_binary_md5(Fd, Bin) ->
-    ioq:call(
-        Fd,
-        {append_bin, assemble_file_chunk(Bin, couch_hash:md5_hash(Bin))},
-        erlang:get(io_priority)
-    ).
 
 append_raw_chunk(Fd, Chunk) ->
     ioq:call(Fd, {append_bin, Chunk}, erlang:get(io_priority)).

--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -14,7 +14,6 @@
 
 -export([go/3]).
 
--include_lib("fabric/include/fabric.hrl").
 -include_lib("mem3/include/mem3.hrl").
 -include_lib("couch/include/couch_db.hrl").
 

--- a/src/rexi/src/rexi.erl
+++ b/src/rexi/src/rexi.erl
@@ -21,8 +21,6 @@
 -export([stream2/1, stream2/2, stream2/3, stream_last/1, stream_last/2]).
 -export([ping/0]).
 
--include_lib("rexi/include/rexi.hrl").
-
 start() ->
     application:start(rexi).
 

--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -460,19 +460,6 @@ maybe_start_compaction(State) ->
             State
     end.
 
-start_compact(State, {schema, DbName, GroupId}) ->
-    case smoosh_utils:ignore_db({DbName, GroupId}) of
-        false ->
-            {ok, Pid} = couch_md_index_manager:get_group_pid(
-                DbName,
-                GroupId
-            ),
-            Ref = erlang:monitor(process, Pid),
-            Pid ! {'$gen_call', {self(), Ref}, compact},
-            State#state{starting = [{Ref, {schema, DbName, GroupId}} | State#state.starting]};
-        _ ->
-            false
-    end;
 start_compact(State, DbName) when is_list(DbName) ->
     start_compact(State, ?l2b(DbName));
 start_compact(State, DbName) when is_binary(DbName) ->

--- a/src/smoosh/src/smoosh_server.erl
+++ b/src/smoosh/src/smoosh_server.erl
@@ -384,20 +384,6 @@ get_priority(Channel, {Shard, GroupId}) ->
             ),
             0
     end;
-get_priority(Channel, {schema, DbName, DDocId}) ->
-    case couch_md_index_manager:get_group_pid(DbName, DDocId) of
-        {ok, Pid} ->
-            {ok, SchemaInfo} = couch_md_index:get_info(Pid),
-            DiskSize = couch_util:get_value(disk_size, SchemaInfo),
-            DataSize = couch_util:get_value(data_size, SchemaInfo),
-            get_priority(Channel, DiskSize, DataSize, false);
-        {error, Reason} ->
-            couch_log:warning(
-                "Failed to get group_pid for ~p ~p ~p: ~p",
-                [Channel, DbName, DDocId, Reason]
-            ),
-            0
-    end;
 get_priority(Channel, DbName) when is_list(DbName) ->
     get_priority(Channel, ?l2b(DbName));
 get_priority(Channel, DbName) when is_binary(DbName) ->

--- a/src/smoosh/src/smoosh_utils.erl
+++ b/src/smoosh/src/smoosh_utils.erl
@@ -13,22 +13,9 @@
 -module(smoosh_utils).
 -include_lib("couch/include/couch_db.hrl").
 
--export([get/2, get/3, group_pid/1, split/1, stringify/1, ignore_db/1]).
+-export([get/2, get/3, split/1, stringify/1, ignore_db/1]).
 -export([in_allowed_window/1, write_to_file/3]).
 -export([log_level/2]).
-
-group_pid({Shard, GroupId}) ->
-    case couch_view_group:open_db_group(Shard, GroupId) of
-        {ok, Group} ->
-            try
-                gen_server:call(couch_view, {get_group_server, Shard, Group})
-            catch
-                _:Error ->
-                    {error, Error}
-            end;
-        Else ->
-            Else
-    end.
 
 get(Channel, Key) ->
     ?MODULE:get(Channel, Key, undefined).


### PR DESCRIPTION
Remove some dead code.

  * Unused include files
  * Experimental functionality (schemas) in smoosh
  * Unused exported functions from `couch_file`
    * `append_binary_md5/2`
    * `assemble_file_chunk/1`
    * `append_term_md5/2`
    * `append_term_md5/3`
    * `pread_binaries/2`
    * `pread_iolists/2`

