### PR TITLE
Fix jwtf support for ES* algorithms

### DIFF
--- a/test/elixir/test/jwtauth_test.exs
+++ b/test/elixir/test/jwtauth_test.exs
@@ -75,7 +75,7 @@ defmodule JwtAuthTest do
   test "jwt auth with EC secret", _context do
     require JwtAuthTest.EC
 
-    private_key = :public_key.generate_key({:namedCurve, :secp384r1})
+    private_key = :public_key.generate_key({:namedCurve, :secp256r1})
     point = EC.point(point: EC.private(private_key, :publicKey))
     public_key = {point, EC.private(private_key, :parameters)}
 
@@ -125,6 +125,7 @@ defmodule JwtAuthTest do
       headers: [authorization: "Bearer #{token}"]
     )
 
+    assert resp.status_code == 200
     assert resp.body["userCtx"]["name"] == "couch@apache.org"
     assert resp.body["info"]["authenticated"] == "jwt"
   end


### PR DESCRIPTION
ES256 support is apparently broken. Here's a test to prove it. I don't know the fix, though. I tried the same example (from jwt.io) with another library (https://github.com/G-Corp/jwerl) and it also fails. Is... Is erlang the problem?
