### PR TITLE
Handle exit(shutdown) error in chttpd

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1140,6 +1140,8 @@ maybe_handle_error(Error) ->
             {500, couch_util:to_binary(Err), couch_util:to_binary(Reason)};
         normal ->
             exit(normal);
+        shutdown ->
+            exit(shutdown);
         Err ->
             {500, <<"unknown_error">>, couch_util:to_binary(Err)}
     end.


### PR DESCRIPTION
We handle mochiweb's `{shutdown, Error}` exit. However, chttpd itself exits with a plain `exit(shutdown)`, and in that case, our nested catch statements [1] will emit an "unknown_error" log line. So, make sure to handle that as well
in order to keep the log noise down.

[1] `handle_req_after_auth/2` is nested inside [`process_request/1`](https://github.com/apache/couchdb/blob/3.x/src/chttpd/src/chttpd.erl#L386) and both call `catch_error/4`
