### PR TITLE
Allow and evaluate nested json claim roles

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -181,10 +181,31 @@ bind_address = 127.0.0.1
 ; List of claims to validate
 ; can be the name of a claim like "exp" or a tuple if the claim requires
 ; a parameter
-; required_claims = exp, {iss, "IssuerNameHere"}
-; roles_claim_name = https://example.com/roles
-;
-; [jwt_keys]
+;required_claims = exp, {iss, "IssuerNameHere"}
+; roles_claim_name is marked as deprecated. Please use roles_claim_path instead!
+; Values for ``roles_claim_name`` can only be top-level attributes in the JWT
+; token. If ``roles_claim_path`` is set, then ``roles_claim_name`` is ignored!
+;roles_claim_name = my-couchdb-roles
+; roles_claim_path was introduced to overcome disadvantages of ``roles_claim_name``,
+; because it is not possible with ``roles_claim_name`` to map nested role
+; attributes in the JWT token. There are only two characters with a special meaning.
+; These are
+;    - ``.`` for nesting json attributes and
+;    - ``\.`` to skip nesting
+; Example JWT data-payload:
+; {
+;   "my": {
+;       "nested": {
+;           "_couchdb.roles": [
+;               ...
+;           ]
+;       }
+;   }
+; }
+; would result in the following parameter config:
+;roles_claim_path = my.nested._couchdb\.roles
+
+;[jwt_keys]
 ; Configure at least one key here if using the JWT auth handler.
 ; If your JWT tokens do not include a "kid" attribute, use "_default"
 ; as the config key, otherwise use the kid as the config key.

--- a/test/elixir/test/jwt_roles_claim_test.exs
+++ b/test/elixir/test/jwt_roles_claim_test.exs
@@ -1,0 +1,167 @@
+defmodule JwtRolesClaimTest do
+  use CouchTestCase
+
+  @global_server_config [
+    %{
+      :section => "chttpd",
+      :key => "authentication_handlers",
+      :value => [
+                  "{chttpd_auth, jwt_authentication_handler}, ",
+                  "{chttpd_auth, cookie_authentication_handler}, ",
+                  "{chttpd_auth, default_authentication_handler})"
+                ] |> Enum.join
+    },
+    %{
+      :section => "jwt_keys",
+      :key => "hmac:myjwttestkey",
+      :value => ~w(
+        NTNv7j0TuYARvmNMmWXo6fKvM4o6nv/aUi9ryX38ZH+L1bkrnD1ObOQ8JAUmHCBq7
+        Iy7otZcyAagBLHVKvvYaIpmMuxmARQ97jUVG16Jkpkp1wXOPsrF9zwew6TpczyH
+        kHgX5EuLg2MeBuiT/qJACs1J0apruOOJCg/gOtkjB4c=) |> Enum.join()
+    }
+  ]
+
+  test "case: roles_claim_name (undefined) / roles_claim_path (undefined)" do
+    server_config = @global_server_config
+
+    run_on_modified_server(server_config, fn ->
+      test_roles(["_couchdb.roles_1", "_couchdb.roles_2"])
+    end)
+  end
+
+  test "case: roles_claim_name (defined) / roles_claim_path (undefined)" do
+    server_config =
+      [
+        %{
+          :section => "jwt_auth",
+          :key => "roles_claim_name",
+          :value => "my._couchdb.roles"
+        }
+      ] ++ @global_server_config
+
+    run_on_modified_server(server_config, fn ->
+      test_roles(["my._couchdb.roles_1", "my._couchdb.roles_2"])
+    end)
+  end
+
+  test "case: roles_claim_name (undefined) / roles_claim_path (defined)" do
+    server_config =
+      [
+        %{
+          :section => "jwt_auth",
+          :key => "roles_claim_path",
+          :value => "foo.bar\\.zonk.baz\\.buu.baa.baa\\.bee.roles"
+        }
+      ] ++ @global_server_config
+
+    run_on_modified_server(server_config, fn ->
+      test_roles(["my_nested_role_1", "my_nested_role_2"])
+    end)
+  end
+
+  test "case: roles_claim_name (defined) / roles_claim_path (defined)" do
+    server_config =
+      [
+        %{
+          :section => "jwt_auth",
+          :key => "roles_claim_name",
+          :value => "my._couchdb.roles"
+        },
+        %{
+          :section => "jwt_auth",
+          :key => "roles_claim_path",
+          :value => "foo.bar\\.zonk.baz\\.buu.baa.baa\\.bee.roles"
+        }
+      ] ++ @global_server_config
+
+    run_on_modified_server(server_config, fn ->
+      test_roles(["my_nested_role_1", "my_nested_role_2"])
+    end)
+  end
+
+  test "case: roles_claim_path with bad input" do
+    server_config =
+      [
+        %{
+          :section => "jwt_auth",
+          :key => "roles_claim_path",
+          :value => "<<foo.bar\\.zonk.baz\\.buu.baa.baa\\.bee.roles"
+        }
+      ] ++ @global_server_config
+
+    run_on_modified_server(server_config, fn ->
+      test_roles_with_bad_input()
+    end)
+
+    server_config =
+      [
+        %{
+          :section => "jwt_auth",
+          :key => "roles_claim_path",
+          :value => "foo.bar\\.zonk.baz\\.buu.baa.baa\\.bee.roles>>"
+        }
+      ] ++ @global_server_config
+
+    run_on_modified_server(server_config, fn ->
+      test_roles_with_bad_input()
+    end)
+
+    server_config =
+      [
+        %{
+          :section => "jwt_auth",
+          :key => "roles_claim_path",
+          :value => "123456"
+        }
+      ] ++ @global_server_config
+
+    run_on_modified_server(server_config, fn ->
+      test_roles_with_bad_input()
+    end)
+  end
+
+  def test_roles(roles) do
+    token = ~w(
+      eyJ0eXAiOiJKV1QiLCJraWQiOiJteWp3dHRlc3RrZXkiLCJhbGciOiJIUzI1NiJ9.
+      eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRyd
+      WUsImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxNzU1Mjk5NDEwLCJteSI6eyJuZXN0ZW
+      QiOnsiX2NvdWNoZGIucm9sZXMiOlsibXlfbmVzdGVkX2NvdWNoZGIucm9sZXNfMSI
+      sIm15X25lc3RlZF9jb3VjaGRiLnJvbGVzXzEiXX19LCJfY291Y2hkYi5yb2xlcyI6
+      WyJfY291Y2hkYi5yb2xlc18xIiwiX2NvdWNoZGIucm9sZXNfMiJdLCJteS5fY291Y
+      2hkYi5yb2xlcyI6WyJteS5fY291Y2hkYi5yb2xlc18xIiwibXkuX2NvdWNoZGIucm
+      9sZXNfMiJdLCJmb28iOnsiYmFyLnpvbmsiOnsiYmF6LmJ1dSI6eyJiYWEiOnsiYmF
+      hLmJlZSI6eyJyb2xlcyI6WyJteV9uZXN0ZWRfcm9sZV8xIiwibXlfbmVzdGVkX3Jv
+      bGVfMiJdfX19fX19.F6kQK-FK0z1kP01bTyw-moXfy2klWfubgF7x7Xitd-0) |> Enum.join()
+
+    resp =
+      Couch.get("/_session",
+        headers: [authorization: "Bearer #{token}"]
+      )
+
+    assert resp.body["userCtx"]["name"] == "1234567890"
+    assert resp.body["userCtx"]["roles"] == roles
+    assert resp.body["info"]["authenticated"] == "jwt"
+  end
+
+  def test_roles_with_bad_input() do
+    token = ~w(
+      eyJ0eXAiOiJKV1QiLCJraWQiOiJteWp3dHRlc3RrZXkiLCJhbGciOiJIUzI1NiJ9.
+      eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRyd
+      WUsImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxNzU1Mjk5NDEwLCJteSI6eyJuZXN0ZW
+      QiOnsiX2NvdWNoZGIucm9sZXMiOlsibXlfbmVzdGVkX2NvdWNoZGIucm9sZXNfMSI
+      sIm15X25lc3RlZF9jb3VjaGRiLnJvbGVzXzEiXX19LCJfY291Y2hkYi5yb2xlcyI6
+      WyJfY291Y2hkYi5yb2xlc18xIiwiX2NvdWNoZGIucm9sZXNfMiJdLCJteS5fY291Y
+      2hkYi5yb2xlcyI6WyJteS5fY291Y2hkYi5yb2xlc18xIiwibXkuX2NvdWNoZGIucm
+      9sZXNfMiJdLCJmb28iOnsiYmFyLnpvbmsiOnsiYmF6LmJ1dSI6eyJiYWEiOnsiYmF
+      hLmJlZSI6eyJyb2xlcyI6WyJteV9uZXN0ZWRfcm9sZV8xIiwibXlfbmVzdGVkX3Jv
+      bGVfMiJdfX19fX19.F6kQK-FK0z1kP01bTyw-moXfy2klWfubgF7x7Xitd-0) |> Enum.join()
+
+    resp =
+      Couch.get("/_session",
+        headers: [authorization: "Bearer #{token}"]
+      )
+
+    assert resp.status_code == 404
+  end
+
+end


### PR DESCRIPTION
## Overview

In a JWT token it is possible to add an attribute for role claims. If the roles are presented as top-level attribute like
```json
{
  "couchdb-roles": [
    "my_role_1",
    "my_role_2"
  ]
}
```
and setting the parameter `roles_claim_name` in the config file to 
```
[jwt_auth]
roles_claim_name = couchdb-roles
```
CouchDB was able to read that attributed and take over that roles.

This doesn't work, if the claim roles are nested, eg:
```
{
  "my" :{
    "nested": {
       "couchdb-roles": [
         "my_role_1",
         "my_role_2"
       ]
    }
  }
}
```
To allow this and for backwards compatibility, a new config parameter `roles_claim_path` is introduced to allow nested role claims. To allow the example from above, yo can use the following syntax:
```
[jwt_auth]
roles_claim_path = my.nested.couchdb-roles
```
If `roles_claim_path` is defined, then `roles_claim_name` is ignored.

## Testing recommendations

Example JWT token:
```
eyJ0eXAiOiJKV1QiLCJraWQiOiJteWp3dHRlc3RrZXkiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxNzU1Mjk5NDEwLCJteSI6eyJuZXN0ZWQiOnsiX2NvdWNoZGIucm9sZXMiOlsibXlfbmVzdGVkX2NvdWNoZGIucm9sZXNfMSIsIm15X25lc3RlZF9jb3VjaGRiLnJvbGVzXzEiXX19LCJfY291Y2hkYi5yb2xlcyI6WyJfY291Y2hkYi5yb2xlc18xIiwiX2NvdWNoZGIucm9sZXNfMiJdLCJteS5fY291Y2hkYi5yb2xlcyI6WyJteS5fY291Y2hkYi5yb2xlc18xIiwibXkuX2NvdWNoZGIucm9sZXNfMiJdLCJmb28iOnsiYmFyLnpvbmsiOnsiYmF6LmJ1dSI6eyJiYWEiOnsiYmFhLmJlZSI6eyJyb2xlcyI6WyJteV9uZXN0ZWRfcm9sZV8xIiwibXlfbmVzdGVkX3JvbGVfMiJdfX19fX19.F6kQK-FK0z1kP01bTyw-moXfy2klWfubgF7x7Xitd-0
```

Example config file:
```
[chttpd]
authentication_handlers = {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}

[jwt_auth]
roles_claim_path = foo.bar\.zonk.baz\.buu.baa.baa\.bee.roles

[jwt_keys]
hmac:myjwttestkey = NTNv7j0TuYARvmNMmWXo6fKvM4o6nv/aUi9ryX38ZH+L1bkrnD1ObOQ8JAUmHCBq7Iy7otZcyAagBLHVKvvYaIpmMuxmARQ97jUVG16Jkpkp1wXOPsrF9zwew6TpczyHkHgX5EuLg2MeBuiT/qJACs1J0apruOOJCg/gOtkjB4c=
```

## Related Issues or Pull Requests

#3758 
#3166 

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation, see https://github.com/apache/couchdb-documentation/pull/737
