### PR TITLE
Optimize couch_key_tree:find_missing/2

### DIFF
--- a/src/couch_pse_tests/src/cpse_test_fold_changes.erl
+++ b/src/couch_pse_tests/src/cpse_test_fold_changes.erl
@@ -123,7 +123,7 @@ cpse_update_second_of_two(Db1) ->
     ?assertEqual([{<<"a">>, 1}, {<<"b">>, 3}], lists:reverse(Changes)).
 
 cpse_check_mutation_ordering(Db1) ->
-    Actions = shuffle(
+    Actions = test_util:shuffle(
         lists:map(
             fun(Seq) ->
                 {create, {docid(Seq), {[]}}}
@@ -168,11 +168,6 @@ do_mutation_ordering(Db, Seq, [{DocId, _OldSeq} | Rest], DocSeqAcc) ->
         couch_db_engine:fold_changes(NewDb, 0, fun fold_fun/2, [], []),
     ?assertEqual(Expected, lists:reverse(RevOrder)),
     do_mutation_ordering(NewDb, Seq + 1, Rest, NewAcc).
-
-shuffle(List) ->
-    Paired = [{couch_rand:uniform(), I} || I <- List],
-    Sorted = lists:sort(Paired),
-    [I || {_, I} <- Sorted].
 
 fold_fun(#full_doc_info{id = Id, update_seq = Seq}, Acc) ->
     {ok, [{Id, Seq} | Acc]}.

--- a/src/mem3/test/eunit/mem3_ring_prop_tests.erl
+++ b/src/mem3/test/eunit/mem3_ring_prop_tests.erl
@@ -92,7 +92,7 @@ g_connected_intervals(Begin, End, Split) when Begin =< End ->
                     Ns = lists:seq(1, N - 1),
                     Bs = lists:usort([rand_range(Begin, End) || _ <- Ns]),
                     Es = [B - 1 || B <- Bs],
-                    shuffle(lists:zip([Begin] ++ Bs, Es ++ [End]))
+                    test_util:shuffle(lists:zip([Begin] ++ Bs, Es ++ [End]))
             end
         end
     ).
@@ -148,10 +148,6 @@ rand_range(B, B) ->
     B;
 rand_range(B, E) ->
     B + rand:uniform(E - B).
-
-shuffle(L) ->
-    Tagged = [{rand:uniform(), X} || X <- L],
-    [X || {_, X} <- lists:sort(Tagged)].
 
 endpoints(Ranges) ->
     {Begins, Ends} = lists:unzip(Ranges),


### PR DESCRIPTION
Previously, we always fully traversed the search keys list, when we partitioned it into possible and impossible sublists. The optimization is we can stop traversing early if the search keys are sorted as soon as we hit a key that is `>=` than the current position in the tree. To keep things simple we can use the [lists:splitwith/2](https://github.com/erlang/otp/blob/40922798411c2d23ee8a99456f96d6637c62b762/lib/stdlib/src/lists.erl#L1426-L1435) function which seems to do what we want.
