### PR TITLE
Add Erlang 25 support

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -150,7 +150,7 @@ DepDescs = [
 {b64url,           "b64url",           {tag, "1.0.3"}},
 {ets_lru,          "ets-lru",          {tag, "1.1.0"}},
 {khash,            "khash",            {tag, "1.1.0"}},
-{snappy,           "snappy",           {tag, "CouchDB-1.0.7"}},
+{snappy,           "snappy",           {tag, "CouchDB-1.0.8"}},
 
 %% Non-Erlang deps
 {docs,             {url, "https://github.com/apache/couchdb-documentation"},
@@ -192,7 +192,7 @@ MakeDep = fun
 end.
 
 AddConfig = [
-    {require_otp_vsn, "20|21|22|23|24"},
+    {require_otp_vsn, "20|21|22|23|24|25"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},


### PR DESCRIPTION
Before merging this PR, PR [couchdb-snappy#16](https://github.com/apache/couchdb-snappy/pull/16) in couchdb-snappy needs to get merged and tagged with CouchDB-1.0.8
