### PR TITLE
Enable replicating purge requests between nodes

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -278,6 +278,12 @@ bind_address = 127.0.0.1
 ; shard_cache_size = 25000
 ; shards_db = _dbs
 ; sync_concurrency = 10
+;
+; When enabled, internal replicator will replicate purge requests between shard
+; copies. It may be helpful to disable it temporarily when doing rolling node
+; upgrades from CouchDB versions before 2.3.0 when clustered purge feature was
+; introduced
+;replicate_purges = true
 
 ; [fabric]
 ; all_docs_concurrency = 10

--- a/src/fabric/src/fabric_doc_purge.erl
+++ b/src/fabric/src/fabric_doc_purge.erl
@@ -132,7 +132,7 @@ create_reqs([], UUIDs, Reqs) ->
 create_reqs([{Id, Revs} | RestIdsRevs], UUIDs, Reqs) ->
     UUID = couch_uuids:new(),
     NewUUIDs = [UUID | UUIDs],
-    NewReqs = [{UUID, Id, Revs} | Reqs],
+    NewReqs = [{UUID, Id, lists:usort(Revs)} | Reqs],
     create_reqs(RestIdsRevs, NewUUIDs, NewReqs).
 
 group_reqs_by_shard(DbName, Reqs) ->

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -301,7 +301,7 @@ repl(#acc{db = Db0} = Acc0) ->
     Acc1 = calculate_start_seq_multi(Acc0),
     try
         Acc3 =
-            case config:get_boolean("mem3", "replicate_purges", false) of
+            case config:get_boolean("mem3", "replicate_purges", true) of
                 true ->
                     Acc2 = pull_purges_multi(Acc1),
                     push_purges_multi(Acc2);


### PR DESCRIPTION
It seems we had forgotten to enable it and in the case a node if off-line when a clustered purge request is issued, and then re-join they won't know to process any purge requests issued to other nodes.

After enabling it @jjrodrig had noticed that sometimes we were getting a duplicate UUID purge error thrown. That's because now there is a chance for a race between the internal replicator and the interactive request, when they both handle the exact same purge request. So, instead of throwing a duplicate UUID request, consider a duplicate purge request a no-op, that's the second commit in the PR.