### PR TITLE
Erlang 25 compatibility - http_uri:parse -> uri_string:parse

### DIFF
--- a/src/couch_replicator/test/eunit/couch_replicator_error_reporting_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_error_reporting_tests.erl
@@ -165,7 +165,7 @@ mock_fail_req(Path, Return) ->
         send_req_direct,
         fun(W, Url, Headers, Meth, Body, Opts, TOut) ->
             Args = [W, Url, Headers, Meth, Body, Opts, TOut],
-            {ok, {_, _, _, _, UPath, _}} = http_uri:parse(Url),
+            #{path := UPath} = uri_string:parse(Url),
             case lists:suffix(Path, UPath) of
                 true -> Return;
                 false -> meck:passthrough(Args)


### PR DESCRIPTION
This fixes the replicator eunit failure: https://github.com/apache/couchdb/pull/4060#issuecomment-1154391783

