### PR TITLE
Prevent error:function_clause in check_security/3 if roles claim is malformed

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -742,18 +742,16 @@ is_authorized(#user_ctx{name = UserName, roles = UserRoles}, Security) ->
         false -> check_security(names, UserName, Names)
     end.
 
-check_security(roles, [], _) ->
-    false;
-check_security(roles, UserRoles, Roles) ->
+check_security(roles, [_ | _] = UserRoles, [_ | _] = Roles) ->
     UserRolesSet = ordsets:from_list(UserRoles),
     RolesSet = ordsets:from_list(Roles),
     not ordsets:is_disjoint(UserRolesSet, RolesSet);
-check_security(names, _, []) ->
+check_security(roles, _, _) ->
     false;
-check_security(names, null, _) ->
-    false;
-check_security(names, UserName, Names) ->
-    lists:member(UserName, Names).
+check_security(names, UserName, [_ | _] = Names) ->
+    lists:member(UserName, Names);
+check_security(names, _, _) ->
+    false.
 
 throw_security_error(#user_ctx{name = null} = UserCtx) ->
     Reason = <<"You are not authorized to access this db.">>,

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -748,6 +748,8 @@ check_security(roles, [_ | _] = UserRoles, [_ | _] = Roles) ->
     not ordsets:is_disjoint(UserRolesSet, RolesSet);
 check_security(roles, _, _) ->
     false;
+check_security(names, null, _) ->
+    false;
 check_security(names, UserName, [_ | _] = Names) ->
     lists:member(UserName, Names);
 check_security(names, _, _) ->


### PR DESCRIPTION
If the given UserRoles/Roles/Names aren't lists, ordersets:from_list/1
or lists:member will fail with an error. Prevent this with Erlang
Pattern Matching or the Robot Butt Rule[1].
Thanks @nickva

[1] https://medium.com/erlang-battleground/ode-to-the-robot-butt-bbd69e69beb2
