### PR TITLE
Update vm.args for Erlang 23+

### DIFF
--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -48,17 +48,12 @@
 -kernel error_logger silent
 -sasl sasl_error_logger false
 
-# Use kernel poll functionality if supported by emulator
-+K true
-
-# Start a pool of asynchronous IO threads
-+A 16
+# Increase the pool of dirty IO schedulers from 10 to 16
+# Dirty IO schedulers are used for file IO.
++SDio 16
 
 # Comment this line out to enable the interactive Erlang shell on startup
 +Bd -noinput
-
-# Force use of the smp scheduler, fixes #1296
--smp enable
 
 # Set maximum SSL session lifetime to reap terminated replication readers
 -ssl session_lifetime 300


### PR DESCRIPTION
 * file IO is using dirty IO schedulers and not the async IO thread pool

 * `-smp enable` does nothing, it's always enalbed

 * kernel polling is always enabled

```
% erl +SDio 16
Erlang/OTP 23 [erts-11.2.2.13] [source] [64-bit] [smp:12:12] [ds:12:12:16] [async-threads:1]

> erlang:system_info(kernel_poll).
true

> erlang:system_info(dirty_io_schedulers).
16
```
