### PR TITLE
Add an option to let custodian always use [cluster] n value

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -753,3 +753,13 @@ port = {{prometheus_port}}
 ; to disable this setting could be if the views need an upgrade but located on
 ; read-only file system.
 ;commit_on_header_upgrade = true
+
+[custodian]
+; When set to `true`, force using `[cluster] n` values as the expected n value
+; of of shard copies. In cases where the application prevents creating
+; non-default n databases, this could help detect case where the shard map was
+; altered by hand, or via an external tools, such that it doesn't have the
+; necessary number of copies for some ranges. By default, when the setting is
+; `false`, the expected n value is based on the number of available copies in
+; the shard map.
+;use_cluster_n_as_expected_n = false


### PR DESCRIPTION
In cases when the application prevents creating dbs with non-default n values (n=1, n=2) setting `[custodian] use_cluster_n_as_expected_n = true` can help detect case when the shard map itself was manipulated and by mistake ended up with less than `[cluster] n` copies for some ranges.

By default the behavior is unchanged and n value will be deduced from the number of copies indicated in the shard map documents.
