### PR TITLE
Add Erlang 25 to PR CI pipeline and Ubuntu Jammy to full CI

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -14,11 +14,11 @@
 // the License.
 
 // Erlang version embedded in binary packages
-ERLANG_VERSION = '23'
+ERLANG_VERSION = '23.3.4.15'
 
 // Erlang version used for rebar in release process. CouchDB will not build from
 // the release tarball on Erlang versions older than this
-MINIMUM_ERLANG_VERSION = '23'
+MINIMUM_ERLANG_VERSION = '23.3.4.15'
 
 // We create parallel build / test / package stages for each OS using the metadata
 // in this map. Adding a new OS should ideally only involve adding a new entry here.
@@ -45,6 +45,12 @@ meta = [
     name: 'Ubuntu 20.04',
     spidermonkey_vsn: '68',
     image: "apache/couchdbci-ubuntu:focal-erlang-${ERLANG_VERSION}"
+  ],
+
+  'jammy': [
+    name: 'Ubuntu 22.04',
+    spidermonkey_vsn: '91',
+    image: "apache/couchdbci-ubuntu:jammy-erlang-default"
   ],
 
   'buster': [
@@ -261,7 +267,7 @@ pipeline {
       agent {
         docker {
           label 'docker'
-          image "apache/couchdbci-debian:erlang-${MINIMUM_ERLANG_VERSION}"
+          image "apache/couchdbci-debian:bullseye-erlang-${MINIMUM_ERLANG_VERSION}"
           args "${DOCKER_ARGS}"
           registryUrl 'https://docker.io/'
           registryCredentialsId 'dockerhub_creds'
@@ -378,7 +384,7 @@ pipeline {
 
       agent {
         docker {
-          image "apache/couchdbci-debian:erlang-${ERLANG_VERSION}"
+          image "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}"
           label 'docker'
           args "${DOCKER_ARGS}"
           registryUrl 'https://docker.io/'

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -38,7 +38,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'Jenkins User'
     GIT_COMMITTER_EMAIL = 'couchdb@apache.org'
     // Parameters for the matrix build
-    DOCKER_IMAGE_BASE = 'apache/couchdbci-debian:erlang'
+    DOCKER_IMAGE_BASE = 'apache/couchdbci-debian:bullseye-erlang'
     // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly
@@ -49,11 +49,7 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    LOW_ERLANG_VER = '23'
-
-    // erlfmt doesn't run with the lowest erlang version so we run it in a
-    // separate stage with a higher erlang version.
-    ERLFMT_ERLANG_VER = '23'
+    LOW_ERLANG_VER = '23.3.4.15'
   }
 
   options {
@@ -70,7 +66,7 @@ pipeline {
     stage('erlfmt') {
       agent {
         docker {
-          image "${DOCKER_IMAGE_BASE}-${ERLFMT_ERLANG_VER}"
+          image "${DOCKER_IMAGE_BASE}-${LOW_ERLANG_VER}"
           label 'docker'
           args "${DOCKER_ARGS}"
           registryUrl 'https://docker.io/'
@@ -140,23 +136,11 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '23', '24'
+            values '23.3.4.15', '24.3.4.2', '25.0.2'
           }
           axis {
             name 'SM_VSN'
-            values '60', '78'
-          }
-        }
-        excludes {
-          exclude {
-            axis {
-              name 'ERLANG_VERSION'
-              values '23', '24'
-            }
-            axis {
-              name 'SM_VSN'
-              notValues '78'
-            }
+            values '78'
           }
         }
 


### PR DESCRIPTION
 * Add Ubuntu Jammy to [full CI](https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FFullPlatformMatrix/detail/jenkins-erlang-25-and-ubuntu-jammy-ci-update/1/pipeline)
 * Add Erlang 25.0.2 to [PR CI](https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FPullRequests/detail/PR-4088/1/pipeline)

This is using the branch new images built in https://github.com/apache/couchdb-ci/pull/39