### PR TITLE
Implement winning_revs_only option for the replicator

### DIFF
--- a/src/couch_replicator/src/couch_replicator_changes_reader.erl
+++ b/src/couch_replicator/src/couch_replicator_changes_reader.erl
@@ -20,7 +20,6 @@
 
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch_replicator/include/couch_replicator_api_wrap.hrl").
--include("couch_replicator.hrl").
 
 -import(couch_util, [
     get_value/2
@@ -49,10 +48,15 @@ start_link(StartSeq, Db, ChangesQueue, Options) ->
 
 read_changes(Parent, StartSeq, Db, ChangesQueue, Options) ->
     Continuous = couch_util:get_value(continuous, Options),
+    Style =
+        case couch_util:get_value(winning_revs_only, Options, false) of
+            true -> main_only;
+            false -> all_docs
+        end,
     try
         couch_replicator_api_wrap:changes_since(
             Db,
-            all_docs,
+            Style,
             StartSeq,
             fun(Item) ->
                 process_change(Item, {Parent, Db, ChangesQueue, Continuous})

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -510,6 +510,10 @@ convert_options([{<<"create_target_params">>, V} | _R]) when not is_tuple(V) ->
     throw({bad_request, <<"parameter `create_target_params` must be a JSON object">>});
 convert_options([{<<"create_target_params">>, V} | R]) ->
     [{create_target_params, V} | convert_options(R)];
+convert_options([{<<"winning_revs_only">>, V} | _R]) when not is_boolean(V) ->
+    throw({bad_request, <<"parameter `winning_revs_only` must be a boolean">>});
+convert_options([{<<"winning_revs_only">>, V} | R]) ->
+    [{winning_revs_only, V} | convert_options(R)];
 convert_options([{<<"continuous">>, V} | _R]) when not is_boolean(V) ->
     throw({bad_request, <<"parameter `continuous` must be a boolean">>});
 convert_options([{<<"continuous">>, V} | R]) ->
@@ -794,6 +798,10 @@ check_convert_options_pass_test() ->
         convert_options([{<<"create_target">>, true}])
     ),
     ?assertEqual(
+        [{winning_revs_only, true}],
+        convert_options([{<<"winning_revs_only">>, true}])
+    ),
+    ?assertEqual(
         [{continuous, true}],
         convert_options([{<<"continuous">>, true}])
     ),
@@ -814,6 +822,10 @@ check_convert_options_fail_test() ->
     ?assertThrow(
         {bad_request, _},
         convert_options([{<<"create_target">>, <<"true">>}])
+    ),
+    ?assertThrow(
+        {bad_request, _},
+        convert_options([{<<"winning_revs_only">>, <<"foo">>}])
     ),
     ?assertThrow(
         {bad_request, _},

--- a/src/couch_replicator/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator/src/couch_replicator_js_functions.hrl
@@ -76,6 +76,12 @@
                 reportError('The `create_target\\' field must be a boolean.');
             }
 
+            if ((typeof newDoc.winning_revs_only !== 'undefined') &&
+                (typeof newDoc.winning_revs_only !== 'boolean')) {
+
+                reportError('The `winning_revs_only\\' field must be a boolean.');
+            }
+
             if ((typeof newDoc.continuous !== 'undefined') &&
                 (typeof newDoc.continuous !== 'boolean')) {
 


### PR DESCRIPTION
`winning_revs_only` option replicates only the winning revisions from the source to the target, effectively discarding conflicts.

This option may be used as an alternative to the custom VDU strategy, or manual _all_docs read and POST to target scripts, often used by users to discard conflicted document revisions.

Behind the scenes the implementation simply switches the `_changes` feed style to `main_only` from the replication default of `all_docs`.

Additionally, when enabled, the `winning_revs_only` option, will generate a different replication ID and use a different set of checkpoints than the default case. This should allows first replicating with `winning_revs_only: true`, and then later replicate normally between the same endpoints, in order to "backfill" the rest of the revisions.

The main test is in the couch_replicator_many_leaves since we already assert how multiple conflicting docs replicate there. The test was also simplified to remove the `{remote, remote}` tuple as we only have remote endpoints currently.

Issue: https://github.com/apache/couchdb/issues/4034

