### PR TITLE
Fix flaky "validate doc update" elixir test

### DIFF
--- a/test/elixir/test/design_docs_test.exs
+++ b/test/elixir/test/design_docs_test.exs
@@ -476,12 +476,13 @@ defmodule DesignDocsTest do
       ddoc_resp.body
       |> Map.put("_deleted", true)
 
-    del_resp =
-      Couch.post("/#{db_name}",
-        body: ddoc
-      )
-
-    assert del_resp.status_code in [201, 202]
+    retry_until(fn ->
+      retry_resp =
+        Couch.post("/#{db_name}",
+          body: ddoc
+        )
+      retry_resp.status_code in [201, 202]
+    end)
 
     {:ok, _} = create_doc(db_name, %{_id: "doc1", value: 4})
   end


### PR DESCRIPTION
We saw it fail quite a few times already so adding a retry around it.

Unfortunately it could now fail with a timeout instead of an assert but since we're updating a document there is no idempotent way to testing it (retry until, then do the actual assert again below).

