### PR TITLE
Skip uploading build logs for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ elixir-credo: elixir-init
 # target: build-report - Generate and upload a build report
 build-report:
 	build-aux/show-test-results.py --suites=10 --tests=10 > test-results.log
-	build-aux/logfile-uploader.py
+	#build-aux/logfile-uploader.py
 
 .PHONY: check-qs
 # target: check-qs - Run query server tests (ruby and rspec required!)

--- a/build-aux/logfile-uploader.py
+++ b/build-aux/logfile-uploader.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# *** NOT CURRENTLY USED AS LOG UPLOADS BROKE ***
 
 import datetime
 import glob


### PR DESCRIPTION
It broke at some point so no need to keep trying to upload them
