### PR TITLE
Smoosh improvements

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -659,6 +659,9 @@ state_dir = {{state_dir}}
 ; Sets the log level for informational compaction related entries.
 ;compaction_log_level = debug
 
+; Enable persistence for smoosh state
+; persist = false
+
 [ioq]
 ; The maximum number of concurrent in-flight IO requests that
 ;concurrency = 10

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -141,10 +141,10 @@ delete_compaction_files(RootDir, FilePath, DelOpts) ->
         [".compact", ".compact.data", ".compact.meta"]
     ).
 
-is_compacting(DbName) ->
+is_compacting([_ | _] = FilePath) ->
     lists:any(
         fun(Ext) ->
-            filelib:is_regular(?b2l(DbName) ++ Ext)
+            filelib:is_regular(FilePath ++ Ext)
         end,
         [".compact", ".compact.data", ".compact.meta"]
     ).

--- a/src/couch/src/couch_db_engine.erl
+++ b/src/couch/src/couch_db_engine.erl
@@ -737,8 +737,8 @@ delete_compaction_files(Engine, RootDir, DbPath, DelOpts) when
 ->
     Engine:delete_compaction_files(RootDir, DbPath, DelOpts).
 
-is_compacting(Engine, DbName) ->
-    Engine:is_compacting(DbName).
+is_compacting(Engine, FilePath) ->
+    Engine:is_compacting(FilePath).
 
 init(Engine, DbPath, Options) ->
     case Engine:init(DbPath, Options) of

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -185,9 +185,11 @@ delete_compaction_files(DbName, DelOpts) when is_binary(DbName) ->
     delete_compaction_files(?b2l(DbName), DelOpts).
 
 is_compacting(DbName) ->
+    RootDir = config:get("couchdb", "database_dir", "."),
     lists:any(
-        fun({_, Engine}) ->
-            couch_db_engine:is_compacting(Engine, DbName)
+        fun({Ext, Engine}) ->
+            FilePath = make_filepath(RootDir, DbName, Ext),
+            couch_db_engine:is_compacting(Engine, FilePath)
         end,
         get_configured_engines()
     ).

--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -110,7 +110,8 @@ init(Name) ->
     erlang:send_after(60 * 1000, self(), check_window),
     process_flag(trap_exit, true),
     Waiting = smoosh_priority_queue:new(Name),
-    case lists:member(Name, ?VIEW_CHANNELS) of
+    Persist = config:get("smoosh", "persist", "false"),
+    case lists:member(Name, ?VIEW_CHANNELS) orelse Persist =:= "false" of
         true ->
             State = #state{name = Name, waiting = Waiting, paused = true, activated = true},
             schedule_unpause();

--- a/src/smoosh/src/smoosh_priority_queue.erl
+++ b/src/smoosh/src/smoosh_priority_queue.erl
@@ -22,7 +22,7 @@
 
 -export([is_empty/1]).
 
--export([file_name/1, write_to_file/1]).
+-export([write_to_file/1]).
 
 -define(VSN, 1).
 

--- a/src/smoosh/test/smoosh_tests.erl
+++ b/src/smoosh/test/smoosh_tests.erl
@@ -13,12 +13,14 @@ setup(ChannelType) ->
     couch_db:close(Db),
     {ok, ChannelPid} = smoosh_server:get_channel(ChannelType),
     smoosh_channel:flush(ChannelPid),
+    ok = config:set("smoosh", "persist", "true", false),
     ok = config:set(config_section(ChannelType), "min_size", "1", false),
     ok = config:set(config_section(ChannelType), "min_priority", "1", false),
     DbName.
 
 teardown(ChannelType, DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]),
+    ok = config:delete("smoosh", "persist", false),
     ok = config:delete(config_section(DbName), "min_size", false),
     ok = config:delete(config_section(DbName), "min_priority", false),
     {ok, ChannelPid} = smoosh_server:get_channel(ChannelType),

--- a/src/smoosh/test/smoosh_tests.erl
+++ b/src/smoosh/test/smoosh_tests.erl
@@ -3,8 +3,6 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
--define(KILOBYTE, binary:copy(<<"x">>, 1024)).
-
 %% ==========
 %% Setup
 %% ----------
@@ -15,12 +13,14 @@ setup(ChannelType) ->
     couch_db:close(Db),
     {ok, ChannelPid} = smoosh_server:get_channel(ChannelType),
     smoosh_channel:flush(ChannelPid),
-    ok = config:set(config_section(ChannelType), "min_size", "200000", false),
+    ok = config:set(config_section(ChannelType), "min_size", "1", false),
+    ok = config:set(config_section(ChannelType), "min_priority", "1", false),
     DbName.
 
 teardown(ChannelType, DbName) ->
     ok = couch_server:delete(DbName, [?ADMIN_CTX]),
     ok = config:delete(config_section(DbName), "min_size", false),
+    ok = config:delete(config_section(DbName), "min_priority", false),
     {ok, ChannelPid} = smoosh_server:get_channel(ChannelType),
     smoosh_channel:flush(ChannelPid),
     ok.
@@ -59,7 +59,8 @@ persistence_tests() ->
 
 channels_tests() ->
     Tests = [
-        fun should_enqueue/2
+        fun should_enqueue/2,
+        fun should_start_compact/2
     ],
     {
         "Various channels tests",
@@ -89,24 +90,30 @@ should_persist_queue(ChannelType, DbName) ->
         ok = application:stop(smoosh),
         ok = application:start(smoosh),
         Q1 = channel_queue(ChannelType),
+        % Assert that queues are not empty
+        ?assertNotEqual(Q0, smoosh_priority_queue:new(ChannelType)),
+        ?assertNotEqual(Q1, smoosh_priority_queue:new(ChannelType)),
         ?assertEqual(Q0, Q1),
+        ok
+    end).
+
+should_start_compact(ChannelType, DbName) ->
+    ?_test(begin
+        {ok, ChannelPid} = smoosh_server:get_channel(ChannelType),
+        ok = grow_db_file(DbName, 3000),
+        smoosh_channel:resume(ChannelPid),
+        ok = wait_compact(ChannelType),
+        ?assertEqual(true, couch_db:is_compacting(DbName)),
+        application:start(smoosh),
         ok
     end).
 
 grow_db_file(DbName, SizeInKb) ->
     {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),
-    FilePath = couch_db:get_filepath(Db),
-    {ok, Fd} = file:open(FilePath, [append]),
-    Bytes = binary:copy(?KILOBYTE, SizeInKb),
-    file:write(Fd, Bytes),
-    ok = file:close(Fd),
-    Doc = couch_doc:from_json_obj(
-        {[
-            {<<"_id">>, ?l2b(?docid())},
-            {<<"value">>, ?l2b(?docid())}
-        ]}
-    ),
-    {ok, _} = couch_db:update_docs(Db, [Doc], []),
+    Data = b64url:encode(crypto:strong_rand_bytes(SizeInKb * 1024)),
+    Body = {[{<<"value">>, Data}]},
+    Doc = #doc{id = <<"doc1">>, body = Body},
+    {ok, _} = couch_db:update_doc(Db, Doc, []),
     couch_db:close(Db),
     ok.
 
@@ -123,6 +130,23 @@ wait_enqueue(ChannelType, DbName) ->
                 ok
         end
     end).
+
+wait_compact(ChannelType) ->
+    {ok, ChannelPid} = smoosh_server:get_channel(ChannelType),
+    test_util:wait(
+        fun() ->
+            {ok, Status} = smoosh_channel:get_status(ChannelPid),
+            {active, Active} = lists:keyfind(active, 1, Status),
+            case Active of
+                1 ->
+                    application:stop(smoosh),
+                    ok;
+                _ ->
+                    wait
+            end
+        end,
+        10000
+    ).
 
 channel_queue(ChannelType) ->
     Q0 = smoosh_priority_queue:new(ChannelType),


### PR DESCRIPTION
## Overview

There are three bugs that are fixed in this PR:

1. When smoosh is checking for compaction files to restore active compaction jobs, it uses the wrong file path. Currently, it looks for `<ShardPath>.{compact, compact.data, compact.meta}` instead of the correct `<ShardPath>.couch.{compact, compact.data, compact.meta}`.
2. Persistence and recovery of view compaction jobs was never intended. This PR adds a check to skip the process for view compaction jobs.
3. There is a subtle race condition where smoosh attempts to open a deleted db when remonitoring the compaction job. This PR adds a check to not remonitor compaction jobs for deleted db files.

Furthermore, a toggle to enable and disable smoosh persistence has been added.

## Testing recommendations

```
make eunit apps=smoosh
```

## Related Issues or Pull Requests

Add smoosh queue persistence: https://github.com/apache/couchdb/pull/3766

## Checklist

- [ ] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
