### PR TITLE
Remove view compaction jobs recovery and improve is_compacting/1 test

### DIFF
--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -17,7 +17,7 @@
 
 % public api.
 -export([start_link/1, close/1, suspend/1, resume/1, activate/1, get_status/1]).
--export([enqueue/3, last_updated/2, flush/1, is_key/2, is_activated/1, persist/1]).
+-export([enqueue/3, last_updated/2, flush/1, is_key/2, is_activated/1]).
 
 % gen_server api.
 -export([
@@ -37,6 +37,7 @@
 -else.
 -define(START_DELAY_IN_MSEC, 0).
 -define(ACTIVATE_DELAY_IN_MSEC, 0).
+-export([persist/1]).
 -endif.
 
 % records.
@@ -94,6 +95,7 @@ is_key(ServerRef, Key) ->
 is_activated(ServerRef) ->
     gen_server:call(ServerRef, is_activated).
 
+% Only exported to force persistence in tests
 persist(ServerRef) ->
     gen_server:call(ServerRef, persist).
 
@@ -103,8 +105,15 @@ init(Name) ->
     erlang:send_after(60 * 1000, self(), check_window),
     process_flag(trap_exit, true),
     Waiting = smoosh_priority_queue:new(Name),
-    State = #state{name = Name, waiting = Waiting, paused = true, activated = false},
-    erlang:send_after(?START_DELAY_IN_MSEC, self(), start_recovery),
+    State =
+        case smoosh_utils:is_view_channel(Name) of
+            true ->
+                schedule_unpause(),
+                #state{name = Name, waiting = Waiting, paused = true, activated = true};
+            false ->
+                erlang:send_after(?START_DELAY_IN_MSEC, self(), start_recovery),
+                #state{name = Name, waiting = Waiting, paused = true, activated = false}
+        end,
     {ok, State}.
 
 handle_call({last_updated, Object}, _From, State) ->

--- a/src/smoosh/src/smoosh_utils.erl
+++ b/src/smoosh/src/smoosh_utils.erl
@@ -14,7 +14,7 @@
 -include_lib("couch/include/couch_db.hrl").
 
 -export([get/2, get/3, split/1, stringify/1, ignore_db/1]).
--export([in_allowed_window/1, write_to_file/3]).
+-export([in_allowed_window/1, is_view_channel/1, write_to_file/3]).
 -export([log_level/2]).
 
 get(Channel, Key) ->
@@ -58,6 +58,12 @@ in_allowed_window(From, To) ->
         false ->
             ({HH, MM} >= From) orelse ({HH, MM} < To)
     end.
+
+is_view_channel(ChannelName) ->
+    ViewChannels = smoosh_utils:split(
+        config:get("smoosh", "view_channels", "upgrade_views,ratio_views,slack_views")
+    ),
+    lists:member(ChannelName, ViewChannels).
 
 file_delete(Path) ->
     case file:delete(Path) of


### PR DESCRIPTION
## Overview

Persistence and recovery of view compaction jobs was never intended. This PR adds a check to skip the process for view compaction jobs and also improves the `is_compacting/1` test.

## Testing recommendations

```
make eunit apps=smoosh
```

## Related Issues or Pull Requests

Add smoosh queue persistence: https://github.com/apache/couchdb/pull/3766

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
