### PR TITLE
4101 add io priority

### DIFF
--- a/src/chttpd/src/chttpd.app.src
+++ b/src/chttpd/src/chttpd.app.src
@@ -27,7 +27,8 @@
         config,
         couch,
         ets_lru,
-        fabric
+        fabric,
+        ioq
     ]},
     {mod, {chttpd_app, []}}
 ]}.

--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -155,7 +155,9 @@ spawn_changes(Since) ->
     Pid.
 
 listen_for_changes(Since) ->
-    ensure_auth_ddoc_exists(dbname(), <<"_design/_auth">>),
+    DbName = dbname(),
+    erlang:put(io_priority, {system, DbName}),
+    ensure_auth_ddoc_exists(DbName, <<"_design/_auth">>),
     CBFun = fun ?MODULE:changes_callback/2,
     Args = #changes_args{
         feed = "continuous",
@@ -163,7 +165,7 @@ listen_for_changes(Since) ->
         heartbeat = true,
         filter = {default, main_only}
     },
-    fabric:changes(dbname(), CBFun, Since, Args).
+    fabric:changes(DbName, CBFun, Since, Args).
 
 changes_callback(waiting_for_updates, Acc) ->
     {ok, Acc};

--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -156,7 +156,7 @@ spawn_changes(Since) ->
 
 listen_for_changes(Since) ->
     DbName = dbname(),
-    erlang:put(io_priority, {system, DbName}),
+    ioq:set_io_priority({system, DbName}),
     ensure_auth_ddoc_exists(DbName, <<"_design/_auth">>),
     CBFun = fun ?MODULE:changes_callback/2,
     Args = #changes_args{

--- a/src/couch_index/src/couch_index.app.src
+++ b/src/couch_index/src/couch_index.app.src
@@ -14,6 +14,6 @@
     {description, "CouchDB Secondary Index Manager"},
     {vsn, git},
     {registered, []},
-    {applications, [kernel, stdlib, couch_epi]},
+    {applications, [kernel, stdlib, couch_epi, ioq]},
     {mod, {couch_index_app, []}}
 ]}.

--- a/src/couch_index/src/couch_index.erl
+++ b/src/couch_index/src/couch_index.erl
@@ -72,6 +72,7 @@ get_compactor_pid(Pid) ->
 
 init({Mod, IdxState}) ->
     DbName = Mod:get(db_name, IdxState),
+    erlang:put(io_priority, {view_update, DbName}),
     erlang:send_after(?CHECK_INTERVAL, self(), maybe_close),
     Resp = couch_util:with_db(DbName, fun(Db) ->
         case Mod:open(Db, IdxState) of

--- a/src/couch_index/src/couch_index.erl
+++ b/src/couch_index/src/couch_index.erl
@@ -72,7 +72,7 @@ get_compactor_pid(Pid) ->
 
 init({Mod, IdxState}) ->
     DbName = Mod:get(db_name, IdxState),
-    erlang:put(io_priority, {view_update, DbName}),
+    ioq:set_io_priority({view_update, DbName}),
     erlang:send_after(?CHECK_INTERVAL, self(), maybe_close),
     Resp = couch_util:with_db(DbName, fun(Db) ->
         case Mod:open(Db, IdxState) of

--- a/src/couch_peruser/src/couch_peruser.app.src
+++ b/src/couch_peruser/src/couch_peruser.app.src
@@ -14,7 +14,7 @@
     {description, "couch_peruser - maintains per-user databases in CouchDB"},
     {vsn, git},
     {registered, [couch_peruser, couch_peruser_sup]},
-    {applications, [kernel, stdlib, config, couch, fabric, mem3]},
+    {applications, [kernel, stdlib, config, couch, fabric, mem3, ioq]},
     {mod, {couch_peruser_app, []}},
     {env, []}
 ]}.

--- a/src/couch_peruser/src/couch_peruser.erl
+++ b/src/couch_peruser/src/couch_peruser.erl
@@ -85,6 +85,7 @@ init_state() ->
                     "couch_httpd_auth", "authentication_db", "_users"
                 )
             ),
+            ioq:set_io_priority({system, DbName}),
             DeleteDbs = config:get_boolean("couch_peruser", "delete_dbs", false),
             Q = config:get_integer("couch_peruser", "q", 1),
             Prefix = config:get("couch_peruser", "database_prefix", ?DEFAULT_USERDB_PREFIX),
@@ -186,6 +187,7 @@ start_listening(
 -spec init_changes_handler(ChangesState :: #changes_state{}) -> ok.
 init_changes_handler(#changes_state{db_name = DbName} = ChangesState) ->
     % couch_log:debug("peruser: init_changes_handler() on DbName ~p", [DbName]),
+    ioq:set_io_priority({system, DbName}),
     try
         {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX, sys_db]),
         FunAcc = {fun ?MODULE:changes_handler/3, ChangesState},

--- a/src/couch_replicator/src/couch_replicator.app.src
+++ b/src/couch_replicator/src/couch_replicator.app.src
@@ -32,6 +32,7 @@
         config,
         couch,
         couch_event,
-        couch_stats
+        couch_stats,
+        ioq
     ]}
 ]}.

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -357,6 +357,7 @@ update_rep_doc(RepDbName, #doc{body = {RepDocBody}} = RepDoc, KVs, _Try) ->
     end.
 
 open_rep_doc(DbName, DocId) ->
+    ioq:maybe_set_io_priority({system, DbName}),
     case couch_db:open_int(DbName, [?CTX, sys_db]) of
         {ok, Db} ->
             try
@@ -369,6 +370,7 @@ open_rep_doc(DbName, DocId) ->
     end.
 
 save_rep_doc(DbName, Doc) ->
+    ioq:maybe_set_io_priority({system, DbName}),
     {ok, Db} = couch_db:open_int(DbName, [?CTX, sys_db]),
     try
         couch_db:update_doc(Db, Doc, [])

--- a/src/global_changes/src/global_changes.app.src
+++ b/src/global_changes/src/global_changes.app.src
@@ -23,7 +23,8 @@
         couch_stats,
         couch,
         mem3,
-        fabric
+        fabric,
+        ioq
     ]},
     {mod, {global_changes_app, []}},
     {env, [

--- a/src/global_changes/src/global_changes_server.erl
+++ b/src/global_changes/src/global_changes_server.erl
@@ -60,6 +60,9 @@ init([]) ->
         end,
     MaxWriteDelay = list_to_integer(MaxWriteDelay0),
 
+    GlobalChangesDbName = global_changes_util:get_dbname(),
+    ioq:set_io_priority({system, GlobalChangesDbName}),
+
     % Start our write triggers
     erlang:send_after(MaxWriteDelay, self(), flush_updates),
 
@@ -68,7 +71,7 @@ init([]) ->
         pending_update_count = 0,
         pending_updates = sets:new(),
         max_write_delay = MaxWriteDelay,
-        dbname = global_changes_util:get_dbname(),
+        dbname = GlobalChangesDbName,
         handler_ref = erlang:monitor(process, Handler)
     },
     {ok, State}.

--- a/src/ioq/src/ioq.erl
+++ b/src/ioq/src/ioq.erl
@@ -16,6 +16,7 @@
 
 -export([start_link/0, call/3]).
 -export([get_queue_lengths/0]).
+-export([get_io_priority/0, set_io_priority/1, maybe_set_io_priority/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, code_change/3, terminate/2]).
 
 % config_listener api
@@ -38,6 +39,18 @@
     from,
     ref
 }).
+
+set_io_priority(Priority) ->
+    erlang:put(io_priority, Priority).
+
+get_io_priority() ->
+    erlang:get(io_priority).
+
+maybe_set_io_priority(Priority) ->
+    case get_io_priority() of
+        undefined -> set_io_priority(Priority);
+        _ -> ok
+    end.
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
@@ -81,6 +94,12 @@ io_class(_, {db_compact, _}) ->
     compaction;
 io_class(_, {view_compact, _, _}) ->
     compaction;
+io_class(_, {system, _}) ->
+    system;
+io_class(_, {search, _}) ->
+    search;
+io_class(_, {search, _, _}) ->
+    search;
 io_class(_, _) ->
     other.
 

--- a/src/mem3/src/mem3.app.src
+++ b/src/mem3/src/mem3.app.src
@@ -35,6 +35,7 @@
         rexi,
         couch_log,
         couch_event,
-        couch_stats
+        couch_stats,
+        ioq
     ]}
 ]}.

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -220,6 +220,8 @@ init([]) ->
     ok = config:listen_for_changes(?MODULE, nil),
     SizeList = config:get("mem3", "shard_cache_size", "25000"),
     WriteTimeout = config:get_integer("mem3", "shard_write_timeout", 1000),
+    DbName = mem3_sync:shards_db(),
+    ioq:set_io_priority({system, DbName}),
     UpdateSeq = get_update_seq(),
     {ok, #st{
         max_size = list_to_integer(SizeList),
@@ -341,7 +343,9 @@ get_update_seq() ->
     Seq.
 
 listen_for_changes(Since) ->
-    {ok, Db} = mem3_util:ensure_exists(mem3_sync:shards_db()),
+    DbName = mem3_sync:shards_db(),
+    ioq:set_io_priority({system, DbName}),
+    {ok, Db} = mem3_util:ensure_exists(DbName),
     Args = #changes_args{
         feed = "continuous",
         since = Since,

--- a/src/mem3/src/mem3_util.erl
+++ b/src/mem3/src/mem3_util.erl
@@ -119,6 +119,7 @@ write_db_doc(Doc) ->
     write_db_doc(mem3_sync:shards_db(), Doc, true).
 
 write_db_doc(DbName, #doc{id = Id, body = Body} = Doc, ShouldMutate) ->
+    ioq:maybe_set_io_priority({system, DbName}),
     {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     try couch_db:open_doc(Db, Id, [ejson_body]) of
         {ok, #doc{body = Body}} ->
@@ -144,6 +145,7 @@ update_db_doc(Doc) ->
     update_db_doc(mem3_sync:shards_db(), Doc, true).
 
 update_db_doc(DbName, #doc{id = Id, body = Body} = Doc, ShouldMutate) ->
+    ioq:maybe_set_io_priority({system, DbName}),
     {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     try couch_db:open_doc(Db, Id, [ejson_body]) of
         {ok, #doc{body = Body}} ->
@@ -174,6 +176,7 @@ delete_db_doc(DocId) ->
     delete_db_doc(mem3_sync:shards_db(), DocId, true).
 
 delete_db_doc(DbName, DocId, ShouldMutate) ->
+    ioq:maybe_set_io_priority({system, DbName}),
     {ok, Db} = couch_db:open(DbName, [?ADMIN_CTX]),
     {ok, Revs} = couch_db:open_doc_revs(Db, DocId, all, []),
     try [Doc#doc{deleted = true} || {ok, #doc{deleted = false} = Doc} <- Revs] of


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This addresses #4101 and adds `io_priority` labels in a number of places that they weren't previously set before. It also introduces the `system` `io_priority` for internal database operations.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

I also took the opportunity to add a few utility functions for setting `io_priority` values, abstracting over the use of the process dictionary for storing these values. We could also update the existing places where `io_priority` is set to use the new functions, but that might be better in a separate PR.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Normal test suite should suffice.

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
