### PR TITLE
Clean up unused code and invalid specs from replicator

### DIFF
--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -207,9 +207,7 @@ init_state(#httpdb{} = HttpDb) ->
                     {error, Error}
             end;
         {error, missing_credentials} ->
-            ignore;
-        {error, Error} ->
-            {error, Error}
+            ignore
     end.
 
 -spec extract_creds(#httpdb{}) ->
@@ -428,7 +426,7 @@ parse_max_age(CaseInsKVs) ->
     end.
 
 -spec maybe_update_cookie(headers(), #state{}) ->
-    {ok, string()} | {error, term()}.
+    {ok, #state{}} | {error, term()}.
 maybe_update_cookie(ResponseHeaders, State) ->
     case parse_cookie(ResponseHeaders) of
         {ok, MaxAge, Cookie} ->

--- a/src/couch_replicator/src/couch_replicator_doc_processor_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor_worker.erl
@@ -38,7 +38,7 @@
 % ?WORKER_TIMEOUT_MSEC timeout period.A timeout is considered a
 %`temporary_error`. Result will be sent as the `Reason` in the {'DOWN',...}
 % message.
--spec spawn_worker(db_doc_id(), #rep{}, seconds(), reference()) -> pid().
+-spec spawn_worker(db_doc_id(), #rep{}, seconds(), reference()) -> pid() | no_return().
 spawn_worker(Id, Rep, WaitSec, WRef) ->
     {Pid, _Ref} = spawn_monitor(fun() ->
         worker_fun(Id, Rep, WaitSec, WRef)

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -396,7 +396,7 @@ rep_user_ctx({RepDoc}) ->
             }
     end.
 
--spec parse_rep_db({[_]} | binary(), binary(), [_]) -> #httpd{} | binary().
+-spec parse_rep_db({[_]} | binary(), [_] | binary(), [_]) -> #httpdb{} | no_return().
 parse_rep_db({Props}, Proxy, Options) ->
     ProxyParams = parse_proxy_params(Proxy),
     ProxyURL =

--- a/src/couch_replicator/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc.erl
@@ -322,6 +322,7 @@ discard_message(ReqId, Worker, Count) ->
         exit({timeout, ibrowse_stream_cleanup})
     end.
 
+-spec maybe_retry(any(), pid(), #httpdb{}, list()) -> no_return().
 maybe_retry(Error, Worker, #httpdb{retries = 0} = HttpDb, Params) ->
     report_error(Worker, HttpDb, Params, {error, Error});
 maybe_retry(

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -809,7 +809,7 @@ ejson_url(#httpdb{} = Httpdb) ->
 ejson_url(DbName) when is_binary(DbName) ->
     DbName.
 
--spec job_ejson(#job{}) -> {[_ | _]}.
+-spec job_ejson(#job{}) -> {[_ | _]} | no_return().
 job_ejson(Job) ->
     Rep = Job#job.rep,
     Source = ejson_url(Rep#rep.source),

--- a/src/couch_replicator/src/couch_replicator_utils.erl
+++ b/src/couch_replicator/src/couch_replicator_utils.erl
@@ -165,7 +165,7 @@ normalize_rep(#rep{} = Rep) ->
         db_name = Rep#rep.db_name
     }.
 
--spec ejson_state_info(binary() | nil) -> binary() | null.
+-spec ejson_state_info([_] | binary() | nil) -> tuple() | null.
 ejson_state_info(nil) ->
     null;
 ejson_state_info(Info) when is_binary(Info) ->
@@ -198,12 +198,12 @@ get_basic_auth_creds(#httpdb{auth_props = AuthProps}) ->
             {undefined, undefined}
     end.
 
--spec remove_basic_auth_creds(#httpd{}) -> #httpdb{}.
+-spec remove_basic_auth_creds(#httpdb{}) -> #httpdb{}.
 remove_basic_auth_creds(#httpdb{auth_props = Props} = HttpDb) ->
     Props1 = lists:keydelete(<<"basic">>, 1, Props),
     HttpDb#httpdb{auth_props = Props1}.
 
--spec set_basic_auth_creds(string(), string(), #httpd{}) -> #httpdb{}.
+-spec set_basic_auth_creds(string(), string(), #httpdb{}) -> #httpdb{}.
 set_basic_auth_creds(undefined, undefined, #httpdb{} = HttpDb) ->
     HttpDb;
 set_basic_auth_creds(User, Pass, #httpdb{} = HttpDb) when

--- a/src/couch_replicator/src/couch_replicator_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_worker.erl
@@ -256,6 +256,7 @@ remote_process_batch([{Id, Revs, PAs} | Rest], Parent) ->
     ),
     remote_process_batch(Rest, Parent).
 
+-spec spawn_doc_reader(#httpdb{}, #httpdb{}, {list(), list(), list()}) -> no_return().
 spawn_doc_reader(Source, Target, FetchParams) ->
     Parent = self(),
     spawn_link(fun() ->
@@ -264,6 +265,7 @@ spawn_doc_reader(Source, Target, FetchParams) ->
         )
     end).
 
+-spec fetch_doc(#httpd{}, {list(), list(), list()}, function(), any()) -> no_return().
 fetch_doc(Source, {Id, Revs, PAs}, DocHandler, Acc) ->
     try
         couch_replicator_api_wrap:open_doc_revs(


### PR DESCRIPTION
Invalid specs confused dialyzer.

For bulk_docs response handling it detected another left-over clause from local endpoint support. 

It also found unnecessarily broad case matches in `couch_replicator_auth_session`

Based on @jaydoane and @chewbranca's advice in https://github.com/apache/couchdb/pull/4103

