### PR TITLE
Fix not calling is_compacting test

### DIFF
--- a/src/couch/test/eunit/couch_bt_engine_compactor_tests.erl
+++ b/src/couch/test/eunit/couch_bt_engine_compactor_tests.erl
@@ -26,6 +26,7 @@ setup() ->
     DbName.
 
 teardown(DbName) when is_binary(DbName) ->
+    meck:unload(),
     couch_server:delete(DbName, [?ADMIN_CTX]),
     ok.
 
@@ -39,7 +40,8 @@ basic_compaction_test_() ->
             fun setup/0,
             fun teardown/1,
             [
-                fun compaction_resume/1
+                fun compaction_resume/1,
+                fun is_compacting_works/1
             ]
         }
     }.


### PR DESCRIPTION
## Overview

The test added in https://github.com/apache/couchdb/pull/4104 was not called and therefore never run. This PR calls the new test.

## Testing recommendations

```
make eunit apps=couch suites=couch_bt_engine_compactor_tests
```

## Related Issues or Pull Requests

Remove view compaction jobs recovery and improve `is_compacting/1` test: https://github.com/apache/couchdb/pull/4104

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
