### PR TITLE
Fix the flaky tests for `create_doc()`

### DIFF
--- a/test/elixir/test/design_docs_test.exs
+++ b/test/elixir/test/design_docs_test.exs
@@ -482,8 +482,7 @@ defmodule DesignDocsTest do
           body: ddoc
         )
       retry_resp.status_code in [201, 202]
+      {:ok, _} = create_doc(db_name, %{_id: "doc1", value: 4})
     end)
-
-    {:ok, _} = create_doc(db_name, %{_id: "doc1", value: 4})
   end
 end


### PR DESCRIPTION
## Overview

Add `retry_until()` to `create_doc()` to remove unstable tests.


## Testing recommendations
```
./configure --dev --spidermonkey-version 60 && make couch
make exunit
make elixir-suite
```

## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
