### PR TITLE
Turn document update mode atoms into defines

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -52,7 +52,7 @@
     options = [],
     rev = nil,
     open_revs = [],
-    update_type = interactive_edit,
+    update_type = ?INTERACTIVE_EDIT,
     atts_since = nil
 }).
 
@@ -648,7 +648,7 @@ db_req(#httpd{method = 'POST', path_parts = [_, <<"_bulk_docs">>], user_ctx = Ct
                     send_json(Req, 417, ErrorsJson)
             end;
         false ->
-            case fabric:update_docs(Db, Docs, [replicated_changes | Options]) of
+            case fabric:update_docs(Db, Docs, [?REPLICATED_CHANGES | Options]) of
                 {ok, Errors} ->
                     chttpd_stats:incr_writes(length(Docs)),
                     ErrorsJson = lists:map(fun update_doc_result_to_json/1, Errors),
@@ -1539,7 +1539,7 @@ send_updated_doc(Req, Db, DocId, Json) ->
     send_updated_doc(Req, Db, DocId, Json, []).
 
 send_updated_doc(Req, Db, DocId, Doc, Headers) ->
-    send_updated_doc(Req, Db, DocId, Doc, Headers, interactive_edit).
+    send_updated_doc(Req, Db, DocId, Doc, Headers, ?INTERACTIVE_EDIT).
 
 send_updated_doc(Req, Db, DocId, Doc, Headers, Type) ->
     {Code, Headers1, Body} = update_doc_req(Req, Db, DocId, Doc, Headers, Type),
@@ -2160,9 +2160,9 @@ parse_doc_query({Key, Value}, Args) ->
             JsonArray = ?JSON_DECODE(RevsJsonStr),
             Args#doc_query_args{atts_since = couch_doc:parse_revs(JsonArray)};
         {"new_edits", "false"} ->
-            Args#doc_query_args{update_type = replicated_changes};
+            Args#doc_query_args{update_type = ?REPLICATED_CHANGES};
         {"new_edits", "true"} ->
-            Args#doc_query_args{update_type = interactive_edit};
+            Args#doc_query_args{update_type = ?INTERACTIVE_EDIT};
         {"att_encoding_info", "true"} ->
             Options = [att_encoding_info | Args#doc_query_args.options],
             Args#doc_query_args{options = Options};

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -46,6 +46,8 @@
     <<"_users">>
 ]).
 
+-define(INTERACTIVE_EDIT, interactive_edit).
+-define(REPLICATED_CHANGES, replicated_changes).
 
 -type branch() :: {Key::term(), Value::term(), Tree::term()}.
 -type path() :: {Start::pos_integer(), branch()}.

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -864,7 +864,7 @@ doc_from_json_obj_validate(#db{} = Db, DocJson) ->
     Doc.
 
 update_doc(Db, Doc, Options) ->
-    update_doc(Db, Doc, Options, interactive_edit).
+    update_doc(Db, Doc, Options, ?INTERACTIVE_EDIT).
 
 update_doc(Db, Doc, Options, UpdateType) ->
     case update_docs(Db, [Doc], Options, UpdateType) of
@@ -1140,7 +1140,7 @@ prep_and_validate_updates(
     ).
 
 update_docs(Db, Docs, Options) ->
-    update_docs(Db, Docs, Options, interactive_edit).
+    update_docs(Db, Docs, Options, ?INTERACTIVE_EDIT).
 
 prep_and_validate_replicated_updates(_Db, [], [], AccPrepped, AccErrors) ->
     Errors2 = [
@@ -1308,7 +1308,7 @@ doc_tag(#doc{meta = Meta}) ->
         Else -> throw({invalid_doc_tag, Else})
     end.
 
-update_docs(Db, Docs0, Options, replicated_changes) ->
+update_docs(Db, Docs0, Options, ?REPLICATED_CHANGES) ->
     Docs = tag_docs(Docs0),
 
     PrepValidateFun = fun(Db0, DocBuckets0, ExistingDocInfos) ->
@@ -1322,7 +1322,7 @@ update_docs(Db, Docs0, Options, replicated_changes) ->
     end,
 
     {ok, DocBuckets, NonRepDocs, DocErrors} =
-        before_docs_update(Db, Docs, PrepValidateFun, replicated_changes),
+        before_docs_update(Db, Docs, PrepValidateFun, ?REPLICATED_CHANGES),
 
     DocBuckets2 = [
         [
@@ -1338,7 +1338,7 @@ update_docs(Db, Docs0, Options, replicated_changes) ->
         [merge_conflicts | Options]
     ),
     {ok, DocErrors};
-update_docs(Db, Docs0, Options, interactive_edit) ->
+update_docs(Db, Docs0, Options, ?INTERACTIVE_EDIT) ->
     Docs = tag_docs(Docs0),
 
     AllOrNothing = lists:member(all_or_nothing, Options),
@@ -1354,7 +1354,7 @@ update_docs(Db, Docs0, Options, interactive_edit) ->
     end,
 
     {ok, DocBuckets, NonRepDocs, DocErrors} =
-        before_docs_update(Db, Docs, PrepValidateFun, interactive_edit),
+        before_docs_update(Db, Docs, PrepValidateFun, ?INTERACTIVE_EDIT),
 
     if
         (AllOrNothing) and (DocErrors /= []) ->

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -100,7 +100,7 @@ handle_call({purge_docs, [], _}, _From, Db) ->
 handle_call({purge_docs, PurgeReqs0, Options}, _From, Db) ->
     % Filter out any previously applied updates during
     % internal replication
-    IsRepl = lists:member(replicated_changes, Options),
+    IsRepl = lists:member(?REPLICATED_CHANGES, Options),
     PurgeReqs =
         if
             not IsRepl ->

--- a/src/couch/src/couch_httpd_db.erl
+++ b/src/couch/src/couch_httpd_db.erl
@@ -51,7 +51,7 @@
     options = [],
     rev = nil,
     open_revs = [],
-    update_type = interactive_edit,
+    update_type = ?INTERACTIVE_EDIT,
     atts_since = nil
 }).
 
@@ -409,7 +409,7 @@ db_req(#httpd{method = 'POST', path_parts = [_, <<"_bulk_docs">>]} = Req, Db) ->
                         end,
                         DocsArray
                     ),
-                    {ok, Errors} = couch_db:update_docs(Db, Docs, Options, replicated_changes),
+                    {ok, Errors} = couch_db:update_docs(Db, Docs, Options, ?REPLICATED_CHANGES),
                     ErrorsJson =
                         lists:map(fun update_doc_result_to_json/1, Errors),
                     send_json(Req, 201, ErrorsJson)
@@ -1311,9 +1311,9 @@ parse_doc_query(Req) ->
                     JsonArray = ?JSON_DECODE(RevsJsonStr),
                     Args#doc_query_args{atts_since = couch_doc:parse_revs(JsonArray)};
                 {"new_edits", "false"} ->
-                    Args#doc_query_args{update_type = replicated_changes};
+                    Args#doc_query_args{update_type = ?REPLICATED_CHANGES};
                 {"new_edits", "true"} ->
-                    Args#doc_query_args{update_type = interactive_edit};
+                    Args#doc_query_args{update_type = ?INTERACTIVE_EDIT};
                 {"att_encoding_info", "true"} ->
                     Options = [att_encoding_info | Args#doc_query_args.options],
                     Args#doc_query_args{options = Options};

--- a/src/couch/test/eunit/couch_db_plugin_tests.erl
+++ b/src/couch/test/eunit/couch_db_plugin_tests.erl
@@ -59,12 +59,12 @@ validate_dbname({false, _Db}, _) -> {decided, false};
 validate_dbname({fail, _Db}, _) -> throw(validate_dbname);
 validate_dbname({pass, _Db}, _) -> no_decision.
 
-before_doc_update({fail, _Doc}, _Db, interactive_edit) ->
+before_doc_update({fail, _Doc}, _Db, ?INTERACTIVE_EDIT) ->
     throw(before_doc_update);
-before_doc_update({true, Doc}, Db, interactive_edit) ->
-    [{true, [before_doc_update | Doc]}, Db, interactive_edit];
-before_doc_update({false, Doc}, Db, interactive_edit) ->
-    [{false, Doc}, Db, interactive_edit].
+before_doc_update({true, Doc}, Db, ?INTERACTIVE_EDIT) ->
+    [{true, [before_doc_update | Doc]}, Db, ?INTERACTIVE_EDIT];
+before_doc_update({false, Doc}, Db, ?INTERACTIVE_EDIT) ->
+    [{false, Doc}, Db, ?INTERACTIVE_EDIT].
 
 after_doc_read({fail, _Doc}, _Db) -> throw(after_doc_read);
 after_doc_read({true, Doc}, Db) -> [{true, [after_doc_read | Doc]}, Db];
@@ -152,7 +152,7 @@ before_doc_update_match() ->
     ?assertMatch(
         {true, [before_doc_update, doc]},
         couch_db_plugin:before_doc_update(
-            fake_db(), {true, [doc]}, interactive_edit
+            fake_db(), {true, [doc]}, ?INTERACTIVE_EDIT
         )
     ).
 
@@ -160,7 +160,7 @@ before_doc_update_no_match() ->
     ?assertMatch(
         {false, [doc]},
         couch_db_plugin:before_doc_update(
-            fake_db(), {false, [doc]}, interactive_edit
+            fake_db(), {false, [doc]}, ?INTERACTIVE_EDIT
         )
     ).
 
@@ -168,7 +168,7 @@ before_doc_update_throw() ->
     ?assertThrow(
         before_doc_update,
         couch_db_plugin:before_doc_update(
-            fake_db(), {fail, [doc]}, interactive_edit
+            fake_db(), {fail, [doc]}, ?INTERACTIVE_EDIT
         )
     ).
 

--- a/src/couch/test/eunit/couchdb_update_conflicts_tests.erl
+++ b/src/couch/test/eunit/couchdb_update_conflicts_tests.erl
@@ -294,7 +294,7 @@ bulk_create_local_doc(DbName) ->
         Db,
         [LocalDoc],
         [],
-        replicated_changes
+        ?REPLICATED_CHANGES
     ),
     ok = couch_db:close(Db),
     ?assertEqual([], Results),
@@ -319,7 +319,7 @@ ignore_invalid_local_doc(DbName) ->
         Db,
         [LocalDoc],
         [],
-        replicated_changes
+        ?REPLICATED_CHANGES
     ),
     ok = couch_db:close(Db),
     ?assertEqual([], Results),

--- a/src/couch_mrview/test/eunit/couch_mrview_purge_docs_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_purge_docs_tests.erl
@@ -146,7 +146,7 @@ test_purge_partial(Db) ->
                 {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
                 {'val', 1.2}
             ]},
-        {ok, [_Rev2]} = save_docs(Db, [Update], [replicated_changes]),
+        {ok, [_Rev2]} = save_docs(Db, [Update], [?REPLICATED_CHANGES]),
 
         PurgeInfos = [{<<"UUID1">>, <<"1">>, [Rev1]}],
 
@@ -534,10 +534,10 @@ save_docs(Db, JsonDocs, Options) ->
         JsonDocs
     ),
     Opts = [full_commit | Options],
-    case lists:member(replicated_changes, Options) of
+    case lists:member(?REPLICATED_CHANGES, Options) of
         true ->
             {ok, []} = couch_db:update_docs(
-                Db, Docs, Opts, replicated_changes
+                Db, Docs, Opts, ?REPLICATED_CHANGES
             ),
             {ok,
                 lists:map(

--- a/src/couch_pse_tests/src/cpse_test_purge_docs.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_docs.erl
@@ -250,7 +250,7 @@ cpse_purge_partial_revs(DbName) ->
             {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
             {vsn, <<"1.2">>}
         ]},
-    {ok, [_Rev2]} = cpse_util:save_docs(DbName, [Update], [replicated_changes]),
+    {ok, [_Rev2]} = cpse_util:save_docs(DbName, [Update], [?REPLICATED_CHANGES]),
 
     PurgeInfos = [
         {cpse_util:uuid(), <<"foo">>, [Rev1]}
@@ -386,7 +386,7 @@ cpse_purge_repeated_revisions(DbName) ->
             {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
             {vsn, <<"1.2">>}
         ]},
-    {ok, [Rev2]} = cpse_util:save_docs(DbName, [Update], [replicated_changes]),
+    {ok, [Rev2]} = cpse_util:save_docs(DbName, [Update], [?REPLICATED_CHANGES]),
 
     cpse_util:assert_db_props(?MODULE, ?LINE, DbName, [
         {doc_count, 1},
@@ -447,7 +447,7 @@ cpse_purge_repeated_uuid(DbName) ->
     ?assertThrow({badreq, _}, cpse_util:purge(DbName, DifferentRevs)),
 
     % Although we can replicate it in
-    {ok, []} = cpse_util:purge(DbName, PurgeInfos, [replicated_changes]),
+    {ok, []} = cpse_util:purge(DbName, PurgeInfos, [?REPLICATED_CHANGES]),
 
     cpse_util:assert_db_props(?MODULE, ?LINE, DbName, [
         {doc_count, 0},

--- a/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
+++ b/src/couch_pse_tests/src/cpse_test_purge_seqs.erl
@@ -100,7 +100,7 @@ cpse_increment_purge_seq_on_partial_purge(DbName) ->
             {'_rev', couch_doc:rev_to_str({1, [couch_hash:md5_hash(<<"1.2">>)]})},
             {vsn, <<"1.2">>}
         ]},
-    {ok, [_Rev2]} = cpse_util:save_docs(DbName, [Update], [replicated_changes]),
+    {ok, [_Rev2]} = cpse_util:save_docs(DbName, [Update], [?REPLICATED_CHANGES]),
 
     cpse_util:assert_db_props(?MODULE, ?LINE, DbName, [
         {doc_count, 1},

--- a/src/couch_pse_tests/src/cpse_util.erl
+++ b/src/couch_pse_tests/src/cpse_util.erl
@@ -132,10 +132,10 @@ save_docs(DbName, JsonDocs, Options) ->
     Opts = [full_commit | Options],
     {ok, Db} = couch_db:open_int(DbName, []),
     try
-        case lists:member(replicated_changes, Options) of
+        case lists:member(?REPLICATED_CHANGES, Options) of
             true ->
                 {ok, []} = couch_db:update_docs(
-                    Db, Docs, Opts, replicated_changes
+                    Db, Docs, Opts, ?REPLICATED_CHANGES
                 ),
                 {ok,
                     lists:map(
@@ -281,7 +281,7 @@ apply_batch(Db, Actions) ->
     false = lists:member(conflict, Resp),
     {ok, Db1} = couch_db:reopen(Db),
 
-    {ok, []} = couch_db:update_docs(Db, Conflicts, [], replicated_changes),
+    {ok, []} = couch_db:update_docs(Db, Conflicts, [], ?REPLICATED_CHANGES),
     {ok, Db2} = couch_db:reopen(Db1),
 
     if

--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -332,12 +332,12 @@ open_doc(#httpdb{} = Db, Id, Options) ->
     ).
 
 update_doc(Db, Doc, Options) ->
-    update_doc(Db, Doc, Options, interactive_edit).
+    update_doc(Db, Doc, Options, ?INTERACTIVE_EDIT).
 
 update_doc(#httpdb{} = HttpDb, #doc{id = DocId} = Doc, Options, Type) ->
     QArgs =
         case Type of
-            replicated_changes ->
+            ?REPLICATED_CHANGES ->
                 [{"new_edits", "false"}];
             _ ->
                 []
@@ -397,7 +397,7 @@ update_doc(#httpdb{} = HttpDb, #doc{id = DocId} = Doc, Options, Type) ->
     ).
 
 update_docs(Db, DocList, Options) ->
-    update_docs(Db, DocList, Options, interactive_edit).
+    update_docs(Db, DocList, Options, ?INTERACTIVE_EDIT).
 
 update_docs(_Db, [], _Options, _UpdateType) ->
     {ok, []};
@@ -405,9 +405,9 @@ update_docs(#httpdb{} = HttpDb, DocList, Options, UpdateType) ->
     FullCommit = atom_to_list(not lists:member(delay_commit, Options)),
     Prefix =
         case UpdateType of
-            replicated_changes ->
+            ?REPLICATED_CHANGES ->
                 <<"{\"new_edits\":false,\"docs\":[">>;
-            interactive_edit ->
+            ?INTERACTIVE_EDIT ->
                 <<"{\"docs\":[">>
         end,
     Suffix = <<"]}">>,

--- a/src/couch_replicator/src/couch_replicator_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_worker.erl
@@ -392,7 +392,7 @@ flush_docs(Target, DocList) ->
         Target,
         DocList,
         [delay_commit],
-        replicated_changes
+        ?REPLICATED_CHANGES
     ),
     handle_flush_docs_result(FlushResult, Target, DocList).
 
@@ -442,7 +442,7 @@ handle_flush_docs_result({error, {bulk_docs_failed, _, _} = Err}, _, _) ->
     exit(Err).
 
 flush_doc(Target, #doc{id = Id, revs = {Pos, [RevId | _]}} = Doc) ->
-    try couch_replicator_api_wrap:update_doc(Target, Doc, [], replicated_changes) of
+    try couch_replicator_api_wrap:update_doc(Target, Doc, [], ?REPLICATED_CHANGES) of
         {ok, _} ->
             ok;
         Error ->

--- a/src/couch_replicator/test/eunit/couch_replicator_many_leaves_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_many_leaves_tests.erl
@@ -158,7 +158,7 @@ add_doc_siblings(Db, DocId, NumLeaves) when NumLeaves > 0 ->
     add_doc_siblings(Db, DocId, NumLeaves, [], []).
 
 add_doc_siblings(Db, _DocId, 0, AccDocs, AccRevs) ->
-    {ok, []} = couch_db:update_docs(Db, AccDocs, [], replicated_changes),
+    {ok, []} = couch_db:update_docs(Db, AccDocs, [], ?REPLICATED_CHANGES),
     {ok, AccRevs};
 add_doc_siblings(Db, DocId, NumLeaves, AccDocs, AccRevs) ->
     Value = ?l2b(?i2l(NumLeaves)),

--- a/src/fabric/src/fabric_doc_open.erl
+++ b/src/fabric/src/fabric_doc_open.erl
@@ -139,7 +139,7 @@ read_repair(#acc{dbname = DbName, replies = Replies, node_revs = NodeRevs}) ->
         [#doc{id = <<?LOCAL_DOC_PREFIX, _/binary>>} | _] ->
             choose_reply(Docs);
         [#doc{id = Id} | _] ->
-            Opts = [?ADMIN_CTX, replicated_changes, {read_repair, NodeRevs}],
+            Opts = [?ADMIN_CTX, ?REPLICATED_CHANGES, {read_repair, NodeRevs}],
             Res = fabric:update_docs(DbName, Docs, Opts),
             case Res of
                 {ok, []} ->

--- a/src/fabric/src/fabric_doc_open_revs.erl
+++ b/src/fabric/src/fabric_doc_open_revs.erl
@@ -224,7 +224,7 @@ dict_repair_docs(Replies, ReplyCount) ->
     end.
 
 read_repair(Db, Docs, NodeRevs) ->
-    Opts = [?ADMIN_CTX, replicated_changes, {read_repair, NodeRevs}],
+    Opts = [?ADMIN_CTX, ?REPLICATED_CHANGES, {read_repair, NodeRevs}],
     Res = fabric:update_docs(Db, Docs, Opts),
     case Res of
         {ok, []} ->

--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -119,14 +119,14 @@ before_doc_update(DbName, Docs, Opts) ->
             %% cluster db is expensive to create so we only do it if we have to
             Db = fabric_util:open_cluster_db(DbName, Opts),
             [
-                couch_replicator_docs:before_doc_update(Doc, Db, replicated_changes)
+                couch_replicator_docs:before_doc_update(Doc, Db, ?REPLICATED_CHANGES)
              || Doc <- Docs
             ];
         {_, true} ->
             %% cluster db is expensive to create so we only do it if we have to
             Db = fabric_util:open_cluster_db(DbName, Opts),
             [
-                couch_users_db:before_doc_update(Doc, Db, interactive_edit)
+                couch_users_db:before_doc_update(Doc, Db, ?INTERACTIVE_EDIT)
              || Doc <- Docs
             ];
         _ ->

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -290,12 +290,12 @@ update_docs(DbName, Docs0, Options) ->
         case couch_util:get_value(read_repair, Options) of
             NodeRevs when is_list(NodeRevs) ->
                 Filtered = read_repair_filter(DbName, Docs0, NodeRevs, Options),
-                {Filtered, replicated_changes};
+                {Filtered, ?REPLICATED_CHANGES};
             undefined ->
                 X =
-                    case proplists:get_value(replicated_changes, Options) of
-                        true -> replicated_changes;
-                        _ -> interactive_edit
+                    case proplists:get_value(?REPLICATED_CHANGES, Options) of
+                        true -> ?REPLICATED_CHANGES;
+                        _ -> ?INTERACTIVE_EDIT
                     end,
                 {Docs0, X}
         end,

--- a/src/mem3/src/mem3_bdu.erl
+++ b/src/mem3/src/mem3_bdu.erl
@@ -25,7 +25,7 @@ before_doc_update(#doc{id = <<?DESIGN_DOC_PREFIX, _/binary>>} = Doc, _Db, _Updat
 before_doc_update(#doc{deleted = true} = Doc, _Db, _UpdateType) ->
     % Skip deleted
     Doc;
-before_doc_update(#doc{} = Doc, _Db, replicated_changes) ->
+before_doc_update(#doc{} = Doc, _Db, ?REPLICATED_CHANGES) ->
     % Skip internal replicator updates
     Doc;
 before_doc_update(#doc{} = Doc, _Db, _UpdateType) ->

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -354,7 +354,7 @@ pull_purges(Db, Count, SrcShard, #tgt{} = Tgt0) ->
         Infos == [] ->
             ok;
         true ->
-            {ok, _} = couch_db:purge_docs(Db, Infos, [replicated_changes]),
+            {ok, _} = couch_db:purge_docs(Db, Infos, [?REPLICATED_CHANGES]),
             Body = purge_cp_body(SrcShard, TgtShard, ThroughSeq),
             mem3_rpc:save_purge_checkpoint(TgtNode, TgtDbName, LocalPurgeId, Body)
     end,
@@ -648,7 +648,7 @@ open_docs(Db, Infos, Missing) ->
 
 save_on_target(Node, Name, Docs) ->
     mem3_rpc:update_docs(Node, Name, Docs, [
-        replicated_changes,
+        ?REPLICATED_CHANGES,
         full_commit,
         ?ADMIN_CTX,
         {io_priority, {internal_repl, Name}}
@@ -657,7 +657,7 @@ save_on_target(Node, Name, Docs) ->
 
 purge_on_target(Node, Name, PurgeInfos) ->
     mem3_rpc:purge_docs(Node, Name, PurgeInfos, [
-        replicated_changes,
+        ?REPLICATED_CHANGES,
         full_commit,
         ?ADMIN_CTX,
         {io_priority, {internal_repl, Name}}


### PR DESCRIPTION
We have made some mistakes there in the past mis-typing those. For example in https://github.com/apache/couchdb/pull/3934, so as a preliminary PR to fix https://github.com/apache/couchdb/issues/4121, where we'd have to again special case logic based on the update type, let's switch them to be defines so the compiler would double-check those values for us.
