### PR TITLE
Revert "Replace SHA-1 with SHA-256 for cookie authentication (#4094)"

### DIFF
--- a/test/elixir/test/config/skip.elixir
+++ b/test/elixir/test/config/skip.elixir
@@ -2,6 +2,10 @@
   "CookieAuthTest": [
     "cookie auth"
   ],
+  "ProxyAuthTest": [
+    "proxy auth with secret",
+    "proxy auth without secret"
+  ],
   "ReaderACLTest": [
     "unrestricted db can be read"
   ],


### PR DESCRIPTION
This reverts commit daff65d8c8772c637eb60365d6e672543163a740.

as discussed in https://github.com/apache/couchdb/issues/4119