### PR TITLE
Fix elixir :logger warnings

### DIFF
--- a/config/integration.exs
+++ b/config/integration.exs
@@ -2,7 +2,9 @@ import Config
 
 config :logger,
   backends: [:console],
-  compile_time_purge_level: :debug,
+  compile_time_purge_matching: [
+    [level_lower_than: :debug]
+  ],
   level: :debug
 
 config :sasl,

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,9 @@ import Config
 
 config :logger,
   backends: [:console],
-  compile_time_purge_level: :debug,
+  compile_time_purge_matching: [
+    [level_lower_than: :debug]
+  ],
   level: :debug
 
 config :kernel,

--- a/test/elixir/config/test.exs
+++ b/test/elixir/config/test.exs
@@ -1,3 +1,5 @@
 config :logger,
   backends: [:console],
-  compile_time_purge_level: :debug
+  compile_time_purge_matching: [
+    [level_lower_than: :debug]
+  ]


### PR DESCRIPTION
Migrate deprecated config option variable to new config option
