### PR TITLE
Address race in cpse_incref_decref test

### DIFF
--- a/src/couch_pse_tests/src/cpse_test_ref_counting.erl
+++ b/src/couch_pse_tests/src/cpse_test_ref_counting.erl
@@ -40,8 +40,15 @@ cpse_incref_decref({Db, _}) ->
     {Pid, _} = Client = start_client(Db),
     wait_client(Client),
 
-    Pids1 = couch_db_engine:monitored_by(Db),
-    ?assert(lists:member(Pid, Pids1)),
+    test_util:wait(
+        fun() ->
+            MonitoredPids1 = couch_db_engine:monitored_by(Db),
+            case lists:member(Pid, MonitoredPids1) of
+                true -> ok;
+                false -> wait
+            end
+        end
+    ),
 
     close_client(Client),
 


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Occasionally, this test fails with the following stack trace:
```
      cpse_gather: make_test_fun (cpse_incref_decref)...*failed*
in function cpse_test_ref_counting:'-cpse_incref_decref/1-fun-0-'/2 (src/cpse_test_ref_counting.erl, line 44)
in call from cpse_test_ref_counting:cpse_incref_decref/1 (src/cpse_test_ref_counting.erl, line 44)
in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
in call from eunit_proc:run_test/1 (eunit_proc.erl, line 522)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 347)
in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 505)
in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 447)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 337)
**error:{assert,[{module,cpse_test_ref_counting},
         {line,44},
         {expression,"lists : member ( Pid , Pids1 )"},
         {expected,true},
         {value,false}]}
  output:<<"">>
```
Wrap the former assertion in a `test_util:wait` call to account for
the apparent race between client readiness and
`couch_db_engine:monitored_by/1`.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
