### PR TITLE
Add editors magic lines

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,5 @@
-%% -*- erlang -*-
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at

--- a/src/chttpd/rebar.config
+++ b/src/chttpd/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -1,3 +1,5 @@
+%% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 %% Licensed under the Apache License, Version 2.0 (the "License"); you may not
 %% use this file except in compliance with the License. You may obtain a copy of
 %% the License at

--- a/src/couch_dist/rebar.config
+++ b/src/couch_dist/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/couch_epi/rebar.config
+++ b/src/couch_epi/rebar.config
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 
 {cover_print_enabled, true}.

--- a/src/couch_event/rebar.config
+++ b/src/couch_event/rebar.config
@@ -1,1 +1,3 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {erl_first_files, ["src/couch_event_listener.erl"]}.

--- a/src/couch_index/rebar.config
+++ b/src/couch_index/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/couch_log/rebar.config
+++ b/src/couch_log/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/couch_mrview/rebar.config
+++ b/src/couch_mrview/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/couch_tests/rebar.config
+++ b/src/couch_tests/rebar.config
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at

--- a/src/custodian/rebar.config.script
+++ b/src/custodian/rebar.config.script
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at

--- a/src/fabric/rebar.config
+++ b/src/fabric/rebar.config
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at

--- a/src/jwtf/rebar.config
+++ b/src/jwtf/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/ken/rebar.config.script
+++ b/src/ken/rebar.config.script
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at

--- a/src/mango/rebar.config.script
+++ b/src/mango/rebar.config.script
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at

--- a/src/mem3/rebar.config
+++ b/src/mem3/rebar.config
@@ -1,3 +1,5 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at

--- a/src/mem3/rebar.config.script
+++ b/src/mem3/rebar.config.script
@@ -1,3 +1,5 @@
+%% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 %% Licensed under the Apache License, Version 2.0 (the "License"); you may not
 %% use this file except in compliance with the License. You may obtain a copy of
 %% the License at

--- a/src/rexi/rebar.config
+++ b/src/rexi/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/smoosh/rebar.config
+++ b/src/smoosh/rebar.config
@@ -1,2 +1,4 @@
+% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.

--- a/src/weatherreport/rebar.config
+++ b/src/weatherreport/rebar.config
@@ -1,3 +1,5 @@
+%% vim: set ft=erlang : -*- erlang -*- % Magic lines for code editors
+
 %% -------------------------------------------------------------------
 %%
 %% derived from riaknostic - automated diagnostic tools for Riak


### PR DESCRIPTION
## Overview

Most of the code editors select syntax highlighting language based on file name extension. However, this approach doesn't work when the extension is not standard. For such cases, there are magic lines. Without the magic lines, files with unknown extensions require extra steps to enable syntax highlighting and auto-completion. This PR adds a magic line for Vim.

## Testing recommendations
Open Emacs or Vim and ensure that it uses Erlang syntax highlighting for `rebar.config*` files.

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
