### PR TITLE
Add ioq:call_search

### DIFF
--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -102,7 +102,7 @@ connected() ->
     end.
 
 rpc(Ref, Msg) ->
-    ioq:call(Ref, Msg, erlang:get(io_priority)).
+    ioq:call_search(Ref, Msg, erlang:get(io_priority)).
 
 clouseau() ->
     list_to_atom(config:get("dreyfus", "name", "clouseau@127.0.0.1")).

--- a/src/ioq/src/ioq.erl
+++ b/src/ioq/src/ioq.erl
@@ -14,7 +14,7 @@
 -behaviour(gen_server).
 -behaviour(config_listener).
 
--export([start_link/0, call/3]).
+-export([start_link/0, call/3, call_search/3]).
 -export([get_queue_lengths/0]).
 -export([get_io_priority/0, set_io_priority/1, maybe_set_io_priority/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, code_change/3, terminate/2]).
@@ -54,6 +54,9 @@ maybe_set_io_priority(Priority) ->
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+call_search(Fd, Msg, Metadata) ->
+    call(Fd, Msg, Metadata).
 
 call(Fd, Msg, Metadata) ->
     Priority = io_class(Msg, Metadata),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add a dedicated `ioq:call_search` function to more clearly distinguish IOQ search traffic from normal couch_file operations.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Standard test suite.

## Related Issues or Pull Requests

This is related to https://github.com/apache/couchdb-ioq/pull/21 for establishing a dedicated IOQ2 process for routing search requests through. 

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
