### PR TITLE
Fix purge request timeouts

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -432,7 +432,7 @@ purge_docs(#db{main_pid = Pid} = Db, UUIDsIdsRevs, Options) ->
             {ok, []};
         [_ | _] ->
             increment_stat(Db, [couchdb, database_purges]),
-            gen_server:call(Pid, {purge_docs, UUIDsIdsRevs2, Options})
+            gen_server:call(Pid, {purge_docs, UUIDsIdsRevs2, Options}, infinity)
     end.
 
 -spec get_purge_infos(#db{}, [UUId]) -> [PurgeInfo] when


### PR DESCRIPTION
Don't rely on the default gen_server 5 second timeout.

Use `infinity` as that's also effectively used for doc updates.

Fixes https://github.com/apache/couchdb/issues/4142
