### PR TITLE
Implement _bulk_get support for the replicator

### DIFF
--- a/src/couch_replicator/src/couch_replicator_changes_reader.erl
+++ b/src/couch_replicator/src/couch_replicator_changes_reader.erl
@@ -119,7 +119,7 @@ process_change(#doc_info{id = Id} = DocInfo, {Parent, Db, ChangesQueue, _}) ->
                 [Id, SourceDb]
             ),
             Stats = couch_replicator_stats:new([{doc_write_failures, 1}]),
-            ok = gen_server:call(Parent, {add_stats, Stats}, infinity);
+            ok = couch_replicator_scheduler_job:sum_stats(Parent, Stats);
         false ->
             ok = couch_work_queue:queue(ChangesQueue, DocInfo),
             put(last_seq, DocInfo#doc_info.high_seq)

--- a/src/couch_replicator/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc.erl
@@ -18,6 +18,7 @@
 
 -export([setup/1]).
 -export([send_req/3]).
+-export([stop_http_worker/0]).
 -export([full_url/2]).
 
 -import(couch_util, [
@@ -101,6 +102,9 @@ send_req(HttpDb, Params1, Callback) ->
         _ ->
             Ret
     end.
+
+stop_http_worker() ->
+    put(?STOP_HTTP_WORKER, stop).
 
 send_ibrowse_req(#httpdb{headers = BaseHeaders} = HttpDb0, Params) ->
     Method = get_value(method, Params, get),

--- a/src/couch_replicator/src/couch_replicator_stats.erl
+++ b/src/couch_replicator/src/couch_replicator_stats.erl
@@ -26,7 +26,9 @@
     missing_found/1,
     docs_read/1,
     docs_written/1,
-    doc_write_failures/1
+    doc_write_failures/1,
+    bulk_get_docs/1,
+    bulk_get_attempts/1
 ]).
 
 new() ->
@@ -50,6 +52,12 @@ docs_written(Stats) ->
 
 doc_write_failures(Stats) ->
     get(doc_write_failures, Stats).
+
+bulk_get_docs(Stats) ->
+    get(bulk_get_docs, Stats).
+
+bulk_get_attempts(Stats) ->
+    get(bulk_get_attempts, Stats).
 
 get(Field, Stats) ->
     case orddict:find(Field, Stats) of
@@ -84,4 +92,8 @@ fmap({docs_written, _}) -> true;
 fmap({<<"docs_written">>, V}) -> {true, {docs_written, V}};
 fmap({doc_write_failures, _}) -> true;
 fmap({<<"doc_write_failures">>, V}) -> {true, {doc_write_failures, V}};
+fmap({bulk_get_docs, _}) -> true;
+fmap({<<"bulk_get_docs">>, V}) -> {true, {bulk_get_docs, V}};
+fmap({bulk_get_attempts, _}) -> true;
+fmap({<<"bulk_get_attempts">>, V}) -> {true, {bulk_get_attempts, V}};
 fmap({_, _}) -> false.

--- a/src/couch_replicator/test/eunit/couch_replicator_retain_stats_between_job_runs.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_retain_stats_between_job_runs.erl
@@ -98,6 +98,8 @@ check_active_tasks(DocsRead, DocsWritten, DocsFailed) ->
     RepTask = wait_for_task_status(DocsWritten),
     ?assertNotEqual(timeout, RepTask),
     ?assertEqual(DocsRead, couch_util:get_value(docs_read, RepTask)),
+    ?assertEqual(DocsRead, couch_util:get_value(bulk_get_docs, RepTask)),
+    ?assertEqual(DocsRead, couch_util:get_value(bulk_get_attempts, RepTask)),
     ?assertEqual(DocsWritten, couch_util:get_value(docs_written, RepTask)),
     ?assertEqual(
         DocsFailed,
@@ -112,12 +114,16 @@ check_scheduler_jobs(DocsRead, DocsWritten, DocFailed) ->
     ?assert(maps:is_key(<<"changes_pending">>, Info)),
     ?assert(maps:is_key(<<"doc_write_failures">>, Info)),
     ?assert(maps:is_key(<<"docs_read">>, Info)),
+    ?assert(maps:is_key(<<"bulk_get_docs">>, Info)),
+    ?assert(maps:is_key(<<"bulk_get_attempts">>, Info)),
     ?assert(maps:is_key(<<"docs_written">>, Info)),
     ?assert(maps:is_key(<<"missing_revisions_found">>, Info)),
     ?assert(maps:is_key(<<"checkpointed_source_seq">>, Info)),
     ?assert(maps:is_key(<<"source_seq">>, Info)),
     ?assert(maps:is_key(<<"revisions_checked">>, Info)),
     ?assertMatch(#{<<"docs_read">> := DocsRead}, Info),
+    ?assertMatch(#{<<"bulk_get_docs">> := DocsRead}, Info),
+    ?assertMatch(#{<<"bulk_get_attempts">> := DocsRead}, Info),
     ?assertMatch(#{<<"docs_written">> := DocsWritten}, Info),
     ?assertMatch(#{<<"doc_write_failures">> := DocFailed}, Info).
 


### PR DESCRIPTION
By now most of the CouchDB implementations support `_bulk_get`, so let's update the replicator to take advantage of that.

To be backwards compatible assume some endpoints will not support `_bulk_get` and may return either a 500 or 400 error. In that case the replicator will fall back to fetching individual document revisions like it did previously. For additional backward compatibility, and to keep things simple, support only the `application/json` `_bulk_get` response format. (Ideally, we'd send multiple Accept headers with various `q` preference parameters for `json` and `multipart/related` content, then do the right thing based on the response, however, none of the recent Apache CouchDB implementations support that scheme properly).

Since fetching attachments with `application/json` response is not optimal, attachments are fetched individually. This means there are two main reasons for the replicator to fall back to fetching individual revisions: 1) when `_bulk_get` endpoint is not supported and 2) when the document revisions contain attachments.

To avoid wasting resource repeatedly attempting to use `_bulk_get `and then falling back to individual doc fetches, maintain some historical stats about the rate of failure, and if it crosses a threshold, skip calling `_bulk_get` altogether. This is implemented with a moving exponential average, along with periodic probing to see if `_bulk_get` usage becomes viable again.

To give the users some indication about how successful `_bulk_get` usage is, introduce two replication statistics parameters:
  * `bulk_get_attempts`: `_bulk_get` document revisions attempts made.
  * `bulk_get_docs` : `_bulk_get` document revisions successfully retrieved.

These are persisted in the replication checkpoints along with the rest of the job statistics and visible in `_scheduler/jobs` and `_active_tasks` output.

Since we updated the replication job statistics, perform some minor cleanups in that area:
  - Stop using the process dictionary for the reporting timestamp. Use a regular record state field instead.
  - Use casts instead of a calls when possible. We still rely on `report_seq_done` calls as a synchronization point to make sure we don't overrun the message queues for the replication worker and scheduler job process.
  - Add stats update API functions instead of relying on naked `gen_server` calls and casts. The functions make it clear which process is being updated: the replication worker or the main replication scheduler job process.

For testing, rely on the variety of existing replication tests running and passing. The recently merged replication test overhaul from [pull #4151](https://github.com/apache/couchdb/pull/4151) switched most of the tests form using the node-local (back-end API) to chttpd (the clustering API), which actually implements `_bulk_get`. In this way, the majority of replication tests should test the `_bulk_get` API usage alongside whatever else they are testing. There there is new test checking that `_bulk_get` fallback works and testing the characteristics of the new statistics parameters.