### PR TITLE
config section for require_valid_user is only [chttpd]

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -472,15 +472,10 @@ def hack_default_ini(ctx, node, contents):
 
 
 def hack_local_ini(ctx, contents):
-    # make sure all three nodes have the same secret
-    secret_line = "secret = %s\n" % COMMON_SALT
-    previous_line = "; require_valid_user = false\n"
-    contents = contents.replace(previous_line, previous_line + secret_line)
-
     if ctx["with_admin_party"]:
         os.environ["COUCHDB_TEST_ADMIN_PARTY_OVERRIDE"] = "1"
         ctx["admin"] = ("Admin Party!", "You do not need any password.")
-        return contents
+        return contents + "\n\n[chttpd_auth]\nsecret %s\n" % COMMON_SALT
 
     # handle admin credentials passed from cli or generate own one
     if ctx["admin"] is None:
@@ -488,7 +483,10 @@ def hack_local_ini(ctx, contents):
     else:
         user, pswd = ctx["admin"]
 
-    return contents + "\n%s = %s" % (user, hashify(pswd))
+    # this relies on [admin] being the last section at the end of the file
+    contents = contents + "\n%s = %s" % (user, hashify(pswd))
+
+    return contents + "\n\n[chttpd_auth]\nsecret = %s\n" % COMMON_SALT
 
 
 def gen_password():

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -247,7 +247,6 @@ bind_address = 127.0.0.1
 
 ; These options are moved from [couch_httpd_auth]
 ;authentication_redirect = /_utils/session.html
-;require_valid_user = false
 ;timeout = 600 ; number of seconds before automatic logout
 ;auth_cache_size = 50 ; size is number of cache entries
 ;allow_persistent_cookies = true ; set to false to disallow persistent cookies
@@ -323,7 +322,7 @@ bind_address = 127.0.0.1
 authentication_db = _users
 
 ; These settings were moved to [chttpd_auth]
-; authentication_redirect, require_valid_user, timeout,
+; authentication_redirect, timeout,
 ; auth_cache_size, allow_persistent_cookies, iterations, min_iterations,
 ; max_iterations, password_scheme, password_regexp, proxy_use_secret,
 ; public_fields, secret, users_db_public, cookie_domain, same_site

--- a/rel/overlay/etc/local.ini
+++ b/rel/overlay/etc/local.ini
@@ -43,12 +43,6 @@
 ; the whitelist.
 ;config_whitelist = [{httpd,config_whitelist}, {log,level}, {etc,etc}]
 
-[chttpd_auth]
-; If you set this to true, you should also uncomment the WWW-Authenticate line
-; above. If you don't configure a WWW-Authenticate header, CouchDB will send
-; Basic realm="server" in order to prevent you getting logged out.
-; require_valid_user = false
-
 [ssl]
 ;enable = true
 ;cert_file = /full/path/to/server_cert.pem

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1173,7 +1173,7 @@ error_headers(#httpd{mochi_req = MochiReq} = Req, 401 = Code, ErrorStr, ReasonSt
                                     {Code, []};
                                 AuthRedirect ->
                                     case
-                                        chttpd_util:get_chttpd_auth_config_boolean(
+                                        chttpd_util:get_chttpd_config_boolean(
                                             "require_valid_user", false
                                         )
                                     of

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -1080,7 +1080,7 @@ error_headers(#httpd{mochi_req = MochiReq} = Req, Code, ErrorStr, ReasonStr) ->
                                             {Code, []};
                                         AuthRedirect ->
                                             case
-                                                chttpd_util:get_chttpd_auth_config_boolean(
+                                                chttpd_util:get_chttpd_config_boolean(
                                                     "require_valid_user", false
                                                 )
                                             of

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -43,7 +43,7 @@
 
 party_mode_handler(Req) ->
     case
-        chttpd_util:get_chttpd_auth_config_boolean(
+        chttpd_util:get_chttpd_config_boolean(
             "require_valid_user", false
         )
     of
@@ -131,7 +131,7 @@ default_authentication_handler(Req, AuthModule) ->
                     Req;
                 false ->
                     case
-                        chttpd_util:get_chttpd_auth_config_boolean(
+                        chttpd_util:get_chttpd_config_boolean(
                             "require_valid_user", false
                         )
                     of

--- a/src/global_changes/test/eunit/global_changes_hooks_tests.erl
+++ b/src/global_changes/test/eunit/global_changes_hooks_tests.erl
@@ -34,7 +34,7 @@ stop({Ctx, DbName}) ->
 setup(default) ->
     add_admin("admin", <<"pass">>),
     config:delete("chttpd_auth", "authentication_redirect", false),
-    config:set("chttpd_auth", "require_valid_user", "false", false),
+    config:set("chttpd", "require_valid_user", "false", false),
     get_host();
 setup(A) ->
     Host = setup(default),


### PR DESCRIPTION
If this gets merged, please also merge https://github.com/apache/couchdb-documentation/pull/753