### PR TITLE
fix missing "=" for admin party in #4153

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -475,7 +475,7 @@ def hack_local_ini(ctx, contents):
     if ctx["with_admin_party"]:
         os.environ["COUCHDB_TEST_ADMIN_PARTY_OVERRIDE"] = "1"
         ctx["admin"] = ("Admin Party!", "You do not need any password.")
-        return contents + "\n\n[chttpd_auth]\nsecret %s\n" % COMMON_SALT
+        return contents + "\n\n[chttpd_auth]\nsecret = %s\n" % COMMON_SALT
 
     # handle admin credentials passed from cli or generate own one
     if ctx["admin"] is None:


### PR DESCRIPTION
In #4153 we missed a "=" in the secret option for the admin party