### PR TITLE
Refactor hash algorithms test for full CI run

### DIFF
--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -15,6 +15,8 @@
 -define(DESIGN_DOC_PREFIX, "_design/").
 -define(DEFAULT_COMPRESSION, snappy).
 
+-define(DEFAULT_HASH_ALGORITHM, sha256).
+
 -define(MIN_STR, <<"">>).
 -define(MAX_STR, <<255>>). % illegal utf string
 


### PR DESCRIPTION
The test doesn't check if the hash algorithm is supported by the
erlang vm. The test for supported hash algorithms was only missing
in the test itself and not in CouchDB.
Refactor test and verify hash names during test runs.

See https://github.com/apache/couchdb/pull/4140.