### PR TITLE
Fix variable already bound compiler warnings

### DIFF
--- a/src/chttpd/test/eunit/chttpd_csp_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_csp_tests.erl
@@ -223,9 +223,10 @@ setup() ->
     DbName.
 
 cleanup(DbName) ->
-    config:delete("csp", "utils_enable", _Persist = false),
-    config:delete("csp", "attachments_enable", _Persist = false),
-    config:delete("csp", "showlist_enable", _Persist = false),
+    Persist = false,
+    config:delete("csp", "utils_enable", Persist),
+    config:delete("csp", "attachments_enable", Persist),
+    config:delete("csp", "showlist_enable", Persist),
     DbUrl = base_url() ++ "/" ++ DbName,
     {200, _} = req(delete, ?ADM, DbUrl),
     UsersDb = config:get("chttpd_auth", "authentication_db"),

--- a/src/chttpd/test/eunit/chttpd_db_attachment_size_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_db_attachment_size_tests.erl
@@ -23,8 +23,9 @@
 
 setup() ->
     Hashed = couch_passwords:hash_admin_password(?PASS),
-    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist = false),
-    ok = config:set("couchdb", "max_attachment_size", "50", _Persist = false),
+    Persist = false,
+    ok = config:set("admins", ?USER, ?b2l(Hashed), Persist),
+    ok = config:set("couchdb", "max_attachment_size", "50", Persist),
     TmpDb = ?tempdb(),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = integer_to_list(mochiweb_socket_server:get(chttpd, port)),

--- a/src/chttpd/test/eunit/chttpd_delayed_test.erl
+++ b/src/chttpd/test/eunit/chttpd_delayed_test.erl
@@ -19,8 +19,9 @@
 
 setup() ->
     Hashed = couch_passwords:hash_admin_password(?PASS),
-    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist = false),
-    ok = config:set("chttpd", "buffer_response", "true", _Persist = false),
+    Persist = false,
+    ok = config:set("admins", ?USER, ?b2l(Hashed), Persist),
+    ok = config:set("chttpd", "buffer_response", "true", Persist),
     TmpDb = ?tempdb(),
     Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
     Port = mochiweb_socket_server:get(chttpd, port),

--- a/src/chttpd/test/eunit/chttpd_session_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_session_tests.erl
@@ -19,14 +19,16 @@
 -define(PASS, "pass").
 
 setup() ->
-    ok = config:delete("chttpd_auth", "authentication_db", _Persist = false),
+    Persist = false,
+    ok = config:delete("chttpd_auth", "authentication_db", Persist),
     Hashed = couch_passwords:hash_admin_password(?PASS),
-    ok = config:set("admins", ?USER, binary_to_list(Hashed), _Persist = false),
+    ok = config:set("admins", ?USER, binary_to_list(Hashed), Persist),
     root_url() ++ "/_session".
 
 cleanup(_) ->
-    ok = config:delete("chttpd_auth", "authentication_db", _Persist = false),
-    ok = config:delete("admins", ?USER, _Persist = false).
+    Persist = false,
+    ok = config:delete("chttpd_auth", "authentication_db", Persist),
+    ok = config:delete("admins", ?USER, Persist).
 
 session_test_() ->
     {

--- a/src/chttpd/test/eunit/chttpd_util_test.erl
+++ b/src/chttpd/test/eunit/chttpd_util_test.erl
@@ -23,36 +23,38 @@ setup() ->
         ["httpd", "chttpd", "couch_httpd_auth", "chttpd_auth"]
     ),
 
+    Persist = false,
     ok = config:set(
         "httpd",
         "authentication_handlers",
         "{couch_httpd_auth, cookie_authentication_handler}, "
         "{couch_httpd_auth, default_authentication_handler}",
-        _Persist = false
+        Persist
     ),
-    ok = config:set("httpd", "backlog", "512", _Persist = false),
-    ok = config:set("chttpd", "require_valid_user", "false", _Persist = false),
-    ok = config:set("httpd", "both_exist", "get_in_httpd", _Persist = false),
-    ok = config:set("chttpd", "both_exist", "get_in_chttpd", _Persist = false),
-    ok = config:set("httpd", "httpd_only", "true", _Persist = false),
-    ok = config:set("chttpd", "chttpd_only", "1", _Persist = false),
-    ok = config:set("couch_httpd_auth", "both_exist", "cha", _Persist = false),
-    ok = config:set("chttpd_auth", "both_exist", "ca", _Persist = false),
-    ok = config:set("couch_httpd_auth", "cha_only", "true", _Persist = false),
-    ok = config:set("chttpd_auth", "ca_only", "1", _Persist = false).
+    ok = config:set("httpd", "backlog", "512", Persist),
+    ok = config:set("chttpd", "require_valid_user", "false", Persist),
+    ok = config:set("httpd", "both_exist", "get_in_httpd", Persist),
+    ok = config:set("chttpd", "both_exist", "get_in_chttpd", Persist),
+    ok = config:set("httpd", "httpd_only", "true", Persist),
+    ok = config:set("chttpd", "chttpd_only", "1", Persist),
+    ok = config:set("couch_httpd_auth", "both_exist", "cha", Persist),
+    ok = config:set("chttpd_auth", "both_exist", "ca", Persist),
+    ok = config:set("couch_httpd_auth", "cha_only", "true", Persist),
+    ok = config:set("chttpd_auth", "ca_only", "1", Persist).
 
 teardown(_) ->
-    ok = config:delete("httpd", "authentication_handlers", _Persist = false),
-    ok = config:delete("httpd", "backlog", _Persist = false),
-    ok = config:delete("chttpd", "require_valid_user", _Persist = false),
-    ok = config:delete("httpd", "both_exist", _Persist = false),
-    ok = config:delete("chttpd", "both_exist", _Persist = false),
-    ok = config:delete("httpd", "httpd_only", _Persist = false),
-    ok = config:delete("chttpd", "chttpd_only", _Persist = false),
-    ok = config:delete("couch_httpd_auth", "both_exist", _Persist = false),
-    ok = config:delete("chttpd_auth", "both_exist", _Persist = false),
-    ok = config:delete("couch_httpd_auth", "cha_only", _Persist = false),
-    ok = config:delete("chttpd_auth", "ca_only", _Persist = false).
+    Persist = false,
+    ok = config:delete("httpd", "authentication_handlers", Persist),
+    ok = config:delete("httpd", "backlog", Persist),
+    ok = config:delete("chttpd", "require_valid_user", Persist),
+    ok = config:delete("httpd", "both_exist", Persist),
+    ok = config:delete("chttpd", "both_exist", Persist),
+    ok = config:delete("httpd", "httpd_only", Persist),
+    ok = config:delete("chttpd", "chttpd_only", Persist),
+    ok = config:delete("couch_httpd_auth", "both_exist", Persist),
+    ok = config:delete("chttpd_auth", "both_exist", Persist),
+    ok = config:delete("couch_httpd_auth", "cha_only", Persist),
+    ok = config:delete("chttpd_auth", "ca_only", Persist).
 
 config_delete_all_keys(Section) ->
     lists:foreach(


### PR DESCRIPTION
## Overview

OTP 25 generates warnings like the following:

```
src/chttpd/test/eunit/chttpd_util_test.erl:33:48: Warning: variable '_Persist' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
```

Create an explicit `Persist` variable set `false` to suppress those warnings.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit
```
should no longer emit those warnings under OTP 25.

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] A PR for documentation changes has been made in https://github.com/apache/couchdb-documentation
