### PR TITLE
return a nice error if non-object passed to _bulk_get

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -2393,7 +2393,10 @@ throw_bad_query_param(Key) when is_binary(Key) ->
     throw({bad_request, Msg}).
 
 bulk_get_open_doc_revs(Db, {Props}, Options) ->
-    bulk_get_open_doc_revs1(Db, Props, Options, {}).
+    bulk_get_open_doc_revs1(Db, Props, Options, {});
+bulk_get_open_doc_revs(_Db, _Invalid, Options) ->
+    Error = {null, bad_request, <<"document must be a JSON object">>},
+    {null, {error, Error}, Options}.
 
 bulk_get_open_doc_revs1(Db, Props, Options, {}) ->
     case couch_util:get_value(<<"id">>, Props) of


### PR DESCRIPTION
If `_bulk_get` is called with malformed input we crash with a function clause and return a broken http response;

```
curl foo:bar@localhost:15984/db1/_bulk_get -Hcontent-type:application/json -d '{"docs":["doc1"]}'
curl: (56) Illegal or missing hexadecimal sequence in chunked-encoding
{"results": [%
```

This is because `chttp_db:bulk_get_open_doc_revs` only has a clause that matches an object.

Be kinder and send an error message within the `_bulk_get` response, like we do if you send an object but omit the required `id` field;

```
curl foo:bar@localhost:15984/db1/_bulk_get -Hcontent-type:application/json -d '{"docs":[{}]}'
{"results": [{"id": null, "docs": [{"error":{"id":null,"rev":null,"error":"bad_request","reason":"document id missed"}}]}]}
```

With this PR we will send an error like;

```
curl foo:bar@localhost:15984/db1/_bulk_get -Hcontent-type:application/json -d '{"docs":["gg"]}'
{"results": [{"id": null, "docs": [{"error":{"id":null,"rev":null,"error":"bad_request","reason":"document must be a JSON object"}}]}]}
```
