### PR TITLE
Show supported hash algorithms at node-local _version endpoint

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -42,8 +42,12 @@ handle_node_req(#httpd{method = 'GET', path_parts = [_, _Node, <<"_versions">>]}
     IcuVer = couch_ejson_compare:get_icu_version(),
     UcaVer = couch_ejson_compare:get_uca_version(),
     ColVer = couch_ejson_compare:get_collator_version(),
+    Hashes = crypto:supports(hashs),
     send_json(Req, 200, #{
-        erlang_version => ?l2b(?COUCHDB_ERLANG_VERSION),
+        erlang => #{
+            version => ?l2b(?COUCHDB_ERLANG_VERSION),
+            supported_hashes => Hashes
+        },
         collation_driver => #{
             name => <<"libicu">>,
             library_version => couch_util:version_to_binary(IcuVer),


### PR DESCRIPTION
Show the supported hash algorithms at the node-local _version endpoint:

Example:
```json
curl -s a:a@127.0.0.1:35984/_node/_local/_versions | jq .
{
  "javascript_engine": {
    "version": "91",
    "name": "spidermonkey"
  },
  "erlang": {
    "version": "25.0.4",
    "supported_hashes": [
      "sha",
      "sha224",
      "sha256",
      "sha384",
      "sha512",
      "sha3_224",
      "sha3_256",
      "sha3_384",
      "sha3_512",
      "blake2b",
      "blake2s",
      "md4",
      "md5",
      "ripemd160"
    ]
  },
  "collation_driver": {
    "name": "libicu",
    "library_version": "70.1",
    "collator_version": "153.112",
    "collation_algorithm_version": "14"
  }
}
```