### PR TITLE
Add test coverage to prevent junk in eventsource

### DIFF
--- a/test/elixir/test/changes_async_test.exs
+++ b/test/elixir/test/changes_async_test.exs
@@ -104,6 +104,30 @@ defmodule ChangesAsyncTest do
   end
 
   @tag :with_db
+  test "eventsource no junk in response", context do
+    db_name = context[:db_name]
+
+    check_empty_db(db_name)
+    create_doc(db_name, sample_doc_foo())
+    create_doc_bar(db_name, "bar")
+
+    resp = Rawresp.get("/#{db_name}/_changes?feed=eventsource&timeout=500")
+
+    lines = String.split(resp.body, "\n")
+
+    all_lines = lines
+    |> Enum.map(fn p -> Enum.at(String.split(p, ":"), 0) end)
+
+    allowed = ["", "data", "id", "event"]
+
+    allowed_lines = all_lines
+    |> Enum.filter(fn p -> Enum.member?(allowed, p) end)
+
+    assert length(all_lines) == length(allowed_lines)
+
+  end
+
+  @tag :with_db
   test "eventsource heartbeat", context do
     db_name = context[:db_name]
 

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -101,6 +101,7 @@
     "continuous filtered changes",
     "continuous filtered changes with doc ids",
     "eventsource changes",
+    "eventsource no junk in response",
     "eventsource heartbeat",
     "live changes",
     "longpoll changes",


### PR DESCRIPTION
## Overview

`eventsource` events should only ever contain `data`, `id`, `event`, or empty lines

This PR adds a test to ensure that new code/changes will not break this rule

## Testing recommendations

Pull this PR Branch into your local dev env and run the following commands:

```bash
# reset the code back before the fix in PR #4176 
git reset --soft 9fab3868de298b44b931a51d791b1d54bdc3c2ed
git restore --staged src/chttpd/src/chttpd_db.erl
git restore --staged src/global_changes/src/global_changes_httpd.erl
git restore src/chttpd/src/chttpd_db.erl
git restore src/global_changes/src/global_changes_httpd.erl

# This test should fail
make
make elixir tests=test/elixir/test/changes_async_test.exs:110

# Restore to latest commit including the fix
git pull

# The test should now pass
make
make elixir tests=test/elixir/test/changes_async_test.exs:110
```

## Related Issues or Pull Requests

#4176 

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [n/a] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [n/a] Documentation changes were made in the `src/docs` folder
