### PR TITLE
Fix the documentation download links

### DIFF
--- a/src/docs/src/conf.py
+++ b/src/docs/src/conf.py
@@ -74,6 +74,7 @@ html_context = {
     "conf_py_path": "/src/docs/src/",
     "github_user": "apache",
     "github_repo": "couchdb",
+    "rtd_ver": os.environ.get("READTHEDOCS_VERSION_NAME") or "latest",
 }
 
 text_newlines = "native"

--- a/src/docs/templates/pages/download.html
+++ b/src/docs/templates/pages/download.html
@@ -16,11 +16,6 @@ specific language governing permissions and limitations under the License.
 {% extends "layout.html" %}
 {% set title = 'Download' %}
 {% set url = 'https://media.readthedocs.org/%s/couchdb/%s/couchdb.%s' %}
-{% if git_branch == 'main' %}
-  {% set rtd_ver = 'latest' %}
-{% else %}
-  {% set rtd_ver = git_branch %}
-{% endif %}
 
 {% block body %}
 <h1>Download Apache CouchDB™ {{ release }} Documentation</h1>


### PR DESCRIPTION
The download page was missing the version part of the template.

Use the RTD version environment [variable](https://docs.readthedocs.io/en/stable/environment-variables.html?highlight=github_version#envvar-READTHEDOCS_VERSION)
