### PR TITLE
Redact passwords in log file

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -45,6 +45,7 @@
 -export([version_to_binary/1]).
 -export([verify_hash_names/2]).
 -export([get_config_hash_algorithms/0]).
+-export([remove_sensitive_data/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -860,3 +861,9 @@ get_config_hash_algorithms() ->
         [] -> [?DEFAULT_HASH_ALGORITHM];
         VerifiedHashNames -> VerifiedHashNames
     end.
+
+-spec remove_sensitive_data(list()) -> list().
+remove_sensitive_data(KVList) ->
+    KVList1 = lists:keyreplace(<<"password">>, 1, KVList, {<<"password">>, <<"****">>}),
+    % some KVList entries are atoms, so test fo this too
+    lists:keyreplace(password, 1, KVList1, {password, <<"****">>}).

--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -166,7 +166,7 @@ enable_cluster_int(Options, false) ->
     Port = proplists:get_value(port, Options),
 
     setup_node(NewCredentials, NewBindAddress, NodeCount, Port),
-    couch_log:debug("Enable Cluster: ~p~n", [Options]).
+    couch_log:debug("Enable Cluster: ~p~n", [couch_util:remove_sensitive_data(Options)]).
 
 set_admin(Username, Password) ->
     config:set("admins", binary_to_list(Username), binary_to_list(Password), #{sensitive => true}).
@@ -325,7 +325,7 @@ add_node(Options) ->
 add_node_int(_Options, false) ->
     {error, cluster_not_enabled};
 add_node_int(Options, true) ->
-    couch_log:debug("add node_int: ~p~n", [Options]),
+    couch_log:debug("add node_int: ~p~n", [couch_util:remove_sensitive_data(Options)]),
     ErlangCookie = erlang:get_cookie(),
 
     % POST to nodeB/_setup

--- a/src/setup/src/setup_httpd.erl
+++ b/src/setup/src/setup_httpd.erl
@@ -19,7 +19,7 @@ handle_setup_req(#httpd{method = 'POST'} = Req) ->
     ok = chttpd:verify_is_server_admin(Req),
     couch_httpd:validate_ctype(Req, "application/json"),
     Setup = get_body(Req),
-    couch_log:notice("Setup: ~p~n", [remove_sensitive(Setup)]),
+    couch_log:notice("Setup: ~p~n", [couch_util:remove_sensitive_data(Setup)]),
     Action = binary_to_list(couch_util:get_value(<<"action">>, Setup, <<"missing">>)),
     case handle_action(Action, Setup) of
         ok ->
@@ -92,7 +92,7 @@ handle_action("enable_cluster", Setup) ->
             ok
     end;
 handle_action("finish_cluster", Setup) ->
-    couch_log:notice("finish_cluster: ~p~n", [remove_sensitive(Setup)]),
+    couch_log:notice("finish_cluster: ~p~n", [couch_util:remove_sensitive_data(Setup)]),
 
     Options = get_options(
         [
@@ -108,7 +108,7 @@ handle_action("finish_cluster", Setup) ->
             ok
     end;
 handle_action("enable_single_node", Setup) ->
-    couch_log:notice("enable_single_node: ~p~n", [remove_sensitive(Setup)]),
+    couch_log:notice("enable_single_node: ~p~n", [couch_util:remove_sensitive_data(Setup)]),
 
     Options = get_options(
         [
@@ -129,7 +129,7 @@ handle_action("enable_single_node", Setup) ->
             ok
     end;
 handle_action("add_node", Setup) ->
-    couch_log:notice("add_node: ~p~n", [remove_sensitive(Setup)]),
+    couch_log:notice("add_node: ~p~n", [couch_util:remove_sensitive_data(Setup)]),
 
     Options = get_options(
         [
@@ -154,9 +154,9 @@ handle_action("add_node", Setup) ->
             ok
     end;
 handle_action("remove_node", Setup) ->
-    couch_log:notice("remove_node: ~p~n", [remove_sensitive(Setup)]);
+    couch_log:notice("remove_node: ~p~n", [couch_util:remove_sensitive_data(Setup)]);
 handle_action("receive_cookie", Setup) ->
-    couch_log:notice("receive_cookie: ~p~n", [remove_sensitive(Setup)]),
+    couch_log:notice("receive_cookie: ~p~n", [couch_util:remove_sensitive_data(Setup)]),
     Options = get_options(
         [
             {cookie, <<"cookie">>}
@@ -181,6 +181,3 @@ get_body(Req) ->
             couch_log:notice("Body Fail: ~p~n", [Else]),
             couch_httpd:send_error(Req, 400, <<"bad_request">>, <<"Missing JSON body'">>)
     end.
-
-remove_sensitive(KVList) ->
-    lists:keyreplace(<<"password">>, 1, KVList, {<<"password">>, <<"****">>}).


### PR DESCRIPTION
In some log messages user passwords were not redacted. 

Examples:
```
[debug] 2022-10-06T18:36:24.615459Z node1@127.0.0.1 <0.659.0> 3f924ac1d2 Enable Cluster: [{node_count,3},{bind_address,<<"0.0.0.0">>},{password,<<"a">>},{username,<<"a">>}]

[debug] 2022-10-06T18:36:24.786483Z node1@127.0.0.1 <0.821.0> 969ca45f27 add node_int: [{name,<<"node2">>},{port,25984},{host,<<"127.0.0.1">>},{password,<<"a">>},{username,<<"a">>}]

[notice] 2022-10-06T18:36:26.778453Z node1@127.0.0.1 <0.840.0> ff4625a79a Setup: [{<<"action">>,<<"add_node">>},{<<"host">>,<<"127.0.0.1">>},{<<"port">>,35984},{<<"name">>,<<"node3">>},{<<"username">>,<<"a">>},{<<"password">>,<<"****">>}]
```
Move and introduce a global helper function `remove_sensitive_data` to redact passwords.
