### PR TITLE
Wait for race in ddoc cache lru test

### DIFF
--- a/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
@@ -202,7 +202,14 @@ check_cache_refill({DbName, _}) ->
     {ok, _} = ddoc_cache_lru:handle_db_event(ShardName, deleted, foo),
     meck:wait(ddoc_cache_ev, event, [evicted, DbName], 1000),
     meck:wait(10, ddoc_cache_ev, event, [removed, '_'], 1000),
-    ?assertEqual(0, ets:info(?CACHE, size)),
+    test_util:wait(
+        fun() ->
+            case ets:info(?CACHE, size) of
+                0 -> ok;
+                _ -> wait
+            end
+        end
+    ),
 
     lists:foreach(
         fun(I) ->


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This failure seems to occur from a race between meck:wait and the test runner:
```
  ddoc_cache_tutil:109: -with/1-fun-1- (check_cache_refill)...*failed*
in function ddoc_cache_lru_test:check_cache_refill/1 (test/eunit/ddoc_cache_lru_test.erl, line 205) in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71) in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531) in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356) in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514) in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456) in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 346) in call from eunit_proc:run_group/2 (eunit_proc.erl, line 570) **error:{assertEqual,[{module,ddoc_cache_lru_test},
              {line,205},
              {expression,"ets : info ( ? CACHE , size )"},
              {expected,0},
              {value,1}]}
  output:<<"">>
```
This changes the test to wait until the table is explicitly empty before proceeding.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

```
make eunit suites=ddoc_cache_lru_test
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
