### PR TITLE
Quiet jwtf keystore test noise

### DIFF
--- a/src/jwtf/test/jwtf_keystore_tests.erl
+++ b/src/jwtf/test/jwtf_keystore_tests.erl
@@ -24,7 +24,8 @@
 ).
 
 setup() ->
-    test_util:start_applications([couch_log, config, jwtf]),
+    meck:expect(couch_log, notice, 2, fun(_, _) -> ok end),
+    test_util:start_applications([config, jwtf]),
     config:set("jwt_keys", "hmac:hmac", ?HMAC_SECRET),
     config:set("jwt_keys", "rsa:hmac", ?HMAC_SECRET),
     config:set("jwt_keys", "ec:hmac", ?HMAC_SECRET),
@@ -38,7 +39,8 @@ setup() ->
     config:set("jwt_keys", "ec:ec", ?EC_SECRET).
 
 teardown(_) ->
-    test_util:stop_applications([couch_log, config, jwtf]).
+    test_util:stop_applications([config, jwtf]),
+    meck:unload().
 
 jwtf_keystore_test_() ->
     {


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

These tests emit a lot of unnecessary noise because they start the `couch_log` application without also starting `folsom`:
```
❯ make eunit apps=jwtf suites=jwtf_keystore_tests
==> jwtf (compile)
==> rel (compile)
==> couchdb (compile)
WARN:  Missing plugins: [pc]
WARN:  Missing plugins: [covertool]
==> couchdb (setup_eunit)
==> jwtf (eunit)
======================== EUnit ======================== module 'jwtf_keystore_tests'
[notice] 2022-10-11T19:01:50.047710Z nonode@nohost <0.190.0> -------- config: [jwt_keys] hmac:hmac set to aGVsbG8= for reason nil [error] 2022-10-11T19:01:50.047718Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068427Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [notice] 2022-10-11T19:01:50.068494Z nonode@nohost <0.190.0> -------- config: [jwt_keys] rsa:hmac set to aGVsbG8= for reason nil [error] 2022-10-11T19:01:50.068501Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068505Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [notice] 2022-10-11T19:01:50.068527Z nonode@nohost <0.190.0> -------- config: [jwt_keys] ec:hmac set to aGVsbG8= for reason nil [error] 2022-10-11T19:01:50.068533Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068536Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068587Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068592Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [notice] 2022-10-11T19:01:50.068595Z nonode@nohost <0.190.0> -------- config: [jwt_keys] hmac:rsa set to -----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAztanwQtIx0sms+x7m1SF\nh7EHJHkM2biTJ41jR89FsDE2gd3MChpaqxemS5GpNvfFKRvuHa4PUZ3JtRCBG1KM\n/7EWIVTy1JQDr2mb8couGlQNqz4uXN2vkNQ0XszgjU4Wn6ZpvYxmqPFbmkRe8QSn\nAy2Wf8jQgjsbez8eaaX0G9S1hgFZUN3KFu7SVmUDQNvWpQdaJPP+ms5Z0CqF7JLa\nvJmSdsU49nlYw9VH/XmwlUBMye6HgR4ZGCLQS85frqF0xLWvi7CsMdchcIjHudXH\nQK1AumD/VVZVdi8Q5Qew7F6VXeXqnhbw9n6Px25cCuNuh6u5+E6GUzXRrMpqo9vO\nqQIDAQAB\n-----END PUBLIC KEY-----\n for reason nil [error] 2022-10-11T19:01:50.068647Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068654Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [notice] 2022-10-11T19:01:50.068661Z nonode@nohost <0.190.0> -------- config: [jwt_keys] rsa:rsa set to -----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAztanwQtIx0sms+x7m1SF\nh7EHJHkM2biTJ41jR89FsDE2gd3MChpaqxemS5GpNvfFKRvuHa4PUZ3JtRCBG1KM\n/7EWIVTy1JQDr2mb8couGlQNqz4uXN2vkNQ0XszgjU4Wn6ZpvYxmqPFbmkRe8QSn\nAy2Wf8jQgjsbez8eaaX0G9S1hgFZUN3KFu7SVmUDQNvWpQdaJPP+ms5Z0CqF7JLa\nvJmSdsU49nlYw9VH/XmwlUBMye6HgR4ZGCLQS85frqF0xLWvi7CsMdchcIjHudXH\nQK1AumD/VVZVdi8Q5Qew7F6VXeXqnhbw9n6Px25cCuNuh6u5+E6GUzXRrMpqo9vO\nqQIDAQAB\n-----END PUBLIC KEY-----\n for reason nil [error] 2022-10-11T19:01:50.068705Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068709Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [notice] 2022-10-11T19:01:50.068712Z nonode@nohost <0.190.0> -------- config: [jwt_keys] ec:rsa set to -----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAztanwQtIx0sms+x7m1SF\nh7EHJHkM2biTJ41jR89FsDE2gd3MChpaqxemS5GpNvfFKRvuHa4PUZ3JtRCBG1KM\n/7EWIVTy1JQDr2mb8couGlQNqz4uXN2vkNQ0XszgjU4Wn6ZpvYxmqPFbmkRe8QSn\nAy2Wf8jQgjsbez8eaaX0G9S1hgFZUN3KFu7SVmUDQNvWpQdaJPP+ms5Z0CqF7JLa\nvJmSdsU49nlYw9VH/XmwlUBMye6HgR4ZGCLQS85frqF0xLWvi7CsMdchcIjHudXH\nQK1AumD/VVZVdi8Q5Qew7F6VXeXqnhbw9n6Px25cCuNuh6u5+E6GUzXRrMpqo9vO\nqQIDAQAB\n-----END PUBLIC KEY-----\n for reason nil
  [notice] 2022-10-11T19:01:50.068739Z nonode@nohost <0.190.0> -------- config: [jwt_keys] hmac:ec set to -----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDsr0lz/Dg3luarb+Kua0Wcj9WrfR23os\nwHzakglb8GhWRDn+oZT0Bt/26sX8uB4/ij9PEOLHPo+IHBtX4ELFFVr5GTzlqcJe\nyctaTDd1OOAPXYuc67EWtGZ3pDAzztRs\n-----END PUBLIC KEY-----\n for reason nil
[error] 2022-10-11T19:01:50.068771Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] jwtf_keystore_tests:49: -jwtf_keystore_test_/0-fun-17-...[error] 2022-10-11T19:01:50.068786Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [notice] 2022-10-11T19:01:50.068855Z nonode@nohost <0.190.0> -------- config: [jwt_keys] rsa:ec set to -----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDsr0lz/Dg3luarb+Kua0Wcj9WrfR23os\nwHzakglb8GhWRDn+oZT0Bt/26sX8uB4/ij9PEOLHPo+IHBtX4ELFFVr5GTzlqcJe\nyctaTDd1OOAPXYuc67EWtGZ3pDAzztRs\n-----END PUBLIC KEY-----\n for reason nil [error] 2022-10-11T19:01:50.068863Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068866Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [notice] 2022-10-11T19:01:50.068903Z nonode@nohost <0.190.0> -------- config: [jwt_keys] ec:ec set to -----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDsr0lz/Dg3luarb+Kua0Wcj9WrfR23os\nwHzakglb8GhWRDn+oZT0Bt/26sX8uB4/ij9PEOLHPo+IHBtX4ELFFVr5GTzlqcJe\nyctaTDd1OOAPXYuc67EWtGZ3pDAzztRs\n-----END PUBLIC KEY-----\n for reason nil [error] 2022-10-11T19:01:50.068908Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [error] 2022-10-11T19:01:50.068912Z nonode@nohost <0.190.0> -------- unknown metric: [couch_log,level,notice] [0.021 s] ok
  jwtf_keystore_tests:50: -jwtf_keystore_test_/0-fun-15-...[0.056 s] ok
  jwtf_keystore_tests:51: -jwtf_keystore_test_/0-fun-13-...ok
  jwtf_keystore_tests:53: -jwtf_keystore_test_/0-fun-11-...ok
  jwtf_keystore_tests:54: -jwtf_keystore_test_/0-fun-9-...[0.102 s] ok
  jwtf_keystore_tests:55: -jwtf_keystore_test_/0-fun-7-...ok
  jwtf_keystore_tests:57: -jwtf_keystore_test_/0-fun-5-...ok
  jwtf_keystore_tests:58: -jwtf_keystore_test_/0-fun-3-...ok
  jwtf_keystore_tests:59: -jwtf_keystore_test_/0-fun-1-...ok
[info] 2022-10-11T19:01:50.275122Z nonode@nohost <0.44.0> -------- Application jwtf exited with reason: stopped [info] 2022-10-11T19:01:50.275139Z nonode@nohost <0.44.0> -------- Application jwtf exited with reason: stopped
  [done in 0.206 s]
=======================================================
  All 9 tests passed.
```
This changes the tests to simply mock the one function of `couch_log` used by `config`, suppressing the noise, and speeding up the test.

## Testing recommendations

New test output should be much more tidy:
```
❯ make eunit apps=jwtf suites=jwtf_keystore_tests
==> jwtf (compile)
==> rel (compile)
==> couchdb (compile)
WARN:  Missing plugins: [pc]
WARN:  Missing plugins: [covertool]
==> couchdb (setup_eunit)
==> jwtf (eunit)
Compiled test/jwtf_keystore_tests.erl
======================== EUnit ========================
module 'jwtf_keystore_tests'
  jwtf_keystore_tests:51: -jwtf_keystore_test_/0-fun-17-...[0.049 s] ok
  jwtf_keystore_tests:52: -jwtf_keystore_test_/0-fun-15-...[0.058 s] ok
  jwtf_keystore_tests:53: -jwtf_keystore_test_/0-fun-13-...ok
  jwtf_keystore_tests:55: -jwtf_keystore_test_/0-fun-11-...ok
  jwtf_keystore_tests:56: -jwtf_keystore_test_/0-fun-9-...[0.112 s] ok
  jwtf_keystore_tests:57: -jwtf_keystore_test_/0-fun-7-...ok
  jwtf_keystore_tests:59: -jwtf_keystore_test_/0-fun-5-...ok
  jwtf_keystore_tests:60: -jwtf_keystore_test_/0-fun-3-...ok
  jwtf_keystore_tests:61: -jwtf_keystore_test_/0-fun-1-...ok
  [done in 0.246 s]
=======================================================
  All 9 tests passed.
```

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
