### PR TITLE
Make sure admin_only_all_dbs applies to _dbs_info as well

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -156,7 +156,7 @@ bind_address = 127.0.0.1
 ; uncomment the next line to enable JWT authentication
 ; authentication_handlers = {chttpd_auth, jwt_authentication_handler}, {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, default_authentication_handler}
 
-; prevent non-admins from accessing /_all_dbs
+; prevent non-admins from accessing /_all_dbs and /_dbs_info
 ; admin_only_all_dbs = true
 
 ; These options are moved from [httpd]

--- a/src/chttpd/src/chttpd_auth_request.erl
+++ b/src/chttpd/src/chttpd_auth_request.erl
@@ -34,12 +34,9 @@ authorize_request_int(#httpd{path_parts = []} = Req) ->
 authorize_request_int(#httpd{path_parts = [<<"favicon.ico">> | _]} = Req) ->
     Req;
 authorize_request_int(#httpd{path_parts = [<<"_all_dbs">> | _]} = Req) ->
-    case config:get_boolean("chttpd", "admin_only_all_dbs", true) of
-        true -> require_admin(Req);
-        false -> Req
-    end;
+    maybe_admin_only_dbs(Req);
 authorize_request_int(#httpd{path_parts = [<<"_dbs_info">> | _]} = Req) ->
-    Req;
+    maybe_admin_only_dbs(Req);
 authorize_request_int(#httpd{path_parts = [<<"_replicator">>], method = 'PUT'} = Req) ->
     require_admin(Req);
 authorize_request_int(#httpd{path_parts = [<<"_replicator">>], method = 'DELETE'} = Req) ->
@@ -154,3 +151,9 @@ check_security(names, null, _) ->
     false;
 check_security(names, UserName, Names) ->
     lists:member(UserName, Names).
+
+maybe_admin_only_dbs(Req) ->
+    case config:get_boolean("chttpd", "admin_only_all_dbs", true) of
+        true -> require_admin(Req);
+        false -> Req
+    end.

--- a/src/docs/src/config/http.rst
+++ b/src/docs/src/config/http.rst
@@ -244,6 +244,18 @@ HTTP Server Options
             [chttpd]
             bulk_get_use_batches = true
 
+     .. config:option:: admin_only_all_dbs :: Require admin for ``_all_dbs`` and ``_dbs_info``
+
+        .. versionadded:: 2.2 implemented for ``_all_dbs`` defaulting to ``false``
+        .. versionchanged:: 3.0 default switched to ``true``, applies to ``_all_dbs``
+        .. versionchanged:: 3.3 applies for ``_all_dbs`` and ``_dbs_info``
+
+        When set to ``true`` admin is required to access ``_all_dbs`` and
+        ``_dbs_info``. ::
+
+           [chttpd]
+           admin_only_all_dbs = true
+
 .. config:section:: httpd :: HTTP Server Options
 
     .. versionchanged:: 3.2 These options were moved to [chttpd] section:


### PR DESCRIPTION
We missed that in the 3.x versions up until now.

Also some documentation around it with version history.

Fixes #4253
