### PR TITLE
Update active db size calculation to use only leaf nodes

### DIFF
--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -440,7 +440,7 @@ check_doc_atts(Db, Doc) ->
             end
     end.
 
-add_sizes(Type, #leaf{sizes = Sizes, atts = AttSizes}, Acc) ->
+add_sizes(leaf, #leaf{sizes = Sizes, atts = AttSizes}, Acc) ->
     % Maybe upgrade from disk_size only
     #size_info{
         active = ActiveSize,
@@ -448,14 +448,13 @@ add_sizes(Type, #leaf{sizes = Sizes, atts = AttSizes}, Acc) ->
     } = upgrade_sizes(Sizes),
     {ASAcc, ESAcc, AttsAcc} = Acc,
     NewASAcc = ActiveSize + ASAcc,
-    NewESAcc =
-        ESAcc +
-            if
-                Type == leaf -> ExternalSize;
-                true -> 0
-            end,
+    NewESAcc = ExternalSize + ESAcc,
     NewAttsAcc = lists:umerge(AttSizes, AttsAcc),
-    {NewASAcc, NewESAcc, NewAttsAcc}.
+    {NewASAcc, NewESAcc, NewAttsAcc};
+add_sizes(_, #leaf{atts = AttSizes}, Acc) ->
+    % For intermediate nodes external and active contribution is 0
+    {ASAcc, ESAcc, AttsAcc} = Acc,
+    {ASAcc, ESAcc, lists:umerge(AttSizes, AttsAcc)}.
 
 upgrade_sizes(#size_info{} = SI) ->
     SI;


### PR DESCRIPTION
Previously it used both leaf and intermediate nodes.

With this PR active db size should decrease when users delete documents. This, in turn, should make smoosh enqueue those dbs for compaction to recover the disk space used by the now deleted document bodies. Previously, it was possible for users to delete gigabytes worth of document bodies and smoosh never noticing and never triggering the compaction.

Original idea and patch provided by Robert Newson in CouchDB dev Slack discussion channel.

Co-authored-by: Robert Newson

Fixes: https://github.com/apache/couchdb/issues/4263