### PR TITLE
Use compaction ioq priority for shard splitting

### DIFF
--- a/src/mem3/src/mem3_reshard_index.erl
+++ b/src/mem3/src/mem3_reshard_index.erl
@@ -103,7 +103,9 @@ hastings_indices(DbName, Doc) ->
             []
     end.
 
-build_index({?MRVIEW, _DbName, MRSt} = Ctx, Try) ->
+build_index({?MRVIEW, DbName, MRSt} = Ctx, Try) ->
+    IdxName = couch_mrview_index:get(idx_name, MRSt),
+    ioq:set_io_priority({view_compact, DbName, IdxName}),
     await_retry(
         couch_index_server:get_index(couch_mrview_index, MRSt),
         fun couch_index:get_state/2,

--- a/src/mem3/src/mem3_reshard_job.erl
+++ b/src/mem3/src/mem3_reshard_job.erl
@@ -367,6 +367,7 @@ initial_copy_impl(#job{source = Source, target = Targets0} = Job) ->
     #shard{name = SourceName} = Source,
     Targets = [{R, N} || #shard{range = R, name = N} <- Targets0],
     TMap = maps:from_list(Targets),
+    ioq:set_io_priority({db_compact, SourceName}),
     LogMsg1 = "~p initial_copy started ~s",
     LogArgs1 = [?MODULE, shardsstr(Source, Targets0)],
     couch_log:notice(LogMsg1, LogArgs1),


### PR DESCRIPTION
Db shard copy uses `db_compact` priority and view building uses `view_compact` priority to avoid inventing new priority levels.
