### PR TITLE
chore: configurable ICU locations

### DIFF
--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -190,7 +190,9 @@ CouchJSEnv = case SMVsn of
 end.
 
 IcuEnv = [{"DRV_CFLAGS",  "$DRV_CFLAGS -DPIC -O2 -fno-common"},
-          {"DRV_LDFLAGS", "$DRV_LDFLAGS -lm -licuuc -licudata -licui18n -lpthread"}].
+          {"DRV_LDFLAGS", "$DRV_LDFLAGS -lm -licuuc -licudata -licui18n -lpthread"},
+          {"LDFLAGS", "$LDFLAGS"},
+          {"CFLAGS", "$CFLAGS"}].
 IcuDarwinEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/opt/icu4c/include -I/opt/homebrew/opt/icu4c/include"},
                 {"LDFLAGS", "-L/usr/local/opt/icu4c/lib -L/opt/homebrew/opt/icu4c/lib"}].
 IcuBsdEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/include"},


### PR DESCRIPTION
add `LDFLAGS` and `CFLAGS` environment variables to `IcuEnv` in rebar config to be able to configure ICU includes and object paths via environment variable without having to patch `rebar.config.script`.