### PR TITLE
Allow = in config key names

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -238,6 +238,13 @@ bind_address = 127.0.0.1
 ; key with newlines replaced with the escape sequence \n.
 ;   rsa:foo = -----BEGIN PUBLIC KEY-----\nMIIBIjAN...IDAQAB\n-----END PUBLIC KEY-----\n
 ;   ec:bar = -----BEGIN PUBLIC KEY-----\nMHYwEAYHK...AzztRs\n-----END PUBLIC KEY-----\n
+; Since version 3.3 it's possible for keys to contain "=" characters when the
+; config setting is in the "key = value" format. In other words, there must be a space
+; between the key and the equals sign, and another space between the equal sign
+; and the value. For example, it should look like this:
+;    rsa:h213h2h1jg3hj2= = <somevalue>
+; and *not* like this:
+;    rsa:h213h2h1jg3hj2==<somevalue>
 
 [couch_peruser]
 ; If enabled, couch_peruser ensures that a private per-user database

--- a/src/docs/src/api/server/authn.rst
+++ b/src/docs/src/api/server/authn.rst
@@ -422,8 +422,14 @@ list as long as the JWT token is valid.
     ; rsa:foo = -----BEGIN PUBLIC KEY-----\nMIIBIjAN...IDAQAB\n-----END PUBLIC KEY-----\n
     ; ec:bar = -----BEGIN PUBLIC KEY-----\nMHYwEAYHK...AzztRs\n-----END PUBLIC KEY-----\n
 
-The ``jwt_key`` section lists all the keys that this CouchDB server trusts. You
+The ``jwt_keys`` section lists all the keys that this CouchDB server trusts. You
 should ensure that all nodes of your cluster have the same list.
+
+Since version 3.3 it's possible to use ``=`` in parameter names, but only when
+the parameter and value are separated `` = ``, i.e. the equal sign is
+surrounded by at least one space on each side. This might be useful in the
+``[jwt_keys]`` section where base64 encoded keys may contain the ``=``
+character.
 
 JWT tokens that do not include a ``kid`` claim will be validated against the
 ``$alg:_default`` key.

--- a/src/docs/src/config/intro.rst
+++ b/src/docs/src/config/intro.rst
@@ -93,6 +93,9 @@ requirement for style and naming.
 Setting parameters via the configuration file
 =============================================
 
+.. versionchanged:: 3.3 added ability to have ``=`` in parameter names
+.. versionchanged:: 3.3 removed the undocumented ability to have multi-line values.
+
 The common way to set some parameters is to edit the ``local.ini`` file
 (location explained above).
 
@@ -116,6 +119,11 @@ The `parameter` specification contains two parts divided by the `equal` sign
 (``=``): the parameter name on the left side and the parameter value on the
 right one. The leading and following whitespace for ``=`` is an optional to
 improve configuration readability.
+
+Since version 3.3 it's possible to use ``=`` in parameter names, but only when
+the parameter and value are separated `` = ``, i.e. the equal sign is surrounded
+by at least one space on each side. This might be useful in the ``[jwt_keys]``
+section, where base64 encoded keys may contain some ``=`` characters.
 
 .. note::
     In case when you'd like to remove some parameter from the `default.ini`


### PR DESCRIPTION
They are allowed only for the "k = v" format and not the "k=v" format. The idea is to split on " = " first, and if that fails to produce a valid kv pair we split on "=" as before.

To implement it, simplify the parsing logic and remove the undocumented multi-line config value feature. The continuation syntax is not documented anywhere and not used by our default.ini or in documentation.

Fix: #3319