### PR TITLE
Fix unbound variable warning

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -416,10 +416,11 @@ all_databases(Fun, Acc0) ->
                 true,
                 fun(Filename, AccIn) ->
                     NormFilename = couch_util:normpath(Filename),
-                    case NormFilename -- NormRoot of
-                        [$/ | RelativeFilename] -> ok;
-                        RelativeFilename -> ok
-                    end,
+                    RelativeFilename =
+                        case NormFilename -- NormRoot of
+                            [$/ | FName] -> FName;
+                            FName -> FName
+                        end,
                     Ext = filename:extension(RelativeFilename),
                     case Fun(?l2b(filename:rootname(RelativeFilename, Ext)), AccIn) of
                         {ok, NewAcc} -> NewAcc;


### PR DESCRIPTION
## Overview

While the variable `RelativeFileName` is not really unbound in the case-statement, use a 
more up-to-date pattern for binding the value.