### PR TITLE
fix(3517): super-simplistic fix to avoid costly AST transforms when t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ rel/dev*
 rel/tmpdata
 share/server/main-coffee.js
 share/server/main.js
+share/server/main-ast-bypass.js
 share/www
 src/bear/
 src/certifi/

--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ clean:
 	@rm -rf src/*/.rebar
 	@rm -rf src/*/priv/*.so
 	@rm -rf src/couch/priv/{couchspawnkillable,couchjs}
-	@rm -rf share/server/main.js share/server/main_ast_bypass.js share/server/main-coffee.js
+	@rm -rf share/server/main.js share/server/main-ast-bypass.js share/server/main-coffee.js
 	@rm -rf tmp dev/data dev/lib dev/logs
 	@rm -rf src/mango/.venv
 	@rm -f src/couch/priv/couchspawnkillable

--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ clean:
 	@rm -rf src/*/.rebar
 	@rm -rf src/*/priv/*.so
 	@rm -rf src/couch/priv/{couchspawnkillable,couchjs}
-	@rm -rf share/server/main.js share/server/main-coffee.js
+	@rm -rf share/server/main.js share/server/main_ast_bypass.js share/server/main-coffee.js
 	@rm -rf tmp dev/data dev/lib dev/logs
 	@rm -rf src/mango/.venv
 	@rm -f src/couch/priv/couchspawnkillable

--- a/Makefile.win
+++ b/Makefile.win
@@ -374,7 +374,7 @@ clean:
 	-@rmdir /s/q src\*\.rebar
 	-@del /f/q/s src\*.dll
 	-@del /f/q src\couch\priv\*.exe
-	-@del /f/q share\server\main.js share\server\main-coffee.js
+	-@del /f/q share\server\main.js share\server\main_ast_bypass.js share\server\main-coffee.js
 	-@rmdir /s/q tmp
 	-@rmdir /s/q dev\data
 	-@rmdir /s/q dev\lib

--- a/Makefile.win
+++ b/Makefile.win
@@ -374,7 +374,7 @@ clean:
 	-@rmdir /s/q src\*\.rebar
 	-@del /f/q/s src\*.dll
 	-@del /f/q src\couch\priv\*.exe
-	-@del /f/q share\server\main.js share\server\main_ast_bypass.js share\server\main-coffee.js
+	-@del /f/q share\server\main.js share\server\main-ast-bypass.js share\server\main-coffee.js
 	-@rmdir /s/q tmp
 	-@rmdir /s/q dev\data
 	-@rmdir /s/q dev\lib

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -141,6 +141,7 @@
     {copy, "overlay/etc"},
     {copy, "../src/couch/priv/couchjs", "bin/couchjs"},
     {copy, "../share/server/main.js", "share/server/main.js"},
+    {copy, "../share/server/main-ast-bypass.js", "share/server/main-ast-bypass.js"},
     {copy, "../share/server/main-coffee.js", "share/server/main-coffee.js"},
     {copy, "../src/weatherreport/weatherreport", "bin/weatherreport"},
     {copy, "files/sys.config", "releases/\{\{rel_vsn\}\}/sys.config"},

--- a/share/server/60/rewrite_fun.js
+++ b/share/server/60/rewrite_fun.js
@@ -16,6 +16,12 @@
 //  https://github.com/dmunch/couch-chakra/blob/master/js/normalizeFunction.js
 
 function rewriteFunInt(fun) {
+    // Skip lengthy AST transforms if the function passed can be
+    // safely wrapped in parenthesis.
+    if (fun.startsWith('function') && fun.endsWith('}')) {
+        return '(' + fun + ')'
+    }
+
     const ast = esprima.parse(fun);
     let idx = ast.body.length - 1;
     let decl = {};

--- a/share/server/60/rewrite_fun_ast_bypass.js
+++ b/share/server/60/rewrite_fun_ast_bypass.js
@@ -16,6 +16,12 @@
 //  https://github.com/dmunch/couch-chakra/blob/master/js/normalizeFunction.js
 
 function rewriteFunInt(fun) {
+    // Skip lengthy AST transforms if the function passed can be
+    // safely wrapped in parentheses.
+    if (fun.startsWith('function') && fun.endsWith('}')) {
+        return '(' + fun + ')'
+    }
+
     const ast = esprima.parse(fun);
     let idx = ast.body.length - 1;
     let decl = {};

--- a/src/docs/src/config/query-servers.rst
+++ b/src/docs/src/config/query-servers.rst
@@ -65,6 +65,19 @@ you can adjust the memory limitation (here, increasing to 512 MiB)::
 
 For more info about the available options, please consult ``couchjs -h``.
 
+.. note::
+    CouchDB versions 3.0.0 to 3.2.2 included a performance regression for
+    custom reduce functions. CouchDB 3.3.0 and later come with an experimental
+    fix to this issue that is included in a separate ``.js`` file.
+
+    To enable the fix, you need to define a custom ``COUCHDB_QUERY_SERVER_JAVASCRIPT``
+    environment variable as outlined above. The path to ``couchjs`` needs to
+    remain the same as you find it on your ``couchdb`` file, and the path to
+    ``main.js`` needs to be set to ``/path/to/couchdb/share/server/main-ast-bypass.js``.
+
+    With a default installation on Linux systems, this is going to be
+    ``COUCHDB_QUERY_SERVER_JAVASCRIPT="/opt/couchdb/bin/couchjs /opt/couchdb/share/server/main-ast-bypass.js"``
+
 .. _Mozilla SpiderMonkey: https://spidermonkey.dev/
 
 .. seealso::

--- a/support/build_js.escript
+++ b/support/build_js.escript
@@ -90,6 +90,7 @@ main([]) ->
     case SMVsn of
         "1.8.5" ->
             ok = Concat(ExtraFiles ++ JsFiles, "share/server/main.js");
+            ok = Concat(ExtraFiles ++ JsFiles, "share/server/main-ast-bypass.js");
         _ ->
             ok = Concat(RewriteFunFile ++ ExtraFiles ++ JsFiles, "share/server/main.js"),
             ok = Concat(RewriteFunWithASTBypassFile ++ ExtraFiles ++ JsFiles, "share/server/main-ast-bypass.js")

--- a/support/build_js.escript
+++ b/support/build_js.escript
@@ -68,10 +68,12 @@ main([]) ->
         _ ->
             [
                 "share/server/60/esprima.js",
-                "share/server/60/escodegen.js",
-                "share/server/60/rewrite_fun.js"
+                "share/server/60/escodegen.js"
             ]
     end,
+
+    RewriteFunFile = ["share/server/60/rewrite_fun.js"],
+    RewriteFunWithASTBypassFile = ["share/server/60/rewrite_fun_ast_bypass.js"],
 
     Pre = "(function () {\n",
     Post = "})();\n",
@@ -85,6 +87,12 @@ main([]) ->
             file:write_file(To, FinalBin)
     end,
 
-    ok = Concat(ExtraFiles ++ JsFiles, "share/server/main.js"),
+    case SMVsn of
+        "1.8.5" ->
+            ok = Concat(ExtraFiles ++ JsFiles, "share/server/main.js");
+        _ ->
+            ok = Concat(RewriteFunFile ++ ExtraFiles ++ JsFiles, "share/server/main.js"),
+            ok = Concat(RewriteFunWithASTBypassFile ++ ExtraFiles ++ JsFiles, "share/server/main_ast_bypass.js")
+    end,
     ok = Concat(ExtraFiles ++ CoffeeFiles, "share/server/main-coffee.js"),
     ok.

--- a/support/build_js.escript
+++ b/support/build_js.escript
@@ -89,7 +89,7 @@ main([]) ->
 
     case SMVsn of
         "1.8.5" ->
-            ok = Concat(ExtraFiles ++ JsFiles, "share/server/main.js");
+            ok = Concat(ExtraFiles ++ JsFiles, "share/server/main.js"),
             ok = Concat(ExtraFiles ++ JsFiles, "share/server/main-ast-bypass.js");
         _ ->
             ok = Concat(RewriteFunFile ++ ExtraFiles ++ JsFiles, "share/server/main.js"),

--- a/support/build_js.escript
+++ b/support/build_js.escript
@@ -92,7 +92,7 @@ main([]) ->
             ok = Concat(ExtraFiles ++ JsFiles, "share/server/main.js");
         _ ->
             ok = Concat(RewriteFunFile ++ ExtraFiles ++ JsFiles, "share/server/main.js"),
-            ok = Concat(RewriteFunWithASTBypassFile ++ ExtraFiles ++ JsFiles, "share/server/main_ast_bypass.js")
+            ok = Concat(RewriteFunWithASTBypassFile ++ ExtraFiles ++ JsFiles, "share/server/main-ast-bypass.js")
     end,
     ok = Concat(ExtraFiles ++ CoffeeFiles, "share/server/main-coffee.js"),
     ok.


### PR DESCRIPTION
…hey are not needed.

```
    // Skip lengthy AST transforms if the function passed can be
    // safely wrapped in parenthesis.
```

I’d also be okay with inventing a new “/* no-ast */” prefix that folks can opt into, say:

```
  "reduce": "/* no-ast */ function(keys, values, rereduce) {…}"
```

to be absolutely safe we don’t break anything.

Fixes #3517 