### PR TITLE
Fix rendering of inline literal with withespaces

### DIFF
--- a/src/docs/src/api/server/authn.rst
+++ b/src/docs/src/api/server/authn.rst
@@ -426,7 +426,7 @@ The ``jwt_keys`` section lists all the keys that this CouchDB server trusts. You
 should ensure that all nodes of your cluster have the same list.
 
 Since version 3.3 it's possible to use ``=`` in parameter names, but only when
-the parameter and value are separated `` = ``, i.e. the equal sign is
+the parameter and value are separated :literal:`\  = \ `, i.e. the equal sign is
 surrounded by at least one space on each side. This might be useful in the
 ``[jwt_keys]`` section where base64 encoded keys may contain the ``=``
 character.


### PR DESCRIPTION
Fixed wrong rendering of an inline literal with whitespaces. 
Use `:literal` as workaround, with escaping whitespaces `\ ` and added non-breakable-whitespace char (U+00A0)

## Overview

Before commit:

![before](https://user-images.githubusercontent.com/9985963/207009302-665f5782-4b92-4e82-91e3-851bf886baf2.png)

After commit:

![after](https://user-images.githubusercontent.com/9985963/207009458-b911a2bd-ac54-4dd2-80cd-ba04f3d97d04.png)
