### PR TITLE
Add note on how to configure replicaton backoff (#4299)

### DIFF
--- a/src/docs/src/replication/replicator.rst
+++ b/src/docs/src/replication/replicator.rst
@@ -417,13 +417,17 @@ retried and don't consume memory or CPU resources.
    database, a permissions error, etc. Repeated consecutive crashes
    result in an exponential backoff. This state is considered temporary
    (non-terminal) and replication jobs will be periodically retried.
-   Maximum backoff interval is around a day or so.
 
  * ``Completed``: This is a terminal, successful state for
    non-continuous replications. Once in this state the replication is
    "forgotten" by the scheduler and it doesn't consume any more CPU or
    memory resources. Continuous replication jobs will never reach this
    state.
+
+.. note:: Maximum backoff interval for states ``Error`` and ``Crashing``
+          is calculated based on the ``replicator.max_history`` option.
+          See :ref:`Replicator configuration section <config/replicator>`
+          for additional information.
 
 .. _Normal vs Continuous Replications:
 


### PR DESCRIPTION
## Overview

Documentation was mentioning the exponential backoff on `Crashing` and `Error` states, but did not mention how to configure it. This commit adds note on relation of `max_history` and maximum backoff with link to appropriate configuration section.

I (hopefully correctly) assumed that `replicator.max_history` affects not only `Crashing` state, but also `Error` state as well.

## Related Issues or Pull Requests

#4299

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
