### PR TITLE
Let's try Lua for a change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ src/unicode_util_compat/
 src/file_system/
 src/rebar3/
 src/erlfmt/
+src/luerl/
 tmp/
 
 src/couch/*.o

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -151,6 +151,7 @@ DepDescs = [
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.2.8"}, [raw]},
 %% Third party deps
+{luerl,            {url, "https://github.com/rvirding/luerl.git"}, {branch, "develop"}},
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -25,6 +25,7 @@
         stdlib,
         syntax_tools,
         xmerl,
+        luerl,
         %% couchdb
         b64url,
         bear,
@@ -90,6 +91,7 @@
     {app, xmerl, [{incl_cond, include}]},
 
     %% couchdb
+    {app, luerl, [{incl_cond, include}]},
     {app, b64url, [{incl_cond, include}]},
     {app, bear, [{incl_cond, include}]},
     {app, chttpd, [{incl_cond, include}]},

--- a/src/couch/src/couch.app.src
+++ b/src/couch/src/couch.app.src
@@ -37,6 +37,7 @@
         % Upstream deps
         ibrowse,
         mochiweb,
+        luerl,
 
         % ASF deps
         couch_epi,


### PR DESCRIPTION
So far can start a cluster `./dev/run ...` then in a remsh can test the sandbox feature:

1) No reductions, use all the CPUs:

```
f(), {R, _} = luerl_sandbox:run("a={}; for i=1,100 do a[i] = 5 end; return 'foo'", luerl_sandbox:init(), _Reductions = 0), R.
[<<"foo">>]
```

2) Slow down, pardner!
```
 f(), luerl_sandbox:run("a={}; for i=1,100 do a[i] = 5 end; return 'foo'", luerl_sandbox:init(), _Reductions = 500).
{error,{reductions,4000}}
```

