### PR TITLE
Ensure we use the chttpd vs httpd section in fix_uri

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -574,7 +574,7 @@ make_uri(Req, Raw) ->
     Port = integer_to_list(mochiweb_socket_server:get(chttpd, port)),
     Url = list_to_binary([
         "http://",
-        config:get("httpd", "bind_address"),
+        config:get("chttpd", "bind_address"),
         ":",
         Port,
         "/",


### PR DESCRIPTION
It's a deprecated feature but we want to make sure it still works.

Possible fix for: https://github.com/apache/couchdb/issues/4313