### PR TITLE
Write relax-message to standard output on Windows

### DIFF
--- a/configure.ps1
+++ b/configure.ps1
@@ -247,4 +247,4 @@ if ( (Test-Path .git -PathType Container) -and (-not $SkipDeps) ) {
 
 Pop-Location
 [Environment]::CurrentDirectory = $PWD
-Write-Verbose "You have configured Apache CouchDB, time to relax. Relax."
+Write-Output "You have configured Apache CouchDB, time to relax. Relax."


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Write the standard relax message after configure to the standard output and not as "verbose" message.