### PR TITLE
Return back to allowing offline configure and make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ escriptize: couch
 
 .PHONY: check
 # target: check - Test everything
-check: all python-black
+check: all
 	@$(MAKE) exunit
 	@$(MAKE) eunit
 	@$(MAKE) mango-test

--- a/Makefile.win
+++ b/Makefile.win
@@ -132,7 +132,7 @@ fauxton: share\www
 
 .PHONY: check
 # target: check - Test everything
-check: all python-black
+check: all
 	@$(MAKE) eunit
 	@$(MAKE) mango-test
 	@$(MAKE) elixir

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -163,7 +163,7 @@ pipeline {
       }
     } // stage Build Docs
 
-    stage('Erlfmt') {
+    stage('Source Format Checks') {
       when {
         beforeOptions true
         expression { ONLY_DOCS_CHANGED == '0' }
@@ -185,6 +185,7 @@ pipeline {
           rm -rf apache-couchdb-*
           ./configure --skip-deps
           make erlfmt-check
+          make python-black
         '''
       }
       post {

--- a/build-aux/couchdb-build-release.sh
+++ b/build-aux/couchdb-build-release.sh
@@ -54,3 +54,5 @@ fi
 
 # copy our rebar
 cp bin/rebar ${REL_DIR}/bin/rebar
+cp bin/rebar3 ${REL_DIR}/bin/rebar3
+cp bin/erlfmt ${REL_DIR}/bin/erlfmt


### PR DESCRIPTION
At some point it broke - it looks like rebar3, erlfmt and python-black usage ended up needing the network to install/update themselves.

Make sure rebar3 and erlfmt is in bin/ alongside rebar, and make python-black is in a separate source formatting stage step in CI and remove it from `make check`.
