### PR TITLE
revert jiffy to 1.0.9

### DIFF
--- a/configure
+++ b/configure
@@ -294,8 +294,7 @@ EOF
 install_local_rebar() {
     if [ ! -x "${rootdir}/bin/rebar" ]; then
         if [ ! -d "${rootdir}/src/rebar" ]; then
-            # git clone --depth 1 https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
-            git clone https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
+            git clone --depth 1 https://github.com/apache/couchdb-rebar.git ${rootdir}/src/rebar
         fi
         make -C ${rootdir}/src/rebar
         mv ${rootdir}/src/rebar/rebar ${rootdir}/bin/rebar

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -154,7 +154,7 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
-{jiffy,            "jiffy",            {tag, "1.1.1"}},
+{jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-1"}},
 {mochiweb,         "mochiweb",         {tag, "v3.1.1"}},
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.2"}}


### PR DESCRIPTION
jiffy > 1.0.9 breaks the windows builds. We tracked this down to jiffy getting rebar3 support in version 1.1.0 and fixes to that support in 1.1.1. We shipped our last release with jiffy 1.0.9 which directly preceded 1.1.0 (tho our tag is CouchDB-1.0.9). As far as I can tell there are no substantial fixes* in 1.1.0+ so we might as well unblock our release by reverting to jiffy 1.0.9.

* https://github.com/davisp/jiffy/compare/1.0.9...1.1.1
