### PR TITLE
Revert jiffy to CouchDB-1.0.9-2 to unblock the 3.3 release

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -154,7 +154,7 @@ DepDescs = [
 {folsom,           "folsom",           {tag, "CouchDB-0.8.4"}},
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
-{jiffy,            "jiffy",            {tag, "1.1.1"}},
+{jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-2"}},
 {mochiweb,         "mochiweb",         {tag, "v3.1.1"}},
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.2"}}


### PR DESCRIPTION
Latest jiffy apparently is blocking windows builds so for now let's revert to the previous version. The previous version didn't quite work right off the bat as enc doesn't load on Erlang 25 any longer. So there is a new 1.0.9-2 release wiht enc rebuilt on Erlang 23.
