### PR TITLE
Reuse installed rebar and rebar3 for mix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ elixir: elixir-init elixir-check-formatted elixir-credo devclean
 .PHONY: elixir-init
 elixir-init: MIX_ENV=test
 elixir-init: config.erl
-	@mix local.rebar --force && mix local.hex --force && mix deps.get
+	@mix local.rebar --force rebar ./bin/rebar && mix local.rebar --force rebar3 ./bin/rebar3 && mix local.hex --force && mix deps.get
 
 .PHONY: elixir-cluster-without-quorum
 elixir-cluster-without-quorum: export MIX_ENV=integration


### PR DESCRIPTION
Instead of having it download its own every time

Another step toward being able to run `make check` on the dist output without a network

This saves some time and is a bit closer to the goal. 

The next hurdle is to do the same for hex. Hex it a bit trickier, since we don't have an explicit clone, it just auto-installs itself whenever. During configure we'd have to treat it like rebar3 -- fetch, recompile locally, stash it in `hex/hex.ez`. Then, `make dist` would copy that over to the dist tarball, and during `make check` we'd install it from that archive `mix archive.install ./hex/hex.ez`)

Related to: https://github.com/apache/couchdb/issues/4312