### PR TITLE
Ignore built win binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.pyc
 *.swp
 *.pdb
+*.dll
+*.lib
+*.exp
 *~
 .venv
 .DS_Store


### PR DESCRIPTION
## Overview

Ignore build Windows binaries to prevent an accidental check-in into source control.
