### PR TITLE
Revert "Reuse installed rebar and rebar3 for mix"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ elixir: elixir-init elixir-check-formatted elixir-credo devclean
 .PHONY: elixir-init
 elixir-init: MIX_ENV=test
 elixir-init: config.erl
-	@mix local.rebar --force rebar ./bin/rebar && mix local.rebar --force rebar3 ./bin/rebar3 && mix local.hex --force && mix deps.get
+	@mix local.rebar --force && mix local.hex --force && mix deps.get
 
 .PHONY: elixir-cluster-without-quorum
 elixir-cluster-without-quorum: export MIX_ENV=integration


### PR DESCRIPTION
This reverts commit b5da5b66b8e2b2f0fe86ca142f1c45a63b5f9e0f.

causes issues:

```
> make elixir
** (Mix) Invalid arguments given to mix local.rebar: ["rebar", "./bin/rebar"]. To find out the proper call syntax run "mix help local.rebar"
```

```
> elixir --version
Erlang/OTP 25 [erts-13.1.3] [source] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit] [dtrace]

Elixir 1.14.2 (compiled with Erlang/OTP 25)
```