### PR TITLE
Fix {eaddrnotavail} in elixir tests under Windows

### DIFF
--- a/test/elixir/lib/couch/dbtest.ex
+++ b/test/elixir/lib/couch/dbtest.ex
@@ -305,8 +305,8 @@ defmodule Couch.DBTest do
         userinfo
       end
 
-    src = set_user(src, userinfo)
-    tgt = set_user(tgt, userinfo)
+    src = set_user(get_absolute_url(src), userinfo)
+    tgt = set_user(get_absolute_url(tgt), userinfo)
 
     defaults = [headers: [], body: %{}, timeout: 30_000]
     options = defaults |> Keyword.merge(options) |> Enum.into(%{})
@@ -318,6 +318,18 @@ defmodule Couch.DBTest do
     resp = Couch.post("/_replicate", Enum.to_list(options))
     assert HTTPotion.Response.success?(resp), "#{inspect(resp)}"
     resp.body
+  end
+
+  defp get_absolute_url("http://" <> _ = uri) do
+    uri
+  end
+
+  defp get_absolute_url("/" <> _ = uri) do
+    Couch.process_url(uri)
+  end
+
+  defp get_absolute_url(uri) do
+    Couch.process_url("/" <> uri)
   end
 
   defp set_user(uri, userinfo) do

--- a/test/elixir/test/security_validation_test.exs
+++ b/test/elixir/test/security_validation_test.exs
@@ -306,7 +306,7 @@ defmodule SecurityValidationTest do
     foo2 = Map.put(foo2, "value", "b")
     assert Couch.put("/#{db_name_b}/foo2", body: foo2, headers: spike).body["ok"]
 
-    result = replicate(db_name_b, db_name_a, headers: spike)
+    result = replicate(db_name_b, db_name_a, [{:userinfo, "spike:dog"}, {:headers, spike}])
     assert Enum.at(result["history"], 0)["docs_written"] == 1
     assert Enum.at(result["history"], 0)["doc_write_failures"] == 2
 


### PR DESCRIPTION
## Overview

Adding full url to database names when replicating.
