### PR TITLE
Fix full CI build

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -275,8 +275,6 @@ pipeline {
         timeout(time: 15, unit: "MINUTES") {
           sh (script: 'rm -rf apache-couchdb-*', label: 'Clean workspace of any previous release artifacts' )
           sh "./configure --spidermonkey-version 78"
-          sh 'make erlfmt-check'
-          sh 'make elixir-check-formatted'
           sh 'make dist'
         }
       }


### PR DESCRIPTION
Don't run erlfmt and elixir format checks

We already ran those during the pull request CI phase
