### PR TITLE
Update Erlang versions

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -14,11 +14,11 @@
 // the License.
 
 // Erlang version embedded in binary packages
-ERLANG_VERSION = '23.3.4.17'
+ERLANG_VERSION = '24.3.4.7'
 
 // Erlang version used for rebar in release process. CouchDB will not build from
 // the release tarball on Erlang versions older than this
-MINIMUM_ERLANG_VERSION = '23.3.4.17'
+MINIMUM_ERLANG_VERSION = '23.3.4.18'
 
 // We create parallel build / test / package stages for each OS using the metadata
 // in this map. Adding a new OS should ideally only involve adding a new entry here.

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -50,7 +50,7 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    LOW_ERLANG_VER = '23.3.4.15'
+    LOW_ERLANG_VER = '23.3.4.18'
   }
 
   options {
@@ -247,7 +247,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '23.3.4.17', '24.3.4.5', '25.1'
+            values '23.3.4.18', '24.3.4.7', '25.2'
           }
           axis {
             name 'SM_VSN'


### PR DESCRIPTION
Update all 23,24,25 to latest patch versions

Use 24 as a base for the full CI run
