### PR TITLE
Add test coverage for replicator user_ctx parser

### DIFF
--- a/src/couch_replicator/src/couch_replicator_parse.erl
+++ b/src/couch_replicator/src/couch_replicator_parse.erl
@@ -583,6 +583,13 @@ check_convert_options_fail_test() ->
         convert_options([{<<"query_params">>, 42}])
     ).
 
+rep_user_ctx_test() ->
+    RepDoc = {[{<<"user_ctx">>, {[]}}]},
+    ?assertEqual(
+        #user_ctx{name = null, roles = [], handler = undefined},
+        rep_user_ctx(RepDoc)
+    ).
+
 local_replication_endpoint_error_test_() ->
     {
         foreach,


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This adds a test to cover the case when a replication doc contains a user_ctx, and subsequently executes `get_json_value/3`.

See: https://github.com/apache/couchdb/pull/4343

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

```
make eunit apps=couch_replicator suites=couch_replicator_parse
```
should show all lines of `rep_user_ctx/1` are covered.

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
