### PR TITLE
feat(build): fail build if xref complains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 include version.mk
 
 REBAR?=$(shell echo `pwd`/bin/rebar)
+REBAR3?=$(shell echo `pwd`/bin/rebar3)
 ERLFMT?=$(shell echo `pwd`/bin/erlfmt)
 
 # Handle the following scenarios:
@@ -152,6 +153,7 @@ escriptize: couch
 .PHONY: check
 # target: check - Test everything
 check: all
+	@$(MAKE) find-bugs
 	@$(MAKE) exunit
 	@$(MAKE) eunit
 	@$(MAKE) mango-test
@@ -367,10 +369,11 @@ dialyze: .rebar
 	@$(REBAR) -r dialyze $(DIALYZE_OPTS)
 
 
-.PHONY: find_bugs
-# target: find_bugs - Find unused exports etc
-find_bugs:
-	@$(REBAR) --keep-going --recursive xref $(DIALYZE_OPTS)
+.PHONY: find-bugs
+# target: xref - find unused exports etc
+find-bugs:
+	@./build-aux/xref-helper.sh $(REBAR) $(DIALYZE_OPTS)
+
 
 .PHONY: introspect
 # target: introspect - Check for commits difference between rebar.config and repository

--- a/build-aux/xref-helper.sh
+++ b/build-aux/xref-helper.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+REBAR=$1
+DIALYZE_OPTS=$2
+
+mkdir -p ./tmp
+
+# run rebar xref, grep out rebar meta output (==> and WARN)
+# pipe the rest into a file
+$REBAR --keep-going --recursive xref $DIALYZE_OPTS | \
+                                      grep -v '==>' | \
+                                      grep -v 'WARN' | \
+                                      grep -v hastings > ./tmp/xref-output.txt
+
+# compare result against known allowed output
+DIFF=`diff -u ./tmp/xref-output.txt ./test/fixtures/allowed-xref.txt`
+
+# if the actual output differs from the allowed output
+# print the difference and exit with 1
+if [ -n "$DIFF" ]; then
+  echo "$DIFF"
+  exit 1
+else
+  exit 0
+fi

--- a/test/fixtures/allowed-xref.txt
+++ b/test/fixtures/allowed-xref.txt
@@ -1,0 +1,2 @@
+src/ioq.erl: Warning: ioq:get_disk_queues/0 is undefined function (Xref)
+src/weatherreport_check_ioq.erl:{95,1}: Warning: weatherreport_check_ioq:check_legacy_int/1 calls undefined function ioq:get_disk_queues/0 (Xref)


### PR DESCRIPTION
only works on Erlang 23. 24 and 25 fail

24 e.g. with:

```==> mem3 (xref)
Warning: hastings_index:await/2 is undefined function (Xref)
Warning: hastings_index:design_doc_to_indexes/1 is undefined function (Xref)
Warning: hastings_index_manager:get_index/2 is undefined function (Xref)
WARN:  Continuing on after abort: [xref]
ERROR: xref failed while processing /Users/jan/Work/asf/tmp/couchdb/src/mem3: {'EXIT',
 {{badmatch,
   [{attribute,{1,1},file,{"src/mem3_reshard_index.erl",1}},
    {attribute,{13,2},module,mem3_reshard_index},
    {attribute,
     {15,2},
     export,
     [{design_docs,1},{target_indices,2},{spawn_builders,1},{build_index,2}]},
… big symbol dump
```