### PR TITLE
Escape special (html) chars in section names

### DIFF
--- a/src/docs/ext/configdomain.py
+++ b/src/docs/ext/configdomain.py
@@ -15,6 +15,7 @@ from sphinx.roles import XRefRole
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
+import html
 
 
 class ConfigObject(ObjectDescription):
@@ -62,7 +63,7 @@ class ConfigIndex(Index):
 
     def generate(self, docnames=None):
         content = dict(
-            (name, [(name, 1, info[0], name, "", "", info[1])])
+            (html.escape(name), [(name, 1, info[0], name, "", "", info[1])])
             for name, info in self.domain.data["section"].items()
         )
 
@@ -70,7 +71,7 @@ class ConfigIndex(Index):
         for idx, info in sorted(options.items()):
             path, descr = info
             section, name = idx.split("/", 1)
-            content[section].append(
+            content[html.escape(section)].append(
                 (name, 2, path, "%s/%s" % (section, name), "", "", descr)
             )
 


### PR DESCRIPTION
## Overview

To correctly generate the configuration reference html output, escape special html characters like '<' and '>' in section names.

Before PR:
<img width="161" alt="grafik" src="https://user-images.githubusercontent.com/9985963/210784263-84ec203b-b5e5-4687-94bc-657876fee29a.png">

```
<a href="#cap-smoosh.<channel>"><strong>smoosh.<channel></strong></a>
```

and

<img width="161" alt="grafik" src="https://user-images.githubusercontent.com/9985963/210784494-a8db8f37-94c5-4a60-a5b1-391264556e39.png">

```
<tr class="cap" id="cap-smoosh.<channel>"><td></td><td>
       <strong>smoosh.<channel></strong></td><td></td></tr>
```

After PR:

<img width="216" alt="grafik" src="https://user-images.githubusercontent.com/9985963/210785053-fac88e13-18d9-45d3-8a58-e80966743e55.png">

```
<a href="#cap-smoosh.&lt;channel&gt;"><strong>smoosh.&lt;channel&gt;</strong></a>
```

and

<img width="161" alt="grafik" src="https://user-images.githubusercontent.com/9985963/210784952-74460e9a-3c35-4fea-802f-1f9a52435ea6.png">

```
<tr class="cap" id="cap-smoosh.&lt;channel&gt;"><td></td><td>
       <strong>smoosh.&lt;channel&gt;</strong></td><td></td></tr>
```

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Checklist

- [x] Code is written and works correctly
