### PR TITLE
Fix Ubuntu Jammy CI image reference

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -50,7 +50,7 @@ meta = [
   'jammy': [
     name: 'Ubuntu 22.04',
     spidermonkey_vsn: '91',
-    image: "apache/couchdbci-ubuntu:jammy-erlang-default"
+    image: "apache/couchdbci-ubuntu:jammy-erlang-${ERLANG_VERSION}"
   ],
 
   'buster': [


### PR DESCRIPTION
Just make it use the Erlang 24 version like all the other images
