### PR TITLE
Fix replication job start_link.

### DIFF
--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -87,7 +87,7 @@ start_link(#rep{id = Id = {BaseId, Ext}, source = Src, target = Tgt} = Rep) ->
     Target = couch_replicator_api_wrap:db_uri(Tgt),
     case couch_replicator_pg:should_start(Id, node()) of
         yes ->
-            case gen_server:start_link({local, ?MODULE}, ?MODULE, Rep, []) of
+            case gen_server:start_link(?MODULE, Rep, []) of
                 {ok, Pid} ->
                     couch_replicator_pg:join(Id, Pid),
                     {ok, Pid};


### PR DESCRIPTION
We don't want to register replication jobs with the module name as that prevents us from running more than one job at a time.

This was introduced when we removed the dependence on global registrations and switched to using pg instead.

Even more embarrassing is we didn't have tests to check multiple replication jobs running at the same time.
