### PR TITLE
Add Prometheus port to Windows couchdb.config

### DIFF
--- a/configure.ps1
+++ b/configure.ps1
@@ -138,6 +138,7 @@ $CouchDBConfig = @"
 {node_name, "-name couchdb@localhost"}.
 {cluster_port, 5984}.
 {backend_port, 5986}.
+{prometheus_port, 17986}.
 "@
 $CouchDBConfig | Out-File "$rootdir\rel\couchdb.config" -encoding ascii
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Add Prometheus port to ./configure.ps1 to catch up with ./configure

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
