### PR TITLE
Wait for dbs_info 500 timeout error

### DIFF
--- a/src/chttpd/test/eunit/chttpd_dbs_info_test.erl
+++ b/src/chttpd/test/eunit/chttpd_dbs_info_test.erl
@@ -183,16 +183,25 @@ should_return_nothing_when_db_not_exist_for_get_dbs_info(_) ->
 
 should_return_500_time_out_when_time_is_not_enough_for_get_dbs_info(_) ->
     mock_timeout(),
-    % Use httpc to avoid ibrowse returning {error, retry_later} in
-    % some cases, causing test_request to sleep and retry, resulting
-    % in timeout failures.
     Auth = base64:encode_to_string(?USER ++ ":" ++ ?PASS),
     Headers = [{"Authorization", "Basic " ++ Auth}],
     Request = {dbs_info_url("buffer_response=true"), Headers},
-    {ok, {{_, Code, _}, _, Body}} = httpc:request(get, Request, [], []),
-    {Props} = jiffy:decode(Body),
-    ?assertEqual(<<"timeout">>, couch_util:get_value(<<"error">>, Props)),
-    ?assertEqual(500, Code).
+    {Props} =
+        test_util:wait(
+            fun() ->
+                % Use httpc to avoid ibrowse returning {error,
+                % retry_later} in some cases, causing test_request to
+                % sleep and retry, resulting in timeout failures.
+                case httpc:request(get, Request, [], []) of
+                    {ok, {{_, Code, _}, _, Body}} ->
+                        ?assertEqual(500, Code),
+                        jiffy:decode(Body);
+                    _ ->
+                        wait
+                end
+            end
+        ),
+    ?assertEqual(<<"timeout">>, couch_util:get_value(<<"error">>, Props)).
 
 should_return_db2_for_get_dbs_info_with_descending({Suffix, Db1, Db2}) ->
     {ok, _, _, ResultBody} = test_request:get(


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

With more recent OTP versions, this test has been observed to fail with the following error:
```
    chttpd_dbs_info_test:88: -dbs_info_test_/0-fun-22- (should_return_500_time_out_when_time_is_not_enough_for_get_dbs_info)...*failed*
in function chttpd_dbs_info_test:should_return_500_time_out_when_time_is_not_enough_for_get_dbs_info/1 (test/eunit/chttpd_dbs_info_test.erl, line 192) in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71) in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531) in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356) in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514) in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456) in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 346) in call from eunit_proc:run_group/2 (eunit_proc.erl, line 570) **error:{badmatch,{error,socket_closed_remotely}}
  output:<<"">>
```
This change waits until the expected 500 timeout error is received.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
