### PR TITLE
Fix replication _scheduler/docs total_rows

### DIFF
--- a/src/couch_replicator/src/couch_replicator_httpd_util.erl
+++ b/src/couch_replicator/src/couch_replicator_httpd_util.erl
@@ -158,7 +158,7 @@ docs_cb({meta, Meta}, #vacc{meta_sent = false, row_sent = false} = Acc) ->
     Parts =
         case couch_util:get_value(total, Meta) of
             undefined -> [];
-            Total -> [io_lib:format("\"total_rows\":~p", [adjust_total(Total)])]
+            Total -> [io_lib:format("\"total_rows\":~p", [Total])]
         end ++
             case couch_util:get_value(offset, Meta) of
                 undefined -> [];
@@ -193,9 +193,3 @@ row_to_json(Row) ->
     Doc0 = couch_util:get_value(doc, Row),
     Doc1 = update_db_name(Doc0),
     ?JSON_ENCODE(Doc1).
-
-%% Adjust Total as there is an automatically created validation design doc
-adjust_total(Total) when is_integer(Total), Total > 0 ->
-    Total - 1;
-adjust_total(Total) when is_integer(Total) ->
-    0.

--- a/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
@@ -1,0 +1,77 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_replicator_scheduler_docs_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+scheduler_docs_test_() ->
+    {
+        foreach,
+        fun() ->
+            Ctx = couch_replicator_test_helper:test_setup(),
+            ok = config:set("replicator", "cluster_start_period", "0", false),
+            Opts = [{q, 1}, {n, 1}, ?ADMIN_CTX],
+            case fabric:create_db(<<"_replicator">>, Opts) of
+                ok -> ok;
+                {error, file_exists} -> ok
+            end,
+            Ctx
+        end,
+        fun(Ctx) ->
+            ok = config:delete("replicator", "cluster_start_period"),
+            ok = fabric:delete_db(<<"_replicator">>, [?ADMIN_CTX]),
+            couch_replicator_test_helper:test_teardown(Ctx)
+        end,
+        [
+            ?TDEF_FE(t_scheduler_docs_total_rows, 10)
+        ]
+    }.
+
+t_scheduler_docs_total_rows({_Ctx, {Source, Target}}) ->
+    SourceUrl = couch_replicator_test_helper:cluster_db_url(Source),
+    TargetUrl = couch_replicator_test_helper:cluster_db_url(Target),
+    RepDoc = jiffy:encode(
+        {[
+            {<<"source">>, SourceUrl},
+            {<<"target">>, TargetUrl}
+        ]}
+    ),
+    RepDocUrl = couch_replicator_test_helper:cluster_db_url(
+        list_to_binary("/_replicator/" ++ ?docid())
+    ),
+    {ok, 201, _, _} = test_request:put(binary_to_list(RepDocUrl), [], RepDoc),
+    SchedulerDocsUrl =
+        couch_replicator_test_helper:cluster_db_url(<<"/_scheduler/docs">>),
+    Body = test_util:wait(
+        fun() ->
+            case test_request:get(binary_to_list(SchedulerDocsUrl), []) of
+                {ok, 200, _, JsonBody} ->
+                    Decoded = jiffy:decode(JsonBody, [return_maps]),
+                    case maps:get(<<"docs">>, Decoded) of
+                        [] ->
+                            wait;
+                        _ ->
+                            Decoded
+                    end;
+                _ ->
+                    wait
+            end
+        end,
+        10000,
+        1000
+    ),
+    Docs = maps:get(<<"docs">>, Body),
+    TotalRows = maps:get(<<"total_rows">>, Body),
+    ?assertEqual(TotalRows, length(Docs)),
+    ok.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The total_rows property was decremented by one to account for the VDU that was automatically added to the total. Now that a BDU has replaced the VDU [1] total_rows is one less than it should be.

This removes the decrement so that total_rows equals the actual doc count.

[1] https://github.com/apache/couchdb/pull/4274

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=couch_replicator suites=couch_replicator_scheduler_docs_tests
```

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
