### PR TITLE
Remove Rebar2 initialization for elixir tests as it is not longer supported by elixir 1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ elixir: elixir-init devclean
 .PHONY: elixir-init
 elixir-init: MIX_ENV=integration
 elixir-init: config.erl
-	@mix local.rebar --force rebar ./bin/rebar && mix local.rebar --force rebar3 ./bin/rebar3 && mix local.hex --force && mix deps.get
+	@mix local.rebar --force rebar3 ./bin/rebar3 && mix local.hex --force && mix deps.get
 
 .PHONY: elixir-cluster-without-quorum
 elixir-cluster-without-quorum: export MIX_ENV=integration


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
  CouchDB build fails at elixir tests initialization when Elixir 1.14 is used.
   Following error stops the build when any Makefile target that depends on `elixir-init` is executed.
```
** (Mix) Invalid arguments given to mix local.rebar: ["rebar", "./bin/rebar"]. To find out the proper call syntax run "mix help local.rebar"
```
 Elixir 1.14 removes support for Rebar 2 which produces the error as we are initializing  Rebar 2 and Rebar 3 for test execution. 

 This PR removes Rebar 2 initialization from `elixit-init` target enabling support for Elixir 1.14 in the build process. 

Windows build seems not to be affected by the same problem as it is not forcing Rebar 2 initialization, but I have not tested it. 

## Testing recommendations

 - Install Elixir 1.14
 - Run 'make couch elixir'

## Related Issues or Pull Requests
None
<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
