### PR TITLE
docs(mango): match description of `$mod` with reality

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -705,8 +705,8 @@ operators require the argument to be in a specific JSON format.
 |               |             |            | document. Non-array fields cannot |
 |               |             |            | match this condition.             |
 +---------------+-------------+------------+-----------------------------------+
-| Miscellaneous | ``$mod``    | [Divisor,  | Divisor and Remainder are both    |
-|               |             | Remainder] | positive or negative integers.    |
+| Miscellaneous | ``$mod``    | [Divisor,  | Divisor is a non-zero integer,    |
+|               |             | Remainder] | Remainder is any integer.         |
 |               |             |            | Non-integer values result in a    |
 |               |             |            | 404. Matches documents where      |
 |               |             |            | ``field % Divisor == Remainder``  |

--- a/src/mango/README.md
+++ b/src/mango/README.md
@@ -302,7 +302,7 @@ Array related operators
 
 Misc related operators
 
-* "$mod" - [Divisor, Remainder], where Divisor and Remainder are both positive integers (ie, greater than 0). Matches documents where (field % Divisor == Remainder) is true. This is false for any non-integer field
+* "$mod" - [Divisor, Remainder], where Divisor is a non-zero integer and Remainder is any integer. Matches documents where (field % Divisor == Remainder) is true.  This is false for any non-integer field
 * "$regex" - string, a regular expression pattern to match against the document field. Only matches when the field is a string value and matches the supplied matches
 
 


### PR DESCRIPTION
The remainder argument for the `$mod` operator can be zero, while its documentation suggests otherwise.  It actually covers a very realistic use case where divisibility is expressed.

[Neither related restrictions could be identified in the sources](https://github.com/apache/couchdb/blob/adf17140e81d0b74f2b2ecdea48fc4f702832eaf/src/mango/src/mango_selector.erl#L512:L513) [nor MongoDB forbids this](https://www.mongodb.com/docs/manual/reference/operator/query/mod/).  Tests also seem to exercise [this specific case](https://github.com/apache/couchdb/blob/0059b8f90e58e10b199a4b768a06a762d12a30d3/src/mango/test/03-operator-test.py#L58).  Thanks @iilyak for checking on these.

Tasks:
- [ ] Backport to all affected branches