### PR TITLE
chore(configure): be more defensive about SpiderMonkey location

### DIFF
--- a/configure
+++ b/configure
@@ -30,10 +30,15 @@ WITH_DOCS=1
 ERLANG_MD5="false"
 SKIP_DEPS=0
 
+run_erlang() {
+    erl -noshell -eval "$1" -eval "halt()."
+}
+
 COUCHDB_USER="$(whoami 2>/dev/null || echo couchdb)"
 SM_VSN=${SM_VSN:-"91"}
 ARCH="$(uname -m)"
-ERLANG_VER="$(erl -eval 'io:put_chars(erlang:system_info(otp_release)), halt().' -noshell)"
+ERLANG_VER="$(run_erlang 'io:put_chars(erlang:system_info(otp_release)).')"
+ERLANG_OS="$(run_erlang 'case os:type() of {OS, _} -> io:format("~s~n", [OS]) end.')"
 
 . ${rootdir}/version.mk
 COUCHDB_VERSION=${vsn_major}.${vsn_minor}.${vsn_patch}
@@ -228,6 +233,26 @@ if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" = "60" ]
 then
   echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use another version instead."
   exit 1
+fi
+
+if [ "${ERLANG_OS}" = "unix" ]
+then
+    case "${SM_VSN}" in
+        1.8.5)
+            SM_HEADERS="js"
+            ;;
+        *)  SM_HEADERS="mozjs-${SM_VSN}"
+            ;;
+        esac
+
+    # This list is taken from src/couch/rebar.config.script, please keep them in sync.
+    if [ ! -d "/usr/include/${SM_HEADERS}" ] && \
+        [ ! -d "/usr/local/include/${SM_HEADERS}" ] && \
+        [ ! -d "/opt/homebrew/include/${SM_HEADERS}" ]
+    then
+        echo "ERROR: SpiderMonkey ${SM_VSN} is not found. Please specify with --spidermonkey-version."
+        exit 1
+    fi
 fi
 
 echo "==> configuring couchdb in rel/couchdb.config"

--- a/configure
+++ b/configure
@@ -229,14 +229,12 @@ parse_opts() {
 
 parse_opts $@
 
-if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" = "60" ]
-then
+if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" = "60" ]; then
   echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use another version instead."
   exit 1
 fi
 
-if [ "${ERLANG_OS}" = "unix" ]
-then
+if [ "${ERLANG_OS}" = "unix" ]; then
     case "${SM_VSN}" in
         1.8.5)
             SM_HEADERS="js"
@@ -248,8 +246,7 @@ then
     # This list is taken from src/couch/rebar.config.script, please keep them in sync.
     if [ ! -d "/usr/include/${SM_HEADERS}" ] && \
         [ ! -d "/usr/local/include/${SM_HEADERS}" ] && \
-        [ ! -d "/opt/homebrew/include/${SM_HEADERS}" ]
-    then
+        [ ! -d "/opt/homebrew/include/${SM_HEADERS}" ]; then
         echo "ERROR: SpiderMonkey ${SM_VSN} is not found. Please specify with --spidermonkey-version."
         exit 1
     fi

--- a/configure.ps1
+++ b/configure.ps1
@@ -103,6 +103,22 @@ If ($Test) {
     exit 0
 }
 
+# Use the MSVC linker to determine if the respective SpiderMonkey library
+# is available on the linker path.  This heuristic is taken from
+# src/couch/rebar.config.script, please keep them in sync.
+If ($SpiderMonkeyVersion -eq "1.8.5") {
+    $SpiderMonkeyLib = "mozjs185-1.0.lib"
+}
+else {
+    $SpiderMonkeyLib = "mozjs-$SpiderMonkeyVersion.lib"
+}
+
+&link $SpiderMonkeyLib /SUBSYSTEM:CONSOLE /NOENTRY /DLL /OUT:NUL *> $null
+If ($LASTEXITCODE -ne 0) {
+    Write-Output "ERROR: SpiderMonkey $SpiderMonkeyVersion is not found. Please specify with -SpiderMonkeyVersion."
+    exit 1
+}
+
 # Translate ./configure variables to CouchDB variables
 $PackageAuthorName="The Apache Software Foundation"
 $InstallDir="$LibDir\couchdb"

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -114,6 +114,9 @@ ProperConfig = case code:lib_dir(proper) of
     _ -> [{d, 'WITH_PROPER'}]
 end.
 
+% The include directories (parameters for the `-I` C compiler flag) are
+% considered in the `configure` script as a pre-check for their existence.
+% Please keep them in sync.
 {JS_CFLAGS, JS_LDFLAGS} = case os:type() of
     {win32, _} when SMVsn == "1.8.5" ->
         {


### PR DESCRIPTION
The `configure` script does not check whether SpiderMonkey actually exists at the presumed location.  This may go wrong when the user has a version different from the default one.  The mistake is spotted only in build time, indirectly, via missing header files.  That is too late and it may not be evident for the user what the problem is.

Add a user-friendly safeguard to prevent this from happening.
