### PR TITLE
Pr 4380 spidermonkey check

### DIFF
--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -183,7 +183,7 @@ pipeline {
       steps {
         sh '''
           rm -rf apache-couchdb-*
-          ./configure --skip-deps
+          ./configure --skip-deps --spidermonkey-version 78
           make erlfmt-check
           make elixir-source-checks
           make python-black

--- a/configure
+++ b/configure
@@ -245,6 +245,7 @@ then
             ;;
         esac
 
+    # This list is taken from src/couch/rebar.config.script, please keep them in sync.
     if [ ! -d "/usr/include/${SM_HEADERS}" ] && \
         [ ! -d "/usr/local/include/${SM_HEADERS}" ] && \
         [ ! -d "/opt/homebrew/include/${SM_HEADERS}" ]

--- a/configure
+++ b/configure
@@ -30,10 +30,15 @@ WITH_DOCS=1
 ERLANG_MD5="false"
 SKIP_DEPS=0
 
+run_erlang() {
+    erl -noshell -eval "$1" -eval "halt()."
+}
+
 COUCHDB_USER="$(whoami 2>/dev/null || echo couchdb)"
 SM_VSN=${SM_VSN:-"91"}
 ARCH="$(uname -m)"
-ERLANG_VER="$(erl -eval 'io:put_chars(erlang:system_info(otp_release)), halt().' -noshell)"
+ERLANG_VER="$(run_erlang 'io:put_chars(erlang:system_info(otp_release)).')"
+ERLANG_OS="$(run_erlang 'case os:type() of {OS, _} -> io:format("~s~n", [OS]) end.')"
 
 . ${rootdir}/version.mk
 COUCHDB_VERSION=${vsn_major}.${vsn_minor}.${vsn_patch}
@@ -228,6 +233,25 @@ if [ "${ARCH}" = "aarch64" ] && [ "${SM_VSN}" = "60" ]
 then
   echo "ERROR: SpiderMonkey 60 is known broken on ARM 64 (aarch64). Use another version instead."
   exit 1
+fi
+
+if [ "${ERLANG_OS}" = "unix" ]
+then
+    case "${SM_VSN}" in
+        1.8.5)
+            SM_HEADERS="js"
+            ;;
+        *)  SM_HEADERS="mozjs-${SM_VSN}"
+            ;;
+        esac
+
+    if [ ! -d "/usr/include/${SM_HEADERS}" ] && \
+        [ ! -d "/usr/local/include/${SM_HEADERS}" ] && \
+        [ ! -d "/opt/homebrew/include/${SM_HEADERS}" ]
+    then
+        echo "ERROR: SpiderMonkey ${SM_VSN} is not found. Please specify with --spidermonkey-version."
+        exit 1
+    fi
 fi
 
 echo "==> configuring couchdb in rel/couchdb.config"

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -114,6 +114,9 @@ ProperConfig = case code:lib_dir(proper) of
     _ -> [{d, 'WITH_PROPER'}]
 end.
 
+% The include directories (parameters for the `-I` C compiler flag) are
+% considered in the `configure` script as a pre-check for their existence.
+% Please keep them in sync.
 {JS_CFLAGS, JS_LDFLAGS} = case os:type() of
     {win32, _} when SMVsn == "1.8.5" ->
         {


### PR DESCRIPTION
THIS IS A TEST PR ONLY. The original is https://github.com/apache/couchdb/pull/4380 where we wondering why Jenkins wasn't picking up the `Jenkinsfile.pr` changes.  Making a new PR from a local branch seems to have solved the issue around modifying `Jenkinsfile.pr`. 

(Authored-by: PÁLI Gábor János [pgj](https://github.com/pgj))

Perhaps one of the committers can split up the ` ./configure --skip-deps --spidermonkey-version 78` into a separate PR.