### PR TITLE
Adding build-report makefile target on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -250,6 +250,11 @@ elixir-check-formatted: elixir-init
 elixir-credo: elixir-init
 	@mix credo
 
+.PHONY: build-report
+# target: build-report - Generate a build report
+build-report:
+	@$(PYTHON) build-aux/show-test-results.py --suites=10 --tests=10 > test-results.log
+
 .PHONY: check-qs
 # target: check-qs - Run query server tests (ruby and rspec required!)
 check-qs:


### PR DESCRIPTION
Backporting the `build-report` target from the *nix makefile to the Windows pendant.

## Overview
Run this on Windows:

```
PS C:\relax\couchdb> make -f Makefile.win build-report
```

## Testing recommendations

```
PS C:\relax\couchdb> cat .\test-results.log
Skipped
=======

  EXUnit - AuthCacheTest - AuthCacheTest - test auth cache management: due to pending filter
  EXUnit - BasicsTest - BasicsTest - test On restart, a request for creating an already existing db can not override: due to pending filter
  EXUnit - BasicsTest - BasicsTest - test PUT doc has a Location header: due to pending filter
  EXUnit - BasicsTest - BasicsTest - test Regression test for COUCHDB-954: due to pending filter
  EXUnit - CompactTest - CompactTest - test compaction reduces size of deleted docs: due to pending filter
  EXUnit - ConfigTest - ConfigTest - test CouchDB respects configured protocols: due to pending filter
  EXUnit - ConfigTest - ConfigTest - test PORT `BUGGED` ?raw tests from config.js: due to pending filter
  EXUnit - PartitionAllDocsTest - PartitionAllDocsTest - test partition _all_docs with timeout: due to pending filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Attachments overriden quorum should return 202-Acepted: due to with_quorum_test filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Attachments should return 201-Created: due to with_quorum_test filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Bulk docs overriden quorum should return 202-Acepted: due to with_quorum_test filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Bulk docs should return 201-Created: due to with_quorum_test filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Copy doc should return 201-Created: due to with_quorum_test filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Creating-Updating/Deleting doc should return 201-Created/200-OK: due to with_quorum_test filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Creating-Updating/Deleting doc with overriden quorum should return 202-Acepted/200-OK: due to with_quorum_test filter
  EXUnit - WithQuorumTest - WithQuorumTest - test Creating/Deleting DB should return 201-Created/202-Acepted: due to with_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Attachments overriden quorum should return 201-Created: due to without_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Attachments should return 202-Acepted: due to without_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Bulk docs overriden quorum should return 201-Created: due to without_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Bulk docs should return 202-Acepted: due to without_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Copy doc should return 202-Acepted: due to without_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Creating-Updating/Deleting doc with overriden quorum should return 201-Created/200-OK: due to without_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Creating/Deleting DB should return 202-Acepted: due to without_quorum_test filter
  EXUnit - WithoutQuorumTest - WithoutQuorumTest - test Creating/Updating/Deleting doc should return 202-Acepted: due to without_quorum_test filter

Collections
===========

     Total    Fixture       Test      Count     Failed     Errors    Skipped
    113.1s       0.0s     113.1s        558          0          0         24 EXUnit
      0.0s       0.0s       0.0s          0          0          0          0 EUnit
      0.0s       0.0s       0.0s          0          0          0          0 JavaScript
      0.0s       0.0s       0.0s          0          0          0          0 Mango

Suites
======

     Total    Fixture       Test      Count     Failed     Errors    Skipped
     16.0s       0.0s      16.0s         17          0          0          0 EXUnit - ReplicationTest
      6.7s       0.0s       6.7s          4          0          0          0 EXUnit - ReduceTest
      5.9s       0.0s       5.9s         10          0          0          0 EXUnit - ChangesAsyncTest
      5.7s       0.0s       5.7s          2          0          0          0 EXUnit - UsersDbTest
      4.8s       0.0s       4.8s          6          0          0          0 EXUnit - ViewPaginationTest
      4.7s       0.0s       4.7s          3          0          0          0 EXUnit - ReduceBuiltinTest
      4.1s       0.0s       4.1s          3          0          0          0 EXUnit - BatchSaveTest
      3.3s       0.0s       3.3s          9          0          0          0 EXUnit - ViewErrorsTest
      3.2s       0.0s       3.2s         12          0          0          0 EXUnit - DesignDocsTest
      2.7s       0.0s       2.7s         12          0          0          0 EXUnit - PartitionSizeTest

Tests
=====

      5.8s EXUnit - ReplicationTest - ReplicationTest - test replication by doc ids - remote-to-remote
      5.4s EXUnit - UsersDbTest - UsersDbTest - test users db
      4.6s EXUnit - ReduceTest - ReduceTest - test More complex array key view row testing
      3.6s EXUnit - ReplicationTest - ReplicationTest - test continuous replication - remote-to-remote
      2.9s EXUnit - ReduceBuiltinTest - ReduceBuiltinTest - test Builtin count and sum reduce for key as array
      2.4s EXUnit - ViewOffsetTest - ViewOffsetTest - test repeated view offsets
      2.4s EXUnit - ViewCompactionTest - ViewCompactionTest - test view compaction
      2.2s EXUnit - ViewErrorsTest - ViewErrorsTest - test infinite loop
      2.1s EXUnit - ReplicationTest - ReplicationTest - test simple remote-to-remote replication - remote-to-remote
      1.5s EXUnit - BatchSaveTest - BatchSaveTest - test batch post
```

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->
Fixes #4377 
