### PR TITLE
Bump recon to 2.5.3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -156,7 +156,7 @@ DepDescs = [
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-2"}},
 {mochiweb,         "mochiweb",         {tag, "v3.1.1"}},
 {meck,             "meck",             {tag, "0.9.2"}},
-{recon,            "recon",            {tag, "2.5.2"}}
+{recon,            "recon",            {tag, "2.5.3"}}
 ].
 
 WithProper = lists:keyfind(with_proper, 1, CouchConfig) == {with_proper, true}.


### PR DESCRIPTION
Changes since 2.5.2: https://github.com/ferd/recon/compare/2.5.2...2.5.3
