### PR TITLE
ci(mac): re-enable mac CI for the full build

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -86,12 +86,11 @@ meta = [
   //   gnu_make: 'gmake'
   // ],
 
-  /// Temporarily bypass macos builder due to rebar version issue
-  // 'macos': [
-  //   name: 'macOS',
-  //   spidermonkey_vsn: '60',
-  //   gnu_make: 'make'
-  // ]
+ 'macos': [
+    name: 'macOS',
+    spidermonkey_vsn: '91',
+    gnu_make: 'make'
+  ]
 ]
 
 // Credit to https://stackoverflow.com/a/69222555 for this technique.


### PR DESCRIPTION
Full CI test for the https://github.com/apache/couchdb/pull/4387 PR