### PR TITLE
docs(mango): match description of `$mod` with reality (3.3.x)

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -705,8 +705,8 @@ operators require the argument to be in a specific JSON format.
 |               |             |            | document. Non-array fields cannot |
 |               |             |            | match this condition.             |
 +---------------+-------------+------------+-----------------------------------+
-| Miscellaneous | ``$mod``    | [Divisor,  | Divisor and Remainder are both    |
-|               |             | Remainder] | positive or negative integers.    |
+| Miscellaneous | ``$mod``    | [Divisor,  | Divisor is a non-zero integer,    |
+|               |             | Remainder] | Remainder is any integer.         |
 |               |             |            | Non-integer values result in a    |
 |               |             |            | 404. Matches documents where      |
 |               |             |            | ``field % Divisor == Remainder``  |

--- a/src/mango/README.md
+++ b/src/mango/README.md
@@ -302,7 +302,7 @@ Array related operators
 
 Misc related operators
 
-* "$mod" - [Divisor, Remainder], where Divisor and Remainder are both positive integers (ie, greater than 0). Matches documents where (field % Divisor == Remainder) is true. This is false for any non-integer field
+* "$mod" - [Divisor, Remainder], where Divisor is a non-zero integer and Remainder is any integer. Matches documents where (field % Divisor == Remainder) is true.  This is false for any non-integer field
 * "$regex" - string, a regular expression pattern to match against the document field. Only matches when the field is a string value and matches the supplied matches
 
 


### PR DESCRIPTION
Backport of aff7a6e7183e6c471a9675e37216baa0bad563a3.