### PR TITLE
Fix flaky windows test

### DIFF
--- a/src/chttpd/test/eunit/chttpd_changes_test.erl
+++ b/src/chttpd/test/eunit/chttpd_changes_test.erl
@@ -370,7 +370,7 @@ t_design_filter({_, DbUrl}) ->
     Params = "?filter=_design",
     {Seq, Pending, Rows} = changes(DbUrl, Params),
     ?assertEqual(7, Seq),
-    ?assertEqual(2, Pending),
+    ?assert(is_integer(Pending), Pending >= 0 andalso Pending < 7),
     ?assertMatch([{_, {?DDOC2, <<"2-c">>}, ?LEAFREV}], Rows).
 
 t_docs_id_filter({_, DbUrl}) ->

--- a/src/chttpd/test/eunit/chttpd_socket_buffer_size_test.erl
+++ b/src/chttpd/test/eunit/chttpd_socket_buffer_size_test.erl
@@ -51,7 +51,11 @@ small_recbuf(_, {_, Db}) ->
         ?_test(begin
             Id = data(2048),
             Response = put_req(url(Db) ++ "/" ++ Id, "{}"),
-            ?assert(Response =:= 400 orelse Response =:= request_failed)
+            ?assert(
+                Response =:= 400 orelse
+                    Response =:= request_failed orelse
+                    Response =:= connection_closed
+            )
         end)}.
 
 small_buffer(_, {_, Db}) ->
@@ -59,7 +63,11 @@ small_buffer(_, {_, Db}) ->
         ?_test(begin
             Id = data(2048),
             Response = put_req(url(Db) ++ "/" ++ Id, "{}"),
-            ?assert(Response =:= 400 orelse Response =:= request_failed)
+            ?assert(
+                Response =:= 400 orelse
+                    Response =:= request_failed orelse
+                    Response =:= connection_closed
+            )
         end)}.
 
 default_buffer(_, {_, Db}) ->


### PR DESCRIPTION
This PR bypasses the socket tests on windows and fixes a flaky chttpd changes tests where we made a too strong of an assumption about the order in which the shards would be returned.

Thanks to @big-r81 for investigating both issues!

See https://github.com/apache/couchdb/pull/4401#issuecomment-1401511199 for his windows test failure report.