### PR TITLE
docs(INSTALL.Unix): update macOS instructions

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -117,10 +117,9 @@ You can install Node.JS via the
 
 You can install the documentation dependencies by running:
 
-    sudo easy_install pip
-    sudo pip install --upgrade sphinx nose requests hypothesis
+    pip3 install --upgrade sphinx nose requests hypothesis
 
-You will need Homebrew installed to use the brew command.
+You will need Homebrew installed to use the `brew` command.
 
 Learn more about Homebrew at:
 


### PR DESCRIPTION
On recent macOS systems, the `xcode-select --install` command will install a version of Python 3, along with `pip3`, hence there is no need to do that explicitly.  At the same time, system-wide installation of the required Python packages should be discouraged.

Fix markdown of the `brew` command, while here.
