### PR TITLE
docs(INSTALL.Unix): update instructions

### DIFF
--- a/INSTALL.Unix.md
+++ b/INSTALL.Unix.md
@@ -51,14 +51,12 @@ To build Fauxton, you should have the following installed:
  * Node.JS (>=10.x)             (https://nodejs.org/)
    -- obtainable from NodeSource (https://github.com/nodesource/distributions)
 
-To build the documentation, you should have the following installed:
- * Python Sphinx (>=1.5)        (http://pypi.python.org/pypi/Sphinx)
- * Sphinx RT theme              (https://github.com/readthedocs/sphinx_rtd_theme)
-
 It is recommended that you install Erlang OTP 20.3.8.11 or above where
-possible. Sphinx and the RTD theme are only required for building the online
-documentation. You can disable Fauxton and/or the documentation builds by
-adding the --disable-fauxton and/or --disable-docs flag(s) to the configure script.
+possible.  Note that the latest Erlang OTP versions might not be supported
+properly and they may produce build errors.
+
+You can disable Fauxton and/or the documentation builds by adding the
+`--disable-fauxton` and/or `--disable-docs` flag(s) to the `configure` script.
 
 ### Debian-based Systems
 
@@ -68,17 +66,9 @@ You can install the dependencies by running:
         build-essential pkg-config erlang erlang-reltool \
         libicu-dev libmozjs-60-dev python3
 
-Your distribution may have libmozjs-68-dev instead of 60. Both are supported.
+Your distribution may have `libmozjs-68-dev` instead of 60. Both are supported.
 
 You can install Node.JS [NodeSource](https://github.com/nodesource/distributions#installation-instructions).
-
-You can install the documentation dependencies by running:
-
-    sudo apt-get --no-install-recommends -y install \
-        python-sphinx
-
-    sudo pip install --upgrade sphinx_rtd_theme nose requests hypothesis
-
 
 Be sure to update the version numbers to match your system's available
 packages.
@@ -93,12 +83,6 @@ You can install the dependencies by running:
         python3
 
 You can install Node.JS via [NodeSource](https://github.com/nodesource/distributions#rpminstall).
-
-The built-in packages for Sphinx in RHEL repositories are too old
-to run the documentation build process. Instead, use pip:
-
-    sudo yum install python-pip
-    sudo pip install --upgrade sphinx nose requests hypothesis
 
 ### Mac OS X
 
@@ -115,12 +99,7 @@ You can then install the other dependencies by running:
 You can install Node.JS via the
 [official Macintosh installer](https://nodejs.org/en/download/).
 
-You can install the documentation dependencies by running:
-
-    sudo easy_install pip
-    sudo pip install --upgrade sphinx nose requests hypothesis
-
-You will need Homebrew installed to use the brew command.
+You will need Homebrew installed to use the `brew` command.
 
 Learn more about Homebrew at:
 
@@ -144,8 +123,7 @@ You can install the remaining dependencies by running:
 
     pkg install openssl icu git bash autoconf \
         www/node npm libtool spidermonkey60 \
-        erlang lang/python py37-sphinx py37-pip
-    pip install --upgrade sphinx_rtd_theme nose requests hypothesis
+        erlang lang/python
 
 ## Installing
 

--- a/build-aux/show-test-results.py
+++ b/build-aux/show-test-results.py
@@ -18,7 +18,7 @@ TEST_COLLECTIONS = {
 
 def _attrs(elem):
     ret = {}
-    for (k, v) in elem.attributes.items():
+    for k, v in elem.attributes.items():
         ret[k.lower()] = v
     return ret
 
@@ -381,7 +381,7 @@ def main():
         args.collection = ["eunit", "exunit", "mango", "javascript"]
 
     collections = []
-    for (name, pattern) in TEST_COLLECTIONS.items():
+    for name, pattern in TEST_COLLECTIONS.items():
         if name.lower() not in args.collection:
             continue
         collections.append(TestCollection(name, pattern))

--- a/dev/run
+++ b/dev/run
@@ -452,7 +452,6 @@ def boot_haproxy(ctx):
 
 
 def hack_default_ini(ctx, node, contents):
-
     contents = re.sub(
         "^\[httpd\]$",
         "[httpd]\nenable = true",
@@ -594,7 +593,6 @@ def check_node_alive(url):
 
 
 def set_boot_env(ctx):
-
     # fudge fauxton path
     if os.path.exists("src/fauxton/dist/release"):
         fauxton_root = "src/fauxton/dist/release"

--- a/src/docs/ext/configdomain.py
+++ b/src/docs/ext/configdomain.py
@@ -56,7 +56,6 @@ class ConfigObject(ObjectDescription):
 
 
 class ConfigIndex(Index):
-
     name = "ref"
     localname = "Configuration Quick Reference"
     shortname = "Config Quick Reference"
@@ -79,7 +78,6 @@ class ConfigIndex(Index):
 
 
 class ConfigDomain(Domain):
-
     name = "config"
     label = "CONFIG"
 

--- a/src/mango/test/06-text-default-field-test.py
+++ b/src/mango/test/06-text-default-field-test.py
@@ -16,7 +16,6 @@ import unittest
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class NoDefaultFieldTest(mango.UserDocsTextTests):
-
     DEFAULT_FIELD = False
 
     def test_basic(self):
@@ -32,7 +31,6 @@ class NoDefaultFieldTest(mango.UserDocsTextTests):
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class NoDefaultFieldWithAnalyzer(mango.UserDocsTextTests):
-
     DEFAULT_FIELD = {"enabled": False, "analyzer": "keyword"}
 
     def test_basic(self):
@@ -47,7 +45,6 @@ class NoDefaultFieldWithAnalyzer(mango.UserDocsTextTests):
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class DefaultFieldWithCustomAnalyzer(mango.UserDocsTextTests):
-
     DEFAULT_FIELD = {"enabled": True, "analyzer": "keyword"}
 
     def test_basic(self):

--- a/src/mango/test/07-text-custom-field-list-test.py
+++ b/src/mango/test/07-text-custom-field-list-test.py
@@ -17,7 +17,6 @@ import user_docs
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class CustomFieldsTest(mango.UserDocsTextTests):
-
     FIELDS = [
         {"name": "favorites.[]", "type": "string"},
         {"name": "manager", "type": "boolean"},
@@ -163,7 +162,6 @@ class CustomFieldsTest(mango.UserDocsTextTests):
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class CustomFieldsExistsTest(mango.UserDocsTextTests):
-
     FIELDS = [
         {"name": "exists_field", "type": "string"},
         {"name": "exists_array.[]", "type": "string"},

--- a/src/mango/test/user_docs.py
+++ b/src/mango/test/user_docs.py
@@ -89,7 +89,7 @@ def add_view_indexes(db, kwargs):
         (["twitter"], "twitter"),
         (["ordered"], "ordered"),
     ]
-    for (idx, name) in indexes:
+    for idx, name in indexes:
         assert db.create_index(idx, name=name, ddoc=name) is True
 
 


### PR DESCRIPTION
This change aims to correct the Unix installation instructions in different ways:

- Note that a too new version of the Erlang OTP can cause build problems.
- On recent macOS systems, the `xcode-select --install` command will install a version of Python 3, along with `pip3`, hence there is no need to do that explicitly.
- Sphinx and the respective theme are installed locally via `venv` for building the documentation, so users should only provide a working Python 3 environment (thanks @nickva for mentioning this).
- Fix markdown of file and command names.

## Checklist

- [ ] Documentation changes were backported (separated PR) to affected branches
