### PR TITLE
Allow _local doc writes to the replicator dbs

### DIFF
--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -225,6 +225,8 @@ save_rep_doc(DbName, Doc) ->
 -spec before_doc_update(#doc{}, Db :: any(), couch_db:update_type()) -> #doc{}.
 before_doc_update(#doc{id = <<?DESIGN_DOC_PREFIX, _/binary>>} = Doc, _Db, _UpdateType) ->
     Doc;
+before_doc_update(#doc{id = <<?LOCAL_DOC_PREFIX, _/binary>>} = Doc, _Db, _UpdateType) ->
+    Doc;
 before_doc_update(#doc{} = Doc, _Db, ?REPLICATED_CHANGES) ->
     % Skip internal replicator updates
     Doc;


### PR DESCRIPTION
During the VDU -> BDU update we inadvertently blocked _local doc writes to _replicator dbs. This commit rectifies that.

Add tests for _local, _design, and regular malformed docs for both the default _replicator db as well for for the prefixed version like $db/_replicator. For completeness, update the _scheduler/docs counts test also test both cases.
