### PR TITLE
Reorder top-level smoosh-settings to the correct section

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -482,7 +482,7 @@ authentication_db = _users
 couch_mrview = true
 
 [feature_flags]
-; This enables any database to be created as a partitioned databases (except system db's). 
+; This enables any database to be created as a partitioned databases (except system db's).
 ; Setting this to false will stop the creation of paritioned databases.
 ; paritioned||allowed* = true will scope the creation of partitioned databases
 ; to databases with 'allowed' prefix.
@@ -739,6 +739,15 @@ partitioned||* = true
 ;db_channels = upgrade_dbs,ratio_dbs,slack_dbs
 ;view_channels = upgrade_views,ratio_views,slack_views
 
+; Directory to store the state of smoosh
+state_dir = {{state_dir}}
+
+; Sets the log level for informational compaction related entries.
+;compaction_log_level = debug
+
+; Enable persistence for smoosh state
+;persist = false
+
 ;[smoosh.ratio_dbs]
 ;priority = ratio
 ;min_priority = 2.0
@@ -754,15 +763,6 @@ partitioned||* = true
 ;[smoosh.slack_views]
 ;priority = slack
 ;min_priority = 536870912
-
-; Directory to store the state of smoosh
-state_dir = {{state_dir}}
-
-; Sets the log level for informational compaction related entries.
-;compaction_log_level = debug
-
-; Enable persistence for smoosh state
-;persist = false
 
 [ioq]
 ; The maximum number of concurrent in-flight IO requests that


### PR DESCRIPTION
Moving some top-level settings into the top-level section
to prevent an accidential setup (if enabled) in the wrong 
section (smoosh.slack_views).