### PR TITLE
mango: JSON index selection cleanup & unit tests

### DIFF
--- a/src/mango/src/mango_cursor_special.erl
+++ b/src/mango/src/mango_cursor_special.erl
@@ -32,7 +32,7 @@ create(Db, Indexes, Selector, Opts) ->
     % catchall is the most expensive range
     FieldRanges = InitialRange ++ CatchAll,
     Composited = mango_cursor_view:composite_indexes(Indexes, FieldRanges),
-    {Index, IndexRanges} = mango_cursor_view:choose_best_index(Db, Composited),
+    {Index, IndexRanges} = mango_cursor_view:choose_best_index(Composited),
 
     Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
     Skip = couch_util:get_value(skip, Opts, 0),

--- a/src/mango/src/mango_cursor_special.erl
+++ b/src/mango/src/mango_cursor_special.erl
@@ -22,8 +22,6 @@
     handle_message/2
 ]).
 
--include_lib("couch/include/couch_db.hrl").
--include_lib("couch_mrview/include/couch_mrview.hrl").
 -include("mango_cursor.hrl").
 
 create(Db, Indexes, Selector, Opts) ->

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -225,7 +225,7 @@ composite_prefix([Col | Rest], Ranges) ->
 % Prefix and the FieldRanges. If that is equal, then
 % choose the index with the least number of
 % fields in the index. If we still cannot break the tie,
-% then choose alphabetically based on ddocId.
+% then choose alphabetically based on (dbname, ddocid, view_name).
 % Return the first element's Index and IndexRanges.
 %
 % In the future we can look into doing a cached parallel
@@ -247,9 +247,12 @@ choose_best_index(IndexRanges) ->
                     M when M < 0 ->
                         true;
                     M when M == 0 ->
-                        % We have no other way to choose, so at this point
-                        % select the index based on (dbname, ddocid, view_name) triple
-                        IdxA =< IdxB;
+                        % Restrict the comparison to the (dbname, ddocid, view_name)
+                        % triple -- in case of their equivalence, the original order
+                        % will be maintained.
+                        #idx{dbname = DbNameA, ddoc = DDocA, name = NameA} = IdxA,
+                        #idx{dbname = DbNameB, ddoc = DDocB, name = NameB} = IdxB,
+                        {DbNameA, DDocA, NameA} =< {DbNameB, DDocB, NameB};
                     _ ->
                         false
                 end;

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -23,7 +23,7 @@
     handle_message/2,
     handle_all_docs_message/2,
     composite_indexes/2,
-    choose_best_index/2
+    choose_best_index/1
 ]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -51,7 +51,7 @@ viewcbargs_get(fields, Args) when is_map(Args) ->
 create(Db, Indexes, Selector, Opts) ->
     FieldRanges = mango_idx_view:field_ranges(Selector),
     Composited = composite_indexes(Indexes, FieldRanges),
-    {Index, IndexRanges} = choose_best_index(Db, Composited),
+    {Index, IndexRanges} = choose_best_index(Composited),
 
     Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
     Skip = couch_util:get_value(skip, Opts, 0),
@@ -230,7 +230,7 @@ composite_prefix([Col | Rest], Ranges) ->
 % In the future we can look into doing a cached parallel
 % reduce view read on each index with the ranges to find
 % the one that has the fewest number of rows or something.
-choose_best_index(_DbName, IndexRanges) ->
+choose_best_index(IndexRanges) ->
     Cmp = fun({IdxA, _PrefixA, PrefixDifferenceA}, {IdxB, _PrefixB, PrefixDifferenceB}) ->
         case PrefixDifferenceA - PrefixDifferenceB of
             N when N < 0 -> true;

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -31,6 +31,7 @@
 -include_lib("fabric/include/fabric.hrl").
 
 -include("mango_cursor.hrl").
+-include("mango_idx.hrl").
 -include("mango_idx_view.hrl").
 
 -define(HEARTBEAT_INTERVAL_IN_USEC, 4000000).
@@ -230,6 +231,11 @@ composite_prefix([Col | Rest], Ranges) ->
 % In the future we can look into doing a cached parallel
 % reduce view read on each index with the ranges to find
 % the one that has the fewest number of rows or something.
+-type range() :: {binary(), any(), binary(), any()} | empty.
+
+-spec choose_best_index(IndexRanges) -> Selection when
+    IndexRanges :: nonempty_list({#idx{}, [range()], integer()}),
+    Selection :: {#idx{}, [range()]}.
 choose_best_index(IndexRanges) ->
     Cmp = fun({IdxA, _PrefixA, PrefixDifferenceA}, {IdxB, _PrefixB, PrefixDifferenceB}) ->
         case PrefixDifferenceA - PrefixDifferenceB of


### PR DESCRIPTION
Per #4413, increase the unit test coverage for the Mango JSON index selection function.  Besides that, this PR:

- introduces a type specification for the function,
- brings the assumed behavior explained in the comments in sync with the implementation,
- removes all the unused parts.

Brief code coverage stats (`make eunit apps=mango`) -- before:

```
Code Coverage:
[..]
mango_cursor_view     :  20%
[..]
Total                 : 15%
```

after:

```
======================== EUnit ========================
module 'mango_cursor_view'
[..]
  mango_cursor_view: choose_best_index_with_singleton_test...ok
  mango_cursor_view: choose_best_index_lowest_difference_test...ok
  mango_cursor_view: choose_best_index_least_number_of_fields_test...ok
  mango_cursor_view: choose_best_index_lowest_index_triple_test...ok
[..]
Code Coverage:
[..]
mango_cursor_view     :  33%
[..]
Total                 : 17%
```