### PR TITLE
Improve replication scheduler docs tests

### DIFF
--- a/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
@@ -60,7 +60,7 @@ scheduler_docs_test_prefixed_db_test_() ->
         fun setup_prefixed_replicator_db/0,
         fun teardown/1,
         [
-            ?TDEF_FE(t_scheduler_docs_total_rows, 10)
+            ?TDEF_FE(t_scheduler_docs_total_rows, 20)
         ]
     }.
 
@@ -117,7 +117,7 @@ t_scheduler_docs_total_rows({_Ctx, {RepDb, Source, Target}}) ->
                 {_, #{}} -> wait
             end
         end,
-        10000,
+        20000,
         1000
     ),
     Docs = maps:get(<<"docs">>, Body),
@@ -161,8 +161,13 @@ t_doc_fields_are_updated({_Ctx, {RepDb, Source, Target}}) ->
     StateDoc = test_util:wait(
         fun() ->
             case req(get, RepDocUrl) of
-                {200, #{<<"_replication_state">> := <<"completed">>} = StDoc} -> StDoc;
-                {_, #{}} -> wait
+                {200, #{<<"_replication_state">> := <<"completed">>} = StDoc} ->
+                    case is_map_key(<<"_replication_id">>, StDoc) of
+                        true -> wait;
+                        false -> StDoc
+                    end;
+                {_, #{}} ->
+                    wait
             end
         end,
         10000,


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Increase timeout for `t_scheduler_docs_total_rows`.

Continue to wait if "_replication_id" is still present in `t_doc_fields_are_updated`.

This should improve the robustness of these failing tests:
```
  couch_replicator_scheduler_docs_tests:63: scheduler_docs_test_prefixed_db_test_ (t_scheduler_docs_total_rows)...*timed out*
in function timer:sleep/1 (timer.erl, line 152)
in call from test_util:wait/5 (src/test_util.erl, line 235)
in call from couch_replicator_scheduler_docs_tests:t_scheduler_docs_total_rows/1 (test/eunit/couch_replicator_scheduler_docs_tests.erl, line 113)
in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356)
in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514)
in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456)
  undefined

couch_replicator_scheduler_docs_tests:99: with (t_doc_fields_are_updated)...*failed*
in function couch_replicator_scheduler_docs_tests:t_doc_fields_are_updated/1 (test/eunit/couch_replicator_scheduler_docs_tests.erl, line 182)
in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356)
in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514)
in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 346)
in call from eunit_proc:run_group/2 (eunit_proc.erl, line 570)
**error:{assert,[{module,couch_replicator_scheduler_docs_tests},
         {line,182},
         {expression,"is_map_key ( << \"_replication_id\" >> , StateDoc )"},
         {expected,false},
         {value,true}]}
  output:<<"">>
```

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit suites=couch_replicator
```
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
