### PR TITLE
fix(mango): fix specification of `choose_best_index/1`

### DIFF
--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -231,7 +231,8 @@ composite_prefix([Col | Rest], Ranges) ->
 % In the future we can look into doing a cached parallel
 % reduce view read on each index with the ranges to find
 % the one that has the fewest number of rows or something.
--type range() :: {binary(), any(), binary(), any()} | empty.
+-type comparator() :: '$lt' | '$lte' | '$eq' | '$gte' | '$gt'.
+-type range() :: {comparator(), any(), comparator(), any()} | empty.
 
 -spec choose_best_index(IndexRanges) -> Selection when
     IndexRanges :: nonempty_list({#idx{}, [range()], integer()}),


### PR DESCRIPTION
Comparators are not represented by binary strings in the selection ranges, captured by the `range/0` type.  Although that is how they are coming from the corresponding parsed JSON object, they are being translated to specific atoms on the fly.  Thanks for @nickva noticing this!