### PR TITLE
docs(`README-DEV`): chase rename of `dreyfus-test` to `elixir-search`

### DIFF
--- a/README-DEV.rst
+++ b/README-DEV.rst
@@ -211,7 +211,7 @@ There is an additional Elixir-based integration test suite for
 Dreyfus, which is not run automatically by the ``check`` target but it
 could be done manually via the corresponding target::
 
-    make dreyfus-test
+    make elixir-search
 
 Note that this requires a running Clouseau instance with the name
 `clouseau@127.0.0.1`.  The easiest way to get it is to clone the


### PR DESCRIPTION
This is a documentation follow-up for #4425.