### PR TITLE
hide shard-sync and purge documents from `_local_docs`

### DIFF
--- a/src/chttpd/test/eunit/chttpd_local_docs_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_local_docs_tests.erl
@@ -1,0 +1,198 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_local_docs_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(USER, "chttpd_local_docs_test_admin").
+-define(PASS, "pass").
+-define(AUTH, {basic_auth, {?USER, ?PASS}}).
+-define(JSON, {"Content-Type", "application/json"}).
+
+setup() ->
+    Hashed = couch_passwords:hash_admin_password(?PASS),
+    ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist = false),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Db = binary_to_list(?tempdb()),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    Url = lists:concat(["http://", Addr, ":", Port, "/"]),
+    ok = create_db(Url, Db),
+    {Url, Db}.
+
+teardown({Url, Db}) ->
+    delete_db(Url, Db),
+    ok = config:delete("admins", ?USER, _Persist = false).
+
+start_couch() ->
+    test_util:start_couch([chttpd]).
+
+stop_couch(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+chttpd_local_docs_test_() ->
+    {
+        "chttpd _local_docs tests",
+        {
+            setup,
+            fun start_couch/0,
+            fun stop_couch/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    ?TDEF_FE(t_local_docs_doesnt_include_system_docs),
+                    ?TDEF_FE(t_local_docs_does_include_system_docs_w_param)
+                ]
+            }
+        }
+    }.
+
+t_local_docs_doesnt_include_system_docs({Top, Db}) ->
+    Path = Top ++ Db,
+    Docs = [
+        #{
+            <<"_id">> => <<"_local/shard-sync-foo-bar">>,
+            <<"_rev">> => <<"0-1">>,
+            <<"seq">> => 1,
+            <<"target_uuid">> => <<"4f3eb3181db904d62176fb81626f84d0">>
+        },
+        #{
+            <<"_id">> => <<"_local/purge-mrview-foo-bar">>,
+            <<"_rev">> => <<"0-1">>,
+            <<"ddoc_id">> => <<"_design/ddoc1">>,
+            <<"purge_seq">> => 0,
+            <<"signature">> => [1, 2, 3],
+            <<"type">> => <<"mrview">>,
+            <<"updated_on">> => 1676995502
+        },
+        #{
+            <<"_id">> => <<"_local/1-foo-bar">>
+        },
+        #{
+            <<"_id">> => <<"_local/2-foo-bar">>
+        }
+    ],
+    Body = #{<<"docs">> => Docs},
+    {Code, _} = req(post, Path ++ "/_bulk_docs", Body),
+    ?assertEqual(201, Code),
+    {Code1, Res} = req(get, Path ++ "/_local_docs"),
+    ?assertEqual(200, Code1),
+    ?assertEqual(
+        #{
+            <<"total_rows">> => null,
+            <<"offset">> => null,
+            <<"rows">> => [
+                #{
+                    <<"id">> => <<"_local/1-foo-bar">>,
+                    <<"key">> => <<"_local/1-foo-bar">>,
+                    <<"value">> => #{<<"rev">> => <<"0-1">>}
+                },
+                #{
+                    <<"id">> => <<"_local/2-foo-bar">>,
+                    <<"key">> => <<"_local/2-foo-bar">>,
+                    <<"value">> => #{<<"rev">> => <<"0-1">>}
+                }
+            ]
+        },
+        Res
+    ).
+
+t_local_docs_does_include_system_docs_w_param({Top, Db}) ->
+    Path = Top ++ Db,
+    Docs = [
+        #{
+            <<"_id">> => <<"_local/shard-sync-foo-bar">>,
+            <<"_rev">> => <<"0-1">>,
+            <<"seq">> => 1,
+            <<"target_uuid">> => <<"4f3eb3181db904d62176fb81626f84d0">>
+        },
+        #{
+            <<"_id">> => <<"_local/purge-mrview-foo-bar">>,
+            <<"_rev">> => <<"0-1">>,
+            <<"ddoc_id">> => <<"_design/ddoc1">>,
+            <<"purge_seq">> => 0,
+            <<"signature">> => [1, 2, 3],
+            <<"type">> => <<"mrview">>,
+            <<"updated_on">> => 1676995502
+        },
+        #{
+            <<"_id">> => <<"_local/1-foo-bar">>
+        },
+        #{
+            <<"_id">> => <<"_local/2-foo-bar">>
+        }
+    ],
+    Body = #{<<"docs">> => Docs},
+    {Code, _} = req(post, Path ++ "/_bulk_docs", Body),
+    ?assertEqual(201, Code),
+    {Code1, Res} = req(get, Path ++ "/_local_docs?include_system=true"),
+    ?assertEqual(200, Code1),
+    ?assertEqual(
+        #{
+            <<"total_rows">> => null,
+            <<"offset">> => null,
+            <<"rows">> => [
+                #{
+                    <<"id">> => <<"_local/1-foo-bar">>,
+                    <<"key">> => <<"_local/1-foo-bar">>,
+                    <<"value">> => #{<<"rev">> => <<"0-1">>}
+                },
+                #{
+                    <<"id">> => <<"_local/2-foo-bar">>,
+                    <<"key">> => <<"_local/2-foo-bar">>,
+                    <<"value">> => #{<<"rev">> => <<"0-1">>}
+                },
+                #{
+                    <<"id">> => <<"_local/purge-mrview-foo-bar">>,
+                    <<"key">> => <<"_local/purge-mrview-foo-bar">>,
+                    <<"value">> => #{<<"rev">> => <<"0-2">>}
+                },
+                #{
+                    <<"id">> => <<"_local/shard-sync-foo-bar">>,
+                    <<"key">> => <<"_local/shard-sync-foo-bar">>,
+                    <<"value">> => #{<<"rev">> => <<"0-2">>}
+                }
+            ]
+        },
+        Res
+    ).
+
+create_db(Top, Db) ->
+    case req(put, Top ++ Db) of
+        {201, #{}} ->
+            ok;
+        Error ->
+            error({failed_to_create_test_db, Db, Error})
+    end.
+
+delete_db(Top, Db) ->
+    case req(delete, Top ++ Db) of
+        {200, #{}} ->
+            ok;
+        Error ->
+            error({failed_to_delete_test_db, Db, Error})
+    end.
+
+req(Method, Url) ->
+    Headers = [?JSON, ?AUTH],
+    {ok, Code, _, Res} = test_request:request(Method, Url, Headers),
+    {Code, jiffy:decode(Res, [return_maps])}.
+
+req(Method, Url, #{} = Body) ->
+    req(Method, Url, jiffy:encode(Body));
+req(Method, Url, Body) ->
+    Headers = [?JSON, ?AUTH],
+    {ok, Code, _, Res} = test_request:request(Method, Url, Headers, Body),
+    {Code, jiffy:decode(Res, [return_maps])}.

--- a/src/docs/src/cluster/purging.rst
+++ b/src/docs/src/cluster/purging.rst
@@ -66,8 +66,10 @@ Local Purge Checkpoint Documents
 Indexes and internal replications of the database with purges create and
 periodically update local checkpoint purge documents:
 ``_local/purge-{type}-{hash}``. These documents report the last ``purge_seq``
-processed by them and the timestamp of the last processing. An example of a
-local checkpoint purge document:
+processed by them and the timestamp of the last processing. These documents
+are only visible in ``_local_docs`` when you add a ``include_system=true``
+parameter, so e.g. ``/test-db/_local_docs?include_system=true``. An example
+of a local checkpoint purge document:
 
 .. code-block:: json
 


### PR DESCRIPTION
It hides the shard-sync and purge documents from the response unless a `?include_system=true` is given.



## Overview

Currently the system docs are included in `_local_docs`. This has shown to confuse users, and they try to delete them, which might fail and/or lead to problems.

## Testing recommendations

```
curl -X PUT http://admin:admin@127.0.0.1:15984/test-db
curl -X PUT http://admin:admin@127.0.0.1:15984/test-db/doc -d '{"a":1}'
curl -X POST http://admin:admin@127.0.0.1:15984/test-db/_purge -d '{"doc":["1-23202479633c2b380f79507a776743d5"]}' -Hcontent-type:application/json

sleep 5

# this shouldn't include any system documents
curl http://admin:admin@127.0.0.1:15984/test-db/_local_docs

# this should include the system documents
curl http://admin:admin@127.0.0.1:15984/test-db/_local_docs?include_system=true
```

## Related Issues or Pull Requests

- #3930

## Checklist

I think most of this is not applicable. Regarding tests, I'm not sure if there should be added tests for this. It would mean a sleep in a test, wouldn't it?

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [x] Documentation changes were backported (separated PR) to affected branches
