### PR TITLE
Fix typo in "feature_flags" section comment

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -483,8 +483,8 @@ couch_mrview = true
 
 [feature_flags]
 ; This enables any database to be created as a partitioned databases (except system db's).
-; Setting this to false will stop the creation of paritioned databases.
-; paritioned||allowed* = true will scope the creation of partitioned databases
+; Setting this to false will stop the creation of partitioned databases.
+; partitioned||allowed* = true will scope the creation of partitioned databases
 ; to databases with 'allowed' prefix.
 partitioned||* = true
 


### PR DESCRIPTION
Fix typo: paritioned -> partitioned