### PR TITLE
Unifying the notation of dynamic parameters in the docs

### DIFF
--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -217,7 +217,7 @@ Authentication Configuration
             To retrieve a complete list of supported hash algorithms you can use our
             ``bin/remsh`` script and retrieve a full list of available hash algorithms
             with ``crypto:supports(hashs).`` or use the
-            :ref:`_node/$node/_versions <api/server/versions>` endpoint to retrieve the
+            :ref:`_node/{node-name}/_versions <api/server/versions>` endpoint to retrieve the
             hashes.
 
         .. warning::

--- a/src/docs/src/config/compaction.rst
+++ b/src/docs/src/config/compaction.rst
@@ -99,7 +99,7 @@ following parameters.
         observe the system and make a smarter decision about what to compact
         first. Hardly ever changed from the default of 30 (seconds).
 
-.. config:section:: smoosh.<channel> :: Per-channel configuration
+.. config:section:: smoosh.{channel-name} :: Per-channel configuration
 
 The following settings control the resource allocation for a given compaction
 channel.

--- a/src/docs/src/maintenance/compaction.rst
+++ b/src/docs/src/maintenance/compaction.rst
@@ -84,7 +84,7 @@ and another one for views.
 Channel Configuration
 ---------------------
 
-Channels are defined using ``[smoosh.<channel_name>]`` configuration blocks, and
+Channels are defined using ``[smoosh.{channel-name}]`` configuration blocks, and
 activated by naming the channel in the ``db_channels`` or ``view_channels``
 configuration setting in the ``[smoosh]`` block. The default configuration is
 

--- a/src/docs/src/whatsnew/2.3.rst
+++ b/src/docs/src/whatsnew/2.3.rst
@@ -99,8 +99,8 @@ Upgrade Notes
   a reverse proxy server in front of CouchDB (such as haproxy) to proxy access to other
   services or domains alongside CouchDB.
 * :ghissue:`1543`: The node-local (default port 5986) ``/_restart`` endpoint has been
-  replaced by the clustered (default port 5984) endpoint ``/_node/$node/_restart`` and
-  ``/_node/_local/_restart`` endpoints. The node-local endpoint has been removed.
+  replaced by the clustered (default port 5984) endpoint ``/_node/{node-name}/_restart``
+  and ``/_node/_local/_restart`` endpoints. The node-local endpoint has been removed.
 * :ghissue:`1764`: All python scripts shipped with CouchDB, including ``couchup`` and the
   ``dev/run`` development cluster script, now specify and require Python 3.x.
 * :ghissue:`1396`: CouchDB is now compatible with Erlang 21.x.

--- a/src/docs/src/whatsnew/3.2.rst
+++ b/src/docs/src/whatsnew/3.2.rst
@@ -57,7 +57,7 @@ Features and Enhancements
   sequences.
 
 * :ghissue:`3798`: ICU driver and collator algorithm versions are
-  returned in the ``_node/$node/_versions`` result.
+  returned in the ``_node/{node-name}/_versions`` result.
 
 * :ghissue:`3801`: Users with the ``_metrics`` role can now read
   ``_prometheus`` metrics.

--- a/src/docs/src/whatsnew/3.3.rst
+++ b/src/docs/src/whatsnew/3.3.rst
@@ -64,7 +64,7 @@ Features and Enhancements
   test coverage to 90%.
 
 * :ghissue:`3798`: Add ``libicu`` version and collation algorithm version to
-  ``/_node/_local/_versions``.
+  ``/_node/{node-name}/_versions``.
 
 * :ghissue:`3837`: The Erlang source tree is now auto-formatted with ``erlfmt``.
 
@@ -134,7 +134,7 @@ Features and Enhancements
   -> sha256). This introduces a new config setting ``hash_algorithms``. New cookie
   values are hashed with sha256, sha1 hashes are still accepted. Admins can set
   this to sha256 only. Sha1 will be disallowed in the next major release. Show
-  supported hash algorithms in ``/_node/_local/_versions`` endpoint.
+  supported hash algorithms in ``/_node/{node-name}/_versions`` endpoint.
 
 * :ghissue:`4179`: Don't double-encode changes sequence strings in the
   replicator.
@@ -408,7 +408,7 @@ Docs
 
 * :ghissue:`4307`, :ghissue:`4174`: Update Sphinx to version 5.3.0
 
-* :ghissue:`4170`: Document the ``/_node/_local/_versions`` endpoint.
+* :ghissue:`4170`: Document the ``/_node/{node-name}/_versions`` endpoint.
 
 Builds
 ------

--- a/src/smoosh/operator_guide.md
+++ b/src/smoosh/operator_guide.md
@@ -115,14 +115,14 @@ file are no longer live; this includes old btree nodes and document bodies.
 Compaction takes this file and writes a new file that only contains live data.
 
 `total_data` is the number of bytes in the file as reported by `ls -al
-filename`. In `db_info` reponse this is the `sizes.file` value.
+filename`. In `db_info` response this is the `sizes.file` value.
 
 ### Defining a channel
 
 Defining a channel is done via normal dbcore configuration, with some
 convention as to the parameter names.
 
-Channel configuration is defined using `smoosh.$channel_name` top level config
+Channel configuration is defined using `smoosh.{channel-name}` top level config
 options. Defining a channel is just setting the various options you want
 for the channel, then bringing it into smoosh's sets of active channels by
 adding it to either `db_channels` or `view_channels`.


### PR DESCRIPTION
The pattern `{var}` has been established to clarify dynamic parameters in the documentation. 
Standardization and clarification of some not yet converted notation of parameters.