### PR TITLE
Upgrade hash algorithm for proxy auth

### DIFF
--- a/src/docs/src/api/server/authn.rst
+++ b/src/docs/src/api/server/authn.rst
@@ -291,22 +291,24 @@ remotely authenticated user. By default, the client just needs to pass specific
 headers to CouchDB with related requests:
 
 - :config:option:`X-Auth-CouchDB-UserName <chttpd_auth/x_auth_username>`:
-  username;
+  username
 - :config:option:`X-Auth-CouchDB-Roles <chttpd_auth/x_auth_roles>`:
-  comma-separated (``,``) list of user roles;
+  comma-separated (``,``) list of user roles
 - :config:option:`X-Auth-CouchDB-Token <chttpd_auth/x_auth_token>`:
   authentication token. When
   :config:option:`proxy_use_secret <chttpd_auth/proxy_use_secret>`
   is set (which is strongly recommended!), this header provides an HMAC of the
   username to authenticate and the secret token to prevent requests from
-  untrusted sources. (Use the SHA1 of the username and sign with the secret)
+  untrusted sources. (Use one of the configured hash algorithms in
+  :config:option:`chttpd_auth/hash_algorithms <chttpd_auth/hash_algorithms>`
+  and sign the username with the secret)
 
 **Creating the token (example with openssl)**:
 
 .. code-block:: sh
 
-    echo -n "foo" | openssl dgst -sha1 -hmac "the_secret"
-    # (stdin)= 22047ebd7c4ec67dfbcbad7213a693249dbfbf86
+    echo -n "foo" | openssl dgst -sha256 -hmac "the_secret"
+    # (stdin)= 3f0786e96b20b0102b77f1a49c041be6977cfb3bf78c41a12adc121cd9b4e68a
 
 **Request**:
 
@@ -318,7 +320,7 @@ headers to CouchDB with related requests:
     Content-Type: application/json; charset=utf-8
     X-Auth-CouchDB-Roles: users,blogger
     X-Auth-CouchDB-UserName: foo
-    X-Auth-CouchDB-Token: 22047ebd7c4ec67dfbcbad7213a693249dbfbf86
+    X-Auth-CouchDB-Token: 3f0786e96b20b0102b77f1a49c041be6977cfb3bf78c41a12adc121cd9b4e68a
 
 **Response**:
 
@@ -351,7 +353,7 @@ headers to CouchDB with related requests:
         }
     }
 
-Note that you don't need to request :ref:`session <api/auth/session>`
+Note that you don't need to request a :ref:`session <api/auth/session>`
 to be authenticated by this method if all required HTTP headers are provided.
 
 .. _api/auth/jwt:

--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -196,14 +196,22 @@ Authentication Configuration
             [chttpd_auth]
             authentication_redirect = /_utils/session.html
 
-    .. config:option:: hash_algorithms :: Supported hash algorithms for cookie auth
+    .. config:option:: hash_algorithms :: Supported hash algorithms for cookie and \
+            proxy auth
 
         .. versionadded:: 3.3
 
-        Sets the HMAC hash algorithm used for cookie authentication. You can provide a
-        comma-separated list of hash algorithms. New cookie sessions or
+        .. note::
+            Until CouchDB version 3.3.1, :ref:`api/auth/proxy` used only the hash
+            algorithm ``sha1`` as validation of
+            :config:option:`X-Auth-CouchDB-Token <chttpd_auth/x_auth_token>`.
+
+        Sets the HMAC hash algorithm used for cookie and proxy authentication. You can
+        provide a comma-separated list of hash algorithms. New cookie sessions or
         session updates are calculated with the first hash algorithm. All values in the
-        list can be used to decode the cookie session. ::
+        list can be used to decode the cookie session and the token
+        :config:option:`X-Auth-CouchDB-Token <chttpd_auth/x_auth_token>` for
+        :ref:`api/auth/proxy`. ::
 
             [chttpd_auth]
             hash_algorithms = sha256, sha


### PR DESCRIPTION
## Overview

Proxy auth can now use one of the configured hash algorithms
from chttpd_auth/hash_algorithms to decode authentication tokens.

## Testing recommendations

Start CouchDB with the following additional config:
```
;Start ProxyAuth Test
[chttpd]
authentication_handlers = {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}

[chttpd_auth]
proxy_use_secret = true
secret = the_secret
hash_algorithms = sha256, sha
;End ProxyAuth Test
```
### Example Tokens
```
CouchDB (sha1;working) = fc4a82fd0c313c1e95ba60b6fd4c769f3f9e230d
CouchDB (sha256;working) = 4441087d94449b0a5e58cd593cfb14341637b120c90884389d9747e93c2463cf
CouchDB (md5;failing) = 3493e0a670bb83ebcdd3fc6201e54fd2
```

### Example requests

#### Working
```
curl -L 'http://localhost:15984/_session' -H 'X-Auth-CouchDB-UserName: CouchDB' -H 'X-Auth-CouchDB-Roles: PROXY-USER-ROLE' -H 'X-Auth-CouchDB-Token: fc4a82fd0c313c1e95ba60b6fd4c769f3f9e230d'
curl -L 'http://localhost:15984/_session' -H 'X-Auth-CouchDB-UserName: CouchDB' -H 'X-Auth-CouchDB-Roles: PROXY-USER-ROLE' -H 'X-Auth-CouchDB-Token: 4441087d94449b0a5e58cd593cfb14341637b120c90884389d9747e93c2463cf'
```
#### Results
```
{"ok":true,"userCtx":{"name":"CouchDB","roles":["PROXY-USER-ROLE"]},"info":{"authentication_handlers":["proxy","default"],"authenticated":"proxy"}}
{"ok":true,"userCtx":{"name":"CouchDB","roles":["PROXY-USER-ROLE"]},"info":{"authentication_handlers":["proxy","default"],"authenticated":"proxy"}}
```

#### Failing (no "info.authenticated" field)
```
curl -L 'http://localhost:15984/_session' -H 'X-Auth-CouchDB-UserName: CouchDB' -H 'X-Auth-CouchDB-Roles: PROXY-USER-ROLE' -H 'X-Auth-CouchDB-Token: 3493e0a670bb83ebcdd3fc6201e54fd2'
```
#### Result
```
{"ok":true,"userCtx":{"name":null,"roles":[]},"info":{"authentication_handlers":["proxy","default"]}}
```

### Running tests
```
$ make eunit apps=chttpd suites=chttpd_auth_tests

======================== EUnit ========================
module 'chttpd_auth_tests'
  _up
    chttpd_auth_tests:97: -should_handle_require_valid_user_except_up_on_up_route/1-fun-4-...[0.001 s] ok
    chttpd_auth_tests:135: -should_handle_require_valid_user_except_up_on_non_up_routes/1-fun-4-...[0.001 s] ok
    [done in 0.011 s]
  Testing hash algorithms for proxy auth
    chttpd_auth_tests:97: -with/1-fun-0- (test_hash_algorithms_with_proxy_auth_should_work)...[0.068 s] ok
    chttpd_auth_tests:97: -with/1-fun-0- (test_hash_algorithms_with_proxy_auth_should_fail)...[0.001 s] ok
    [done in 0.075 s]
  [done in 1.931 s]
=======================================================
  All 4 tests passed.
```

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [n/a] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [n/a] Documentation changes were backported (separated PR) to affected branches
