### PR TITLE
Unifying the notation of dynamic parameters in the docs 2

### DIFF
--- a/src/docs/src/api/server/authn.rst
+++ b/src/docs/src/api/server/authn.rst
@@ -457,7 +457,7 @@ surrounded by at least one space on each side. This might be useful in the
 character.
 
 JWT tokens that do not include a ``kid`` claim will be validated against the
-``$alg:_default`` key.
+``{alg}:_default`` key.
 
 It is mandatory to specify the algorithm associated with every key for security
 reasons (notably presenting a HMAC-signed token using an RSA or EC public key

--- a/src/docs/src/cluster/purging.rst
+++ b/src/docs/src/cluster/purging.rst
@@ -65,7 +65,7 @@ Local Purge Checkpoint Documents
 ====================================
 Indexes and internal replications of the database with purges create and
 periodically update local checkpoint purge documents:
-``_local/purge-$type-$hash``. These documents report the last ``purge_seq``
+``_local/purge-{type}-{hash}``. These documents report the last ``purge_seq``
 processed by them and the timestamp of the last processing. An example of a
 local checkpoint purge document:
 

--- a/src/docs/src/config/replicator.rst
+++ b/src/docs/src/config/replicator.rst
@@ -329,7 +329,7 @@ Fair Share Replicator Share Allocation
 
 .. config:section:: replicator.shares :: Per-Database Fair Share Allocation
 
-    .. config:option:: $replicator_db :: Value for a replicator database
+    .. config:option:: {replicator_db} :: Value for a replicator database
 
         .. versionadded:: 3.2.0
 
@@ -338,7 +338,7 @@ Fair Share Replicator Share Allocation
         value is 100, minimum is 1 and maximum is 1000. The
         configuration may be set even if the database does not exist.
 
-        In this context the option ``$replicator_db`` acts as a placeholder
+        In this context the option ``{replicator_db}`` acts as a placeholder
         for your replicator database name. The default replicator database is
         ``_replicator``. Additional replicator databases can be created. To be
         recognized as such by the system, their database names should end with


### PR DESCRIPTION
The pattern {var} has been established to clarify dynamic parameters in the documentation. Standardization and clarification of some not yet converted notation of parameters.
