### PR TITLE
Enable FIPS mode at runtime

### DIFF
--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -99,3 +99,14 @@
 #-proto_dist couch
 #-couch_dist no_tls '"clouseau@127.0.0.1"'
 #-ssl_dist_optfile <path/to/couch_ssl_dist.conf>
+
+# Enable FIPS mode
+#   https://www.erlang.org/doc/apps/crypto/fips.html
+#   Ensure that:
+#    - Erlang is built with --enable-fips configuration option
+#    - Crypto library (e.g. OpenSSL) supports this mode
+#
+# When the mode is successfully enabled "Welcome" message should show `fips`
+# in the features list.
+#
+#-crypto fips_mode true

--- a/src/config/test/config_tests.erl
+++ b/src/config/test/config_tests.erl
@@ -651,11 +651,14 @@ should_enable_features() ->
 
     ?assertEqual(ok, config:enable_feature(snek)),
     ?assertEqual([snek], config:features()),
+    ?assert(config:is_enabled(snek)),
 
     ?assertEqual(ok, config:enable_feature(snek)),
     ?assertEqual([snek], config:features()),
 
     ?assertEqual(ok, config:enable_feature(dogo)),
+    ?assert(config:is_enabled(dogo)),
+    ?assert(config:is_enabled(snek)),
     ?assertEqual([dogo, snek], config:features()).
 
 should_disable_features() ->
@@ -666,9 +669,11 @@ should_disable_features() ->
     ?assertEqual([snek], config:features()),
 
     ?assertEqual(ok, config:disable_feature(snek)),
+    ?assertNot(config:is_enabled(snek)),
     ?assertEqual([], config:features()),
 
     ?assertEqual(ok, config:disable_feature(snek)),
+    ?assertNot(config:is_enabled(snek)),
     ?assertEqual([], config:features()).
 
 should_keep_features_on_config_restart() ->
@@ -678,6 +683,7 @@ should_keep_features_on_config_restart() ->
     config:enable_feature(snek),
     ?assertEqual([snek], config:features()),
     with_process_restart(config),
+    ?assert(config:is_enabled(snek)),
     ?assertEqual([snek], config:features()).
 
 should_notify_on_config_reload(Subscription, {_Apps, Pid}) ->

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -274,14 +274,6 @@ init([N]) ->
     % Mark being able to receive documents with an _access property as a supported feature
     config:enable_feature('access-ready'),
 
-    % Mark if fips is enabled
-    case crypto:info_fips() == enabled of
-        true ->
-            config:enable_feature('fips');
-        false ->
-            ok
-    end,
-
     % read config and register for configuration changes
 
     % just stop if one of the config settings change. couch_server_sup

--- a/src/couch/test/eunit/couch_hash_test.erl
+++ b/src/couch/test/eunit/couch_hash_test.erl
@@ -1,0 +1,52 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_hash_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+-define(XY_HASH, <<62, 68, 16, 113, 112, 165, 32, 88, 42, 222, 82, 47, 167, 60, 29, 21>>).
+
+couch_hash_test_() ->
+    {
+        foreach,
+        fun setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(t_fips_disabled),
+            ?TDEF_FE(t_fips_enabled)
+        ]
+    }.
+
+setup() ->
+    Ctx = test_util:start_couch([crypto]),
+    config:disable_feature(fips),
+    Ctx.
+
+teardown(Ctx) ->
+    config:disable_feature(fips),
+    test_util:stop_couch(Ctx).
+
+t_fips_disabled(_) ->
+    ?assertEqual(?XY_HASH, couch_hash:md5_hash(<<"xy">>)),
+    H = couch_hash:md5_hash_init(),
+    H1 = couch_hash:md5_hash_update(H, <<"x">>),
+    H2 = couch_hash:md5_hash_update(H1, <<"y">>),
+    ?assertEqual(?XY_HASH, couch_hash:md5_hash_final(H2)).
+
+t_fips_enabled(_) ->
+    config:enable_feature(fips),
+    ?assertEqual(?XY_HASH, couch_hash:md5_hash(<<"xy">>)),
+    H = couch_hash:md5_hash_init(),
+    H1 = couch_hash:md5_hash_update(H, <<"x">>),
+    H2 = couch_hash:md5_hash_update(H1, <<"y">>),
+    ?assertEqual(?XY_HASH, couch_hash:md5_hash_final(H2)).


### PR DESCRIPTION
This enables configuring FIPS mode at runtime without the need for a custom build.

Use a persistent term for this, and all other features. This should allow quick feature checks [1]

[1] Silly benchmark shows about a 0.3 microsecond overhead

```
(node1@127.0.0.1)32> element(1, timer:tc(fun() -> (fun F(0) -> ok; F(N) -> ok, F(N-1) end)(1000000) end)) / 1000000.
0.574429
(node1@127.0.0.1)33> element(1, timer:tc(fun() -> (fun F(0) -> ok; F(N) -> config:is_enabled(fips), F(N-1) end)(1000000) end)) / 1000000.
0.783567
```

Issue: #4442
