### PR TITLE
Update Erlang 24 for CI

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -14,7 +14,7 @@
 // the License.
 
 // Erlang version embedded in binary packages
-ERLANG_VERSION = '24.3.4.7'
+ERLANG_VERSION = '24.3.4.9'
 
 // Erlang version used for rebar in release process. CouchDB will not build from
 // the release tarball on Erlang versions older than this

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -247,7 +247,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '23.3.4.18', '24.3.4.7', '25.2'
+            values '23.3.4.18', '24.3.4.9', '25.2'
           }
           axis {
             name 'SM_VSN'


### PR DESCRIPTION
Multi-arch images were updated in https://hub.docker.com/r/apache/couchdbci-debian/tags
