### PR TITLE
Fix file writer default reopen CHECK_INTERVAL

### DIFF
--- a/src/couch_log/src/couch_log_writer_file.erl
+++ b/src/couch_log/src/couch_log_writer_file.erl
@@ -29,7 +29,7 @@
     last_check
 }).
 
--define(CHECK_INTERVAL, 30000000).
+-define(CHECK_INTERVAL, 30000).
 
 -ifdef(TEST).
 -export([


### PR DESCRIPTION
## Overview

Logging file_writer CHECK_INTERVAL appears to be set to 8 hours. Deleting the log file would take 8 hours to be detected. Couch documentation says this value should be 30 seconds. 

## Testing recommendations

Use file writer for logging. Delete log file. Wait 30 seconds and observe file is not recreated.

## Related Issues or Pull Requests


## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
