### PR TITLE
Update last_check in file logger record

### DIFF
--- a/src/couch_log/src/couch_log_writer_file.erl
+++ b/src/couch_log/src/couch_log_writer_file.erl
@@ -107,8 +107,11 @@ maybe_reopen(St) ->
     } = St,
     Now = os:timestamp(),
     case timer:now_diff(Now, LastCheck) > ?CHECK_INTERVAL of
-        true -> reopen(St);
-        false -> {ok, St}
+        true ->
+            NewSt = St#st{last_check = Now},
+            reopen(NewSt);
+        false ->
+            {ok, St}
     end.
 
 reopen(St) ->


### PR DESCRIPTION
## Overview

While investigating issues in my deployment around logrotate I discovered the file logger last_check doesn't appear to be updated after init is called, this could result in maybe_reopen being called with every log write 30 seconds after init is called. The fix works as the documentation specifies, but I wasn't able to measure a meaningful performance harm from the previous functionality. Throwing it up in case it's desirable.

## Testing recommendations

With the fix observe it can take up to 30 seconds from the last check before the log is recreated after deletion. Without the fix the log gets recreated much more quickly.

## Related Issues or Pull Requests

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
