### PR TITLE
Fix bad prometheus section name

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -848,6 +848,8 @@ state_dir = {{state_dir}}
 additional_port = false
 bind_address = 127.0.0.1
 port = {{prometheus_port}}
+; Refresh interval in seconds
+;interval = 5
 
 [view_upgrade]
 ; When enabled, views with more than one collator versions will be submitted

--- a/src/couch_prometheus/src/couch_prometheus_server.erl
+++ b/src/couch_prometheus/src/couch_prometheus_server.erl
@@ -195,7 +195,7 @@ drain_refresh_messages() ->
 
 update_refresh_timer() ->
     drain_refresh_messages(),
-    RefreshTime = 1000 * config:get_integer("couch_prometheus", "interval", ?REFRESH_INTERVAL),
+    RefreshTime = 1000 * config:get_integer("prometheus", "interval", ?REFRESH_INTERVAL),
     erlang:send_after(RefreshTime, self(), refresh).
 
 -ifdef(TEST).

--- a/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
+++ b/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
@@ -85,6 +85,8 @@ setup_prometheus(WithAdditionalPort) ->
     % It's already started by default, so restart to pick up config
     ok = application:stop(couch_prometheus),
     ok = application:start(couch_prometheus),
+    % Flush so that stats aggregator starts using the new, shorter interval
+    couch_stats_aggregator:flush(),
     Ctx.
 
 t_chttpd_port(Port) ->


### PR DESCRIPTION
Interval was not read from the correct section.

The tests had the correct section.

This should fix the prometheus flaky test [1]. This was apparent on MacOS a bit more. The interval in the test was still 5 seconds instead of 1, so it was right at the edge of timing out (5 seconds is the default eunit timeout).

[1] https://github.com/apache/couchdb/issues/4397#issuecomment-1425027913
