### PR TITLE
Fix flaky LRU test

### DIFF
--- a/src/ets_lru/test/ets_lru_test.erl
+++ b/src/ets_lru/test/ets_lru_test.erl
@@ -291,6 +291,12 @@ test_limits([{max_lifetime, N}], {ok, LRU}) ->
             "Entry was expired",
             ?_test(begin
                 timer:sleep(round(N * 1.5)),
+                test_util:wait(fun() ->
+                    case ets_lru:lookup(LRU, foo) of
+                        not_found -> ok;
+                        _ -> wait
+                    end
+                end),
                 ?assertEqual(not_found, ets_lru:lookup(LRU, foo))
             end)
         }


### PR DESCRIPTION
Try to fix flaky test which was noticed on the MacOS CI worker [1]:

```
[2023-02-17T07:40:34.978Z]     ets_lru_test:285: -test_limits/2-fun-7- (Expire leaves new entries)...ok
[2023-02-17T07:40:34.978Z]     ets_lru_test:292: -test_limits/2-fun-5- (Entry was expired)...*failed*
[2023-02-17T07:40:34.978Z] in function ets_lru_test:'-test_limits/2-fun-5-'/2 (test/ets_lru_test.erl, line 294)
```

[1] https://github.com/apache/couchdb/issues/4397#issuecomment-1434764920
