### PR TITLE
Fix flaky elixir users_db_tests

### DIFF
--- a/test/elixir/test/users_db_test.exs
+++ b/test/elixir/test/users_db_test.exs
@@ -104,8 +104,12 @@ defmodule UsersDbTest do
   test "users db", context do
     db_name = context[:db_name]
     # test that the users db is born with the auth ddoc
-    ddoc = Couch.get("/#{@users_db_name}/_design/_auth")
-    assert ddoc.body["validate_doc_update"] != nil
+    get_ddoc = fn ->
+         ddoc = Couch.get("/#{@users_db_name}/_design/_auth")
+         ddoc.body["validate_doc_update"]
+    end
+    retry_until(fn -> get_ddoc.() != nil end)
+    assert get_ddoc.() != nil
 
     jchris_user_doc =
       prepare_user_doc([


### PR DESCRIPTION
This fails more often on MacOS CI workers [1] but it seems to be a general flaky test as the users auth ddoc is not guaranteed to be inserted synchronously.

[1] https://github.com/apache/couchdb/issues/4397#issue-1551336429
