### PR TITLE
mango: correct text index selection for queries with `$regex`

### DIFF
--- a/src/couch/src/test_util.erl
+++ b/src/couch/src/test_util.erl
@@ -37,6 +37,8 @@
 
 -export([shuffle/1]).
 
+-export([as_selector/1]).
+
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 -include("couch_db_int.hrl").
@@ -488,3 +490,7 @@ shuffle(List) ->
     Paired = [{couch_rand:uniform(), I} || I <- List],
     Sorted = lists:sort(Paired),
     [I || {_, I} <- Sorted].
+
+%% Create a valid Mango selector from an Erlang map.
+as_selector(Map) ->
+    mango_selector:normalize(jiffy:decode(jiffy:encode(Map))).

--- a/src/mango/src/mango.hrl
+++ b/src/mango/src/mango.hrl
@@ -11,3 +11,12 @@
 % the License.
 
 -define(MANGO_ERROR(R), throw({mango_error, ?MODULE, R})).
+
+-type abstract_text_selector() :: {'op_and', [abstract_text_selector()]}
+				| {'op_or', [abstract_text_selector()]}
+				| {'op_not', {abstract_text_selector(), abstract_text_selector()}}
+				| {'op_not', {_, 'false'}}
+				| {'op_field', {iolist() | binary(), _}}
+				| {'op_fieldname', {_, _}}
+				| {'op_null', {_, _}}
+				| {'op_default', _}.

--- a/src/mango/src/mango.hrl
+++ b/src/mango/src/mango.hrl
@@ -19,4 +19,5 @@
 				| {'op_field', {iolist() | binary(), _}}
 				| {'op_fieldname', {_, _}}
 				| {'op_null', {_, _}}
-				| {'op_default', _}.
+				| {'op_default', _}
+				| {'op_regex', binary()}.

--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -344,8 +344,6 @@ indexable_fields(Fields, {op_not, {ExistsQuery, Arg}}) when is_tuple(Arg) ->
 % forces "$exists" : false to use _all_docs
 indexable_fields(_, {op_not, {_, false}}) ->
     [];
-indexable_fields(Fields, {op_insert, Arg}) when is_binary(Arg) ->
-    Fields;
 %% fieldname.[]:length is not a user defined field.
 indexable_fields(Fields, {op_field, {[_, <<":length">>], _}}) ->
     Fields;

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -231,8 +231,6 @@ to_query({op_not, {ExistsQuery, Arg}}) when is_tuple(Arg) ->
 %% For $exists:false
 to_query({op_not, {ExistsQuery, false}}) ->
     ["($fieldnames:/.*/ ", " AND NOT (", to_query(ExistsQuery), "))"];
-to_query({op_insert, Arg}) when is_binary(Arg) ->
-    ["(", Arg, ")"];
 %% We escape : and / for now for values and all lucene chars for fieldnames
 %% This needs to be resolved.
 to_query({op_field, {Name, Value}}) ->

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -19,7 +19,6 @@
     append_sort_type/2
 ]).
 
--include_lib("couch/include/couch_db.hrl").
 -include("mango.hrl").
 
 %% Regex for <<"\\.">>

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -334,3 +334,28 @@ class MultiTextIndexSelectionTests(mango.UserDocsTests):
     def test_use_index_works(self):
         resp = self.db.find({"$text": "a query"}, use_index="foo", explain=True)
         self.assertEqual(resp["index"]["ddoc"], "_design/foo")
+
+
+@unittest.skipUnless(mango.has_text_service(), "requires text service")
+class RegexVsTextIndexTest(mango.DbPerClass):
+    @classmethod
+    def setUpClass(klass):
+        super(RegexVsTextIndexTest, klass).setUpClass()
+
+    def test_regex_works_with_text_index(self):
+        doc = {"currency": "HUF", "location": "EUROPE"}
+        self.db.save_docs([doc], w=3)
+
+        selector = {"currency": {"$regex": "HUF"}}
+        docs = self.db.find(selector)
+        assert docs == [doc]
+
+        # Now that it is confirmed to be working, try again the
+        # previous query with a text index on `location`.  This
+        # attempt should succeed as well.
+        self.db.create_text_index(
+            name="TextIndexByLocation", fields=[{"name": "location", "type": "string"}]
+        )
+
+        docs = self.db.find(selector)
+        assert docs == [doc]

--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -171,8 +171,13 @@ class IndexSelectorJson(mango.DbPerClass):
         docs = self.db.find(selector, use_index="oldschool")
         self.assertEqual(len(docs), 3)
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_saves_partialfilterselector_in_index(self):
+@unittest.skipUnless(mango.has_text_service(), "requires text service")
+class IndexSelectorText(mango.DbPerClass):
+    def setUp(self):
+        self.db.recreate()
+        self.db.save_docs(copy.deepcopy(DOCS))
+
+    def test_saves_partialfilterselector_in_index(self):
         selector = {"location": {"$gte": "FRA"}}
         self.db.create_text_index(
             fields=[{"name": "location", "type": "string"}],
@@ -181,8 +186,7 @@ class IndexSelectorJson(mango.DbPerClass):
         indexes = self.db.list_indexes()
         self.assertEqual(indexes[1]["def"]["partial_filter_selector"], selector)
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_uses_partial_index_for_query_selector(self):
+    def test_uses_partial_index_for_query_selector(self):
         selector = {"location": {"$gte": "FRA"}}
         self.db.create_text_index(
             fields=[{"name": "location", "type": "string"}],
@@ -195,8 +199,7 @@ class IndexSelectorJson(mango.DbPerClass):
         docs = self.db.find(selector, use_index="Selected", fields=["_id", "location"])
         self.assertEqual(len(docs), 3)
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_uses_partial_index_with_different_selector(self):
+    def test_uses_partial_index_with_different_selector(self):
         selector = {"location": {"$gte": "FRA"}}
         selector2 = {"location": {"$gte": "A"}}
         self.db.create_text_index(
@@ -210,8 +213,7 @@ class IndexSelectorJson(mango.DbPerClass):
         docs = self.db.find(selector2, use_index="Selected")
         self.assertEqual(len(docs), 3)
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_doesnot_use_selector_when_not_specified(self):
+    def test_doesnot_use_selector_when_not_specified(self):
         selector = {"location": {"$gte": "FRA"}}
         self.db.create_text_index(
             fields=[{"name": "location", "type": "string"}],
@@ -222,8 +224,7 @@ class IndexSelectorJson(mango.DbPerClass):
         resp = self.db.find(selector, explain=True)
         self.assertEqual(resp["index"]["name"], "_all_docs")
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_doesnot_use_selector_when_not_specified_with_index(self):
+    def test_doesnot_use_selector_when_not_specified_with_index(self):
         selector = {"location": {"$gte": "FRA"}}
         self.db.create_text_index(
             fields=[{"name": "location", "type": "string"}],
@@ -237,8 +238,7 @@ class IndexSelectorJson(mango.DbPerClass):
         resp = self.db.find(selector, explain=True)
         self.assertEqual(resp["index"]["name"], "NotSelected")
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_old_selector_still_supported(self):
+    def test_old_selector_still_supported(self):
         selector = {"location": {"$gte": "FRA"}}
         self.db.save_doc(oldschoolddoctext)
         resp = self.db.find(selector, explain=True, use_index="oldschooltext")
@@ -246,8 +246,7 @@ class IndexSelectorJson(mango.DbPerClass):
         docs = self.db.find(selector, use_index="oldschooltext")
         self.assertEqual(len(docs), 3)
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_old_selector_still_supported_via_api(self):
+    def test_old_selector_still_supported_via_api(self):
         selector = {"location": {"$gte": "FRA"}}
         self.db.create_text_index(
             fields=[{"name": "location", "type": "string"}],
@@ -258,8 +257,7 @@ class IndexSelectorJson(mango.DbPerClass):
         docs = self.db.find({"location": {"$exists": True}}, use_index="Selected")
         self.assertEqual(len(docs), 3)
 
-    @unittest.skipUnless(mango.has_text_service(), "requires text service")
-    def test_text_partial_filter_only_in_return_if_not_default(self):
+    def test_partial_filter_only_in_return_if_not_default(self):
         self.db.create_text_index(fields=[{"name": "location", "type": "string"}])
         index = self.db.list_indexes()[1]
         self.assertEqual("partial_filter_selector" in index["def"], False)


### PR DESCRIPTION
Upon adding a text index, Mango queries may not return documents that should match a selector that contains the `$regex` operator.  Steps to reproduce (thanks to @willholley), that are also captured in the integration tests:

1. Create an empty database. 
2. Add a document:

```json
{ 
    "_id": "foo",
    "currency": "HUF",
    "location": "EUROPE"
}
```

3. Run a Mango query without indexes -- this should return the document above:

```json
{
    "selector": {
        "currency": {
            "$regex": "HUF"
        }
    }
}
```

4. Add a text index for `location`:

```json
{
    "index": {
        "fields": [
            {
                "name": "location",
                "type": "string"
            }
       ]
   },
   "name": "location-text",
   "type": "text"
}
```

5. Run the query once more -- this time, no documents are returned.

This is because the text index is chosen to answer the query even if it does not contain the field on which the `$regex` match should be run.  This is due to the permissive logic of the index selection where the fields with `$regex` in the selector are not cross-checked against the fields in the index.

The PR implements the necessary changes to ensure that text indexes are chosen more carefully and covers them with tests.  Note that this also means an increase in the unit test coverage of the related functions to be less dependent on a working Clouseau instance.  As an extra, it aims to improve the readability by introducing extra commentary (thanks to @mikerhodes) and type specifications.

Random stats on coverage, before:

```console
$ make eunit apps=mango
==> mango (compile)
==> rel (compile)
==> couchdb (compile)
WARN:  Missing plugins: [covertool]
WARN:  Missing plugins: [pc]
==> couchdb (setup_eunit)
==> mango (eunit)
======================== EUnit ========================
[..]
=======================================================
  All 55 tests passed.
[..]
Code Coverage:
Code Coverage:
mango_app             :   0%
mango_crud            :   0%
mango_cursor          :   0%
mango_cursor_special  :   0%
mango_cursor_text     :   0%
mango_cursor_view     :  33%
mango_doc             :   3%
mango_epi             : 100%
mango_error           :   0%
mango_execution_stats :   0%
mango_fields          :  50%
mango_httpd           :   0%
mango_httpd_handlers  :   0%
mango_idx             :  18%
mango_idx_special     :   0%
mango_idx_text        :  29%
mango_idx_view        :   1%
mango_json            :  10%
mango_json_bookmark   :   0%
mango_native_proc     :   5%
mango_opts            :  25%
mango_selector        :  52%
mango_selector_text   :   0%
mango_sort            :   0%
mango_sup             :   0%
mango_util            :  23%

Total                 : 17%
==> rel (eunit)
==> couchdb (eunit)
```

after:

```console
$ make eunit apps=mango
==> mango (compile)
==> rel (compile)
==> couchdb (compile)
WARN:  Missing plugins: [covertool]
WARN:  Missing plugins: [pc]
==> couchdb (setup_eunit)
==> mango (eunit)
======================== EUnit ========================
[..]
module 'mango_idx_text'
[..]
  mango_idx_text: indexable_fields_test...[0.106 s] ok
  mango_idx_text: is_usable_test...ok
  [done in 5.703 s]
[..]
module 'mango_selector_text'
  mango_selector_text: convert_fields_test...ok
  mango_selector_text: convert_default_test...ok
  mango_selector_text: convert_lt_test...ok
  mango_selector_text: convert_lte_test...ok
  mango_selector_text: convert_eq_test...ok
  mango_selector_text: convert_ne_test...ok
  mango_selector_text: convert_gte_test...ok
  mango_selector_text: convert_gt_test...ok
  mango_selector_text: convert_all_test...ok
  mango_selector_text: convert_elemMatch_test...ok
  mango_selector_text: convert_allMatch_test...ok
  mango_selector_text: convert_keyMapMatch_test...ok
  mango_selector_text: convert_in_test...ok
  mango_selector_text: convert_nin_test...ok
  mango_selector_text: convert_exists_test...ok
  mango_selector_text: convert_type_test...ok
  mango_selector_text: convert_mod_test...ok
  mango_selector_text: convert_regex_test...ok
  mango_selector_text: convert_size_test...ok
  mango_selector_text: convert_not_test...ok
  mango_selector_text: convert_and_test...ok
  mango_selector_text: convert_or_test...ok
  mango_selector_text: convert_nor_test...ok
  mango_selector_text: to_query_test...ok
  [done in 0.074 s]
[..]
=======================================================
  All 81 tests passed.
[..]
Code Coverage:
mango_app             :   0%
mango_crud            :   0%
mango_cursor          :   0%
mango_cursor_special  :   0%
mango_cursor_text     :   0%
mango_cursor_view     :  33%
mango_doc             :   3%
mango_epi             : 100%
mango_error           :   0%
mango_execution_stats :   0%
mango_fields          :  50%
mango_httpd           :   0%
mango_httpd_handlers  :   0%
mango_idx             :  18%
mango_idx_special     :   0%
mango_idx_text        :  61%
mango_idx_view        :   1%
mango_json            :  10%
mango_json_bookmark   :   0%
mango_native_proc     :   5%
mango_opts            :  25%
mango_selector        :  62%
mango_selector_text   :  86%
mango_sort            :   0%
mango_sup             :   0%
mango_util            :  38%

Total                 : 31%
==> rel (eunit)
==> couchdb (eunit)
```
