### PR TITLE
Fix erlfmt-format on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -181,12 +181,12 @@ just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 
 # target: erlfmt-check - Check Erlang source code formatting
-erlfmt-check: export ERLFMT_PATH := $(ERLFMT)
+erlfmt-check: export ERLFMT_PATH = $(ERLFMT)
 erlfmt-check:
 	@$(PYTHON) dev\format_check.py
 
 # target: erlfmt-format - Apply Erlang source code format standards automatically
-erlfmt-format: export ERLFMT_PATH := $(ERLFMT)
+erlfmt-format: export ERLFMT_PATH = $(ERLFMT)
 erlfmt-format:
 	@$(PYTHON) dev\format_all.py
 

--- a/dev/format_lib.py
+++ b/dev/format_lib.py
@@ -48,7 +48,7 @@ def get_source_paths():
     ):
         path = pathlib.Path(item)
         if path.parent != curdir:
-            yield str(path.parent.joinpath("*.erl"))
+            yield str(path.parent.joinpath("*.erl").as_posix())
             curdir = path.parent
     if curdir is not None:
-        yield str(curdir.joinpath("*.erl"))
+        yield str(curdir.joinpath("*.erl").as_posix())


### PR DESCRIPTION
The erlfmt executable likes POSIX paths on Windows too.

Fixes #4333. 