### PR TITLE
Fabric attachment timeout was defaulting to 10m

### DIFF
--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -81,7 +81,7 @@ all_docs_timeout() ->
     timeout("all_docs", "10000").
 
 attachments_timeout() ->
-    timeout("attachments", "600000").
+    timeout("attachments", "60000").
 
 view_timeout(Args) ->
     PartitionQuery = couch_mrview_util:get_extra(Args, partition, false),


### PR DESCRIPTION
Default ini has this value as 1m



## Overview

While investigating long open connections for attachments I stumbled on this. Uncertain if this is correct or the default ini value is correct.

## Testing recommendations


## Related Issues or Pull Requests


## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
