### PR TITLE
fix: remove duplicate couchdb_erlang* stats from _prometheus

### DIFF
--- a/src/couch_prometheus/src/couch_prometheus_server.erl
+++ b/src/couch_prometheus/src/couch_prometheus_server.erl
@@ -108,7 +108,6 @@ get_couchdb_stats() ->
 get_system_stats() ->
     lists:flatten([
         get_uptime_stat(),
-        get_vm_stats(),
         get_io_stats(),
         get_message_queue_stats(),
         get_run_queue_stats(),


### PR DESCRIPTION
## Overview

The `_node/_local/_prometheus` was returning duplicate rows for the following metrics:

```
couchdb_erlang_memory_bytes
couchdb_erlang_gc_collections_total
couchdb_erlang_gc_words_reclaimed_total
couchdb_erlang_context_switches_total
couchdb_erlang_reductions_total
couchdb_erlang_processes
couchdb_erlang_process_limit
```

Prometheus will gracefully handle the duplication, picking the first entry only, but the duplication bloats the output and can cause some confusion when manually reading the response to get the list of metrics.

This fix is to remove a duplicate call to `get_vm_stats()` in the prometheus endpoint handler.

## Testing recommendations

I added a unit test for duplicate metrics in `couch_prometheus`. This fails prior to the fix and now passes, though my Erlang is likely a bit clunky!

One can also observe the output of `/_node/_local/_prometheus` before and after this change.

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
