### PR TITLE
Avoid re-compiling filter view functions

### DIFF
--- a/share/server/filter.js
+++ b/share/server/filter.js
@@ -28,11 +28,6 @@ var Filter = (function() {
         respond([true, results]);
       },
       filter_view : function(fun, ddoc, args) {
-        // recompile
-        var sandbox = create_filter_sandbox();
-        var source = fun.toSource();
-        fun = evalcx(source, sandbox);
-
         var results = [];
         var docs = args[0];
         for (var i=0; i < docs.length; i++) {

--- a/share/server/loop.js
+++ b/share/server/loop.js
@@ -87,7 +87,10 @@ var DDoc = (function() {
                        " on design doc " + ddocId]);
               }
               if (typeof fun != "function") {
-                fun = Couch.compileFunction(fun, ddoc, funPath.join('.'));
+                // For filter_view we want the emit() function to be overridden
+                // and just toggle a flag instead of accumulating rows
+                var sandbox = (cmd === "views") ? create_filter_sandbox() : create_sandbox();
+                fun = Couch.compileFunction(fun, ddoc, funPath.join('.'), sandbox);
                 // cache the compiled fun on the ddoc
                 point[funPath[i]] = fun;
               };

--- a/share/server/util.js
+++ b/share/server/util.js
@@ -58,11 +58,11 @@ var resolveModule = function(names, mod, root) {
 
 var Couch = {
   // moving this away from global so we can move to json2.js later
-  compileFunction : function(source, ddoc, name) {
+  compileFunction : function(source, ddoc, name, sandbox) {
     if (!source) throw(["error","not_found","missing function"]);
 
     var functionObject = null;
-    var sandbox = create_sandbox();
+    var sandbox = sandbox || create_sandbox();
 
     var require = function(name, module) {
       module = module || {};


### PR DESCRIPTION
Filter view functions feature re-uses view map function for filtering _changes feeds. Instead of accumulating emitted KVs, it uses custom emit() function which just toggles a flag. However, in order to use this optimisation, the function is compiled first with the regular emit function, then the function source is queried with a non-portable toSource() method, and re-compiled again with a new sandbox where emit is overridden.

Instead of reparsing and re-compiling it, pass the sandbox to the compile function and compile filter views with that correct sandbox to start with. Moreover, this helps remove another non-portable function call.
