### PR TITLE
feat: add type and descriptions to prometheus output

### DIFF
--- a/src/couch_prometheus/src/couch_prometheus_server.erl
+++ b/src/couch_prometheus/src/couch_prometheus_server.erl
@@ -134,7 +134,7 @@ get_vm_stats() ->
         to_prom(
             erlang_memory_bytes,
             gauge,
-            "size of memory dynamically allocated by the Erlang emulator",
+            "size of memory (in bytes) dynamically allocated by the Erlang emulator",
             MemLabels
         ),
         to_prom(


### PR DESCRIPTION
## Overview

The `/_node/_local/_prometheus` is a missing `TYPE` annotation for `couchdb_httpd_status_codes`.

In addition, it contains no `HELP` annotations, which are useful when exploring the metrics, particularly where
metrics do not strictly match those returned by the `_stats` or `_system` endpoints.

This PR adds the missing `TYPE` annotation and adds `HELP` annotations to all metrics. It also adds additional spacing between the metrics series, making it easier for humans to parse.

The spec for the prometheus text format is at https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md, for reference.

## couch_prometheus_util:to_prom/3

`couch_prometheus_util:to_prom/3` is replaced by `couch_prometheus_util:to_prom/4` which requires a description alongside the metric name and type.

## couch_prometheus_util:couch_to_prom/3

`couch_prometheus_util:couch_to_prom/3` now extracts the metrics description from the metric metadata returned by `couch_stats`.

In cases where there transformation of the `couch_stats` result, the description is explicitly specified to match the new metric series.

[_prometheus output before](https://github.com/apache/couchdb/files/10960969/prometheus_before.txt)
[_prometheus output after](https://github.com/apache/couchdb/files/10960980/prometheus_after.txt)

## Testing recommendations

Unit tests are updated to expect the `# HELP` annotations alongside the `# TYPE` annotations for each metric.

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
