### PR TITLE
Add report logging

### DIFF
--- a/src/couch_log/include/couch_log.hrl
+++ b/src/couch_log/include/couch_log.hrl
@@ -15,7 +15,8 @@
     pid,
     msg,
     msg_id,
-    time_stamp
+    time_stamp,
+    type
 }).
 
 

--- a/src/couch_log/priv/stats_descriptions.cfg
+++ b/src/couch_log/priv/stats_descriptions.cfg
@@ -46,3 +46,7 @@
     {type, counter},
     {desc, <<"number of logged warning messages">>}
 ]}.
+{[couch_log, level, report], [
+    {type, counter},
+    {desc, <<"number of logged report messages">>}
+]}.

--- a/src/couch_log/priv/stats_descriptions.cfg
+++ b/src/couch_log/priv/stats_descriptions.cfg
@@ -50,3 +50,7 @@
     {type, counter},
     {desc, <<"number of logged report messages">>}
 ]}.
+{[couch_log, level, report_error], [
+    {type, counter},
+    {desc, <<"number of failed report messages">>}
+]}.

--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -21,7 +21,7 @@
     critical/2,
     alert/2,
     emergency/2,
-
+    report/2,
     set_level/1
 ]).
 
@@ -49,16 +49,25 @@ alert(Fmt, Args) -> log(alert, Fmt, Args).
 -spec emergency(string(), list()) -> ok.
 emergency(Fmt, Args) -> log(emergency, Fmt, Args).
 
+-spec report(string(), map()) -> ok.
+report(ReportId, Meta) when is_map(Meta) ->
+    couch_stats:increment_counter([couch_log, level, report]),
+    Entry = couch_log_formatter:format(report, self(), ReportId, "", [], Meta),
+    ok = couch_log_server:report(Entry).
+
 -spec set_level(atom() | string() | integer()) -> true.
 set_level(Level) ->
     config:set("log", "level", couch_log_util:level_to_string(Level)).
 
 -spec log(atom(), string(), list()) -> ok.
 log(Level, Fmt, Args) ->
+    log(Level, undefined, Fmt, Args, #{}).
+
+log(Level, Type, Fmt, Args, Meta) ->
     case couch_log_util:should_log(Level) of
         true ->
             couch_stats:increment_counter([couch_log, level, Level]),
-            Entry = couch_log_formatter:format(Level, self(), Fmt, Args),
+            Entry = couch_log_formatter:format(Level, self(), Type, Fmt, Args, Meta),
             ok = couch_log_server:log(Entry);
         false ->
             ok

--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -64,7 +64,6 @@ report(ReportId, Fmt, Args, Meta0) when is_map(Meta0) ->
     end,
     couch_stats:increment_counter([couch_log, level, report]),
     Entry = couch_log_formatter:format(report, self(), ReportId, Fmt, Args, Meta),
-    %%ok = couch_log_server:report(Entry).
     ok = couch_log_server:log(Entry).
 
 -spec set_level(atom() | string() | integer()) -> true.

--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -50,14 +50,7 @@ alert(Fmt, Args) -> log(alert, Fmt, Args).
 emergency(Fmt, Args) -> log(emergency, Fmt, Args).
 
 -spec report(string(), map()) -> true | false.
-report(ReportId, Meta0) when is_map(Meta0) ->
-    Meta =
-        case maps:is_key(type, Meta0) of
-            true ->
-                Meta0;
-            false ->
-                Meta0#{type => ReportId}
-        end,
+report(ReportId, Meta) when is_map(Meta) ->
     couch_stats:increment_counter([couch_log, level, report]),
     case couch_log_formatter:format_report(self(), ReportId, Meta) of
         {error, emsgtoolong} ->

--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -21,7 +21,7 @@
     critical/2,
     alert/2,
     emergency/2,
-    report/2,
+    report/4,
     set_level/1
 ]).
 
@@ -49,11 +49,12 @@ alert(Fmt, Args) -> log(alert, Fmt, Args).
 -spec emergency(string(), list()) -> ok.
 emergency(Fmt, Args) -> log(emergency, Fmt, Args).
 
--spec report(string(), map()) -> ok.
-report(ReportId, Meta) when is_map(Meta) ->
+-spec report(string(), string(), list(), map()) -> ok.
+report(ReportId, Fmt, Args, Meta) when is_map(Meta) ->
     couch_stats:increment_counter([couch_log, level, report]),
-    Entry = couch_log_formatter:format(report, self(), ReportId, "", [], Meta),
-    ok = couch_log_server:report(Entry).
+    Entry = couch_log_formatter:format(report, self(), ReportId, Fmt, Args, Meta),
+    %%ok = couch_log_server:report(Entry).
+    ok = couch_log_server:log(Entry).
 
 -spec set_level(atom() | string() | integer()) -> true.
 set_level(Level) ->

--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -51,12 +51,13 @@ emergency(Fmt, Args) -> log(emergency, Fmt, Args).
 
 -spec report(string(), map()) -> true | false.
 report(ReportId, Meta0) when is_map(Meta0) ->
-    Meta = case maps:is_key(type, Meta0) of
-        true ->
-            Meta0;
-        false ->
-            Meta0#{type => ReportId}
-    end,
+    Meta =
+        case maps:is_key(type, Meta0) of
+            true ->
+                Meta0;
+            false ->
+                Meta0#{type => ReportId}
+        end,
     couch_stats:increment_counter([couch_log, level, report]),
     case couch_log_formatter:format_report(self(), ReportId, Meta) of
         {error, emsgtoolong} ->

--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -21,6 +21,7 @@
     critical/2,
     alert/2,
     emergency/2,
+    report/2,
     report/4,
     set_level/1
 ]).
@@ -49,8 +50,18 @@ alert(Fmt, Args) -> log(alert, Fmt, Args).
 -spec emergency(string(), list()) -> ok.
 emergency(Fmt, Args) -> log(emergency, Fmt, Args).
 
+-spec report(string(), map()) -> ok.
+report(ReportId, Meta) when is_map(Meta) ->
+    report(ReportId, "", [], Meta).
+
 -spec report(string(), string(), list(), map()) -> ok.
-report(ReportId, Fmt, Args, Meta) when is_map(Meta) ->
+report(ReportId, Fmt, Args, Meta0) when is_map(Meta0) ->
+    Meta = case maps:is_key(type, Meta0) of
+        true ->
+            Meta0;
+        false ->
+            Meta0#{type => ReportId}
+    end,
     couch_stats:increment_counter([couch_log, level, report]),
     Entry = couch_log_formatter:format(report, self(), ReportId, Fmt, Args, Meta),
     %%ok = couch_log_server:report(Entry).

--- a/src/couch_log/src/couch_log_config.erl
+++ b/src/couch_log/src/couch_log_config.erl
@@ -43,6 +43,7 @@ entries() ->
     [
         {level, "level", "info"},
         {level_int, "level", "info"},
+        {report_level, "report_level", "info"},
         {max_message_size, "max_message_size", "16000"},
         {strip_last_msg, "strip_last_msg", "true"},
         {filter_fields, "filter_fields", "[pid, registered_name, error_info, messages]"}
@@ -86,6 +87,8 @@ forms() ->
     [erl_syntax:revert(X) || X <- Statements].
 
 transform(level, LevelStr) ->
+    couch_log_util:level_to_atom(LevelStr);
+transform(report_level, LevelStr) ->
     couch_log_util:level_to_atom(LevelStr);
 transform(level_int, LevelStr) ->
     Level = couch_log_util:level_to_atom(LevelStr),

--- a/src/couch_log/src/couch_log_config_dyn.erl
+++ b/src/couch_log/src/couch_log_config_dyn.erl
@@ -22,6 +22,7 @@
 ]).
 
 get(level) -> info;
+get(report_level) -> info;
 get(level_int) -> 2;
 get(max_message_size) -> 16000;
 get(strip_last_msg) -> true;

--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -37,10 +37,11 @@
 
 format_report(Pid, Type, Meta) ->
     MaxMsgSize = couch_log_config:get(max_message_size),
-    Msg = case format_meta(Meta) of
-        ""   -> "";
-        Msg0 -> ["[", Msg0, "]"]
-    end,
+    Msg =
+        case format_meta(Meta) of
+            "" -> "";
+            Msg0 -> ["[", Msg0, "]"]
+        end,
     case iolist_size(Msg) > MaxMsgSize of
         true ->
             {error, emsgtoolong};

--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -465,9 +465,16 @@ supervisor_name(Name) -> Name.
 format_meta(Meta) ->
     %% https://www.rfc-editor.org/rfc/rfc5424.html#section-6.3
     %% iut="3" eventSource="Application" eventID="1011"
-    string:join(maps:fold(fun(K, V, Acc) ->
-        [to_str(K, V) | Acc]
-    end, [], Meta), " ").
+    string:join(
+        maps:fold(
+            fun(K, V, Acc) ->
+                [to_str(K, V) | Acc]
+            end,
+            [],
+            Meta
+        ),
+        " "
+    ).
 
 %% passing complex terms as meta value is a mistake so we are going
 %% to eat it, because we cannot bubble up errors from logger

--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -493,6 +493,8 @@ to_str(_K, Term) when is_tuple(Term) ->
     "";
 to_str(_K, Term) when is_map(Term) ->
     "";
+to_str(K, Term) when is_number(Term) ->
+    io_lib:format("~s=~p", [K, Term]);
 to_str(K, Term) when is_binary(Term) ->
     io_lib:format("~s=\"~s\"", [K, Term]);
 to_str(K, Term) ->

--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -38,12 +38,10 @@
 format_report(Pid, Type, Meta) ->
     MaxMsgSize = couch_log_config:get(max_message_size),
     Msg = case format_meta(Meta) of
-        "" ->
-            "";
-        MetaStr ->
-            ["[", MetaStr, "]"]
+        ""   -> "";
+        Msg0 -> ["[", Msg0, "]"]
     end,
-    case length(Msg) > MaxMsgSize of
+    case iolist_size(Msg) > MaxMsgSize of
         true ->
             {error, emsgtoolong};
         false ->

--- a/src/couch_log/src/couch_log_sup.erl
+++ b/src/couch_log/src/couch_log_sup.erl
@@ -59,6 +59,8 @@ handle_config_change("log", Key, _, _, S) ->
     case Key of
         "level" ->
             couch_log_config:reconfigure();
+        "report_level" ->
+            couch_log_config:reconfigure();
         "max_message_size" ->
             couch_log_config:reconfigure();
         "strip_last_msg" ->

--- a/src/couch_log/src/couch_log_util.erl
+++ b/src/couch_log/src/couch_log_util.erl
@@ -21,7 +21,9 @@
     level_to_atom/1,
     level_to_string/1,
 
-    string_p/1
+    string_p/1,
+
+    maybe_format_type/1
 ]).
 
 -include("couch_log.hrl").
@@ -29,6 +31,8 @@
 -spec should_log(#log_entry{} | atom()) -> boolean().
 should_log(#log_entry{level = Level}) ->
     should_log(Level);
+should_log(report) ->
+    should_log(couch_log_config:get(report_level));
 should_log(Level) ->
     level_to_integer(Level) >= couch_log_config:get(level_int).
 
@@ -145,3 +149,10 @@ string_p1([]) ->
     true;
 string_p1(_) ->
     false.
+
+maybe_format_type(#log_entry{type = undefined} = Entry) ->
+    Entry;
+maybe_format_type(#log_entry{type = Type, msg = [$[ | Msg]} = Entry) ->
+    Entry#log_entry{msg = ["[", Type, " " | Msg]};
+maybe_format_type(#log_entry{} = Entry) ->
+    Entry.

--- a/src/couch_log/src/couch_log_util.erl
+++ b/src/couch_log/src/couch_log_util.erl
@@ -154,5 +154,7 @@ maybe_format_type(#log_entry{type = undefined} = Entry) ->
     Entry;
 maybe_format_type(#log_entry{type = Type, msg = [$[ | Msg]} = Entry) ->
     Entry#log_entry{msg = ["[", Type, " " | Msg]};
+maybe_format_type(#log_entry{type = Type, msg = [_|_]=Msg} = Entry) ->
+    Entry#log_entry{msg = [Type, " " | Msg]};
 maybe_format_type(#log_entry{} = Entry) ->
     Entry.

--- a/src/couch_log/src/couch_log_util.erl
+++ b/src/couch_log/src/couch_log_util.erl
@@ -152,9 +152,7 @@ string_p1(_) ->
 
 maybe_format_type(#log_entry{type = undefined} = Entry) ->
     Entry;
-maybe_format_type(#log_entry{type = Type, msg = [$[ | Msg]} = Entry) ->
+maybe_format_type(#log_entry{type = Type, msg = ["[" | Msg]} = Entry) ->
     Entry#log_entry{msg = ["[", Type, " " | Msg]};
-maybe_format_type(#log_entry{type = Type, msg = [_ | _] = Msg} = Entry) ->
-    Entry#log_entry{msg = [Type, " " | Msg]};
 maybe_format_type(#log_entry{} = Entry) ->
     Entry.

--- a/src/couch_log/src/couch_log_util.erl
+++ b/src/couch_log/src/couch_log_util.erl
@@ -154,7 +154,7 @@ maybe_format_type(#log_entry{type = undefined} = Entry) ->
     Entry;
 maybe_format_type(#log_entry{type = Type, msg = [$[ | Msg]} = Entry) ->
     Entry#log_entry{msg = ["[", Type, " " | Msg]};
-maybe_format_type(#log_entry{type = Type, msg = [_|_]=Msg} = Entry) ->
+maybe_format_type(#log_entry{type = Type, msg = [_ | _] = Msg} = Entry) ->
     Entry#log_entry{msg = [Type, " " | Msg]};
 maybe_format_type(#log_entry{} = Entry) ->
     Entry.

--- a/src/couch_log/src/couch_log_writer_file.erl
+++ b/src/couch_log/src/couch_log_writer_file.erl
@@ -77,7 +77,7 @@ write(Entry, St) ->
         msg = Msg,
         msg_id = MsgId,
         time_stamp = TimeStamp
-    } = Entry,
+    } = couch_log_util:maybe_format_type(Entry),
     Fmt = "[~s] ~s ~s ~p ~s ",
     Args = [
         couch_log_util:level_to_string(Level),

--- a/src/couch_log/src/couch_log_writer_stderr.erl
+++ b/src/couch_log/src/couch_log_writer_stderr.erl
@@ -27,7 +27,7 @@ init() ->
 terminate(_, _St) ->
     ok.
 
-write(#log_entry{type=Type}=Entry, St) ->
+write(#log_entry{type = Type} = Entry, St) ->
     #log_entry{
         level = Level,
         pid = Pid,

--- a/src/couch_log/src/couch_log_writer_stderr.erl
+++ b/src/couch_log/src/couch_log_writer_stderr.erl
@@ -27,14 +27,14 @@ init() ->
 terminate(_, _St) ->
     ok.
 
-write(Entry, St) ->
+write(#log_entry{type=Type}=Entry, St) ->
     #log_entry{
         level = Level,
         pid = Pid,
         msg = Msg,
         msg_id = MsgId,
         time_stamp = TimeStamp
-    } = Entry,
+    } = couch_log_util:maybe_format_type(Entry),
     Fmt = "[~s] ~s ~s ~p ~s ",
     Args = [
         couch_log_util:level_to_string(Level),

--- a/src/couch_log/src/couch_log_writer_syslog.erl
+++ b/src/couch_log/src/couch_log_writer_syslog.erl
@@ -78,7 +78,7 @@ write(#log_entry{level = report} = Entry, #st{enterprise_number = undefined} = S
 write(#log_entry{level = report, type = Type} = Entry0, #st{report_level = Level} = St) ->
     % append @${enterprise_number} to the type to conform with
     % https://www.rfc-editor.org/rfc/rfc5424.html#page-15
-    TypeSDID = lists:flatten(io_lib:format("~s@~s", [Type, St#st.enterprise_number])),
+    TypeSDID = lists:flatten(io_lib:format("~s-DB@~s", [Type, St#st.enterprise_number])),
     Entry = Entry0#log_entry{
         type = TypeSDID,
         level = Level

--- a/src/couch_log/src/couch_log_writer_syslog.erl
+++ b/src/couch_log/src/couch_log_writer_syslog.erl
@@ -93,10 +93,9 @@ do_write(Entry, St) ->
         pid = Pid,
         msg = Msg,
         msg_id = MsgId,
-        type = Type,
         time_stamp = TimeStamp
     } = couch_log_util:maybe_format_type(Entry),
-    Fmt = "<~B>~B ~s ~s ~s ~p ~p ~s - ",
+    Fmt = "<~B>~B ~s ~s ~s ~p ~s - ",
     Args = [
         St#st.facility bor get_level(Level),
         ?SYSLOG_VERSION,
@@ -104,7 +103,6 @@ do_write(Entry, St) ->
         St#st.hostname,
         St#st.appid,
         Pid,
-        Type,
         MsgId
     ],
     Pre = io_lib:format(Fmt, Args),

--- a/src/couch_log/src/couch_log_writer_syslog.erl
+++ b/src/couch_log/src/couch_log_writer_syslog.erl
@@ -57,7 +57,7 @@ init() ->
                         undefined
                 end
         end,
-    Level = list_to_atom(config:get("log", "syslog_report_level", "info")),
+    Level = list_to_atom(config:get("log", "report_level", "info")),
     {ok, #st{
         socket = Socket,
         host = Host,

--- a/src/couch_log/src/couch_log_writer_syslog.erl
+++ b/src/couch_log/src/couch_log_writer_syslog.erl
@@ -74,7 +74,7 @@ terminate(_Reason, St) ->
     gen_udp:close(St#st.socket).
 
 write(#log_entry{level = report} = Entry, #st{enterprise_number = undefined} = St) ->
-    do_write(Entry#log_entry{level = error}, St);
+    do_write(Entry#log_entry{level = St#st.report_level}, St);
 write(#log_entry{level = report, type = Type} = Entry0, #st{report_level = Level} = St) ->
     % append @${enterprise_number} to the type to conform with
     % https://www.rfc-editor.org/rfc/rfc5424.html#page-15

--- a/src/couch_log/src/couch_log_writer_syslog.erl
+++ b/src/couch_log/src/couch_log_writer_syslog.erl
@@ -93,9 +93,10 @@ do_write(Entry, St) ->
         pid = Pid,
         msg = Msg,
         msg_id = MsgId,
+        type = Type,
         time_stamp = TimeStamp
     } = couch_log_util:maybe_format_type(Entry),
-    Fmt = "<~B>~B ~s ~s ~s ~p ~s - ",
+    Fmt = "<~B>~B ~s ~s ~s ~p ~p ~s - ",
     Args = [
         St#st.facility bor get_level(Level),
         ?SYSLOG_VERSION,
@@ -103,6 +104,7 @@ do_write(Entry, St) ->
         St#st.hostname,
         St#st.appid,
         Pid,
+        Type,
         MsgId
     ],
     Pre = io_lib:format(Fmt, Args),

--- a/src/couch_log/test/eunit/couch_log_config_test.erl
+++ b/src/couch_log/test/eunit/couch_log_config_test.erl
@@ -20,6 +20,7 @@
 couch_log_config_test_() ->
     {setup, fun couch_log_test_util:start/0, fun couch_log_test_util:stop/1, [
         ?T(check_level),
+        ?T(check_report_level),
         ?T(check_max_message_size),
         ?T(check_bad_level),
         ?T(check_bad_max_message_size),
@@ -28,6 +29,23 @@ couch_log_config_test_() ->
         ?T(check_filter_fields),
         ?T(check_bad_filter_fields)
     ]}.
+
+check_report_level() ->
+    % Default report_level is info
+    ?assertEqual(info, couch_log_config:get(report_level)),
+    couch_log_test_util:with_config_listener(fun() ->
+        config:set("log", "report_level", "emerg"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(emergency, couch_log_config:get(report_level)),
+
+        config:set("log", "report_level", "debug"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(debug, couch_log_config:get(report_level)),
+
+        config:delete("log", "report_level"),
+        couch_log_test_util:wait_for_config(),
+        ?assertEqual(info, couch_log_config:get(report_level))
+    end).
 
 check_level() ->
     % Default level is info

--- a/src/couch_log/test/eunit/couch_log_formatter_test.erl
+++ b/src/couch_log/test/eunit/couch_log_formatter_test.erl
@@ -25,6 +25,17 @@ truncate_test() ->
     Entry = couch_log_formatter:format(info, self(), Msg),
     ?assert(length(Entry#log_entry.msg) =< 16000).
 
+format_report_test() ->
+    MsgFmt = "This is a reason: ~r",
+    Reason = {foo, [{x, k, 3}, {c, d, 2}]},
+    Entry = couch_log_formatter:format(report, self(), report123, MsgFmt, [Reason], #{
+        foo => 123,
+        bar => "barStr",
+        baz => baz
+    }),
+    Formatted = "[foo=\"123\" baz=\"baz\" bar=\"barStr\"] This is a reason: foo at x:k/3 <= c:d/2",
+    ?assertEqual(Formatted, lists:flatten(Entry#log_entry.msg)).
+
 format_reason_test() ->
     MsgFmt = "This is a reason: ~r",
     Reason = {foo, [{x, k, 3}, {c, d, 2}]},

--- a/src/couch_log/test/eunit/couch_log_formatter_test.erl
+++ b/src/couch_log/test/eunit/couch_log_formatter_test.erl
@@ -38,7 +38,7 @@ format_report_test() ->
         bar => "barStr",
         baz => baz
     }),
-    Formatted = "[foo=\"123\" baz=\"baz\" bar=\"barStr\"]",
+    Formatted = "[foo=123 baz=\"baz\" bar=\"barStr\"]",
     ?assertEqual(Formatted, lists:flatten(Entry#log_entry.msg)).
 
 format_reason_test() ->

--- a/src/couch_log/test/eunit/couch_log_formatter_test.erl
+++ b/src/couch_log/test/eunit/couch_log_formatter_test.erl
@@ -26,7 +26,7 @@ truncate_test() ->
     ?assert(length(Entry#log_entry.msg) =< 16000).
 
 format_report_etoolong_test() ->
-    Payload = lists:flatten(["a" || _ <- lists:seq(1, 1048576)]),
+    Payload = lists:flatten(lists:duplicate(1048576, "a")),
     Resp = couch_log_formatter:format_report(self(), report123, #{
         msg => Payload
     }),

--- a/src/couch_log/test/eunit/couch_log_formatter_test.erl
+++ b/src/couch_log/test/eunit/couch_log_formatter_test.erl
@@ -38,6 +38,8 @@ format_report_test() ->
         bar => "barStr",
         baz => baz
     }),
+    % NOTE: this currently hardcodes the ordering of the keys, however, map
+    % key order is not guaranteed and this may break.
     Formatted = "[foo=123 baz=\"baz\" bar=\"barStr\"]",
     ?assertEqual(Formatted, lists:flatten(Entry#log_entry.msg)).
 

--- a/src/couch_log/test/eunit/couch_log_formatter_test.erl
+++ b/src/couch_log/test/eunit/couch_log_formatter_test.erl
@@ -25,15 +25,20 @@ truncate_test() ->
     Entry = couch_log_formatter:format(info, self(), Msg),
     ?assert(length(Entry#log_entry.msg) =< 16000).
 
+format_report_etoolong_test() ->
+    Payload = lists:flatten(["a" || _ <- lists:seq(1, 1048576)]),
+    Resp = couch_log_formatter:format_report(self(), report123, #{
+        msg => Payload
+    }),
+    ?assertEqual({error, emsgtoolong}, Resp).
+
 format_report_test() ->
-    MsgFmt = "This is a reason: ~r",
-    Reason = {foo, [{x, k, 3}, {c, d, 2}]},
-    Entry = couch_log_formatter:format(report, self(), report123, MsgFmt, [Reason], #{
+    {ok, Entry} = couch_log_formatter:format_report(self(), report123, #{
         foo => 123,
         bar => "barStr",
         baz => baz
     }),
-    Formatted = "[foo=\"123\" baz=\"baz\" bar=\"barStr\"] This is a reason: foo at x:k/3 <= c:d/2",
+    Formatted = "[foo=\"123\" baz=\"baz\" bar=\"barStr\"]",
     ?assertEqual(Formatted, lists:flatten(Entry#log_entry.msg)).
 
 format_reason_test() ->

--- a/src/couch_log/test/eunit/couch_log_writer_ets.erl
+++ b/src/couch_log/test/eunit/couch_log_writer_ets.erl
@@ -30,9 +30,10 @@ terminate(_, _St) ->
     ok.
 
 write(Entry0, St) ->
-    Entry = Entry0#log_entry{
-        msg = lists:flatten(Entry0#log_entry.msg),
-        time_stamp = lists:flatten(Entry0#log_entry.time_stamp)
+    Entry1 = couch_log_util:maybe_format_type(Entry0),
+    Entry = Entry1#log_entry{
+        msg = lists:flatten(Entry1#log_entry.msg),
+        time_stamp = lists:flatten(Entry1#log_entry.time_stamp)
     },
     Ignored = application:get_env(couch_log, ignored_pids, []),
     case lists:member(Entry#log_entry.pid, Ignored) of

--- a/src/couch_log/test/eunit/couch_log_writer_syslog_test.erl
+++ b/src/couch_log/test/eunit/couch_log_writer_syslog_test.erl
@@ -97,7 +97,7 @@ check_format() ->
         Entry = #log_entry{
             level = report,
             pid = list_to_pid("<0.1.0>"),
-            msg = "[foo=1] stuff",
+            msg = ["[", "foo=1", "]"],
             msg_id = "msg_id",
             time_stamp = "time_stamp",
             type = report123
@@ -117,7 +117,7 @@ check_format() ->
     ?assertEqual("couchdb", AppId),
     ?assertEqual("msg_id", MsgId),
     ?assert(is_pid(catch list_to_pid(Pid))),
-    ?assertEqual("[report123@12345 foo=1] stuff\n", string:join(Rest, " ")),
+    ?assertEqual("[report123-DB@12345 foo=1]\n", string:join(Rest, " ")),
     ?assert(meck:called(gen_udp, close, 1)),
     ?assert(meck:validate(gen_udp)).
 

--- a/src/couch_log/test/eunit/couch_log_writer_syslog_test.erl
+++ b/src/couch_log/test/eunit/couch_log_writer_syslog_test.erl
@@ -121,8 +121,6 @@ check_format() ->
     ?assert(meck:called(gen_udp, close, 1)),
     ?assert(meck:validate(gen_udp)).
 
-
-
 facility_test() ->
     Names = [
         "kern",

--- a/src/mango/src/mango_cursor_nouveau.erl
+++ b/src/mango/src/mango_cursor_nouveau.erl
@@ -122,10 +122,10 @@ execute(Cursor, UserFun, UserAcc) ->
             JsonBM = nouveau_bookmark:pack(FinalBM),
             Arg = {add_key, bookmark, JsonBM},
             {_Go, FinalUserAcc} = UserFun(Arg, LastUserAcc),
-            FinalUserAcc0 = mango_execution_stats:maybe_add_stats(
+            {FinalUserAcc0, Stats1} = mango_execution_stats:maybe_add_stats(
                 Opts, UserFun, Stats0, FinalUserAcc
             ),
-            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, Stats0, FinalUserAcc0),
+            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, Stats1, FinalUserAcc0),
             {ok, FinalUserAcc1}
     end.
 

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -127,9 +127,11 @@ execute(Cursor, UserFun, UserAcc) ->
             JsonBM = dreyfus_bookmark:pack(FinalBM),
             Arg = {add_key, bookmark, JsonBM},
             {_Go, FinalUserAcc} = UserFun(Arg, LastUserAcc),
-            FinalUserAcc0 = mango_execution_stats:maybe_add_stats(
+            {FinalUserAcc0, Stats1} = mango_execution_stats:maybe_add_stats(
                 Opts, UserFun, Stats0, FinalUserAcc
             ),
+            %% This needs Stats1 as log_end is called in maybe_add_stats
+            mango_execution_stats:log_stats(Stats1),
             FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, Stats0, FinalUserAcc0),
             {ok, FinalUserAcc1}
     end.

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -132,7 +132,7 @@ execute(Cursor, UserFun, UserAcc) ->
             ),
             %% This needs Stats1 as log_end is called in maybe_add_stats
             mango_execution_stats:log_stats(Stats1),
-            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, Stats0, FinalUserAcc0),
+            FinalUserAcc1 = mango_cursor:maybe_add_warning(UserFun, Cursor, Stats1, FinalUserAcc0),
             {ok, FinalUserAcc1}
     end.
 

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -229,12 +229,13 @@ execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFu
                     Arg = {add_key, bookmark, NewBookmark},
                     {_Go, FinalUserAcc} = UserFun(Arg, LastCursor#cursor.user_acc),
                     Stats0 = LastCursor#cursor.execution_stats,
-                    mango_execution_stats:log_stats(Stats0),
-                    FinalUserAcc0 = mango_execution_stats:maybe_add_stats(
+                    {FinalUserAcc0, Stats1} = mango_execution_stats:maybe_add_stats(
                         Opts, UserFun, Stats0, FinalUserAcc
                     ),
+                    %% This needs Stats1 as log_end is called in maybe_add_stats
+                    mango_execution_stats:log_stats(Stats1),
                     FinalUserAcc1 = mango_cursor:maybe_add_warning(
-                        UserFun, Cursor, Stats0, FinalUserAcc0
+                        UserFun, Cursor, Stats1, FinalUserAcc0
                     ),
                     {ok, FinalUserAcc1};
                 {error, Reason} ->

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -229,6 +229,7 @@ execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFu
                     Arg = {add_key, bookmark, NewBookmark},
                     {_Go, FinalUserAcc} = UserFun(Arg, LastCursor#cursor.user_acc),
                     Stats0 = LastCursor#cursor.execution_stats,
+                    mango_execution_stats:log_stats(Stats0),
                     FinalUserAcc0 = mango_execution_stats:maybe_add_stats(
                         Opts, UserFun, Stats0, FinalUserAcc
                     ),

--- a/src/mango/src/mango_execution_stats.erl
+++ b/src/mango/src/mango_execution_stats.erl
@@ -21,6 +21,7 @@
     incr_results_returned/1,
     log_start/1,
     log_end/1,
+    log_stats/1,
     maybe_add_stats/4
 ]).
 
@@ -74,6 +75,9 @@ log_end(Stats) ->
 maybe_add_stats(Opts, UserFun, Stats0, UserAcc) ->
     Stats1 = log_end(Stats0),
     couch_stats:update_histogram([mango, query_time], Stats1#execution_stats.executionTimeMs),
+    %% TODO: validate rows/reads assignments
+    chttpd_stats:incr_rows(Stats1#execution_stats.totalDocsExamined),
+    chttpd_stats:incr_reads(Stats1#execution_stats.totalQuorumDocsExamined),
 
     case couch_util:get_value(execution_stats, Opts) of
         true ->
@@ -84,3 +88,10 @@ maybe_add_stats(Opts, UserFun, Stats0, UserAcc) ->
         _ ->
             UserAcc
     end.
+
+log_stats(Stats) ->
+    {JStats0} = to_json(Stats),
+    Nonce = list_to_binary(couch_log_util:get_msg_id()),
+    JStats = {[{<<"nonce">>, Nonce} | JStats0]},
+	%% TODO: switch to report
+    couch_log:report("FIXME-reportid", "[ASDFMARKER] GOT MANGO EXEC STATS: ~s", [binary_to_list(jiffy:encode(JStats))], #{}).

--- a/src/mango/src/mango_execution_stats.erl
+++ b/src/mango/src/mango_execution_stats.erl
@@ -89,15 +89,16 @@ maybe_add_stats(Opts, UserFun, Stats0, UserAcc) ->
     %% TODO: add docs vs quorum docs
     chttpd_stats:incr_reads(Stats1#execution_stats.totalDocsExamined),
 
-    FinalAcc = case couch_util:get_value(execution_stats, Opts) of
-        true ->
-            JSONValue = to_json(Stats1),
-            Arg = {add_key, execution_stats, JSONValue},
-            {_Go, FinalUserAcc} = UserFun(Arg, UserAcc),
-            FinalUserAcc;
-        _ ->
-            UserAcc
-    end,
+    FinalAcc =
+        case couch_util:get_value(execution_stats, Opts) of
+            true ->
+                JSONValue = to_json(Stats1),
+                Arg = {add_key, execution_stats, JSONValue},
+                {_Go, FinalUserAcc} = UserFun(Arg, UserAcc),
+                FinalUserAcc;
+            _ ->
+                UserAcc
+        end,
     {FinalAcc, Stats1}.
 
 log_stats(Stats) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This PR introduces a mechanism for logging metadata about requests and system activity outside of the normal http log entry. In particular, this work is meant to provide tooling for logging things like the quantity of work performed to fulfill a particular request.

For example, given we make a `_find` query like so:

```
(chewbranca)-(jobs:0)-(~)                                                                                                                                                                                                                                                                                                   
(! 2793)-> curl  -u adm:pass -X POST localhost:15984/foo/_find?include_docs=true -d '{"selector":{"blah":"blah blah"},"use_index":"_design/67ca9ba1e20371ee9d7e703c1f04eb1d03521b57","execution_stats":true}' -H content-type:application/json                                                                              
{"docs":[                                                                                                                                                                                                                                                                                                                   
{"_id":"493609ddc70fa41dec7ec28fc3000bf0","_rev":"1-6440c84fecde0669be847bf9639110b5","blah":"blah blah"},                                                                                                                                                                                                                  
...*SNIP*...                                                                                                                                                                                                                                                                                                                
{"_id":"7ea025f22312db0d494f7a3d0f2614d4","_rev":"1-6440c84fecde0669be847bf9639110b5","blah":"blah blah"},                                                                                                                                                                                                                  
{"_id":"7ea025f22312db0d494f7a3d0f2622ee","_rev":"1-6440c84fecde0669be847bf9639110b5","blah":"blah blah"}                                                                                                                                                                                                                   
],                                                                                                                                                                                                                                                                                                                          
"bookmark": "g1AAAABfeJzLYWBgYMpgSmHgKy5JLCrJTq2MT8lPzkzJBYormKcmGhiZphkZGRsapSQZpJhYmqSZJxqnGKQZmRkZpaaC9HHA9OUAdTCCtHEm5SRmKICIrCwAuMMZsw",                                                                                                                                                                               
"execution_stats": {"total_keys_examined":0,"total_docs_examined":1243,"total_quorum_docs_examined":0,"results_returned":1243,"execution_time_ms":190.988}}                                                                                                                                                                 
```

This PR will generate a log entry report of the form:

> [report] 2023-03-20T23:39:03.763470Z node1@127.0.0.1 <0.7071.0> ecded843da mango-stats [type="mango-stats" total_quorum_docs_examined="0" total_keys_examined="0" total_docs_examined="1243" results_returned="1243" nonce="ecded843da" execution_time_ms="190.988"]

The report metadata is logged in format compliant with [RFC5424](https://www.rfc-editor.org/rfc/rfc5424.html#section-6.3) such that syslog can pickup the metadata entries. This allows us to extend what metadata is introduced over time in such a way that parsing at the log/syslog level will not need further modifications for new data. This means we can easily introduce additional data logging around volume or IO operations or other statistics at a lower granularity than the doc level.

It could be argued that this data should be directly coupled with the underlying http log, and I offer two counterpoints:

  1) currently `mango_crud:find/5` returns an accumulated response, rather than a request handle, so we lose the metadata generated inside `mango` when it passes back into the `chttpd` layer, hence `chttpd` no longer has the relevant stats to include in the log when we finally log the post http request entry in `chttpd`. We _could_ modify the relevant code paths to introduce a data structure containing both the response and metadata values allowing us to funnel data to be logged up from lower levels in the system than chttpd; I think this is potentially worthwhile, but I also think item 2) below makes this less of an immediate concern.

  2) I believe strongly we need the ability to collect data about the overhead performed by a particular task and then log that data such that we can more clearly articulate what CouchDB is doing as a function of time. This is certainly incredibly important for http requests that generate load to understand expensive requests, but also just as important for background operations as we have some blind spots in the amount of `couch_btree:foldl` operations induced per operation, be it a view/_all_docs or a background job like compaction of view building. Therefore we have areas to generate these report logs where there's no existing http request context to hook into. Furthermore, I think it's worthwhile to be able to record stats along these lines on the RPC side rather than funneling all the data back to the coordinator to do the logging there.

I do think there's merit to 1) above, however, I think 2) necessitates report logging outside of an http context so I'm not convinced we should do 1) as part of this PR. That said, feedback is welcome.

<hr />

The current structure of this PR is functional and allows for a hybrid approach for the report logging such that the RFC5424 metadata can be introduced _along with_ an additional arbitrary string message afterwards. While working through the logic here, in practice, supporting the hybrid approach complicates the underlying logic in the codebase and also seems to complicate the ability for RFC5424 parsers to extract the metadata and parse the log entry. For example, here's a [RFC5424 parser Splunk plugin](https://splunkbase.splunk.com/app/978) I've been looking at and one of the caveats is:

> The MSG section of the event, if it exists, is not parsed by this app.

and a sample message from RFC5424 demonstrating structured metadata followed by a string `MSG`:

```
           <165>1 2003-10-11T22:14:15.003Z mymachine.example.com
           evntslog - ID47 [exampleSDID@32473 iut="3" eventSource=
           "Application" eventID="1011"] BOMAn application
           event log entry...
```

So it's a valid log entry to introduce structured metadata _and also_ follow that with an arbitrary log `MSG` string, but like I said this seems to complicate a lot of things both from a parsing standpoint and the logistics of short circuiting empty messages and format strings through `couch_log_formatter`. I'm inclined to remove this functionality, especially since it feels that in practice, the most useful thing here is logging the metadata block, rather than an additional `MSG` payload.

I wanted to get broader feedback before going down that route of removing the additional MSG, so the PR is in the current form outlined above, but I've got an initial diff below to drop that functionality. This would also cleanup all the additional logic introduced by `couch_log:log/3 --> couch_log:log/5`, and so my preferred direction for this PR to go is to apply this diff and then drop out all support for metadata logging outside of a very specifically targeted `couch_log:report`. Here's the wip diff:

```diff
diff --git a/src/couch_log/src/couch_log.erl b/src/couch_log/src/couch_log.erl
index 379326b52..2fb5808bb 100644
--- a/src/couch_log/src/couch_log.erl
+++ b/src/couch_log/src/couch_log.erl
@@ -22,7 +22,6 @@
     alert/2,
     emergency/2,
     report/2,
-    report/4,
     set_level/1
 ]).
 
@@ -51,11 +50,7 @@ alert(Fmt, Args) -> log(alert, Fmt, Args).
 emergency(Fmt, Args) -> log(emergency, Fmt, Args).
 
 -spec report(string(), map()) -> ok.
-report(ReportId, Meta) when is_map(Meta) ->
-    report(ReportId, "", [], Meta).
-
--spec report(string(), string(), list(), map()) -> ok.
-report(ReportId, Fmt, Args, Meta0) when is_map(Meta0) ->
+report(ReportId, Meta0) when is_map(Meta0) ->
     Meta = case maps:is_key(type, Meta0) of
         true ->
             Meta0;
@@ -63,7 +58,7 @@ report(ReportId, Fmt, Args, Meta0) when is_map(Meta0) ->
             Meta0#{type => ReportId}
     end,
     couch_stats:increment_counter([couch_log, level, report]),
-    Entry = couch_log_formatter:format(report, self(), ReportId, Fmt, Args, Meta),
+    Entry = couch_log_formatter:format_report(self(), ReportId, Meta),
     ok = couch_log_server:log(Entry).
 
 -spec set_level(atom() | string() | integer()) -> true.
diff --git a/src/couch_log/src/couch_log_formatter.erl b/src/couch_log/src/couch_log_formatter.erl
index bf7571975..5b23f7ed5 100644
--- a/src/couch_log/src/couch_log_formatter.erl
+++ b/src/couch_log/src/couch_log_formatter.erl
@@ -22,6 +22,8 @@
     format/3,
     format/1,
 
+    format_report/3,
+
     format_reason/1,
     format_mfa/1,
     format_trace/1,
@@ -32,6 +34,28 @@
 
 -define(DEFAULT_TRUNCATION, 1024).
 
+-define(REPORT_LEVEL, report).
+
+format_report(Pid, Type, Meta) ->
+    MaxMsgSize = couch_log_config:get(max_message_size),
+    Msg = case format_meta(Meta) of
+        "" ->
+            "";
+        MetaStr when length(MetaStr) > MaxMsgSize ->
+            %% TODO: what to do when meta formatted data is too large?
+            error(what_to_do_here);
+        MetaStr ->
+            ["[", MetaStr, "]"]
+    end,
+    #log_entry{
+        level = couch_log_util:level_to_atom(?REPORT_LEVEL),
+        pid = Pid,
+        msg = Msg,
+        msg_id = couch_log_util:get_msg_id(),
+        time_stamp = couch_log_util:iso8601_timestamp(),
+        type = Type
+    }.
+
 format(Level, Pid, Fmt, Args) ->
     format(Level, Pid, undefined, Fmt, Args, #{}).
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
