### PR TITLE
catch and log any error from mem3:local_shards

### DIFF
--- a/src/couch_index/src/couch_index_server.erl
+++ b/src/couch_index/src/couch_index_server.erl
@@ -312,7 +312,11 @@ handle_db_event(<<"shards/", _/binary>> = DbName, {ddoc_updated, DDocId}, St) ->
         try
             mem3:local_shards(mem3:dbname(DbName))
         catch
-            error:database_does_not_exist ->
+            Class:Msg ->
+                couch_log:warning(
+                    "~p got ~p:~p when fetching local shards for ~p",
+                    [?MODULE, Class, Msg, DbName]
+                ),
                 []
         end,
     DbShards = [mem3:name(Sh) || Sh <- LocalShards],


### PR DESCRIPTION
Enhance the fix in 06ab38d0c7607abeea7d63aeb47a5229fe0129da to cover all errors thrown by mem3:local_shards. The consequences of a crash here takes down a couch_index_server, which messily kills any in-flight view or find requests for that server.