### PR TITLE
Bump Erlang 24 and 25 in CI

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -14,7 +14,7 @@
 // the License.
 
 // Erlang version embedded in binary packages
-ERLANG_VERSION = '24.3.4.9'
+ERLANG_VERSION = '24.3.4.10'
 
 // Erlang version used for rebar in release process. CouchDB will not build from
 // the release tarball on Erlang versions older than this

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -247,7 +247,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '23.3.4.18', '24.3.4.9', '25.2'
+            values '23.3.4.18', '24.3.4.10', '25.3'
           }
           axis {
             name 'SM_VSN'


### PR DESCRIPTION
It fixes aliases leak and prepares for new package updates
