### PR TITLE
Couch index fixes

### DIFF
--- a/src/couch_index/src/couch_index_server.erl
+++ b/src/couch_index/src/couch_index_server.erl
@@ -312,11 +312,7 @@ handle_db_event(<<"shards/", _/binary>> = DbName, {ddoc_updated, DDocId}, St) ->
         try
             mem3:local_shards(mem3:dbname(DbName))
         catch
-            Class:Msg ->
-                couch_log:warning(
-                    "~p got ~p:~p when fetching local shards for ~p",
-                    [?MODULE, Class, Msg, DbName]
-                ),
+            error:database_does_not_exist ->
                 []
         end,
     DbShards = [mem3:name(Sh) || Sh <- LocalShards],

--- a/src/couch_index/test/eunit/couch_index_ddoc_updated_tests.erl
+++ b/src/couch_index/test/eunit/couch_index_ddoc_updated_tests.erl
@@ -109,7 +109,8 @@ check_all_indexers_exit_on_ddoc_change({_Ctx, DbName}) ->
                     couch_db:name(DbShard),
                     {ddoc_updated, DDocID},
                     {st, "", couch_index_server:server_name(I), couch_index_server:by_sig(I),
-                        couch_index_server:by_pid(I), couch_index_server:by_db(I)}
+                        couch_index_server:by_pid(I), couch_index_server:by_db(I),
+                        couch_index_server:openers(I)}
                 )
             end,
             seq()


### PR DESCRIPTION
couch_index_server can crash if;

1) an index, opened with new_index, crashes while doing so
2) the db event listener pid crashes

This PR improves behaviour as follows;

1) log original stack in couch_event_listener_mfa:db_event (but still throw)
2) prevent couch_index_server:handle_db_event from crashing
3) track the opener pids in couch_index_server, don't crash couch_index_server if they terminate abnormally