### PR TITLE
Suppress sasl_error_logger output on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -153,7 +153,7 @@ endif
 .PHONY: eunit
 # target: eunit - Run EUnit tests, use EUNIT_OPTS to provide custom options
 eunit: export BUILDDIR = $(shell echo %cd%)
-eunit: export ERL_AFLAGS = $(shell echo "-config %cd%/rel/files/eunit.config")
+eunit: export ERL_AFLAGS = -config $(shell echo "%cd%")/rel/files/eunit.config
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 eunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 eunit: couch
@@ -164,19 +164,19 @@ eunit: couch
 # target: exunit - Run ExUnit tests, use EXUNIT_OPTS to provide custom options
 exunit: export BUILDDIR = $(shell echo %cd%)
 exunit: export MIX_ENV=test
-exunit: export ERL_LIBS = $(shell echo %cd%)\src
-exunit: export ERL_AFLAGS = $(shell echo "-config %cd%/rel/files/eunit.config")
+exunit: export ERL_LIBS = $(shell echo %cd%)/src
+exunit: export ERL_AFLAGS = -config $(shell echo "%cd%")/rel/files/eunit.config
 exunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(shell echo %cd%)/bin/couchjs $(shell echo %cd%)/share/server/main.js
 exunit: couch elixir-init setup-eunit elixir-check-formatted elixir-credo
 	@mix test --cover --trace $(EXUNIT_OPTS)
 
 setup-eunit: export BUILDDIR = $(shell echo %cd%)
-setup-eunit: export ERL_AFLAGS = $(shell echo "-config %cd%/rel/files/eunit.config")
+setup-eunit: export ERL_AFLAGS = -config $(shell echo "%cd%")/rel/files/eunit.config
 setup-eunit:
 	@$(REBAR) setup_eunit 2> nul
 
 just-eunit: export BUILDDIR = $(shell echo %cd%)
-just-eunit: export ERL_AFLAGS = $(shell echo "-config %cd%/rel/files/eunit.config")
+just-eunit: export ERL_AFLAGS = -config $(shell echo "%cd%")/rel/files/eunit.config
 just-eunit:
 	@$(REBAR) -r eunit $(EUNIT_OPTS)
 


### PR DESCRIPTION
Correct env variable `ERL_AFLAGS` to suppress `sasl_error_logger` output.

Suppressing messages like:
```
=ERROR REPORT==== 22-Mar-2023::22:47:36.788000 ===
Error in process <0.998.0> with exit value:
{database_does_not_exist,
    [{mem3_shards,load_shards_from_db,"_users",
         [{file,"src/mem3_shards.erl"},{line,430}]},
     {mem3_shards,load_shards_from_disk,1,
         [{file,"src/mem3_shards.erl"},{line,405}]},
     {mem3_shards,load_shards_from_disk,2,
         [{file,"src/mem3_shards.erl"},{line,434}]},
     {mem3_shards,for_docid,3,[{file,"src/mem3_shards.erl"},{line,100}]},
     {fabric_doc_open,go,3,[{file,"src/fabric_doc_open.erl"},{line,39}]},
     {chttpd_auth_cache,ensure_auth_ddoc_exists,2,
         [{file,"src/chttpd_auth_cache.erl"},{line,214}]},
     {chttpd_auth_cache,listen_for_changes,1,
         [{file,"src/chttpd_auth_cache.erl"},{line,160}]}]}

    chttpd_socket_buffer_size_test:51: small_recbuf...[0.006 s] ok
=INFO REPORT==== 22-Mar-2023::22:47:36.897000 ===
    application: chttpd
    exited: stopped
    type: temporary

=INFO REPORT==== 22-Mar-2023::22:47:36.897000 ===
    application: fabric
    exited: stopped
    type: temporary
```