### PR TITLE
Add log directory to eunit setup template

### DIFF
--- a/rel/files/eunit.ini
+++ b/rel/files/eunit.ini
@@ -30,7 +30,7 @@ port = 0
 [log]
 ; log to a file to save our terminals from log spam
 writer = file
-file = couch.log
+file = {{log_dir}}/couch.log
 level = info
 
 [replicator]

--- a/rel/plugins/eunit_plugin.erl
+++ b/rel/plugins/eunit_plugin.erl
@@ -31,12 +31,14 @@ build_eunit_config(Config0, AppFile) ->
     ViewIndexDir = Cwd ++ "/tmp/data",
     StateDir = Cwd ++ "/tmp/data",
     TmpDataDir = Cwd ++ "/tmp/tmp_data",
+    LogDir = Cwd ++ "/tmp",
     cleanup_dirs([DataDir, TmpDataDir]),
     Config1 = rebar_config:set_global(Config0, template, "setup_eunit"),
     Config2 = rebar_config:set_global(Config1, prefix, Cwd),
     Config3 = rebar_config:set_global(Config2, data_dir, DataDir),
     Config4 = rebar_config:set_global(Config3, view_index_dir, ViewIndexDir),
-    Config = rebar_config:set_global(Config4, state_dir, StateDir),
+    Config5 = rebar_config:set_global(Config4, log_dir, LogDir),
+    Config = rebar_config:set_global(Config5, state_dir, StateDir),
     rebar_templater:create(Config, AppFile).
 
 cleanup_dirs(Dirs) ->

--- a/setup_eunit.template
+++ b/setup_eunit.template
@@ -8,7 +8,8 @@
     {data_dir, "/tmp"},
     {prefix, "/tmp"},
     {view_index_dir, "/tmp"},
-    {state_dir, "/tmp"}
+    {state_dir, "/tmp"},
+    {log_dir, "/tmp"}
 ]}.
 {dir, "tmp"}.
 {dir, "tmp/etc"}.


### PR DESCRIPTION
To log messages of test runs to file we need to add a absoulute path to the file logger.