### PR TITLE
Treat single-element keys as key

### DIFF
--- a/src/chttpd/test/eunit/chttpd_view_test.erl
+++ b/src/chttpd/test/eunit/chttpd_view_test.erl
@@ -19,45 +19,47 @@
 -define(PASS, "pass").
 -define(AUTH, {basic_auth, {?USER, ?PASS}}).
 -define(CONTENT_JSON, {"Content-Type", "application/json"}).
--define(DDOC,
-    "{\"_id\": \"_design/bar\", \"views\": {\"baz\":\n"
-    "               {\"map\": \"function(doc) {emit(doc._id, doc._id);}\"}}}"
-).
 
--define(FIXTURE_TXT, ?ABS_PATH(?FILE)).
--define(i2l(I), integer_to_list(I)).
+-define(DOCS, #{
+    <<"docs">> => [
+        #{<<"_id">> => <<"a">>, <<"key">> => <<"a">>, <<"value">> => 1},
+        #{<<"_id">> => <<"b">>, <<"key">> => <<"b">>, <<"value">> => 2},
+        #{<<"_id">> => <<"c">>, <<"key">> => <<"c">>, <<"value">> => 3},
+        #{<<"_id">> => <<"d">>, <<"key">> => <<"d">>, <<"_deleted">> => true}
+    ]
+}).
+-define(DDOC, #{
+    <<"_id">> => <<"_design/ddoc">>,
+    <<"views">> => #{
+        <<"map">> => #{<<"map">> => <<"function(doc) { emit(doc.key, doc.value) }">>},
+        <<"map_reduce">> => #{
+            <<"map">> => <<"function(doc) { emit(doc.key, doc.value) }">>,
+            <<"reduce">> => <<"_sum">>
+        }
+    }
+}).
+-define(ERROR_KEYS_INCOMPATIBLE, #{
+    <<"error">> := <<"query_parse_error">>,
+    <<"reason">> := <<"`keys` is incompatible with `key`, `start_key` and `end_key`">>
+}).
+
 % seconds
 -define(TIMEOUT, 60).
 
 setup() ->
     Hashed = couch_passwords:hash_admin_password(?PASS),
     ok = config:set("admins", ?USER, ?b2l(Hashed), _Persist = false),
-    TmpDb = ?tempdb(),
-    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
-    Port = mochiweb_socket_server:get(chttpd, port),
-    Url = lists:concat(["http://", Addr, ":", Port, "/", ?b2l(TmpDb)]),
-    create_db(Url),
-    Url.
+    Db = ?tempdb(),
+    ok = create_db(Db),
+    ok = create_docs(Db),
+    ok = create_ddoc(Db),
+    Db.
 
-teardown(Url) ->
-    delete_db(Url),
+teardown(Db) ->
+    ok = fabric:delete_db(Db),
     ok = config:delete("admins", ?USER, _Persist = false).
 
-create_db(Url) ->
-    {ok, Status, _, _} = test_request:put(Url, [?CONTENT_JSON, ?AUTH], "{}"),
-    ?assert(Status =:= 201 orelse Status =:= 202).
-
-create_doc(Url, Id) ->
-    test_request:put(
-        Url ++ "/" ++ Id,
-        [?CONTENT_JSON, ?AUTH],
-        "{\"mr\": \"rockoartischocko\"}"
-    ).
-
-delete_db(Url) ->
-    {ok, 200, _, _} = test_request:delete(Url, [?AUTH]).
-
-all_view_test_() ->
+view_test_() ->
     {
         "chttpd view tests",
         {
@@ -69,86 +71,343 @@ all_view_test_() ->
                 fun setup/0,
                 fun teardown/1,
                 [
-                    fun should_succeed_on_view_with_queries_keys/1,
-                    fun should_succeed_on_view_with_queries_limit_skip/1,
-                    fun should_succeed_on_view_with_multiple_queries/1
+                    ?TDEF_FE(t_view_with_queries_keys, ?TIMEOUT),
+                    ?TDEF_FE(t_view_with_queries_limit_skip, ?TIMEOUT),
+                    ?TDEF_FE(t_view_with_multiple_queries, ?TIMEOUT),
+                    ?TDEF_FE(t_view_with_key_and_start_key),
+                    ?TDEF_FE(t_view_with_key_and_end_key),
+                    ?TDEF_FE(t_view_with_single_keys_and_start_key),
+                    ?TDEF_FE(t_view_with_keys_and_start_key),
+                    ?TDEF_FE(t_view_with_key_non_existent_docs),
+                    ?TDEF_FE(t_view_with_keys_non_existent_docs),
+                    ?TDEF_FE(t_view_with_key_deleted_docs),
+                    ?TDEF_FE(t_view_with_keys_deleted_docs),
+                    ?TDEF_FE(t_view_map_reduce_with_key),
+                    ?TDEF_FE(t_view_map_reduce_with_single_keys),
+                    ?TDEF_FE(t_view_map_reduce_with_single_keys_and_group),
+                    ?TDEF_FE(t_view_map_reduce_with_keys),
+                    ?TDEF_FE(t_view_map_reduce_with_keys_and_group)
                 ]
             }
         }
     }.
 
-should_succeed_on_view_with_queries_keys(Url) ->
-    {timeout, ?TIMEOUT,
-        ?_test(begin
-            [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-            {ok, _, _, _} = test_request:put(
-                Url ++ "/_design/bar",
-                [?CONTENT_JSON, ?AUTH],
-                ?DDOC
-            ),
-            QueryDoc =
-                "{\"queries\": [{\"keys\": [ \"testdoc3\",\n"
-                "            \"testdoc8\"]}]}",
-            {ok, _, _, RespBody} = test_request:post(
-                Url ++ "/_design/bar/" ++
-                    "_view/baz/queries/",
-                [?CONTENT_JSON, ?AUTH],
-                QueryDoc
-            ),
-            {ResultJson} = ?JSON_DECODE(RespBody),
-            ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
-            {InnerJson} = lists:nth(1, ResultJsonBody),
-            ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson)))
-        end)}.
+all_docs_test_() ->
+    {
+        "chttpd all docs tests",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    ?TDEF_FE(t_all_docs_with_key_and_start_key),
+                    ?TDEF_FE(t_all_docs_with_key_and_end_key),
+                    ?TDEF_FE(t_all_docs_with_single_keys_and_start_key),
+                    ?TDEF_FE(t_all_docs_with_keys_and_start_key),
+                    ?TDEF_FE(t_all_docs_with_key_non_existent_docs),
+                    ?TDEF_FE(t_all_docs_with_keys_non_existent_docs),
+                    ?TDEF_FE(t_all_docs_with_key_deleted_docs),
+                    ?TDEF_FE(t_all_docs_with_keys_deleted_docs)
+                ]
+            }
+        }
+    }.
 
-should_succeed_on_view_with_queries_limit_skip(Url) ->
-    {timeout, ?TIMEOUT,
-        ?_test(begin
-            [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-            {ok, _, _, _} = test_request:put(
-                Url ++ "/_design/bar",
-                [?CONTENT_JSON, ?AUTH],
-                ?DDOC
-            ),
-            QueryDoc = "{\"queries\": [{\"limit\": 5, \"skip\": 2}]}",
-            {ok, RC, _, RespBody} = test_request:post(
-                Url ++ "/_design/bar/" ++
-                    "_view/baz/queries/",
-                [?CONTENT_JSON, ?AUTH],
-                QueryDoc
-            ),
-            ?assertEqual(200, RC),
-            {ResultJson} = ?JSON_DECODE(RespBody),
-            ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
-            {InnerJson} = lists:nth(1, ResultJsonBody),
-            ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson)),
-            ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson)))
-        end)}.
+t_view_with_queries_keys(Db) ->
+    QueryDoc = #{<<"queries">> => [#{<<"keys">> => [<<"a">>, <<"c">>]}]},
+    {Code, Res} = req(post, url(Db, "_design/ddoc/_view/map/queries"), QueryDoc),
+    ?assertMatch(
+        #{
+            <<"results">> := [
+                #{
+                    <<"total_rows">> := 3,
+                    <<"offset">> := 1,
+                    <<"rows">> := [#{<<"id">> := <<"a">>}, #{<<"id">> := <<"c">>}]
+                }
+            ]
+        },
+        Res
+    ),
+    ?assertEqual(200, Code).
 
-should_succeed_on_view_with_multiple_queries(Url) ->
-    {timeout, ?TIMEOUT,
-        ?_test(begin
-            [create_doc(Url, "testdoc" ++ ?i2l(I)) || I <- lists:seq(1, 10)],
-            {ok, _, _, _} = test_request:put(
-                Url ++ "/_design/bar",
-                [?CONTENT_JSON, ?AUTH],
-                ?DDOC
-            ),
-            QueryDoc =
-                "{\"queries\": [{\"keys\": [ \"testdoc3\",\n"
-                "            \"testdoc8\"]}, {\"limit\": 5, \"skip\": 2}]}",
-            {ok, RC, _, RespBody} = test_request:post(
-                Url ++ "/_design/bar/" ++
-                    "_view/baz/queries/",
-                [?CONTENT_JSON, ?AUTH],
-                QueryDoc
-            ),
-            ?assertEqual(200, RC),
-            {ResultJson} = ?JSON_DECODE(RespBody),
-            ResultJsonBody = couch_util:get_value(<<"results">>, ResultJson),
-            {InnerJson1} = lists:nth(1, ResultJsonBody),
-            ?assertEqual(2, length(couch_util:get_value(<<"rows">>, InnerJson1))),
-            {InnerJson2} = lists:nth(2, ResultJsonBody),
-            ?assertEqual(2, couch_util:get_value(<<"offset">>, InnerJson2)),
-            ?assertEqual(5, length(couch_util:get_value(<<"rows">>, InnerJson2)))
-        end)}.
+t_view_with_queries_limit_skip(Db) ->
+    QueryDoc = #{<<"queries">> => [#{<<"limit">> => 1, <<"skip">> => 1}]},
+    {Code, Res} = req(post, url(Db, "_design/ddoc/_view/map/queries/"), QueryDoc),
+    ?assertMatch(
+        #{
+            <<"results">> := [
+                #{<<"total_rows">> := 3, <<"offset">> := 1, <<"rows">> := [#{<<"id">> := <<"b">>}]}
+            ]
+        },
+        Res
+    ),
+    ?assertEqual(200, Code).
+
+t_view_with_multiple_queries(Db) ->
+    QueryDoc = #{
+        <<"queries">> => [#{<<"keys">> => [<<"a">>, <<"c">>], <<"limit">> => 1, <<"skip">> => 1}]
+    },
+    {Code, Res} = req(post, url(Db, "_design/ddoc/_view/map/queries/"), QueryDoc),
+    ?assertMatch(
+        #{
+            <<"results">> := [
+                #{<<"total_rows">> := 3, <<"offset">> := 2, <<"rows">> := [#{<<"id">> := <<"c">>}]}
+            ]
+        },
+        Res
+    ),
+    ?assertEqual(200, Code).
+
+t_view_with_key_and_start_key(Db) ->
+    {Code1, Res1} = req(get, url(Db, "_design/ddoc/_view/map", "key=\"a\"&startkey=\"b\"")),
+    {Code2, Res2} = req(get, url(Db, "_design/ddoc/_view/map", "startkey=\"b\"&key=\"a\"")),
+    ?assertMatch(
+        #{
+            <<"error">> := <<"query_parse_error">>,
+            <<"reason">> :=
+                <<"No rows can match your key range, reverse your start_key and end_key or set descending=true">>
+        },
+        Res1
+    ),
+    ?assertMatch(#{<<"rows">> := [#{<<"id">> := <<"a">>}]}, Res2),
+    ?assertEqual(400, Code1),
+    ?assertEqual(200, Code2).
+
+t_all_docs_with_key_and_start_key(Db) ->
+    {Code1, Res1} = req(get, url(Db, "_all_docs", "key=\"a\"&startkey=\"b\"")),
+    {Code2, Res2} = req(get, url(Db, "_all_docs", "startkey=\"b\"&key=\"a\"")),
+    ?assertMatch(#{<<"rows">> := []}, Res1),
+    ?assertMatch(#{<<"rows">> := [#{<<"id">> := <<"a">>}]}, Res2),
+    ?assertEqual(200, Code1),
+    ?assertEqual(200, Code2).
+
+t_view_with_key_and_end_key(Db) ->
+    test_helper_key_and_end_key(Db, "_design/ddoc/_view/map").
+
+t_all_docs_with_key_and_end_key(Db) ->
+    test_helper_key_and_end_key(Db, "_all_docs").
+
+test_helper_key_and_end_key(Db, Path) ->
+    {Code1, Res1} = req(get, url(Db, Path, "key=\"a\"&endkey=\"b\"")),
+    {Code2, Res2} = req(get, url(Db, Path, "endkey=\"b\"&key=\"a\"")),
+    ?assertMatch(#{<<"rows">> := [#{<<"id">> := <<"a">>}, #{<<"id">> := <<"b">>}]}, Res1),
+    ?assertMatch(#{<<"rows">> := [#{<<"id">> := <<"a">>}]}, Res2),
+    ?assertEqual(200, Code1),
+    ?assertEqual(200, Code2).
+
+t_view_with_single_keys_and_start_key(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map?keys=[\"a\"]&startkey=\"b\"")),
+    ?assertMatch(
+        #{
+            <<"error">> := <<"query_parse_error">>,
+            <<"reason">> :=
+                <<"No rows can match your key range, reverse your start_key and end_key or set descending=true">>
+        },
+        Res
+    ),
+    ?assertEqual(400, Code).
+
+t_all_docs_with_single_keys_and_start_key(Db) ->
+    {Code, Res} = req(get, url(Db, "_all_docs?keys=[\"a\"]&startkey=\"b\"")),
+    ?assertMatch(?ERROR_KEYS_INCOMPATIBLE, Res),
+    ?assertEqual(400, Code).
+
+t_view_with_keys_and_start_key(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map", "keys=[\"a\",\"b\"]&start_key=\"b\"")),
+    ?assertMatch(?ERROR_KEYS_INCOMPATIBLE, Res),
+    ?assertEqual(400, Code).
+
+t_all_docs_with_keys_and_start_key(Db) ->
+    {Code, Res} = req(get, url(Db, "_all_docs", "keys=[\"a\",\"b\"]&start_key=\"b\"")),
+    ?assertMatch(?ERROR_KEYS_INCOMPATIBLE, Res),
+    ?assertEqual(400, Code).
+
+t_view_with_key_non_existent_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map", "key=\"not_exist\"")),
+    ?assertMatch(#{<<"total_rows">> := 3, <<"offset">> := 3, <<"rows">> := []}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map"), #{<<"key">> => <<"not_exist">>}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_all_docs_with_key_non_existent_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_all_docs", "key=\"not_exist\"")),
+    ?assertMatch(#{<<"total_rows">> := 4, <<"offset">> := 4, <<"rows">> := []}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_all_docs"), #{<<"key">> => <<"not_exist">>}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_with_keys_non_existent_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map", "keys=[\"not_exist\"]")),
+    ?assertMatch(#{<<"total_rows">> := 3, <<"offset">> := 3, <<"rows">> := []}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map"), #{<<"keys">> => [<<"not_exist">>]}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_all_docs_with_keys_non_existent_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_all_docs", "keys=[\"not_exist\"]")),
+    ?assertMatch(
+        #{
+            <<"total_rows">> := 4,
+            <<"offset">> := null,
+            <<"rows">> := [#{<<"key">> := <<"not_exist">>, <<"error">> := <<"not_found">>}]
+        },
+        Res
+    ),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_all_docs"), #{<<"keys">> => [<<"not_exist">>]}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_with_key_deleted_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map", "key=\"d\"")),
+    ?assertMatch(#{<<"total_rows">> := 3, <<"offset">> := 3, <<"rows">> := []}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map"), #{<<"key">> => <<"d">>}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_all_docs_with_key_deleted_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_all_docs", "key=\"d\"")),
+    ?assertMatch(#{<<"total_rows">> := 4, <<"offset">> := 4, <<"rows">> := []}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_all_docs"), #{<<"key">> => <<"d">>}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_with_keys_deleted_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map", "keys=[\"d\"]")),
+    ?assertMatch(#{<<"total_rows">> := 3, <<"offset">> := 3, <<"rows">> := []}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map"), #{<<"keys">> => [<<"d">>]}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_all_docs_with_keys_deleted_docs(Db) ->
+    {Code, Res} = req(get, url(Db, "_all_docs", "keys=[\"d\"]")),
+    ?assertMatch(
+        #{
+            <<"total_rows">> := 4,
+            <<"offset">> := null,
+            <<"rows">> := [
+                #{
+                    <<"id">> := <<"d">>,
+                    <<"key">> := <<"d">>,
+                    <<"value">> := #{<<"deleted">> := true}
+                }
+            ]
+        },
+        Res
+    ),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_all_docs"), #{<<"keys">> => [<<"d">>]}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_map_reduce_with_key(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map_reduce", "key=\"a\"")),
+    ?assertMatch(#{<<"rows">> := [#{<<"key">> := null, <<"value">> := 1}]}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map_reduce"), #{<<"key">> => <<"a">>}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_map_reduce_with_single_keys(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map_reduce", "keys=[\"a\"]")),
+    ?assertMatch(#{<<"rows">> := [#{<<"key">> := null, <<"value">> := 1}]}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map_reduce"), #{<<"keys">> => [<<"a">>]}),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_map_reduce_with_single_keys_and_group(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map_reduce?keys=[\"a\"]&group=true")),
+    ?assertMatch(#{<<"rows">> := [#{<<"key">> := <<"a">>, <<"value">> := 1}]}, Res),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map_reduce"), #{
+        <<"keys">> => [<<"a">>], <<"group">> => <<"true">>
+    }),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_map_reduce_with_keys(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map_reduce?keys=[\"a\",\"b\"]")),
+    ?assertMatch(
+        #{
+            <<"error">> := <<"query_parse_error">>,
+            <<"reason">> := <<"Multi-key fetches for reduce views must use `group=true`">>
+        },
+        Res
+    ),
+    ?assertEqual(400, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map_reduce"), #{
+        <<"keys">> => [<<"a">>, <<"b">>]
+    }),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+t_view_map_reduce_with_keys_and_group(Db) ->
+    {Code, Res} = req(get, url(Db, "_design/ddoc/_view/map_reduce?keys=[\"a\",\"b\"]&group=true")),
+    ?assertMatch(
+        #{
+            <<"rows">> := [
+                #{<<"key">> := <<"a">>, <<"value">> := 1},
+                #{<<"key">> := <<"b">>, <<"value">> := 2}
+            ]
+        },
+        Res
+    ),
+    ?assertEqual(200, Code),
+    {Code1, Res1} = req(post, url(Db, "_design/ddoc/_view/map_reduce"), #{
+        <<"keys">> => [<<"a">>, <<"b">>], <<"group">> => true
+    }),
+    ?assertEqual(Res, Res1),
+    ?assertEqual(Code, Code1).
+
+%%%%%%%%%%%%%%%%%%%% Utility Functions %%%%%%%%%%%%%%%%%%%%
+url(Db) ->
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    lists:concat(["http://", Addr, ":", Port, "/", ?b2l(Db)]).
+
+url(Db, Path) ->
+    url(Db) ++ "/" ++ Path.
+
+url(Db, Path, Parameters) ->
+    url(Db) ++ "/" ++ Path ++ "?" ++ Parameters.
+
+create_db(Db) ->
+    case req(put, url(Db)) of
+        {201, #{}} -> ok;
+        Error -> error({failed_to_create_test_db, Db, Error})
+    end.
+
+create_docs(Db) ->
+    case req(post, url(Db) ++ "/_bulk_docs", ?DOCS) of
+        {201, _} -> ok;
+        Error -> error({failed_to_create_docs, Db, Error})
+    end.
+
+create_ddoc(Db) ->
+    case req(post, url(Db), ?DDOC) of
+        {201, _} -> ok;
+        Error -> error({failed_to_create_ddocs, Db, Error})
+    end.
+
+req(Method, Url) ->
+    Headers = [?CONTENT_JSON, ?AUTH],
+    {ok, Code, _, Res} = test_request:request(Method, Url, Headers),
+    {Code, jiffy:decode(Res, [return_maps])}.
+
+req(Method, Url, #{} = Body) ->
+    req(Method, Url, jiffy:encode(Body));
+req(Method, Url, Body) ->
+    Headers = [?CONTENT_JSON, ?AUTH],
+    {ok, Code, _, Res} = test_request:request(Method, Url, Headers, Body),
+    {Code, jiffy:decode(Res, [return_maps])}.

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -564,7 +564,7 @@ validate_args(Args) ->
         {red, exact, _} ->
             ok;
         {red, _, KeyList} when is_list(KeyList) ->
-            Msg = <<"Multi-key fetchs for reduce views must use `group=true`">>,
+            Msg = <<"Multi-key fetches for reduce views must use `group=true`">>,
             mrverror(Msg);
         _ ->
             ok
@@ -581,13 +581,12 @@ validate_args(Args) ->
             ok;
         {[], _, _} ->
             ok;
+        {[Key], Key, Key} ->
+            ok;
         {[_ | _], undefined, undefined} ->
             ok;
         _ ->
-            mrverror(<<
-                "`keys` is incompatible with `key`"
-                ", `start_key` and `end_key`"
-            >>)
+            mrverror(<<"`keys` is incompatible with `key`, `start_key` and `end_key`">>)
     end,
 
     case Args#mrargs.start_key_docid of

--- a/src/couch_mrview/test/eunit/couch_mrview_all_docs_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_all_docs_tests.erl
@@ -40,6 +40,8 @@ all_docs_test_() ->
                 [
                     fun should_query/1,
                     fun should_query_with_range/1,
+                    fun should_query_with_range_and_same_keys/1,
+                    fun raise_error_query_with_range_and_different_keys/1,
                     fun should_query_with_range_rev/1,
                     fun should_query_with_limit_and_skip/1,
                     fun should_query_with_include_docs/1,
@@ -78,6 +80,20 @@ should_query_with_range(Db) ->
             mk_row(<<"5">>, <<"1-aaac5d460fd40f9286e57b9bf12e23d2">>)
         ]},
     ?_assertEqual(Expect, Result).
+
+should_query_with_range_and_same_keys(Db) ->
+    Result = run_query(Db, [{keys, [<<"3">>]}, {start_key, <<"3">>}, {end_key, <<"3">>}]),
+    Expect =
+        {ok, [
+            {meta, [{total, 11}, {offset, 0}]},
+            mk_row(<<"3">>, <<"1-7fbf84d56f8017880974402d60f5acd6">>)
+        ]},
+    ?_assertEqual(Expect, Result).
+
+raise_error_query_with_range_and_different_keys(Db) ->
+    Error = {query_parse_error, <<"`keys` is incompatible with `key`, `start_key` and `end_key`">>},
+    ?_assertThrow(Error, run_query(Db, [{keys, [<<"1">>]}, {start_key, <<"5">>}])),
+    ?_assertThrow(Error, run_query(Db, [{keys, [<<"5">>]}, {start_key, <<"5">>}])).
 
 should_query_with_range_rev(Db) ->
     Result = run_query(Db, [

--- a/src/couch_mrview/test/eunit/couch_mrview_http_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_http_tests.erl
@@ -33,5 +33,34 @@ mrview_http_test_() ->
                 undefined,
                 #mrargs{}
             )
+        ),
+
+        ?_assertEqual(
+            #mrargs{start_key = 1, end_key = 1, group_level = undefined, group = undefined},
+            couch_mrview_http:parse_params(
+                [{"key", "1"}],
+                undefined,
+                #mrargs{}
+            )
+        ),
+
+        ?_assertEqual(
+            #mrargs{start_key = 1, end_key = 1, group_level = undefined},
+            couch_mrview_http:parse_params(
+                [{"keys", "[1]"}],
+                undefined,
+                #mrargs{}
+            )
+        ),
+
+        ?_assertEqual(
+            #mrargs{
+                keys = [1, 2], start_key = undefined, end_key = undefined, group_level = undefined
+            },
+            couch_mrview_http:parse_params(
+                [{"keys", "[1, 2]"}],
+                undefined,
+                #mrargs{}
+            )
         )
     ].


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
 - Request `_view` with reduce function, treat single-element `keys` as `key`
 - Add treat_single_keys_as_key/2 function for POST `_view`.
    If we query `_all_docs` for deleted or nonexistent docs using single-element
    `keys`, we can get {deleted:true} and {error:not_found}.
- Add documentation on using key, keys, start_key, and end_key


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
make eunit apps=chttpd,couch_mrview


<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
Fixed https://github.com/apache/couchdb/issues/2243

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
