### PR TITLE
Treat javascript internal errors as fatal

### DIFF
--- a/share/server/loop.js
+++ b/share/server/loop.js
@@ -130,6 +130,14 @@ var Loop = function() {
       quit(-1);
     } else if (type == "error") {
       respond(e);
+    } else if (e.name == "InternalError") {
+      // If the internal error is caught by handleViewError it will be
+      // re-thrown as a ["fatal", ...] error, and we already handle that above.
+      // Here we handle the case when the error is thrown outside of
+      // handleViewError, for instance when serializing the rows to be sent
+      // back to the user
+      respond(["error", e.name, e.message]);
+      quit(-1);
     } else if (e.error && e.reason) {
       // compatibility with old error format
       respond(["error", e.error, e.reason]);

--- a/share/server/views.js
+++ b/share/server/views.js
@@ -73,6 +73,8 @@ var Views = (function() {
       // Throwing errors of the form ["fatal","error_key","reason"]
       // will kill the OS process. This is not normally what you want.
       throw(err);
+    } else if (err.name == "InternalError") {
+      throw(["fatal", err.name, err.message]);
     }
     var message = "function raised exception " + err.toSource();
     if (doc) message += " with doc._id " + doc._id;


### PR DESCRIPTION
Spidermonkey sometimes throws an `InternalError` when exceeding memory limits, when normally we'd expect it to crash or exit with a non-0 exit code. Because we trap exceptions, and continue emitting rows, it is possible for users views to randomly miss indexed rows based on whether GC had run or not, other internal runtime state which may have been consuming more or less memory until that time.

To prevent the view continuing processing documents, and randomly dropping emitted rows, depending on memory pressure in the JS runtime at the time, choose to treat Internal errors as fatal.

After an InternalError is raised we expect the process to exit just like it would during OOM.

Add a test to assert this happens.

Fix https://github.com/apache/couchdb/issues/4504
