### PR TITLE
Make remsh work with quoted cookie

### DIFF
--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -49,10 +49,14 @@ NODE="${NODE:-$DEFAULT_NODE}"
 
 # If present, extract cookie from ERL_FLAGS
 # This is used by the CouchDB Dockerfile and Helm chart
-COOKIE=$(echo "$ERL_FLAGS" | sed 's/^.*setcookie \([^ ][^ ]*\).*$/\1/g')
+COOKIE=$(echo "$ERL_FLAGS" | sed -r '
+  s/.*-setcookie[ ]*['\''](.*)['\''].*/\1/
+  s/.*-setcookie[ ]*["](.*)["].*/\1/
+  s/.*-setcookie[ ]*([^ ]*).*/\1/
+')
 if test -f "$ARGS_FILE"; then
 # else attempt to extract from vm.args
-  ARGS_FILE_COOKIE=$(awk '$1=="-setcookie"{print $2}' "$ARGS_FILE")
+  ARGS_FILE_COOKIE=$(awk '$1=="-setcookie"{st=index($0," "); print substr($0,st+1)}' "$ARGS_FILE" | tr -d \" | tr -d \')
   COOKIE="${COOKIE:-$ARGS_FILE_COOKIE}"
 fi
 
@@ -111,7 +115,12 @@ fi
 
 # If present, strip -name or -setcookie from ERL_FLAGS
 # to avoid conflicts with the cli parameters
-ERL_FLAGS_CLEAN=$(echo "$ERL_FLAGS" | sed 's/-setcookie \([^ ][^ ]*\)//g' | sed 's/-name \([^ ][^ ]*\)//g')
+ERL_FLAGS_CLEAN=$(echo "$ERL_FLAGS" | sed -r '
+  s/-setcookie[ ]*['\''].*['\'']//
+  s/-setcookie[ ]*["].*["]//
+  s/-setcookie[ ]*[^ ]*//
+  s/-name[ ]*[^ ]*//
+')
 
 if [ -z "${COOKIE}" ]; then
     echo "No Erlang cookie could be found, please specify with -c" >&2
@@ -120,11 +129,11 @@ fi
 
 if [ -z "$TLSCONF" ]; then
   exec env ERL_FLAGS="$ERL_FLAGS_CLEAN" "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
-      -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie $COOKIE \
+      -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie "$COOKIE" \
       "$@"
 else
   exec env ERL_FLAGS="$ERL_FLAGS_CLEAN" "$BINDIR/erl" -boot "$ROOTDIR/releases/$APP_VSN/start_clean" \
-      -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie $COOKIE \
+      -name remsh$$@$LHOST -remsh $NODE -hidden -setcookie "$COOKIE" \
       -proto_dist inet_tls -ssl_dist_optfile $TLSCONF \
       "$@"
 fi


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Allow space and other special characters in cookies.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behavior that the end users
     could notice? -->
First set the cookie in `vm.args`, then run the script below:
e.g.: `-setcookie 'a b\n\t\xd#{}()[]$&^!-=+?|//c\\d\\\e\\\\f'`
or `-setcookie "a b\n\t\xd#{}()[]$&^!-=+?|//c\\d\\\e\\\\f"`

```bash
make release
cd rel/couchdb
./bin/couchdb
./bin/remsh
```


## Related Issues or Pull Requests
fix https://github.com/apache/couchdb/issues/4405
<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
