### PR TITLE
feat(mango): keys-only covering indexes

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -23,7 +23,7 @@
 -export([to_binary/1, to_integer/1, to_list/1, url_encode/1]).
 -export([json_encode/1, json_decode/1, json_decode/2]).
 -export([verify/2, simple_call/2, shutdown_sync/1]).
--export([get_value/2, get_value/3]).
+-export([get_value/2, get_value/3, set_value/3]).
 -export([reorder_results/2, reorder_results/3]).
 -export([url_strip_password/1]).
 -export([encode_doc_id/1]).
@@ -262,6 +262,9 @@ get_value(Key, List, Default) ->
         false ->
             Default
     end.
+
+set_value(Key, List, Value) ->
+    lists:keyreplace(Key, 1, List, {Key, Value}).
 
 get_nested_json_value({Props}, [Key | Keys]) ->
     case couch_util:get_value(Key, Props, nil) of

--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -1317,6 +1317,9 @@ it easier to take advantage of future improvements to query planning
     :>header Content-Type: - :mimetype:`application/json`
     :>header Transfer-Encoding: ``chunked``
 
+    :>json boolean covered: Tell if the query could be answered only
+        by relying on the data stored in the index.  When ``true``, no
+        documents are fetched, which results in a faster response.
     :>json string dbname: Name of database.
     :>json object index: Index used to fulfill the query.
     :>json object selector: Query selector used.
@@ -1364,6 +1367,7 @@ it easier to take advantage of future improvements to query planning
         Transfer-Encoding: chunked
 
         {
+            "covered": false,
             "dbname": "movies",
             "index": {
                 "ddoc": "_design/0d61d9177426b1e2aa8d0fe732ec6e506f5d443c",

--- a/src/mango/src/mango.hrl
+++ b/src/mango/src/mango.hrl
@@ -12,6 +12,8 @@
 
 -define(MANGO_ERROR(R), throw({mango_error, ?MODULE, R})).
 
+-type maybe(A) :: A | undefined.
+
 -type abstract_text_selector() :: {'op_and', [abstract_text_selector()]}
 				| {'op_or', [abstract_text_selector()]}
 				| {'op_not', {abstract_text_selector(), abstract_text_selector()}}
@@ -21,3 +23,13 @@
 				| {'op_null', {_, _}}
 				| {'op_default', _}
 				| {'op_regex', binary()}.
+
+-type database() :: binary().
+-type field() :: binary().
+-type fields() :: all_fields | [field()].
+-type selector() :: any().
+-type ejson() :: {[{atom(), any()}]}.
+
+-type shard_stats() :: {docs_examined, non_neg_integer()}.
+-type row_property_key() :: id | key | value | doc.
+-type row_properties() :: [{row_property_key(), any()}].

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -742,13 +742,20 @@ choose_best_index_with_singleton_test() ->
 
 %% - choose the index with the lowest difference between its prefix and field ranges
 choose_best_index_lowest_difference_test() ->
-    IndexRanges =
+    IndexRanges1 =
         [
             {index1, ranges1, 3},
             {index2, ranges2, 2},
             {index3, ranges3, 1}
         ],
-    ?assertEqual({index3, ranges3}, choose_best_index(IndexRanges)).
+    ?assertEqual({index3, ranges3}, choose_best_index(IndexRanges1)),
+    IndexRanges2 =
+        [
+            {index1, ranges1, 3},
+            {index2, ranges2, 1},
+            {index3, ranges3, 2}
+        ],
+    ?assertEqual({index2, ranges2}, choose_best_index(IndexRanges2)).
 
 %% - if that is equal, choose the index with the least number of fields in the index
 choose_best_index_least_number_of_fields_test() ->

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -538,3 +538,27 @@ covers(Idx, Fields) ->
             Available = [<<"_id">> | columns(Idx)],
             sets:is_subset(sets:from_list(Fields), sets:from_list(Available))
     end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+covers_all_fields_test() ->
+    ?assertNot(covers(undefined, all_fields)).
+
+covers_all_docs_test() ->
+    ?assertNot(covers(#idx{def = all_docs}, undefined)).
+
+covers_empty_index_test() ->
+    Index = #idx{def = {[{<<"fields">>, {[]}}]}},
+    ?assert(covers(Index, [])),
+    ?assert(covers(Index, [<<"_id">>])).
+
+covers_regular_index_test() ->
+    Index = #idx{def = {[{<<"fields">>, {[{field1, undefined}, {field2, undefined}]}}]}},
+    ?assert(covers(Index, [])),
+    ?assert(covers(Index, [<<"_id">>])),
+    ?assert(covers(Index, [field1])),
+    ?assert(covers(Index, [field2, field1])),
+    ?assert(covers(Index, [<<"_id">>, field1, field2])),
+    ?assertNot(covers(Index, [field3, field1, field2])).
+-endif.

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -527,6 +527,7 @@ can_use_sort([Col | RestCols], SortFields, Selector) ->
 % There is no information available about the full set of fields which
 % comes the following consequences: an index cannot (reliably) cover
 % an "all fields" type of query and nested fields are out of scope.
+-spec covers(#idx{}, fields()) -> boolean().
 covers(_, all_fields) ->
     false;
 covers(Idx, Fields) ->

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -21,10 +21,6 @@
 
 -include("mango.hrl").
 
--ifdef(TEST).
--import(test_util, [as_selector/1]).
--endif.
-
 %% Regex for <<"\\.">>
 -define(PERIOD, "\\.").
 
@@ -441,22 +437,25 @@ replace_array_indexes([Part | Rest], NewPartsAcc, HasIntAcc) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+convert_selector(Selector) ->
+    convert([], test_util:as_selector(Selector)).
+
 convert_fields_test() ->
     ?assertEqual(
         {op_null, {[[<<"field">>], <<":">>, <<"null">>], <<"true">>}},
-        convert([], as_selector(#{<<"field">> => null}))
+        convert_selector(#{<<"field">> => null})
     ),
     ?assertEqual(
         {op_field, {[[<<"field">>], <<":">>, <<"boolean">>], <<"true">>}},
-        convert([], as_selector(#{<<"field">> => true}))
+        convert_selector(#{<<"field">> => true})
     ),
     ?assertEqual(
         {op_field, {[[<<"field">>], <<":">>, <<"number">>], <<"42">>}},
-        convert([], as_selector(#{<<"field">> => 42}))
+        convert_selector(#{<<"field">> => 42})
     ),
     ?assertEqual(
         {op_field, {[[<<"field">>], <<":">>, <<"string">>], <<"\"value\"">>}},
-        convert([], as_selector(#{<<"field">> => <<"value">>}))
+        convert_selector(#{<<"field">> => <<"value">>})
     ),
     ?assertEqual(
         {op_and, [
@@ -465,74 +464,74 @@ convert_fields_test() ->
             {op_field, {[[<<"field">>, <<".">>, <<"[]">>], <<":">>, <<"number">>], <<"2">>}},
             {op_field, {[[<<"field">>, <<".">>, <<"[]">>], <<":">>, <<"number">>], <<"3">>}}
         ]},
-        convert([], as_selector(#{<<"field">> => [1, 2, 3]}))
+        convert_selector(#{<<"field">> => [1, 2, 3]})
     ),
     ?assertEqual(
         {op_field, {
             [[<<"field1">>, <<".">>, <<"field2">>], <<":">>, <<"string">>], <<"\"value\"">>
         }},
-        convert([], as_selector(#{<<"field1">> => #{<<"field2">> => <<"value">>}}))
+        convert_selector(#{<<"field1">> => #{<<"field2">> => <<"value">>}})
     ),
     ?assertEqual(
         {op_and, [
             {op_field, {[[<<"field2">>], <<":">>, <<"string">>], <<"\"value2\"">>}},
             {op_field, {[[<<"field1">>], <<":">>, <<"string">>], <<"\"value1\"">>}}
         ]},
-        convert([], as_selector(#{<<"field1">> => <<"value1">>, <<"field2">> => <<"value2">>}))
+        convert_selector(#{<<"field1">> => <<"value1">>, <<"field2">> => <<"value2">>})
     ).
 
 convert_default_test() ->
     ?assertEqual(
         {op_default, <<"\"text\"">>},
-        convert([], as_selector(#{<<"$default">> => #{<<"$text">> => <<"text">>}}))
+        convert_selector(#{<<"$default">> => #{<<"$text">> => <<"text">>}})
     ).
 
 convert_lt_test() ->
     ?assertEqual(
         {op_field,
             {[[<<"field">>], <<":">>, <<"number">>], [<<"[-Infinity TO ">>, <<"42">>, <<"}">>]}},
-        convert([], as_selector(#{<<"field">> => #{<<"$lt">> => 42}}))
+        convert_selector(#{<<"field">> => #{<<"$lt">> => 42}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$lt">> => [1, 2, 3]}}))
+        convert_selector(#{<<"field">> => #{<<"$lt">> => [1, 2, 3]}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$lt">> => null}}))
+        convert_selector(#{<<"field">> => #{<<"$lt">> => null}})
     ).
 
 convert_lte_test() ->
     ?assertEqual(
         {op_field,
             {[[<<"field">>], <<":">>, <<"number">>], [<<"[-Infinity TO ">>, <<"42">>, <<"]">>]}},
-        convert([], as_selector(#{<<"field">> => #{<<"$lte">> => 42}}))
+        convert_selector(#{<<"field">> => #{<<"$lte">> => 42}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$lte">> => [1, 2, 3]}}))
+        convert_selector(#{<<"field">> => #{<<"$lte">> => [1, 2, 3]}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$lte">> => null}}))
+        convert_selector(#{<<"field">> => #{<<"$lte">> => null}})
     ).
 
 convert_eq_test() ->
     ?assertEqual(
         {op_field, {[[<<"field">>], <<":">>, <<"number">>], <<"42">>}},
-        convert([], as_selector(#{<<"field">> => #{<<"$eq">> => 42}}))
+        convert_selector(#{<<"field">> => #{<<"$eq">> => 42}})
     ),
     ?assertEqual(
         {op_and, [
@@ -541,11 +540,11 @@ convert_eq_test() ->
             {op_field, {[[<<"field">>, <<".">>, <<"[]">>], <<":">>, <<"number">>], <<"2">>}},
             {op_field, {[[<<"field">>, <<".">>, <<"[]">>], <<":">>, <<"number">>], <<"3">>}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$eq">> => [1, 2, 3]}}))
+        convert_selector(#{<<"field">> => #{<<"$eq">> => [1, 2, 3]}})
     ),
     ?assertEqual(
         {op_null, {[[<<"field">>], <<":">>, <<"null">>], <<"true">>}},
-        convert([], as_selector(#{<<"field">> => #{<<"$eq">> => null}}))
+        convert_selector(#{<<"field">> => #{<<"$eq">> => null}})
     ).
 
 convert_ne_test() ->
@@ -557,49 +556,49 @@ convert_ne_test() ->
             ]},
             {op_field, {[[<<"field">>], <<":">>, <<"number">>], <<"42">>}}
         }},
-        convert([], as_selector(#{<<"field">> => #{<<"$ne">> => 42}}))
+        convert_selector(#{<<"field">> => #{<<"$ne">> => 42}})
     ).
 
 convert_gte_test() ->
     ?assertEqual(
         {op_field,
             {[[<<"field">>], <<":">>, <<"number">>], [<<"[">>, <<"42">>, <<" TO Infinity]">>]}},
-        convert([], as_selector(#{<<"field">> => #{<<"$gte">> => 42}}))
+        convert_selector(#{<<"field">> => #{<<"$gte">> => 42}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$gte">> => [1, 2, 3]}}))
+        convert_selector(#{<<"field">> => #{<<"$gte">> => [1, 2, 3]}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$gte">> => null}}))
+        convert_selector(#{<<"field">> => #{<<"$gte">> => null}})
     ).
 
 convert_gt_test() ->
     ?assertEqual(
         {op_field,
             {[[<<"field">>], <<":">>, <<"number">>], [<<"{">>, <<"42">>, <<" TO Infinity]">>]}},
-        convert([], as_selector(#{<<"field">> => #{<<"$gt">> => 42}}))
+        convert_selector(#{<<"field">> => #{<<"$gt">> => 42}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$gt">> => [1, 2, 3]}}))
+        convert_selector(#{<<"field">> => #{<<"$gt">> => [1, 2, 3]}})
     ),
     ?assertEqual(
         {op_or, [
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$gt">> => null}}))
+        convert_selector(#{<<"field">> => #{<<"$gt">> => null}})
     ).
 
 convert_all_test() ->
@@ -612,37 +611,31 @@ convert_all_test() ->
                 [[<<"field">>, <<".">>, <<"[]">>], <<":">>, <<"string">>], <<"\"value2\"">>
             }}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$all">> => [<<"value1">>, <<"value2">>]}}))
+        convert_selector(#{<<"field">> => #{<<"$all">> => [<<"value1">>, <<"value2">>]}})
     ).
 
 convert_elemMatch_test() ->
     ?assertEqual(
         {op_field, {[[<<"field">>, <<".">>, <<"[]">>], <<":">>, <<"string">>], <<"\"value\"">>}},
-        convert(
-            [], as_selector(#{<<"field">> => #{<<"$elemMatch">> => #{<<"$eq">> => <<"value">>}}})
-        )
+        convert_selector(#{<<"field">> => #{<<"$elemMatch">> => #{<<"$eq">> => <<"value">>}}})
     ).
 
 convert_allMatch_test() ->
     ?assertEqual(
         {op_field, {[[<<"field">>, <<".">>, <<"[]">>], <<":">>, <<"string">>], <<"\"value\"">>}},
-        convert(
-            [], as_selector(#{<<"field">> => #{<<"$allMatch">> => #{<<"$eq">> => <<"value">>}}})
-        )
+        convert_selector(#{<<"field">> => #{<<"$allMatch">> => #{<<"$eq">> => <<"value">>}}})
     ).
 
 convert_keyMapMatch_test() ->
     ?assertThrow(
         {mango_error, mango_selector_text, {invalid_operator, <<"$keyMapMatch">>}},
-        convert(
-            [], as_selector(#{<<"field">> => #{<<"$keyMapMatch">> => #{<<"key">> => <<"value">>}}})
-        )
+        convert_selector(#{<<"field">> => #{<<"$keyMapMatch">> => #{<<"key">> => <<"value">>}}})
     ).
 
 convert_in_test() ->
     ?assertEqual(
         {op_or, []},
-        convert([], as_selector(#{<<"field">> => #{<<"$in">> => []}}))
+        convert_selector(#{<<"field">> => #{<<"$in">> => []}})
     ),
     ?assertEqual(
         {op_or, [
@@ -659,7 +652,7 @@ convert_in_test() ->
                 }}
             ]}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$in">> => [<<"value1">>, <<"value2">>]}}))
+        convert_selector(#{<<"field">> => #{<<"$in">> => [<<"value1">>, <<"value2">>]}})
     ).
 
 convert_nin_test() ->
@@ -671,7 +664,7 @@ convert_nin_test() ->
             ]},
             {op_or, []}
         }},
-        convert([], as_selector(#{<<"field">> => #{<<"$nin">> => []}}))
+        convert_selector(#{<<"field">> => #{<<"$nin">> => []}})
     ),
     ?assertEqual(
         {op_not, {
@@ -690,7 +683,7 @@ convert_nin_test() ->
                 ]}
             ]}
         }},
-        convert([], as_selector(#{<<"field">> => #{<<"$nin">> => [1, 2]}}))
+        convert_selector(#{<<"field">> => #{<<"$nin">> => [1, 2]}})
     ).
 
 convert_exists_test() ->
@@ -699,7 +692,7 @@ convert_exists_test() ->
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$exists">> => true}}))
+        convert_selector(#{<<"field">> => #{<<"$exists">> => true}})
     ),
     ?assertEqual(
         {op_not, {
@@ -709,7 +702,7 @@ convert_exists_test() ->
             ]},
             false
         }},
-        convert([], as_selector(#{<<"field">> => #{<<"$exists">> => false}}))
+        convert_selector(#{<<"field">> => #{<<"$exists">> => false}})
     ).
 
 convert_type_test() ->
@@ -718,25 +711,25 @@ convert_type_test() ->
             {op_fieldname, {[[<<"field">>], ":"], "*"}},
             {op_fieldname, {[[<<"field">>]], ".*"}}
         ]},
-        convert([], as_selector(#{<<"field">> => #{<<"$type">> => <<"string">>}}))
+        convert_selector(#{<<"field">> => #{<<"$type">> => <<"string">>}})
     ).
 
 convert_mod_test() ->
     ?assertEqual(
         {op_fieldname, {[[<<"field">>], ":"], "number"}},
-        convert([], as_selector(#{<<"field">> => #{<<"$mod">> => [2, 0]}}))
+        convert_selector(#{<<"field">> => #{<<"$mod">> => [2, 0]}})
     ).
 
 convert_regex_test() ->
     ?assertEqual(
         {op_regex, [<<"field">>]},
-        convert([], as_selector(#{<<"field">> => #{<<"$regex">> => <<".*">>}}))
+        convert_selector(#{<<"field">> => #{<<"$regex">> => <<".*">>}})
     ).
 
 convert_size_test() ->
     ?assertEqual(
         {op_field, {[[<<"field">>, <<".">>, <<"[]">>], <<":length">>], <<"6">>}},
-        convert([], as_selector(#{<<"field">> => #{<<"$size">> => 6}}))
+        convert_selector(#{<<"field">> => #{<<"$size">> => 6}})
     ).
 
 convert_not_test() ->
@@ -748,57 +741,51 @@ convert_not_test() ->
             ]},
             {op_fieldname, {[[<<"field">>], ":"], "number"}}
         }},
-        convert([], as_selector(#{<<"field">> => #{<<"$not">> => #{<<"$mod">> => [2, 0]}}}))
+        convert_selector(#{<<"field">> => #{<<"$not">> => #{<<"$mod">> => [2, 0]}}})
     ).
 
 convert_and_test() ->
     ?assertEqual(
         {op_and, []},
-        convert([], as_selector(#{<<"$and">> => []}))
+        convert_selector(#{<<"$and">> => []})
     ),
     ?assertEqual(
         {op_and, [{op_field, {[[<<"field">>], <<":">>, <<"string">>], <<"\"value\"">>}}]},
-        convert([], as_selector(#{<<"$and">> => [#{<<"field">> => <<"value">>}]}))
+        convert_selector(#{<<"$and">> => [#{<<"field">> => <<"value">>}]})
     ),
     ?assertEqual(
         {op_and, [
             {op_field, {[[<<"field1">>], <<":">>, <<"string">>], <<"\"value1\"">>}},
             {op_field, {[[<<"field2">>], <<":">>, <<"string">>], <<"\"value2\"">>}}
         ]},
-        convert(
-            [],
-            as_selector(#{
-                <<"$and">> => [#{<<"field1">> => <<"value1">>}, #{<<"field2">> => <<"value2">>}]
-            })
-        )
+        convert_selector(#{
+            <<"$and">> => [#{<<"field1">> => <<"value1">>}, #{<<"field2">> => <<"value2">>}]
+        })
     ).
 
 convert_or_test() ->
     ?assertEqual(
         {op_or, []},
-        convert([], as_selector(#{<<"$or">> => []}))
+        convert_selector(#{<<"$or">> => []})
     ),
     ?assertEqual(
         {op_or, [{op_field, {[[<<"field">>], <<":">>, <<"string">>], <<"\"value\"">>}}]},
-        convert([], as_selector(#{<<"$or">> => [#{<<"field">> => <<"value">>}]}))
+        convert_selector(#{<<"$or">> => [#{<<"field">> => <<"value">>}]})
     ),
     ?assertEqual(
         {op_or, [
             {op_field, {[[<<"field1">>], <<":">>, <<"string">>], <<"\"value1\"">>}},
             {op_field, {[[<<"field2">>], <<":">>, <<"string">>], <<"\"value2\"">>}}
         ]},
-        convert(
-            [],
-            as_selector(#{
-                <<"$or">> => [#{<<"field1">> => <<"value1">>}, #{<<"field2">> => <<"value2">>}]
-            })
-        )
+        convert_selector(#{
+            <<"$or">> => [#{<<"field1">> => <<"value1">>}, #{<<"field2">> => <<"value2">>}]
+        })
     ).
 
 convert_nor_test() ->
     ?assertEqual(
         {op_and, []},
-        convert([], as_selector(#{<<"$nor">> => []}))
+        convert_selector(#{<<"$nor">> => []})
     ),
     ?assertEqual(
         {op_and, [
@@ -810,7 +797,7 @@ convert_nor_test() ->
                 {op_field, {[[<<"field">>], <<":">>, <<"string">>], <<"\"value\"">>}}
             }}
         ]},
-        convert([], as_selector(#{<<"$nor">> => [#{<<"field">> => <<"value">>}]}))
+        convert_selector(#{<<"$nor">> => [#{<<"field">> => <<"value">>}]})
     ),
     ?assertEqual(
         {op_and, [
@@ -829,12 +816,9 @@ convert_nor_test() ->
                 {op_field, {[[<<"field2">>], <<":">>, <<"string">>], <<"\"value2\"">>}}
             }}
         ]},
-        convert(
-            [],
-            as_selector(#{
-                <<"$nor">> => [#{<<"field1">> => <<"value1">>}, #{<<"field2">> => <<"value2">>}]
-            })
-        )
+        convert_selector(#{
+            <<"$nor">> => [#{<<"field1">> => <<"value1">>}, #{<<"field2">> => <<"value2">>}]
+        })
     ).
 
 to_query_test() ->

--- a/src/mango/test/22-covering-index-test.py
+++ b/src/mango/test/22-covering-index-test.py
@@ -1,0 +1,115 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import mango
+
+
+class CoveringIndexTests(mango.UserDocsTests):
+    def is_covered(self, selector, fields, index, use_index=None):
+        resp = self.db.find(selector, fields=fields, use_index=use_index, explain=True)
+        self.assertEqual(resp["index"]["type"], "json")
+        self.assertEqual(resp["index"]["name"], index)
+        self.assertEqual(resp["mrargs"]["include_docs"], False)
+        self.assertEqual(resp["covered"], True)
+
+    def is_not_covered(self, selector, fields):
+        resp = self.db.find(selector, fields=fields, explain=True)
+        self.assertEqual(resp["mrargs"]["include_docs"], True)
+        self.assertEqual(resp["covered"], False)
+
+    def test_index_covers_query_1field_index_id(self):
+        self.is_covered({"age": {"$gte": 32}}, ["_id"], "age")
+
+    def test_index_covers_query_2field_index_id(self):
+        self.is_covered(
+            {"company": "Lyria", "manager": True}, ["_id"], "company_and_manager"
+        )
+
+    def test_index_covers_query_2field_index_extract_field(self):
+        self.is_covered(
+            {"company": {"$exists": True}, "manager": True},
+            ["company"],
+            "company_and_manager",
+        )
+
+    def test_index_covers_query_2field_index_extract_field_force_index(self):
+        self.is_covered(
+            {"company": {"$exists": True}, "manager": True},
+            ["company"],
+            "company_and_manager",
+            use_index="company_and_manager",
+        )
+
+    def test_index_covers_query_elemMatch(self):
+        self.is_covered(
+            {"favorites": {"$elemMatch": {"$eq": "Erlang"}}}, ["favorites"], "favorites"
+        )
+
+    def test_index_covers_query_composite_field_id(self):
+        self.is_covered(
+            {"name": {"first": "Stephanie", "last": "Kirkland"}}, ["_id"], "name"
+        )
+
+    def test_index_does_not_cover_query_empty_selector(self):
+        self.is_not_covered({}, ["_id"])
+
+    def test_index_does_not_cover_query_field_not_in_index(self):
+        self.is_not_covered({"age": {"$gte": 32}}, ["name"])
+
+    def test_index_does_not_cover_query_all_fields(self):
+        self.is_not_covered({"age": {"$gte": 32}}, None)
+
+    def test_index_does_not_cover_query_partial_selector_id(self):
+        self.is_not_covered({"location.state": "Nevada"}, ["_id"])
+
+    def test_index_does_not_cover_query_partial_selector(self):
+        self.is_not_covered({"name.last": "Hernandez"}, ["name.first"])
+
+    def test_covering_index_provides_correct_answer_id(self):
+        docs = self.db.find({"age": {"$gte": 32}}, fields=["_id"])
+        expected = [
+            {"_id": "659d0430-b1f4-413a-a6b7-9ea1ef071325"},
+            {"_id": "48ca0455-8bd0-473f-9ae2-459e42e3edd1"},
+            {"_id": "e900001d-bc48-48a6-9b1a-ac9a1f5d1a03"},
+            {"_id": "b31dad3f-ae8b-4f86-8327-dfe8770beb27"},
+            {"_id": "71562648-6acb-42bc-a182-df6b1f005b09"},
+            {"_id": "c78c529f-0b07-4947-90a6-d6b7ca81da62"},
+            {"_id": "8e1c90c0-ac18-4832-8081-40d14325bde0"},
+            {"_id": "6c0afcf1-e57e-421d-a03d-0c0717ebf843"},
+            {"_id": "5b61abc1-a3d3-4092-b9d7-ced90e675536"},
+            {"_id": "a33d5457-741a-4dce-a217-3eab28b24e3e"},
+            {"_id": "b06aadcf-cd0f-4ca6-9f7e-2c993e48d4c4"},
+            {"_id": "b1e70402-8add-4068-af8f-b4f3d0feb049"},
+            {"_id": "0461444c-e60a-457d-a4bb-b8d811853f21"},
+        ]
+        self.assertEqual(docs, expected)
+
+    def test_covering_index_provides_correct_answer_2field_index(self):
+        docs = self.db.find(
+            {"company": {"$exists": True}, "manager": True},
+            sort=[{"company": "asc"}],
+            fields=["company"],
+            use_index="company_and_manager",
+        )
+        expected = [
+            {"company": "Affluex"},
+            {"company": "Globoil"},
+            {"company": "Lyria"},
+            {"company": "Manglo"},
+            {"company": "Myopium"},
+            {"company": "Niquent"},
+            {"company": "Oulu"},
+            {"company": "Prosely"},
+            {"company": "Tasmania"},
+            {"company": "Zialactic"},
+        ]
+        self.assertEqual(docs, expected)


### PR DESCRIPTION
This pull request aims to implement the first phase of the covering indexes work (_"keys-only covering indexes"_) as it was described in the corresponding RFC document by @mikerhodes, see #4410 and #4413 for the details.

Ideally, end users should not notice any change in the behavior but speed-ups for certain kind of queries.  Performance results obtained by [k6](https://k6.io/) on my MacBook Pro 2021 M1 Max, with 10,000 documents, compared against `c5a7809f` with 3 nodes:

- 1-field index covers the query:
  - before: `min=0.59ms  max=498.29ms   p(95)=313.02ms  p(98)=357.44ms  p(99)=390.75ms`
  - after: `min=0.53ms max=127.26ms   p(95)=33.15ms   p(98)=37.53ms   p(99)=39.99ms`
- 2-field index covers the query:
  - before: `min=19.68ms max=893.79ms   p(95)=674.84ms  p(98)=739.12ms  p(99)=774.02ms`
  - after: `min=1.95ms max=163.22ms   p(95)=50.13ms   p(98)=57.11ms   p(99)=63.38ms`
- generic case:
  - before: `min=0.70ms  max=3786.70ms  p(95)=2733.86ms p(98)=3265.91ms p(99)=3452.13ms`
  - after: `min=0.72ms max=3590.26ms  p(95)=2631.55ms p(98)=2777.04ms p(99)=2879.50ms`

Please find the details of the performance evaluation in [`pgj/couchdb-k6/mango/couchdb_4482`](https://github.com/pgj/couchdb-k6/tree/main/mango/couchdb_4482).

Unit test coverage increased significantly, see before:

```console
$ make eunit apps=mango
==> mango (compile)
==> rel (compile)
==> couchdb (compile)
==> couchdb (setup_eunit)
==> mango (eunit)
======================== EUnit ========================
[..]
module 'mango_selector'
  mango_selector: is_constant_field_basic_test...ok
  mango_selector: is_constant_field_basic_two_test...ok
  mango_selector: is_constant_field_not_eq_test...ok
  mango_selector: is_constant_field_missing_field_test...ok
  mango_selector: is_constant_field_or_field_test...ok
  mango_selector: is_constant_field_empty_selector_test...ok
  mango_selector: is_constant_nested_and_test...ok
  mango_selector: is_constant_combined_or_and_equals_test...ok
  mango_selector: has_required_fields_basic_test...ok
  mango_selector: has_required_fields_basic_failure_test...ok
  mango_selector: has_required_fields_empty_selector_test...ok
  mango_selector: has_required_fields_exists_false_test...ok
  mango_selector: has_required_fields_and_true_test...ok
  mango_selector: has_required_fields_nested_and_true_test...ok
  mango_selector: has_required_fields_and_false_test...ok
  mango_selector: has_required_fields_or_false_test...ok
  mango_selector: has_required_fields_or_true_test...ok
  mango_selector: has_required_fields_and_nested_or_true_test...ok
  mango_selector: has_required_fields_and_nested_or_false_test...ok
  mango_selector: has_required_fields_or_nested_and_true_test...ok
  mango_selector: has_required_fields_or_nested_or_true_test...ok
  mango_selector: has_required_fields_or_nested_or_false_test...ok
  mango_selector:1013: match_demo_test_...[0.008 s] ok
  mango_selector:1014: match_demo_test_...ok
  mango_selector:1015: match_demo_test_...ok
  mango_selector:1017: match_demo_test_...ok
  mango_selector:1019: match_demo_test_...ok
  mango_selector:1020: match_demo_test_...ok
  [done in 0.066 s]
[..]
module 'mango_idx_view'
module 'mango_cursor_view'
  mango_cursor_view: does_not_refetch_doc_with_value_test...ok
  mango_cursor_view: doc_member_and_extract_fields_test...ok
  mango_cursor_view: match_and_extract_doc_match_test...ok
  mango_cursor_view: match_and_extract_doc_matchextract_test...ok
  mango_cursor_view: match_and_extract_doc_nomatch_test...ok
  mango_cursor_view: match_and_extract_doc_nomatch_fields_test...ok
  mango_cursor_view: choose_best_index_with_singleton_test...ok
  mango_cursor_view: choose_best_index_lowest_difference_test...ok
  mango_cursor_view: choose_best_index_least_number_of_fields_test...ok
  mango_cursor_view: choose_best_index_lowest_index_triple_test...ok
  [done in 0.030 s]
[..]
=======================================================
  All 81 tests passed.
[..]

Code Coverage:
mango_app             :   0%
mango_crud            :   0%
mango_cursor          :   0%
mango_cursor_special  :   0%
mango_cursor_text     :   0%
mango_cursor_view     :  33%
mango_doc             :   3%
mango_epi             : 100%
mango_error           :   0%
mango_execution_stats :   0%
mango_fields          :  50%
mango_httpd           :   0%
mango_httpd_handlers  :   0%
mango_idx             :  18%
mango_idx_special     :   0%
mango_idx_text        :  63%
mango_idx_view        :   1%
mango_json            :  10%
mango_json_bookmark   :   0%
mango_native_proc     :   5%
mango_opts            :  25%
mango_selector        :  62%
mango_selector_text   :  86%
mango_sort            :   0%
mango_sup             :   0%
mango_util            :  38%

Total                 : 31%
==> rel (eunit)
==> couchdb (eunit)
```

and then after:

```console
==> mango (compile)
==> rel (compile)
==> couchdb (compile)
==> couchdb (setup_eunit)
==> mango (eunit)
======================== EUnit ========================
[..]
module 'mango_selector'
  mango_selector: is_constant_field_basic_test...ok
  mango_selector: is_constant_field_basic_two_test...ok
  mango_selector: is_constant_field_not_eq_test...ok
  mango_selector: is_constant_field_missing_field_test...ok
  mango_selector: is_constant_field_or_field_test...ok
  mango_selector: is_constant_field_empty_selector_test...ok
  mango_selector: is_constant_nested_and_test...ok
  mango_selector: is_constant_combined_or_and_equals_test...ok
  mango_selector: has_required_fields_basic_test...ok
  mango_selector: has_required_fields_basic_failure_test...ok
  mango_selector: has_required_fields_empty_selector_test...ok
  mango_selector: has_required_fields_exists_false_test...ok
  mango_selector: has_required_fields_and_true_test...ok
  mango_selector: has_required_fields_nested_and_true_test...ok
  mango_selector: has_required_fields_and_false_test...ok
  mango_selector: has_required_fields_or_false_test...ok
  mango_selector: has_required_fields_or_true_test...ok
  mango_selector: has_required_fields_and_nested_or_true_test...ok
  mango_selector: has_required_fields_and_nested_or_false_test...ok
  mango_selector: has_required_fields_or_nested_and_true_test...ok
  mango_selector: has_required_fields_or_nested_or_true_test...ok
  mango_selector: has_required_fields_or_nested_or_false_test...ok
  mango_selector:1013: match_demo_test_...[0.008 s] ok
  mango_selector:1014: match_demo_test_...ok
  mango_selector:1015: match_demo_test_...ok
  mango_selector:1017: match_demo_test_...ok
  mango_selector:1019: match_demo_test_...ok
  mango_selector:1020: match_demo_test_...ok
  mango_selector: fields_empty_test...ok
  mango_selector: fields_primitive_test...ok
  mango_selector: fields_nested_test...ok
  mango_selector: fields_and_test...ok
  mango_selector: fields_or_test...ok
  mango_selector: fields_nor_test...ok
  [done in 0.110 s]
[..]
module 'mango_idx_view'
  mango_idx_view: indexable_fields_empty_test...ok
  mango_idx_view: indexable_fields_and_test...ok
  mango_idx_view: indexable_fields_or_test...ok
  mango_idx_view: indexable_fields_nor_test...ok
  mango_idx_view: indexable_fields_all_test...ok
  mango_idx_view: indexable_fields_elemMatch_test...ok
  mango_idx_view: indexable_fields_allMatch_test...ok
  mango_idx_view: indexable_fields_keyMapMatch_test...ok
  mango_idx_view: indexable_fields_in_test...ok
  mango_idx_view: indexable_fields_nin_test...ok
  mango_idx_view: indexable_fields_not_test...ok
  mango_idx_view: indexable_fields_lt_test...ok
  mango_idx_view: indexable_fields_lte_test...ok
  mango_idx_view: indexable_fields_eq_test...ok
  mango_idx_view: indexable_fields_ne_test...ok
  mango_idx_view: indexable_fields_gte_test...ok
  mango_idx_view: indexable_fields_gt_test...ok
  mango_idx_view: indexable_fields_mod_test...ok
  mango_idx_view: indexable_fields_regex_test...ok
  mango_idx_view: indexable_fields_exists_test...ok
  mango_idx_view: indexable_fields_type_test...ok
  mango_idx_view: indexable_fields_size_test...ok
  mango_idx_view: covers_all_fields_test...ok
  mango_idx_view: covers_all_docs_test...ok
  mango_idx_view: covers_empty_index_test...ok
  mango_idx_view: covers_regular_index_test...ok
  [done in 0.081 s]
module 'mango_cursor_view'
  mango_cursor_view: viewcbargs_test...ok
  mango_cursor_view: maybe_replace_max_json_test...ok
  mango_cursor_view: base_opts_test...ok
  mango_cursor_view: apply_opts_empty_test...ok
  mango_cursor_view: apply_opts_r_test...ok
  mango_cursor_view: apply_opts_conflicts_test...ok
  mango_cursor_view: apply_opts_sort_test...ok
  mango_cursor_view: apply_opts_stale_test...ok
  mango_cursor_view: apply_opts_stable_test...ok
  mango_cursor_view: apply_opts_update_test...ok
  mango_cursor_view: apply_opts_partition_test...[0.020 s] ok
  mango_cursor_view: consider_index_coverage_positive_test...ok
  mango_cursor_view: consider_index_coverage_negative_test...ok
  mango_cursor_view: derive_doc_from_index_test...ok
  mango_cursor_view: composite_indexes_test...ok
  mango_cursor_view: create_test...ok
  mango_cursor_view: explain_test...ok
  mango_cursor_view:944: execute_test_ (t_execute_empty)...[0.005 s] ok
  mango_cursor_view:945: execute_test_ (t_execute_ok_all_docs)...[0.003 s] ok
  mango_cursor_view:946: execute_test_ (t_execute_ok_query_view)...[0.003 s] ok
  mango_cursor_view:947: execute_test_ (t_execute_error)...[0.001 s] ok
  mango_cursor_view:1112: view_cb_test_ (t_view_cb_meta)...[0.002 s] ok
  mango_cursor_view:1113: view_cb_test_ (t_view_cb_row_matching_regular_doc)...[0.002 s] ok
  mango_cursor_view:1114: view_cb_test_ (t_view_cb_row_non_matching_regular_doc)...[0.002 s] ok
  mango_cursor_view:1115: view_cb_test_ (t_view_cb_row_null_doc)...[0.002 s] ok
  mango_cursor_view:1116: view_cb_test_ (t_view_cb_row_missing_doc_triggers_quorum_fetch)...[0.001 s] ok
  mango_cursor_view:1117: view_cb_test_ (t_view_cb_row_matching_covered_doc)...[0.002 s] ok
  mango_cursor_view:1118: view_cb_test_ (t_view_cb_row_non_matching_covered_doc)...[0.002 s] ok
  mango_cursor_view:1119: view_cb_test_ (t_view_cb_row_backwards_compatible)...[0.001 s] ok
  mango_cursor_view:1120: view_cb_test_ (t_view_cb_complete)...[0.003 s] ok
  mango_cursor_view:1121: view_cb_test_ (t_view_cb_ok)...[0.001 s] ok
  mango_cursor_view:1279: maybe_send_mango_ping_test_ (t_maybe_send_mango_ping_nop)...[0.001 s] ok
  mango_cursor_view:1280: maybe_send_mango_ping_test_ (t_maybe_send_mango_ping_happens)...[0.001 s] ok
  mango_cursor_view: ddocid_test...ok
  mango_cursor_view: is_design_doc_test...ok
  mango_cursor_view:1316: handle_message_test_ (t_handle_message_meta)...ok
  mango_cursor_view:1317: handle_message_test_ (t_handle_message_row_ok_above_limit)...[0.002 s] ok
  mango_cursor_view:1318: handle_message_test_ (t_handle_message_row_ok_at_limit)...ok
  mango_cursor_view:1319: handle_message_test_ (t_handle_message_row_ok_skip)...ok
  mango_cursor_view:1320: handle_message_test_ (t_handle_message_row_ok_triggers_quorum_fetch_match)...[0.648 s] ok
  mango_cursor_view:1321: handle_message_test_ (t_handle_message_row_ok_triggers_quorum_fetch_no_match)...[0.001 s] ok
  mango_cursor_view:1322: handle_message_test_ (t_handle_message_row_no_match)...ok
  mango_cursor_view:1323: handle_message_test_ (t_handle_message_row_error)...[0.020 s] ok
  mango_cursor_view:1324: handle_message_test_ (t_handle_message_execution_stats)...ok
  mango_cursor_view:1325: handle_message_test_ (t_handle_message_complete)...ok
  mango_cursor_view:1326: handle_message_test_ (t_handle_message_error)...ok
  mango_cursor_view: handle_all_docs_message_ddoc_test...ok
  mango_cursor_view: handle_all_docs_message_row_test...ok
  mango_cursor_view: handle_all_docs_message_regular_test...ok
  mango_cursor_view: does_not_refetch_doc_with_value_test...ok
  mango_cursor_view: doc_member_and_extract_fields_test...ok
  mango_cursor_view: match_and_extract_doc_match_test...ok
  mango_cursor_view: match_and_extract_doc_matchextract_test...ok
  mango_cursor_view: match_and_extract_doc_nomatch_test...ok
  mango_cursor_view: match_and_extract_doc_nomatch_fields_test...ok
  mango_cursor_view: choose_best_index_with_singleton_test...ok
  mango_cursor_view: choose_best_index_lowest_difference_test...ok
  mango_cursor_view: choose_best_index_least_number_of_fields_test...ok
  mango_cursor_view: choose_best_index_lowest_index_triple_test...ok
  mango_cursor_view: update_bookmark_keys_test...ok
  [done in 3.526 s]
[..]
=======================================================
  All 166 tests passed.
[..]

Code Coverage:
mango_app             :   0%
mango_crud            :   0%
mango_cursor          :  20%
mango_cursor_special  :   0%
mango_cursor_text     :   0%
mango_cursor_view     : 100%
mango_doc             :   4%
mango_epi             : 100%
mango_error           :   0%
mango_execution_stats :  63%
mango_fields          :  57%
mango_httpd           :   0%
mango_httpd_handlers  :   0%
mango_idx             :  21%
mango_idx_special     :   0%
mango_idx_text        :  63%
mango_idx_view        :  39%
mango_json            :  12%
mango_json_bookmark   :  25%
mango_native_proc     :   5%
mango_opts            :  27%
mango_selector        :  66%
mango_selector_text   :  86%
mango_sort            :   5%
mango_sup             :   0%

Total                 : 49%
==> rel (eunit)
==> couchdb (eunit)
```

Tasks:

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Documentation changes were made in the `src/docs` folder
