### PR TITLE
fix(mango): GET invalid path under `_index` should not cause 500

### DIFF
--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -107,8 +107,6 @@ handle_index_req(#httpd{method = 'POST', path_parts = [_, _]} = Req, Db) ->
                 end
         end,
     chttpd:send_json(Req, {[{result, Status}, {id, Id}, {name, Name}]});
-handle_index_req(#httpd{path_parts = [_, _]} = Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST");
 %% Essentially we just iterate through the list of ddoc ids passed in and
 %% delete one by one. If an error occurs, all previous documents will be
 %% deleted, but an error will be thrown for the current ddoc id.
@@ -189,7 +187,9 @@ handle_index_req(
             ?MANGO_ERROR({error_saving_ddoc, Error})
     end;
 handle_index_req(#httpd{path_parts = [_, _, _DDocId0, _Type, _Name]} = Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "DELETE").
+    chttpd:send_method_not_allowed(Req, "DELETE");
+handle_index_req(#httpd{path_parts = [_, _ | _]} = Req, _Db) ->
+    chttpd:send_method_not_allowed(Req, "GET,POST").
 
 handle_explain_req(#httpd{method = 'POST'} = Req, Db) ->
     chttpd:validate_ctype(Req, "application/json"),

--- a/src/mango/test/01-index-crud-test.py
+++ b/src/mango/test/01-index-crud-test.py
@@ -88,6 +88,10 @@ class IndexCrudTests(mango.DbPerClass):
             else:
                 raise AssertionError("bad create index")
 
+    def test_bad_url(self):
+        r = self.db.sess.get(self.db.path("_index/foo"))
+        self.assertEqual(r.status_code, 405)
+
     def test_create_idx_01(self):
         fields = ["foo", "bar"]
         ret = self.db.create_index(fields, name="idx_01")


### PR DESCRIPTION
Sending `GET` requests targeting paths under the `/{db}/_index` endpoint, e.g. `/{db}/_index/something`, cause an internal error. Change the endpoint's behavior to gracefully return HTTP 405 "Method Not Allowed" instead to be inconsistent with other endpoints.
