### PR TITLE
docs(_find): Remove redundancy from sample `_explain` response

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -1384,7 +1384,6 @@ it easier to take advantage of future improvements to query planning
                 }
             },
             "opts": {
-                "use_index": [],
                 "bookmark": "nil",
                 "limit": 2,
                 "skip": 0,


### PR DESCRIPTION
Acciddentally in `467e14ef`, the `use_index` field got doubled in one of the sample responses.
