### PR TITLE
docs: Fixed _compact/{ddoc} and _shards/{docid} examples

### DIFF
--- a/src/docs/src/api/database/compact.rst
+++ b/src/docs/src/api/database/compact.rst
@@ -94,7 +94,7 @@
     It may be that compacting a large view can return more storage than
     compacting the actual db. Thus, you can use this in place of the full
     database compaction if you know a specific set of view indexes have been
-    affected by a recent database change.
+    affected by a recent database change. See :ref:`compact/views` for details.
 
     :param db: Database name
     :param ddoc: Design document name
@@ -114,7 +114,7 @@
 
     .. code-block:: http
 
-        POST /db/_compact/posts HTTP/1.1
+        POST /db/_compact/ddoc HTTP/1.1
         Accept: application/json
         Content-Type: application/json
         Host: localhost:5984

--- a/src/docs/src/api/database/shard.rst
+++ b/src/docs/src/api/database/shard.rst
@@ -132,12 +132,9 @@
 
     .. code-block:: http
 
-        HTTP/1.1 200 OK
-        Cache-Control: must-revalidate
-        Content-Length: 94
-        Content-Type: application/json
-        Date: Fri, 18 Jan 2019 20:08:07 GMT
-        Server: CouchDB/2.3.0-9d4cb03c2 (Erlang OTP/19)
+        GET /db/_shards/docid HTTP/1.1
+        Accept: */*
+        Host: localhost:5984
 
     **Response**:
 

--- a/src/docs/src/maintenance/compaction.rst
+++ b/src/docs/src/maintenance/compaction.rst
@@ -334,9 +334,24 @@ Manual View Compaction
 
 Views also need compaction. Unlike databases, views are compacted by groups
 per `design document`. To start their compaction, send the HTTP
-:post:`/{db}/_compact/{ddoc}` request::
+:post:`/{db}/_compact/{ddoc}` request:
 
-    curl -H "Content-Type: application/json" -X POST http://localhost:5984/dbname/_compact/designname
+**Design Document**:
+
+.. code-block:: json
+
+    {
+        "_id": "_design/ddoc-name",
+        "views": {
+            "view-name": {
+                "map": "function(doc) { emit(doc.key, doc.value) }"
+            }
+        }
+    }
+
+.. code-block:: bash
+
+    curl -H "Content-Type: application/json" -X POST http://localhost:5984/dbname/_compact/ddoc-name
 
 .. code-block:: javascript
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

- Modified the example and add a `manual view compaction` link to the
api `/{db}/_compact/{ddoc}` to facilitate users to view `_compact`
related documents.

- Fixed example request for GET /{db}/_shards/{docid}

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
fixed https://github.com/apache/couchdb/issues/4219, https://github.com/apache/couchdb/issues/4223

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
