### PR TITLE
 Add key range check for _all_docs

### DIFF
--- a/src/docs/src/api/ddoc/views.rst
+++ b/src/docs/src/api/ddoc/views.rst
@@ -651,7 +651,7 @@ multi-element ``keys``. For single-element ``keys``, treat it as a ``key``.
     $ curl http://adm:pass@127.0.0.1:5984/db/_design/ddoc/_view/reduce'?key="a"'
     {"rows":[{"key":null,"value":1}]}
 
-    $ curl http://adm:pass@127.0.0.1:5984/db/_design/ddoc/_view/reduce'?keys="[\"a\"]"'
+    $ curl http://adm:pass@127.0.0.1:5984/db/_design/ddoc/_view/reduce'?keys=\["a"\]'
     {"rows":[{"key":null,"value":1}]}
 
     $ curl http://adm:pass@127.0.0.1:5984/db/_design/ddoc/_view/reduce'?keys=\["a","b"\]'


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Using key and start/end_key in a different order will produce different responses when querying `_all_docs`.
To reduce confusion, add a key range check for `_all_docs`.

- If direction=fwd, start_key > end_key throws an error
- If direction=rev, start_key < end_key throws an error
- Otherwise, return relevant responses

**Previous behavior:**
```bash
$ curl -XPUT $DB/db
$ curl -XPOST $DB/db/_bulk_docs -H 'Content-Type: application/json' -d '{"docs": [{"_id": "a"},{"_id": "b"},{"_id": "c"}]}'

$ curl $DB/db/_all_docs'?key="c"&endkey="a"'
{"total_rows":3,"offset":2,"rows":[ ]}

$ curl $DB/db/_all_docs'?key="c"&endkey="a"&descending=true'
{"total_rows":3,"offset":0,"rows":[
  {"id":"c","key":"c","value":{"rev":"1-967a00dff5e02add41819138abb3284d"}},
  {"id":"b","key":"b","value":{"rev":"1-967a00dff5e02add41819138abb3284d"}},
  {"id":"a","key":"a","value":{"rev":"1-967a00dff5e02add41819138abb3284d"}}
]}
```

**After the change:**
```bash
$ curl $DB/db/_all_docs'?key="c"&endkey="a"'
{"error":"query_parse_error","reason":"No rows can match your key range, reverse your start_key and end_key or set descending=true"}

$ curl $DB/db/_all_docs'?key="c"&endkey="a"&descending=true'
{"total_rows":3,"offset":0,"rows":[
  {"id":"c","key":"c","value":{"rev":"1-967a00dff5e02add41819138abb3284d"}},
  {"id":"b","key":"b","value":{"rev":"1-967a00dff5e02add41819138abb3284d"}},
  {"id":"a","key":"a","value":{"rev":"1-967a00dff5e02add41819138abb3284d"}}
]}
```

## Testing recommendations
make eunit apps=chttpd,couch_mrview

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
https://github.com/apache/couchdb/issues/3977
<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
