### PR TITLE
Add s390x back into the CI matrix

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -73,6 +73,13 @@ meta = [
     node_label: 'ppc64le'
   ],
 
+  'bullseye-s390x': [
+    name: 'Debian 11 s390x',
+    spidermonkey_vsn: '78',
+    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+    node_label: 's390x'
+  ],
+
   'bullseye': [
     name: 'Debian 11',
     spidermonkey_vsn: '78',


### PR DESCRIPTION
Linux Z (s390x) has returned back and should now be able to run in the full CI.

Previously we had an issue with spidermonkey on in. Let's see if it still there.

