### PR TITLE
Querying `_all_docs` with non-string `key` should return an empty list

### DIFF
--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -903,12 +903,12 @@ all_docs_key_opts(#mrargs{keys = Keys, direction = Dir} = Args, Extra) ->
         Keys
     ).
 
-ad_skey_opts(#mrargs{start_key = SKey}) when is_binary(SKey) ->
+ad_skey_opts(#mrargs{start_key = SKey}) when SKey =/= undefined ->
     [{start_key, SKey}];
 ad_skey_opts(#mrargs{start_key_docid = SKeyDocId}) ->
     [{start_key, SKeyDocId}].
 
-ad_ekey_opts(#mrargs{end_key = EKey} = Args) when is_binary(EKey) ->
+ad_ekey_opts(#mrargs{end_key = EKey} = Args) when EKey =/= undefined ->
     Type =
         if
             Args#mrargs.inclusive_end -> end_key;


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Querying `_all_docs` with a non-string `key` should return an empty list, but currently, it will return all documents. This PR should fix it.


## Testing recommendations
`make eunit apps=couch_mrview suites=couch_mrview_all_docs_tests`
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests
fix https://github.com/apache/couchdb/issues/1479
<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
