### PR TITLE
feat (prometheus): additional metrics to match _system

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
             // apache/couchdbci-debian:bullseye-erlang-24.3.4.2
             // apache/couchdbci-debian:bullseye-erlang-23.3.4.15
             //
-            "COUCHDB_IMAGE": "apache/couchdbci-debian:bullseye-erlang-25.0.2"
+            "COUCHDB_IMAGE": "apache/couchdbci-debian:bullseye-erlang-24.3.4.10"
         }
     },
 

--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -287,7 +287,7 @@ get_stats() ->
     {NumberOfGCs, WordsReclaimed, _} = statistics(garbage_collection),
     {{input, Input}, {output, Output}} = statistics(io),
 
-    {CF, CDU} = db_pid_stats(),
+    {CF, CDU} = db_pid_stats_formatted(),
     MessageQueuesHist = [
         {couch_file, {CF}},
         {couch_db_updater, {CDU}}
@@ -315,6 +315,10 @@ get_stats() ->
         {distribution, {get_distribution_stats()}}
     ].
 
+db_pid_stats_formatted() ->
+    {CF, CDU} = db_pid_stats(),
+    {format_pid_stats(CF), format_pid_stats(CDU)}.
+
 db_pid_stats() ->
     {monitors, M} = process_info(whereis(couch_stats_process_tracker), monitors),
     Candidates = [Pid || {process, Pid} <- M],
@@ -323,7 +327,7 @@ db_pid_stats() ->
     {CouchFiles, CouchDbUpdaters}.
 
 db_pid_stats(Mod, Candidates) ->
-    Mailboxes = lists:foldl(
+    lists:foldl(
         fun(Pid, Acc) ->
             case process_info(Pid, [message_queue_len, dictionary]) of
                 undefined ->
@@ -343,8 +347,7 @@ db_pid_stats(Mod, Candidates) ->
         end,
         [],
         Candidates
-    ),
-    format_pid_stats(Mailboxes).
+    ).
 
 format_pid_stats([]) ->
     [];

--- a/src/couch_prometheus/src/couch_prometheus_util.erl
+++ b/src/couch_prometheus/src/couch_prometheus_util.erl
@@ -16,6 +16,7 @@
     couch_to_prom/3,
     to_bin/1,
     to_prom/4,
+    to_prom/2,
     to_prom_summary/2
 ]).
 

--- a/src/couch_prometheus/src/couch_prometheus_util.erl
+++ b/src/couch_prometheus/src/couch_prometheus_util.erl
@@ -125,6 +125,8 @@ type_def(Metric, Type, Desc) ->
 
 % support creating a metric series with multiple label/values.
 % Instances is of the form [{[{LabelName, LabelValue}], Value}, ...]
+to_prom(_Metric, _Type, _Desc, []) ->
+    [];
 to_prom(Metric, Type, Desc, Instances) when is_list(Instances) ->
     TypeStr = type_def(Metric, Type, Desc),
     [TypeStr] ++ lists:flatmap(fun(Inst) -> to_prom(Metric, Inst) end, Instances);


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

This adds some of the metrics available via the `/_node/_local/_system` endpoint to the `/_node/_local/_prometheus` endpoint. Specifically:

 1. Aggregated message queue sizes for `couch_server` and `index_server` (since these applications are sharded, the standard metrics return a queue size for each shard, which isn't useful in most cases):
      ```couchdb_erlang_message_queue_size{queue_name="couch_server"} 0
      couchdb_erlang_message_queue_size{queue_name="index_server"} 0
      ```
 2. `couch_db_updater` and `couch_file` message queue histogram/summaries:
      ```
      # HELP couchdb_erlang_message_queue_couch_file size of message queue across couch_file processes
      # TYPE couchdb_erlang_message_queue_couch_file summary
      couchdb_erlang_message_queue_couch_file{quantile="0.5"} 0
      couchdb_erlang_message_queue_couch_file{quantile="0.9"} 0
      couchdb_erlang_message_queue_couch_file{quantile="0.99"} 0
      couchdb_erlang_message_queue_couch_file_sum 0
      couchdb_erlang_message_queue_couch_file_count 4
      couchdb_erlang_message_queue_couch_file_min 0
      couchdb_erlang_message_queue_couch_file_max 0
      
      # HELP couchdb_erlang_message_queue_couch_db_updater size of message queue across couch_db_updater processes
      # TYPE couchdb_erlang_message_queue_couch_db_updater summary
      couchdb_erlang_message_queue_couch_db_updater{quantile="0.5"} 0
      couchdb_erlang_message_queue_couch_db_updater{quantile="0.9"} 0
      couchdb_erlang_message_queue_couch_db_updater{quantile="0.99"} 0
      couchdb_erlang_message_queue_couch_db_updater_sum 0
      couchdb_erlang_message_queue_couch_db_updater_count 4
      couchdb_erlang_message_queue_couch_db_updater_min 0
      couchdb_erlang_message_queue_couch_db_updater_max 0
      ```
 3. Erlang distribution stats:
      ```
      # HELP couchdb_erlang_distribution_recv_oct_bytes_total Number of bytes received by the socket.
      # TYPE couchdb_erlang_distribution_recv_oct_bytes_total counter
      couchdb_erlang_distribution_recv_oct_bytes_total{node="node2@127.0.0.1"} 28335
      couchdb_erlang_distribution_recv_oct_bytes_total{node="node3@127.0.0.1"} 26416
      
      # HELP couchdb_erlang_distribution_recv_cnt_packets_total number of packets received by the socket.
      # TYPE couchdb_erlang_distribution_recv_cnt_packets_total counter
      couchdb_erlang_distribution_recv_cnt_packets_total{node="node2@127.0.0.1"} 151
      couchdb_erlang_distribution_recv_cnt_packets_total{node="node3@127.0.0.1"} 157
      
      # HELP couchdb_erlang_distribution_recv_max_bytes size of the largest packet, in bytes, received by the socket.
      # TYPE couchdb_erlang_distribution_recv_max_bytes gauge
      couchdb_erlang_distribution_recv_max_bytes{node="node2@127.0.0.1"} 5549
      couchdb_erlang_distribution_recv_max_bytes{node="node3@127.0.0.1"} 5549
      
      # HELP couchdb_erlang_distribution_recv_avg_bytes average size of packets, in bytes, received by the socket.
      # TYPE couchdb_erlang_distribution_recv_avg_bytes gauge
      couchdb_erlang_distribution_recv_avg_bytes{node="node2@127.0.0.1"} 187
      couchdb_erlang_distribution_recv_avg_bytes{node="node3@127.0.0.1"} 168
      
      # HELP couchdb_erlang_distribution_recv_dvi_bytes average packet size deviation, in bytes, received by the socket.
      # TYPE couchdb_erlang_distribution_recv_dvi_bytes gauge
      couchdb_erlang_distribution_recv_dvi_bytes{node="node2@127.0.0.1"} 34
      couchdb_erlang_distribution_recv_dvi_bytes{node="node3@127.0.0.1"} 30
      
      # HELP couchdb_erlang_distribution_send_oct_bytes_total Number of bytes sent by the socket.
      # TYPE couchdb_erlang_distribution_send_oct_bytes_total counter
      couchdb_erlang_distribution_send_oct_bytes_total{node="node2@127.0.0.1"} 20591
      couchdb_erlang_distribution_send_oct_bytes_total{node="node3@127.0.0.1"} 21732
      
      # HELP couchdb_erlang_distribution_send_cnt_packets_total number of packets sent by the socket.
      # TYPE couchdb_erlang_distribution_send_cnt_packets_total counter
      couchdb_erlang_distribution_send_cnt_packets_total{node="node2@127.0.0.1"} 156
      couchdb_erlang_distribution_send_cnt_packets_total{node="node3@127.0.0.1"} 145
      
      # HELP couchdb_erlang_distribution_send_max_bytes size of the largest packet, in bytes, sent by the socket.
      # TYPE couchdb_erlang_distribution_send_max_bytes gauge
      couchdb_erlang_distribution_send_max_bytes{node="node2@127.0.0.1"} 1203
      couchdb_erlang_distribution_send_max_bytes{node="node3@127.0.0.1"} 1205
      
      # HELP couchdb_erlang_distribution_send_avg_bytes average size of packets, in bytes, sent by the socket.
      # TYPE couchdb_erlang_distribution_send_avg_bytes gauge
      couchdb_erlang_distribution_send_avg_bytes{node="node2@127.0.0.1"} 131
      couchdb_erlang_distribution_send_avg_bytes{node="node3@127.0.0.1"} 149
      
      # HELP couchdb_erlang_distribution_send_pend_bytes number of bytes waiting to be sent by the socket.
      # TYPE couchdb_erlang_distribution_send_pend_bytes gauge
      couchdb_erlang_distribution_send_pend_bytes{node="node2@127.0.0.1"} 0
      couchdb_erlang_distribution_send_pend_bytes{node="node3@127.0.0.1"} 0
      ```

## Testing recommendations

The simplest test is to query `http://localhost:15984/_node/_local/_prometheus`.

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
