### PR TITLE
Improve couch_proc_manager

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -382,6 +382,13 @@ authentication_db = _users
 ;query_limit = 268435456
 ;partition_query_limit = 268435456
 
+; Configure what to use as the db tag when selecting design doc couchjs
+; processes. The choices are:
+;  - name (default) : Use the entire db name
+;  - prefix : Use only db prefix before the first "/" character
+;  - none : Do not use a db tag at all
+;db_tag = name
+
 [mango]
 ; Set to true to disable the "index all fields" text index, which can lead
 ; to out of memory issues when users have documents with nested array fields.

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -189,11 +189,14 @@
 -record(proc, {
     pid,
     lang,
-    client = nil,
-    ddoc_keys = [],
+    client,
+    db_key,
+    ddoc_keys = #{},
     prompt_fun,
     set_timeout_fun,
-    stop_fun
+    stop_fun,
+    threshold_ts,
+    last_use_ts
 }).
 
 -record(leaf,  {

--- a/src/couch/src/couch_changes.erl
+++ b/src/couch/src/couch_changes.erl
@@ -233,7 +233,7 @@ filter(_Db, DocInfo, {design_docs, Style}) ->
     end;
 filter(Db, DocInfo, {view, Style, DDoc, VName}) ->
     Docs = open_revs(Db, DocInfo, Style),
-    {ok, Passes} = couch_query_servers:filter_view(DDoc, VName, Docs),
+    {ok, Passes} = couch_query_servers:filter_view(Db, DDoc, VName, Docs),
     filter_revs(Passes, Docs);
 filter(Db, DocInfo, {custom, Style, Req0, DDoc, FName}) ->
     Req = case Req0 of

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -950,7 +950,7 @@ load_validation_funs(#db{main_pid=Pid}=Db) ->
     end,
     DDocs = lists:map(OpenDocs, DDocInfos),
     Funs = lists:flatmap(fun(DDoc) ->
-        case couch_doc:get_validate_doc_fun(DDoc) of
+        case couch_doc:get_validate_doc_fun(Db, DDoc) of
             nil -> [];
             Fun -> [Fun]
         end

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -330,7 +330,7 @@ refresh_validate_doc_funs(Db0) ->
         fun(DesignDocInfo) ->
             {ok, DesignDoc} = couch_db:open_doc_int(
                 Db, DesignDocInfo, [ejson_body]),
-            case couch_doc:get_validate_doc_fun(DesignDoc) of
+            case couch_doc:get_validate_doc_fun(Db, DesignDoc) of
             nil -> [];
             Fun -> [Fun]
             end

--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -16,7 +16,7 @@
 -export([from_json_obj/1, from_json_obj_validate/1]).
 -export([from_json_obj/2, from_json_obj_validate/2]).
 -export([to_json_obj/2, has_stubs/1, merge_stubs/2]).
--export([validate_docid/1, validate_docid/2, get_validate_doc_fun/1]).
+-export([validate_docid/1, validate_docid/2, get_validate_doc_fun/2]).
 -export([doc_from_multi_part_stream/2, doc_from_multi_part_stream/3]).
 -export([doc_from_multi_part_stream/4]).
 -export([doc_to_multi_part_stream/5, len_doc_to_multi_part_stream/4]).
@@ -400,15 +400,15 @@ is_deleted(Tree) ->
     end.
 
 
-get_validate_doc_fun({Props}) ->
-    get_validate_doc_fun(couch_doc:from_json_obj({Props}));
-get_validate_doc_fun(#doc{body={Props}}=DDoc) ->
+get_validate_doc_fun(Db, {Props}) ->
+    get_validate_doc_fun(Db, couch_doc:from_json_obj({Props}));
+get_validate_doc_fun(Db, #doc{body={Props}}=DDoc) ->
     case couch_util:get_value(<<"validate_doc_update">>, Props) of
     undefined ->
         nil;
     _Else ->
         fun(EditDoc, DiskDoc, Ctx, SecObj) ->
-            couch_query_servers:validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj)
+            couch_query_servers:validate_doc_update(Db, DDoc, EditDoc, DiskDoc, Ctx, SecObj)
         end
     end.
 

--- a/src/couch/src/couch_native_process.erl
+++ b/src/couch/src/couch_native_process.erl
@@ -115,7 +115,7 @@ handle_cast(_Msg, State) ->
     {noreply, State, State#evstate.idle}.
 
 handle_info(timeout, State) ->
-    gen_server:cast(couch_proc_manager, {os_proc_idle, self()}),
+    couch_proc_manager:os_proc_idle(self()),
     erlang:garbage_collect(),
     {noreply, State, State#evstate.idle};
 handle_info({'EXIT',_,normal}, State) ->

--- a/src/couch/src/couch_os_process.erl
+++ b/src/couch/src/couch_os_process.erl
@@ -229,7 +229,7 @@ handle_cast(Msg, #os_proc{idle=Idle}=OsProc) ->
     {noreply, OsProc, Idle}.
 
 handle_info(timeout, #os_proc{idle=Idle}=OsProc) ->
-    gen_server:cast(couch_proc_manager, {os_proc_idle, self()}),
+    couch_proc_manager:os_proc_idle(self()),
     erlang:garbage_collect(),
     {noreply, OsProc, Idle};
 handle_info({Port, {exit_status, 0}}, #os_proc{port=Port}=OsProc) ->

--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -14,16 +14,16 @@
 
 -export([try_compile/4]).
 -export([start_doc_map/3, map_doc_raw/2, stop_doc_map/1, raw_to_ejson/1]).
--export([reduce/3, rereduce/3,validate_doc_update/5]).
+-export([reduce/3, rereduce/3, validate_doc_update/6]).
 -export([filter_docs/5]).
--export([filter_view/3]).
+-export([filter_view/4]).
 -export([finalize/2]).
 -export([rewrite/3]).
 
--export([with_ddoc_proc/2, proc_prompt/2, ddoc_prompt/3, ddoc_proc_prompt/3, json_doc/1]).
+-export([with_ddoc_proc/3, proc_prompt/2, ddoc_prompt/4, ddoc_proc_prompt/3, json_doc/1]).
 
 % For 210-os-proc-pool.t
--export([get_os_process/1, get_ddoc_process/2, ret_os_process/1]).
+-export([get_os_process/1, get_ddoc_process/3, ret_os_process/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -355,17 +355,19 @@ approx_count_distinct(rereduce, Reds) ->
     hyper:union([Filter || [_, Filter] <- Reds]).
 
 % use the function stored in ddoc.validate_doc_update to test an update.
--spec validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) -> ok when
+-spec validate_doc_update(Db, DDoc, EditDoc, DiskDoc, Ctx, SecObj) -> ok when
+    Db :: term(),
     DDoc    :: ddoc(),
     EditDoc :: doc(),
     DiskDoc :: doc() | nil,
     Ctx     :: user_ctx(),
     SecObj  :: sec_obj().
 
-validate_doc_update(DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
+validate_doc_update(Db, DDoc, EditDoc, DiskDoc, Ctx, SecObj) ->
     JsonEditDoc = couch_doc:to_json_obj(EditDoc, [revs]),
     JsonDiskDoc = json_doc(DiskDoc),
     Resp = ddoc_prompt(
+        Db,
         DDoc,
         [<<"validate_doc_update">>],
         [JsonEditDoc, JsonDiskDoc, Ctx, SecObj]
@@ -392,7 +394,7 @@ rewrite(Req, Db, DDoc) ->
               F =/= <<"info">>, F =/= <<"form">>,
               F =/= <<"uuid">>, F =/= <<"id">>],
     JsonReq = chttpd_external:json_req_obj(Req, Db, null, Fields),
-    case couch_query_servers:ddoc_prompt(DDoc, [<<"rewrites">>], [JsonReq]) of
+    case ddoc_prompt(Db, DDoc, [<<"rewrites">>], [JsonReq]) of
         {[{<<"forbidden">>, Message}]} ->
             throw({forbidden, Message});
         {[{<<"unauthorized">>, Message}]} ->
@@ -480,10 +482,10 @@ json_doc(nil, _) ->
 json_doc(Doc, Options) ->
     couch_doc:to_json_obj(Doc, Options).
 
-filter_view(DDoc, VName, Docs) ->
+filter_view(Db, DDoc, VName, Docs) ->
     Options = json_doc_options(),
     JsonDocs = [json_doc(Doc, Options) || Doc <- Docs],
-    [true, Passes] = ddoc_prompt(DDoc, [<<"views">>, VName, <<"map">>], [JsonDocs]),
+    [true, Passes] = ddoc_prompt(Db, DDoc, [<<"views">>, VName, <<"map">>], [JsonDocs]),
     {ok, Passes}.
 
 filter_docs(Req, Db, DDoc, FName, Docs) ->
@@ -496,33 +498,34 @@ filter_docs(Req, Db, DDoc, FName, Docs) ->
     Options = json_doc_options(),
     JsonDocs = [json_doc(Doc, Options) || Doc <- Docs],
     try
-        {ok, filter_docs_int(DDoc, FName, JsonReq, JsonDocs)}
+        {ok, filter_docs_int(Db, DDoc, FName, JsonReq, JsonDocs)}
     catch
         throw:{os_process_error,{exit_status,1}} ->
             %% batch used too much memory, retry sequentially.
             Fun = fun(JsonDoc) ->
-                filter_docs_int(DDoc, FName, JsonReq, [JsonDoc])
+                filter_docs_int(Db, DDoc, FName, JsonReq, [JsonDoc])
             end,
             {ok, lists:flatmap(Fun, JsonDocs)}
     end.
 
-filter_docs_int(DDoc, FName, JsonReq, JsonDocs) ->
-    [true, Passes] = ddoc_prompt(DDoc, [<<"filters">>, FName],
+filter_docs_int(Db, DDoc, FName, JsonReq, JsonDocs) ->
+    [true, Passes] = ddoc_prompt(Db, DDoc, [<<"filters">>, FName],
         [JsonDocs, JsonReq]),
     Passes.
 
 ddoc_proc_prompt({Proc, DDocId}, FunPath, Args) ->
     proc_prompt(Proc, [<<"ddoc">>, DDocId, FunPath, Args]).
 
-ddoc_prompt(DDoc, FunPath, Args) ->
-    with_ddoc_proc(DDoc, fun({Proc, DDocId}) ->
+ddoc_prompt(Db, DDoc, FunPath, Args) ->
+    with_ddoc_proc(Db, DDoc, fun({Proc, DDocId}) ->
         proc_prompt(Proc, [<<"ddoc">>, DDocId, FunPath, Args])
     end).
 
-with_ddoc_proc(#doc{id=DDocId,revs={Start, [DiskRev|_]}}=DDoc, Fun) ->
+with_ddoc_proc(Db, #doc{id = DDocId, revs = {Start, [DiskRev | _]}} = DDoc, Fun) ->
     Rev = couch_doc:rev_to_str({Start, DiskRev}),
+    DbKey = db_key(Db),
     DDocKey = {DDocId, Rev},
-    Proc = get_ddoc_process(DDoc, DDocKey),
+    Proc = get_ddoc_process(DDoc, DbKey, DDocKey),
     try Fun({Proc, DDocId}) of
         Resp ->
             ok = ret_os_process(Proc),
@@ -531,6 +534,22 @@ with_ddoc_proc(#doc{id=DDocId,revs={Start, [DiskRev|_]}}=DDoc, Fun) ->
         catch proc_stop(Proc),
         erlang:raise(Tag, Err, Stack)
     end.
+
+db_key(DbName) when is_binary(DbName) ->
+    Name = mem3:dbname(DbName),
+    case config:get("query_server_config", "db_tag", "name") of
+        "prefix" ->
+            case binary:split(Name, <<"/">>) of
+                [Prefix, _] when byte_size(Prefix) > 0 -> Prefix;
+                _ -> Name
+            end;
+        "none" ->
+            undefined;
+        _ ->
+            Name
+    end;
+db_key(Db) ->
+    db_key(couch_db:name(Db)).
 
 proc_prompt(Proc, Args) ->
      case proc_prompt_raw(Proc, Args) of
@@ -622,12 +641,9 @@ proc_set_timeout(Proc, Timeout) ->
     {Mod, Func} = Proc#proc.set_timeout_fun,
     apply(Mod, Func, [Proc#proc.pid, Timeout]).
 
-get_os_process_timeout() ->
-    config:get_integer("couchdb", "os_process_timeout", 5000).
-
-get_ddoc_process(#doc{} = DDoc, DDocKey) ->
+get_ddoc_process(#doc{} = DDoc, DbKey, DDocKey) ->
     % remove this case statement
-    case gen_server:call(couch_proc_manager, {get_proc, DDoc, DDocKey}, get_os_process_timeout()) of
+    case couch_proc_manager:get_proc(DDoc, DbKey, DDocKey) of
     {ok, Proc, {QueryConfig}} ->
         % process knows the ddoc
         case (catch proc_prompt(Proc, [<<"reset">>, {QueryConfig}])) of
@@ -636,14 +652,14 @@ get_ddoc_process(#doc{} = DDoc, DDocKey) ->
             Proc;
         _ ->
             catch proc_stop(Proc),
-            get_ddoc_process(DDoc, DDocKey)
+                    get_ddoc_process(DDoc, DbKey, DDocKey)
         end;
     Error ->
         throw(Error)
     end.
 
 get_os_process(Lang) ->
-    case gen_server:call(couch_proc_manager, {get_proc, Lang}, get_os_process_timeout()) of
+    case couch_proc_manager:get_proc(Lang) of
     {ok, Proc, {QueryConfig}} ->
         case (catch proc_prompt(Proc, [<<"reset">>, {QueryConfig}])) of
         true ->
@@ -658,7 +674,7 @@ get_os_process(Lang) ->
     end.
 
 ret_os_process(Proc) ->
-    true = gen_server:call(couch_proc_manager, {ret_proc, Proc}, infinity),
+    true = couch_proc_manager:ret_proc(Proc),
     catch unlink(Proc#proc.pid),
     ok.
 
@@ -670,7 +686,10 @@ throw_stat_error(Else) ->
 
 
 -ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+-define(TDEF_FE(Name), fun(Arg) -> {atom_to_list(Name), ?_test(Name(Arg))} end).
 
 builtin_sum_rows_negative_test() ->
     A = [{[{<<"a">>, 1}]}, {[{<<"a">>, 2}]}, {[{<<"a">>, 3}]}],
@@ -798,5 +817,43 @@ force_utf8_test() ->
             io:format(standard_error, "~p~n~p~n", [T, R])
         end
     end, NotOk).
+
+db_key_test_() ->
+    {
+        foreach,
+        fun setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(t_db_key_default),
+            ?TDEF_FE(t_db_key_prefix),
+            ?TDEF_FE(t_db_key_none)
+        ]
+    }.
+
+setup() ->
+    meck:new(config, [passthrough]),
+    meck:expect(config, get, fun(_, _, Default) -> Default end),
+    ok.
+
+teardown(_) ->
+    meck:unload().
+
+t_db_key_default(_) ->
+    ?assertEqual(<<"foo">>, db_key(<<"foo">>)),
+    ?assertEqual(<<"foo/bar">>, db_key(<<"foo/bar">>)),
+    ?assertEqual(<<"foo/bar">>, db_key(<<"shards/00000000-3fffffff/foo/bar.1415960794">>)).
+
+t_db_key_prefix(_) ->
+    meck:expect(config, get, fun(_, "db_tag", _) -> "prefix" end),
+    ?assertEqual(<<"foo">>, db_key(<<"foo">>)),
+    ?assertEqual(<<"foo">>, db_key(<<"foo/bar">>)),
+    ?assertEqual(<<"foo">>, db_key(<<"shards/00000000-3fffffff/foo/bar.1415960794">>)),
+    ?assertEqual(<<"/foo">>, db_key(<<"/foo">>)).
+
+t_db_key_none(_) ->
+    meck:expect(config, get, fun(_, "db_tag", _) -> "none" end),
+    ?assertEqual(undefined, db_key(<<"foo">>)),
+    ?assertEqual(undefined, db_key(<<"foo/bar">>)),
+    ?assertEqual(undefined, db_key(<<"shards/00000000-3fffffff/foo/bar.1415960794">>)).
 
 -endif.

--- a/src/couch/test/eunit/couch_auth_cache_tests.erl
+++ b/src/couch/test/eunit/couch_auth_cache_tests.erl
@@ -345,5 +345,6 @@ validate(DiskDoc, NewDoc) ->
 
 validate(DiskDoc, NewDoc, JSONCtx) ->
     {ok, DDoc0} = couch_auth_cache:auth_design_doc(<<"_design/anything">>),
+    Db = <<"validate_couch_auth_cache_tests">>,
     DDoc = DDoc0#doc{revs = {1, [<<>>]}},
-    couch_query_servers:validate_doc_update(DDoc, NewDoc, DiskDoc, JSONCtx, []).
+    couch_query_servers:validate_doc_update(Db, DDoc, NewDoc, DiskDoc, JSONCtx, []).

--- a/src/couch/test/eunit/couch_query_servers_tests.erl
+++ b/src/couch/test/eunit/couch_query_servers_tests.erl
@@ -110,7 +110,7 @@ should_return_object_on_false() ->
 
 should_split_large_batches() ->
     Req = {json_req, {[]}},
-    Db = undefined,
+    Db = <<"somedb">>,
     DDoc = #doc{
         id = <<"_design/foo">>,
         revs = {0, [<<"bork bork bork">>]},

--- a/src/couch/test/eunit/couchdb_os_proc_pool.erl
+++ b/src/couch/test/eunit/couchdb_os_proc_pool.erl
@@ -15,240 +15,492 @@
 -include_lib("couch/include/couch_eunit.hrl").
 -include_lib("couch/include/couch_db.hrl").
 
+-define(TDEF_FE(Name), fun(Arg) -> {atom_to_list(Name), ?_test(Name(Arg))} end).
+
 -define(TIMEOUT, 1000).
 
 
 setup() ->
-    ok = couch_proc_manager:reload(),
+    Ctx = test_util:start_couch(),
     meck:new(couch_os_process, [passthrough]),
-    ok = setup_config().
+    meck:new(couch_proc_manager, [passthrough]),
+    ok = setup_config(),
+    Ctx.
 
-teardown(_) ->
+teardown(Ctx) ->
+    ok = teardown_config(),
     meck:unload(),
+    test_util:stop_couch(Ctx),
     ok.
 
 os_proc_pool_test_() ->
     {
         "OS processes pool tests",
         {
-            setup,
-            fun test_util:start_couch/0, fun test_util:stop_couch/1,
-            {
-                foreach,
-                fun setup/0, fun teardown/1,
-                [
-                    should_block_new_proc_on_full_pool(),
-                    should_free_slot_on_proc_unexpected_exit(),
-                    should_reuse_known_proc(),
-%                    should_process_waiting_queue_as_fifo(),
-                    should_reduce_pool_on_idle_os_procs(),
-                    should_not_return_broken_process_to_the_pool()
-                ]
-            }
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                ?TDEF_FE(should_block_new_proc_on_full_pool),
+                ?TDEF_FE(should_free_slot_on_proc_unexpected_exit),
+                ?TDEF_FE(should_reuse_known_proc),
+                ?TDEF_FE(should_process_waiting_queue_as_fifo),
+                ?TDEF_FE(should_reduce_pool_on_idle_os_procs),
+                ?TDEF_FE(should_reduce_pool_of_tagged_processes_on_idle),
+                ?TDEF_FE(should_not_return_broken_process_to_the_pool),
+                ?TDEF_FE(oldest_tagged_process_is_reaped),
+                ?TDEF_FE(untagged_process_is_replenished),
+                ?TDEF_FE(exact_ddoc_tagged_process_is_picked_first),
+                ?TDEF_FE(db_tagged_process_is_second_choice),
+                ?TDEF_FE(if_no_tagged_process_found_new_must_be_spawned),
+                ?TDEF_FE(db_tag_none_works),
+                ?TDEF_FE(stale_procs_are_cleaned),
+                ?TDEF_FE(bad_query_language)
+            ]
         }
     }.
 
+should_block_new_proc_on_full_pool(_) ->
+    Client1 = spawn_client(),
+    Client2 = spawn_client(),
+    Client3 = spawn_client(),
 
-should_block_new_proc_on_full_pool() ->
-    ?_test(begin
-        Client1 = spawn_client(),
-        Client2 = spawn_client(),
-        Client3 = spawn_client(),
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+    ?assertEqual(ok, ping_client(Client3)),
 
-        ?assertEqual(ok, ping_client(Client1)),
-        ?assertEqual(ok, ping_client(Client2)),
-        ?assertEqual(ok, ping_client(Client3)),
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+    Proc3 = get_client_proc(Client3, "3"),
 
-        Proc1 = get_client_proc(Client1, "1"),
-        Proc2 = get_client_proc(Client2, "2"),
-        Proc3 = get_client_proc(Client3, "3"),
+    ?assertNotEqual(Proc1, Proc2),
+    ?assertNotEqual(Proc2, Proc3),
+    ?assertNotEqual(Proc3, Proc1),
 
-        ?assertNotEqual(Proc1, Proc2),
-        ?assertNotEqual(Proc2, Proc3),
-        ?assertNotEqual(Proc3, Proc1),
+    Client4 = spawn_client(),
+    ?assertEqual(timeout, ping_client(Client4)),
 
-        Client4 = spawn_client(),
-        ?assertEqual(timeout, ping_client(Client4)),
+    ?assertEqual(ok, stop_client(Client1)),
+    ?assertEqual(ok, ping_client(Client4)),
 
-        ?assertEqual(ok, stop_client(Client1)),
-        ?assertEqual(ok, ping_client(Client4)),
+    Proc4 = get_client_proc(Client4, "4"),
 
-        Proc4 = get_client_proc(Client4, "4"),
+    ?assertEqual(Proc1#proc.pid, Proc4#proc.pid),
+    ?assertNotEqual(Proc1#proc.client, Proc4#proc.client),
 
-        ?assertEqual(Proc1#proc.pid, Proc4#proc.pid),
-        ?assertNotEqual(Proc1#proc.client, Proc4#proc.client),
+    stop_clients([Client2, Client3, Client4]).
 
-        lists:map(fun(C) ->
-            ?assertEqual(ok, stop_client(C))
-        end, [Client2, Client3, Client4])
-    end).
+should_free_slot_on_proc_unexpected_exit(_) ->
+    Client1 = spawn_client(),
+    Client2 = spawn_client(),
+    Client3 = spawn_client(),
 
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+    ?assertEqual(ok, ping_client(Client3)),
 
-should_free_slot_on_proc_unexpected_exit() ->
-    ?_test(begin
-        Client1 = spawn_client(),
-        Client2 = spawn_client(),
-        Client3 = spawn_client(),
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+    Proc3 = get_client_proc(Client3, "3"),
 
-        ?assertEqual(ok, ping_client(Client1)),
-        ?assertEqual(ok, ping_client(Client2)),
-        ?assertEqual(ok, ping_client(Client3)),
+    ?assertNotEqual(Proc1#proc.pid, Proc2#proc.pid),
+    ?assertNotEqual(Proc1#proc.client, Proc2#proc.client),
+    ?assertNotEqual(Proc2#proc.pid, Proc3#proc.pid),
+    ?assertNotEqual(Proc2#proc.client, Proc3#proc.client),
+    ?assertNotEqual(Proc3#proc.pid, Proc1#proc.pid),
+    ?assertNotEqual(Proc3#proc.client, Proc1#proc.client),
 
-        Proc1 = get_client_proc(Client1, "1"),
-        Proc2 = get_client_proc(Client2, "2"),
-        Proc3 = get_client_proc(Client3, "3"),
+    ?assertEqual(ok, kill_client(Client1)),
 
-        ?assertNotEqual(Proc1#proc.pid, Proc2#proc.pid),
-        ?assertNotEqual(Proc1#proc.client, Proc2#proc.client),
-        ?assertNotEqual(Proc2#proc.pid, Proc3#proc.pid),
-        ?assertNotEqual(Proc2#proc.client, Proc3#proc.client),
-        ?assertNotEqual(Proc3#proc.pid, Proc1#proc.pid),
-        ?assertNotEqual(Proc3#proc.client, Proc1#proc.client),
+    Client4 = spawn_client(),
+    ?assertEqual(ok, ping_client(Client4)),
 
-        ?assertEqual(ok, kill_client(Client1)),
+    Proc4 = get_client_proc(Client4, "4"),
 
-        Client4 = spawn_client(),
-        ?assertEqual(ok, ping_client(Client4)),
+    ?assertEqual(Proc4#proc.pid, Proc1#proc.pid),
+    ?assertNotEqual(Proc4#proc.client, Proc1#proc.client),
+    ?assertNotEqual(Proc2#proc.pid, Proc4#proc.pid),
+    ?assertNotEqual(Proc2#proc.client, Proc4#proc.client),
+    ?assertNotEqual(Proc3#proc.pid, Proc4#proc.pid),
+    ?assertNotEqual(Proc3#proc.client, Proc4#proc.client),
 
-        Proc4 = get_client_proc(Client4, "4"),
+    stop_clients([Client2, Client3, Client4]).
 
-        ?assertEqual(Proc4#proc.pid, Proc1#proc.pid),
-        ?assertNotEqual(Proc4#proc.client, Proc1#proc.client),
-        ?assertNotEqual(Proc2#proc.pid, Proc4#proc.pid),
-        ?assertNotEqual(Proc2#proc.client, Proc4#proc.client),
-        ?assertNotEqual(Proc3#proc.pid, Proc4#proc.pid),
-        ?assertNotEqual(Proc3#proc.client, Proc4#proc.client),
+should_reuse_known_proc(_) ->
+    Db = <<"db">>,
+    Client1 = spawn_client(Db, <<"ddoc1">>),
+    Client2 = spawn_client(Db, <<"ddoc2">>),
 
-        lists:map(fun(C) ->
-            ?assertEqual(ok, stop_client(C))
-        end, [Client2, Client3, Client4])
-    end).
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
 
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+    ?assertNotEqual(Proc1#proc.pid, Proc2#proc.pid),
 
-should_reuse_known_proc() ->
-    ?_test(begin
-        Client1 = spawn_client(<<"ddoc1">>),
-        Client2 = spawn_client(<<"ddoc2">>),
+    ?assertEqual(ok, stop_client(Client1)),
+    ?assertEqual(ok, stop_client(Client2)),
+    ?assert(is_process_alive(Proc1#proc.pid)),
+    ?assert(is_process_alive(Proc2#proc.pid)),
 
-        ?assertEqual(ok, ping_client(Client1)),
-        ?assertEqual(ok, ping_client(Client2)),
+    Client1Again = spawn_client(Db, <<"ddoc1">>),
+    ?assertEqual(ok, ping_client(Client1Again)),
+    Proc1Again = get_client_proc(Client1Again, "1-again"),
+    ?assertEqual(Proc1#proc.pid, Proc1Again#proc.pid),
+    ?assertNotEqual(Proc1#proc.client, Proc1Again#proc.client),
+    ?assertEqual(ok, stop_client(Client1Again)).
 
-        Proc1 = get_client_proc(Client1, "1"),
-        Proc2 = get_client_proc(Client2, "2"),
-        ?assertNotEqual(Proc1#proc.pid, Proc2#proc.pid),
+should_process_waiting_queue_as_fifo(_) ->
+    Db = <<"db">>,
+    meck:reset(couch_proc_manager),
+    Client1 = spawn_client(Db, <<"ddoc1">>),
+    meck:wait(1, couch_proc_manager, handle_call, [{get_proc, '_'}, '_', '_'], 1000),
+    Client2 = spawn_client(Db, <<"ddoc2">>),
+    meck:wait(2, couch_proc_manager, handle_call, [{get_proc, '_'}, '_', '_'], 1000),
+    Client3 = spawn_client(Db, <<"ddoc3">>),
+    meck:wait(3, couch_proc_manager, handle_call, [{get_proc, '_'}, '_', '_'], 1000),
+    Client4 = spawn_client(Db, <<"ddoc4">>),
+    meck:wait(4, couch_proc_manager, handle_call, [{get_proc, '_'}, '_', '_'], 1000),
+    Client5 = spawn_client(Db, <<"ddoc5">>),
+    meck:wait(5, couch_proc_manager, handle_call, [{get_proc, '_'}, '_', '_'], 1000),
 
-        ?assertEqual(ok, stop_client(Client1)),
-        ?assertEqual(ok, stop_client(Client2)),
-        ?assert(is_process_alive(Proc1#proc.pid)),
-        ?assert(is_process_alive(Proc2#proc.pid)),
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+    ?assertEqual(ok, ping_client(Client3)),
+    ?assertEqual(timeout, ping_client(Client4)),
+    ?assertEqual(timeout, ping_client(Client5)),
 
-        Client1Again = spawn_client(<<"ddoc1">>),
-        ?assertEqual(ok, ping_client(Client1Again)),
-        Proc1Again = get_client_proc(Client1Again, "1-again"),
-        ?assertEqual(Proc1#proc.pid, Proc1Again#proc.pid),
-        ?assertNotEqual(Proc1#proc.client, Proc1Again#proc.client),
-        ?assertEqual(ok, stop_client(Client1Again))
-    end).
+    Proc1 = get_client_proc(Client1, "1"),
+    ?assertEqual(ok, stop_client(Client1)),
+    ?assertEqual(ok, ping_client(Client4)),
+    Proc4 = get_client_proc(Client4, "4"),
 
+    ?assertNotEqual(Proc4#proc.client, Proc1#proc.client),
+    ?assertEqual(Proc1#proc.pid, Proc4#proc.pid),
+    ?assertEqual(timeout, ping_client(Client5)),
 
-%should_process_waiting_queue_as_fifo() ->
-%    ?_test(begin
-%        Client1 = spawn_client(<<"ddoc1">>),
-%        Client2 = spawn_client(<<"ddoc2">>),
-%        Client3 = spawn_client(<<"ddoc3">>),
-%        Client4 = spawn_client(<<"ddoc4">>),
-%        timer:sleep(100),
-%        Client5 = spawn_client(<<"ddoc5">>),
-%
-%        ?assertEqual(ok, ping_client(Client1)),
-%        ?assertEqual(ok, ping_client(Client2)),
-%        ?assertEqual(ok, ping_client(Client3)),
-%        ?assertEqual(timeout, ping_client(Client4)),
-%        ?assertEqual(timeout, ping_client(Client5)),
-%
-%        Proc1 = get_client_proc(Client1, "1"),
-%        ?assertEqual(ok, stop_client(Client1)),
-%        ?assertEqual(ok, ping_client(Client4)),
-%        Proc4 = get_client_proc(Client4, "4"),
-%
-%        ?assertNotEqual(Proc4#proc.client, Proc1#proc.client),
-%        ?assertEqual(Proc1#proc.pid, Proc4#proc.pid),
-%        ?assertEqual(timeout, ping_client(Client5)),
-%
-%        ?assertEqual(ok, stop_client(Client2)),
-%        ?assertEqual(ok, stop_client(Client3)),
-%        ?assertEqual(ok, stop_client(Client4)),
-%        ?assertEqual(ok, stop_client(Client5))
-%    end).
+    ?assertEqual(ok, stop_client(Client2)),
+    ?assertEqual(ok, stop_client(Client3)),
+    ?assertEqual(ok, stop_client(Client4)),
+    ?assertEqual(ok, stop_client(Client5)).
 
+should_reduce_pool_on_idle_os_procs(_) ->
+    %% os_process_idle_limit is in sec
+    cfg_set("os_process_idle_limit", "1"),
 
-should_reduce_pool_on_idle_os_procs() ->
-    ?_test(begin
-        %% os_process_idle_limit is in sec
-        config:set("query_server_config",
-            "os_process_idle_limit", "1", false),
-        ok = confirm_config("os_process_idle_limit", "1"),
+    Db = undefined,
+    Client1 = spawn_client(Db, <<"ddoc1">>),
+    Client2 = spawn_client(Db, <<"ddoc2">>),
+    Client3 = spawn_client(Db, <<"ddoc3">>),
 
-        Client1 = spawn_client(<<"ddoc1">>),
-        Client2 = spawn_client(<<"ddoc2">>),
-        Client3 = spawn_client(<<"ddoc3">>),
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+    ?assertEqual(ok, ping_client(Client3)),
 
-        ?assertEqual(ok, ping_client(Client1)),
-        ?assertEqual(ok, ping_client(Client2)),
-        ?assertEqual(ok, ping_client(Client3)),
+    ?assertEqual(3, couch_proc_manager:get_proc_count()),
 
-        ?assertEqual(3, couch_proc_manager:get_proc_count()),
+    ?assertEqual(ok, stop_client(Client1)),
+    ?assertEqual(ok, stop_client(Client2)),
+    ?assertEqual(ok, stop_client(Client3)),
 
-        ?assertEqual(ok, stop_client(Client1)),
-        ?assertEqual(ok, stop_client(Client2)),
-        ?assertEqual(ok, stop_client(Client3)),
+    % granularity of idle limit is in seconds
+    timer:sleep(1000),
+    wait_process_count(1).
 
-        timer:sleep(1200),
-        ?assertEqual(1, couch_proc_manager:get_proc_count())
-    end).
+should_reduce_pool_of_tagged_processes_on_idle(_) ->
+    %% os_process_idle_limit is in sec
+    cfg_set("os_process_idle_limit", "1"),
 
+    Db = <<"reduce_pool_on_idle_db">>,
+    Client1 = spawn_client(Db, <<"ddoc1">>),
+    Client2 = spawn_client(Db, <<"ddoc2">>),
+    Client3 = spawn_client(Db, <<"ddoc3">>),
 
-should_not_return_broken_process_to_the_pool() ->
-    ?_test(begin
-        config:set("query_server_config",
-            "os_process_soft_limit", "1", false),
-        ok = confirm_config("os_process_soft_limit", "1"),
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+    ?assertEqual(ok, ping_client(Client3)),
 
-        config:set("query_server_config",
-            "os_process_limit", "1", false),
-        ok = confirm_config("os_process_limit", "1"),
+    ?assertEqual(3, couch_proc_manager:get_proc_count()),
 
-        DDoc1 = ddoc(<<"_design/ddoc1">>),
+    stop_clients([Client1, Client2, Client3]),
 
-        meck:reset(couch_os_process),
+    timer:sleep(1000),
+    wait_process_count(0).
 
-        ?assertEqual(0, couch_proc_manager:get_proc_count()),
-        ok = couch_query_servers:with_ddoc_proc(DDoc1, fun(_) -> ok end),
-        ?assertEqual(0, meck:num_calls(couch_os_process, stop, 1)),
-        ?assertEqual(1, couch_proc_manager:get_proc_count()),
+oldest_tagged_process_is_reaped(_) ->
+    Client1 = spawn_client(<<"db1">>, <<"ddoc1">>),
+    Client2 = spawn_client(<<"db2">>, <<"ddoc1">>),
+    Client3 = spawn_client(<<"db3">>, <<"ddoc1">>),
 
-        ?assertError(bad, couch_query_servers:with_ddoc_proc(DDoc1, fun(_) ->
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+    ?assertEqual(ok, ping_client(Client3)),
+
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+    Proc3 = get_client_proc(Client3, "3"),
+
+    ?assert(all_alive_all_different([Proc1, Proc2, Proc3])),
+
+    stop_clients([Client1, Client2, Client3]),
+
+    % All procs should be released back into the pool
+    wait_tagged_idle_count(3),
+
+    % Processes should be alive
+    ?assert(all_alive([Proc1, Proc2, Proc3])),
+
+    % Spawning a new tagged proc with a different tag should kill
+    % the oldest unused proc and spawn a new one
+    Client4 = spawn_client(<<"db4">>, <<"ddoc1">>),
+    ?assertEqual(ok, ping_client(Client4)),
+    Proc4 = get_client_proc(Client4, "4"),
+
+    ?assert(all_alive_all_different([Proc2, Proc3, Proc4])),
+    ?assertNot(is_process_alive(Proc1#proc.pid)),
+
+    ?assertEqual(ok, stop_client(Client4)).
+
+untagged_process_is_replenished(_) ->
+    Client1 = spawn_client(),
+    Client2 = spawn_client(),
+
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+
+    ?assert(all_alive_all_different([Proc1, Proc2])),
+
+    stop_clients([Client1, Client2]),
+
+    % All procs should be released back into the pool
+    % and they are now all untagged idle
+    wait_idle_count(2),
+    ?assertEqual(0, tagged_idle_count()),
+
+    % Processes should still be alive
+    ?assert(all_alive([Proc1, Proc2])),
+
+    % Spawning a new tagged proc should tag one of the procs
+    % and also asynchronously replenish the untagged pool
+    Client3 = spawn_client(<<"db">>, <<"ddoc1">>),
+    ?assertEqual(ok, ping_client(Client3)),
+
+    % The process is one of the previously untagged ones
+    Proc3 = get_client_proc(Client3, "3"),
+    Pid3 = Proc3#proc.pid,
+    ?assert(lists:member(Pid3, proc_pids([Proc1, Proc2]))),
+
+    % wait for replinishment
+    wait_idle_count(2),
+
+    ?assertEqual(ok, stop_client(Client3)).
+
+exact_ddoc_tagged_process_is_picked_first(_) ->
+    Client1 = spawn_client(<<"db">>, <<"ddoc1">>),
+    Client2 = spawn_client(<<"db">>, <<"ddoc2">>),
+
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+
+    ?assert(all_alive_all_different([Proc1, Proc2])),
+
+    stop_clients([Client1, Client2]),
+
+    % All procs should be released back into the pool
+    % and they now tagged and idle
+    wait_tagged_idle_count(2),
+    wait_idle_count(2),
+
+    % Processes should still be alive
+    ?assert(all_alive([Proc1, Proc2])),
+
+    % Spawning a new tagged proc should pick the one with
+    % matching ddoc
+    Client3 = spawn_client(<<"db">>, <<"ddoc1">>),
+    ?assertEqual(ok, ping_client(Client3)),
+    Proc3 = get_client_proc(Client3, "3"),
+    ?assertEqual(Proc1#proc.pid, Proc3#proc.pid),
+
+    ?assertEqual(ok, stop_client(Client3)).
+
+db_tagged_process_is_second_choice(_) ->
+    Client1 = spawn_client(<<"db1">>, <<"ddoc1">>),
+    Client2 = spawn_client(<<"db2">>, <<"ddoc2">>),
+
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+
+    ?assert(all_alive_all_different([Proc1, Proc2])),
+
+    stop_clients([Client1, Client2]),
+
+    % All procs should be released back into the pool
+    % and they now tagged and idle
+    wait_tagged_idle_count(2),
+    wait_idle_count(2),
+
+    % Processes should still be alive
+    ?assert(all_alive([Proc1, Proc2])),
+
+    % Spawning a new tagged proc should pick the one with
+    % the matching ddoc
+    Client3 = spawn_client(<<"db1">>, <<"ddoc3">>),
+    ?assertEqual(ok, ping_client(Client3)),
+    Proc3 = get_client_proc(Client3, "3"),
+    ?assertEqual(Proc1#proc.pid, Proc3#proc.pid),
+
+    ?assertEqual(ok, stop_client(Client3)).
+
+if_no_tagged_process_found_new_must_be_spawned(_) ->
+    Client1 = spawn_client(<<"db1">>, <<"ddoc">>),
+    Client2 = spawn_client(<<"db2">>, <<"ddoc">>),
+
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+
+    ?assert(all_alive_all_different([Proc1, Proc2])),
+
+    stop_clients([Client1, Client2]),
+
+    % All procs should be released back into the pool
+    % and they now tagged and idle
+    wait_tagged_idle_count(2),
+    wait_idle_count(2),
+
+    % Processes should still be alive
+    ?assert(all_alive([Proc1, Proc2])),
+
+    % If new tagged process with new db should spawn
+    % new process never pick up an existing one
+    Client3 = spawn_client(<<"db3">>, <<"ddoc">>),
+    ?assertEqual(ok, ping_client(Client3)),
+    Proc3 = get_client_proc(Client3, "3"),
+    ?assertNotEqual(Proc1#proc.pid, Proc3#proc.pid),
+    ?assertNotEqual(Proc2#proc.pid, Proc3#proc.pid),
+
+    % db1 and db2 procs should still be sitting idle
+    ?assertEqual(2, tagged_idle_count()),
+
+    % After 3rd proc returns to the pool there should
+    % be 3 tagged idle processes
+    ?assertEqual(ok, stop_client(Client3)),
+    wait_tagged_idle_count(3),
+    ?assertEqual(3, idle_count()).
+
+db_tag_none_works(_) ->
+    cfg_set("db_tag", "none"),
+    Client1 = spawn_client(undefined, <<"ddoc1">>),
+    Client2 = spawn_client(undefined, <<"ddoc2">>),
+
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+
+    ?assert(all_alive_all_different([Proc1, Proc2])),
+
+    stop_clients([Client1, Client2]),
+
+    % All procs should be released back into the pool
+    % they should be untagged effectively
+    wait_idle_count(2),
+    ?assertEqual(0, tagged_idle_count()),
+
+    % Processes should still be alive
+    ?assert(all_alive([Proc1, Proc2])),
+
+    % If new tagged process with new db should spawn
+    % new process and pick based on ddoc id matching
+    Client3 = spawn_client(undefined, <<"ddoc1">>),
+    ?assertEqual(ok, ping_client(Client3)),
+    Proc3 = get_client_proc(Client3, "3"),
+    ?assertEqual(Proc1#proc.pid, Proc3#proc.pid),
+    ?assertNotEqual(Proc2#proc.pid, Proc3#proc.pid),
+
+    wait_idle_count(1),
+
+    % After 3rd client stop there should be 2 idle
+    % untagged procs
+    ?assertEqual(ok, stop_client(Client3)),
+    wait_idle_count(2),
+    ?assertEqual(0, tagged_idle_count()).
+
+stale_procs_are_cleaned(_) ->
+    Client1 = spawn_client(),
+    Client2 = spawn_client(),
+
+    ?assertEqual(ok, ping_client(Client1)),
+    ?assertEqual(ok, ping_client(Client2)),
+
+    Proc1 = get_client_proc(Client1, "1"),
+    Proc2 = get_client_proc(Client2, "2"),
+
+    ?assert(all_alive_all_different([Proc1, Proc2])),
+
+    ?assertEqual(0, couch_proc_manager:get_stale_proc_count()),
+    ?assertEqual(ok, couch_proc_manager:reload()),
+    ?assertEqual(2, couch_proc_manager:get_stale_proc_count()),
+
+    stop_clients([Client1, Client2]),
+    ?assertEqual(ok, couch_proc_manager:terminate_stale_procs()),
+    wait_idle_count(0),
+    ?assertEqual(0, couch_proc_manager:get_proc_count()).
+
+bad_query_language(_) ->
+    Expect = {unknown_query_language, <<"bad">>},
+    ?assertThrow(Expect, couch_query_servers:get_os_process(<<"bad">>)).
+
+should_not_return_broken_process_to_the_pool(_) ->
+    cfg_set("os_process_soft_limit", "1"),
+    cfg_set("os_process_limit", "1"),
+
+    Db = <<"thedb">>,
+    DDoc1 = ddoc(<<"_design/ddoc1">>),
+
+    meck:reset(couch_os_process),
+
+    ?assertEqual(0, couch_proc_manager:get_proc_count()),
+    ok = couch_query_servers:with_ddoc_proc(Db, DDoc1, fun(_) -> ok end),
+    ?assertEqual(0, meck:num_calls(couch_os_process, stop, 1)),
+    ?assertEqual(1, couch_proc_manager:get_proc_count()),
+
+    ?assertError(
+        bad,
+        couch_query_servers:with_ddoc_proc(Db, DDoc1, fun(_) ->
             error(bad)
-        end)),
-        ?assertEqual(1, meck:num_calls(couch_os_process, stop, 1)),
+        end)
+    ),
+    ?assertEqual(1, meck:num_calls(couch_os_process, stop, 1)),
 
-        WaitFun = fun() ->
-            case couch_proc_manager:get_proc_count() of
-                0 -> ok;
-                N when is_integer(N), N > 0 -> wait
-            end
-        end,
-        case test_util:wait(WaitFun, 5000) of
-            timeout -> error(timeout);
-            _ -> ok
-        end,
-        ?assertEqual(0, couch_proc_manager:get_proc_count()),
+    WaitFun = fun() ->
+        case couch_proc_manager:get_proc_count() of
+            0 -> ok;
+            N when is_integer(N), N > 0 -> wait
+        end
+    end,
+    case test_util:wait(WaitFun, 5000) of
+        timeout -> error(timeout);
+        _ -> ok
+    end,
+    ?assertEqual(0, couch_proc_manager:get_proc_count()),
 
-        DDoc2 = ddoc(<<"_design/ddoc2">>),
-        ok = couch_query_servers:with_ddoc_proc(DDoc2, fun(_) -> ok end),
-        ?assertEqual(1, meck:num_calls(couch_os_process, stop, 1)),
-        ?assertEqual(1, couch_proc_manager:get_proc_count())
-    end).
+    DDoc2 = ddoc(<<"_design/ddoc2">>),
+    ok = couch_query_servers:with_ddoc_proc(Db, DDoc2, fun(_) -> ok end),
+    ?assertEqual(1, meck:num_calls(couch_os_process, stop, 1)),
+    ?assertEqual(1, couch_proc_manager:get_proc_count()).
 
 
 ddoc(DDocId) ->
@@ -269,26 +521,14 @@ setup_config() ->
     config:set("native_query_servers", "enable_erlang_query_server", "true", false),
     config:set("query_server_config", "os_process_limit", "3", false),
     config:set("query_server_config", "os_process_soft_limit", "2", false),
-    ok = confirm_config("os_process_soft_limit", "2").
+    ok.
 
-confirm_config(Key, Value) ->
-    confirm_config(Key, Value, 0).
-
-confirm_config(Key, Value, Count) ->
-    case config:get("query_server_config", Key) of
-        Value ->
-            ok;
-        _ when Count > 10 ->
-            erlang:error({config_setup, [
-                {module, ?MODULE},
-                {line, ?LINE},
-                {value, timeout}
-            ]});
-        _ ->
-            %% we need to wait to let gen_server:cast finish
-            timer:sleep(10),
-            confirm_config(Key, Value, Count + 1)
-    end.
+teardown_config() ->
+    config:delete("native_query_servers", "enable_erlang_query_server", false),
+    config:delete("query_server_config", "os_process_limit", false),
+    config:delete("query_server_config", "os_process_soft_limit", false),
+    config:delete("query_server_config", "db_tag", false),
+    ok.
 
 spawn_client() ->
     Parent = self(),
@@ -299,13 +539,13 @@ spawn_client() ->
     end),
     {Pid, Ref}.
 
-spawn_client(DDocId) ->
+spawn_client(Db, DDocId) ->
     Parent = self(),
     Ref = make_ref(),
     Pid = spawn(fun() ->
         DDocKey = {DDocId, <<"1-abcdefgh">>},
         DDoc = #doc{body={[{<<"language">>, <<"erlang">>}]}},
-        Proc = couch_query_servers:get_ddoc_process(DDoc, DDocKey),
+        Proc = couch_query_servers:get_ddoc_process(DDoc, Db, DDocKey),
         loop(Parent, Ref, Proc)
     end),
     {Pid, Ref}.
@@ -332,20 +572,30 @@ get_client_proc({Pid, Ref}, ClientName) ->
     end.
 
 stop_client({Pid, Ref}) ->
+    MRef = erlang:monitor(process, Pid),
     Pid ! stop,
     receive
         {stop, Ref} ->
+            receive
+                {'DOWN', MRef, process, Pid, _} -> ok
+            end,
             ok
     after ?TIMEOUT ->
+        erlang:demonitor(MRef, [flush]),
         timeout
     end.
 
 kill_client({Pid, Ref}) ->
+    MRef = erlang:monitor(process, Pid),
     Pid ! die,
     receive
         {die, Ref} ->
+            receive
+                {'DOWN', MRef, process, Pid, _} -> ok
+            end,
             ok
     after ?TIMEOUT ->
+        erlang:demonitor(MRef, [flush]),
         timeout
     end.
 
@@ -364,3 +614,68 @@ loop(Parent, Ref, Proc) ->
             Parent ! {die, Ref},
             exit(some_error)
     end.
+
+proc_pids(Procs) ->
+    [P#proc.pid || P <- Procs].
+
+all_alive(Procs) ->
+    lists:all(fun is_process_alive/1, proc_pids(Procs)).
+
+all_different(Procs) ->
+    lists:usort(proc_pids(Procs)) =:= lists:sort(proc_pids(Procs)).
+
+all_alive_all_different(Procs) ->
+    all_alive(Procs) andalso all_different(Procs).
+
+idle_count() ->
+    ets:info(couch_proc_manager_idle_by_db, size).
+
+tagged_idle_count() ->
+    ets:info(couch_proc_manager_idle_access, size).
+
+stop_clients(Clients) ->
+    Fun = fun(C) -> ?assertEqual(ok, stop_client(C)) end,
+    lists:map(Fun, Clients).
+
+wait_tagged_idle_count(N) ->
+    WaitFun = fun() ->
+        case tagged_idle_count() == N of
+            true -> ok;
+            false -> wait
+        end
+    end,
+    case test_util:wait(WaitFun, 5000) of
+        timeout -> error(timeout);
+        _ -> ok
+    end,
+    ?assertEqual(N, tagged_idle_count()).
+
+wait_idle_count(N) ->
+    WaitFun = fun() ->
+        case idle_count() == N of
+            true -> ok;
+            false -> wait
+        end
+    end,
+    case test_util:wait(WaitFun, 5000) of
+        timeout -> error(timeout);
+        _ -> ok
+    end,
+    ?assertEqual(N, idle_count()).
+
+wait_process_count(N) ->
+    WaitFun = fun() ->
+        case couch_proc_manager:get_proc_count() == N of
+            true -> ok;
+            false -> wait
+        end
+    end,
+    case test_util:wait(WaitFun, 5000) of
+        timeout -> error(timeout);
+        _ -> ok
+    end,
+    ?assertEqual(N, couch_proc_manager:get_proc_count()).
+
+cfg_set(K, V) ->
+    config:set("query_server_config", K, V, false),
+    ok.

--- a/src/couch_mrview/src/couch_mrview_show.erl
+++ b/src/couch_mrview/src/couch_mrview_show.erl
@@ -77,7 +77,7 @@ handle_doc_show(Req, Db, DDoc, ShowName, Doc, DocId) ->
         JsonReq = chttpd_external:json_req_obj(Req, Db, DocId),
         JsonDoc = couch_query_servers:json_doc(Doc),
         [<<"resp">>, ExternalResp] =
-            couch_query_servers:ddoc_prompt(DDoc, [<<"shows">>, ShowName],
+            couch_query_servers:ddoc_prompt(Db, DDoc, [<<"shows">>, ShowName],
                 [JsonDoc, JsonReq]),
         JsonResp = apply_etag(ExternalResp, CurrentEtag),
         chttpd_external:send_external_response(Req, JsonResp)
@@ -122,7 +122,7 @@ send_doc_update_response(Req, Db, DDoc, UpdateName, Doc, DocId) ->
     JsonReq = chttpd_external:json_req_obj(Req, Db, DocId),
     JsonDoc = couch_query_servers:json_doc(Doc),
     Cmd = [<<"updates">>, UpdateName],
-    UpdateResp = couch_query_servers:ddoc_prompt(DDoc, Cmd, [JsonDoc, JsonReq]),
+    UpdateResp = couch_query_servers:ddoc_prompt(Db, DDoc, Cmd, [JsonDoc, JsonReq]),
     JsonResp = case UpdateResp of
         [<<"up">>, {NewJsonDoc}, {JsonResp0}] ->
             case chttpd:header_value(
@@ -196,7 +196,7 @@ handle_view_list(Req, Db, DDoc, LName, VDDoc, VName, Keys) ->
     end,
     Args = Args0#mrargs{preflight_fun=ETagFun},
     couch_httpd:etag_maybe(Req, fun() ->
-        couch_query_servers:with_ddoc_proc(DDoc, fun(QServer) ->
+        couch_query_servers:with_ddoc_proc(Db, DDoc, fun(QServer) ->
             Acc = #lacc{db=Db, req=Req, qserver=QServer, lname=LName},
             case VName of
               <<"_all_docs">> ->

--- a/src/ddoc_cache/src/ddoc_cache_entry_validation_funs.erl
+++ b/src/ddoc_cache/src/ddoc_cache_entry_validation_funs.erl
@@ -32,7 +32,7 @@ ddocid(_) ->
 recover(DbName) ->
     {ok, DDocs} = fabric:design_docs(mem3:dbname(DbName)),
     Funs = lists:flatmap(fun(DDoc) ->
-        case couch_doc:get_validate_doc_fun(DDoc) of
+        case couch_doc:get_validate_doc_fun(DbName, DDoc) of
             nil -> [];
             Fun -> [Fun]
         end


### PR DESCRIPTION
This a backport of https://github.com/apache/couchdb/pull/4529 to 3.2.x

The original PR comment follows:

---

The main improvement is speeding up process lookup. This should result in improved latency for concurrent requests which quickly acquire and release couchjs processes. Testing with concurrent vdu and map/reduce calls showed a 1.6 -> 6x performance speedup [1].

Previously, couch_proc_manager linearly searched through all the processes and executed a custom callback function for each to match design doc IDs. Instead, use a separate ets table index for idle processes to avoid scanning assigned processes.

Use a db tag in addition to a ddoc id to quickly find idle processes. This could improve performance, but if that's not the case, allow configuring the tagging scheme to use a db prefix only, or disable the scheme altogether.

Use the new `map_get` ets select guard [2] to perform ddoc id lookups during the ets select traversal without a custom matcher callback.

In ordered ets tables use the partially bound key trick [3]. This helps skip scanning processes using a different query language altogether.

Waiting clients used `os:timestamp/0` as a unique client identifier. It turns out, `os:timestamp/0` is not guaranteed to be unique and could result in some clients never getting a response. This bug was mostly likely the reason the "fifo client order" test had to be commented out. Fix the issue by using a newer monotonic timestamp function, and for uniqueness add the client's gen_server return tag at the end. Uncomment the previously commented out test so it can hopefully run again.

When clients tag a previously untagged process, asynchronously replace the untagged process with a new process. This happens in the background and the client doesn't have to wait for it.

When a ddoc tagged process cannot be found, before giving up, stop the oldest unused ddoc processes to allow spawning new fresh ones. To avoid doing a linear scan here, keep a separate `?IDLE_ACCESS` index with an ordered list of idle ddoc proceses sorted by their last usage time.

When processes are returned to the pool, quickly respond to the client with an early return, instead of forcing them to wait until we re-insert the process back into the idle ets table. This should improve client latency.

If the waiting client list gets long enough, where it waits longer than the gen_server get_proc timeout, do not waste time assigning or spawning a new process for that client, since it already timed-out.

When gathering stats, avoid making gen_server calls, at least for the total number of processes spawned metric. Table sizes can be easily computed with `ets:info(Table, size)` from outside the main process.

In addition to peformance improvements clean up the couch_proc_manager API by forcing all the calls to go through properly exported functions instead of doing direct gen_server calls.

Remove `#proc_int{}` and use only `#proc{}`. The cast to a list/tuple between `#proc_int{}` and `#proc{}` was dangerous and it avoided the compiler checking that we're using the proper fields. Adding an extra field to the record resulted in mis-matched fields being assigned.

To simplify the code a bit, keep the per-language count in an ets table. This helps not having to thread the old and updated state everywhere. Everything else was mostly kept in ets tables anyway, so we're staying consistent with that general pattern.

Improve test coverage and convert the tests to use the `?TDEF_FE` macro so there is no need for the awkward `?_test(begin ... end)` construct.

[1] https://gist.github.com/nickva/f088accc958f993235e465b9591e5fac
[2] https://www.erlang.org/doc/apps/erts/match_spec.html
[3] https://www.erlang.org/doc/man/ets.html#table-traversal
