### PR TITLE
put lucene 9 indexes in subdir

### DIFF
--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/resources/IndexResource.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/resources/IndexResource.java
@@ -121,7 +121,7 @@ public final class IndexResource {
     private IndexLoader indexLoader() {
         return (path, indexDefinition) -> {
             final Analyzer analyzer = Lucene9AnalyzerFactory.fromDefinition(indexDefinition);
-            final Directory dir = new DirectIODirectory(FSDirectory.open(path));
+            final Directory dir = new DirectIODirectory(FSDirectory.open(path.resolve("9")));
             final IndexWriterConfig config = new IndexWriterConfig(analyzer);
             config.setUseCompoundFile(false);
             final IndexWriter writer = new IndexWriter(dir, config);


### PR DESCRIPTION
makes it easier for the future 9->10 migration via rebuild.
