### PR TITLE
Noticed the new internal error couchjs test was flaky

### DIFF
--- a/src/couch/test/eunit/couch_js_tests.erl
+++ b/src/couch/test/eunit/couch_js_tests.erl
@@ -265,6 +265,12 @@ should_exit_on_internal_error() ->
         % emits an error log before dying
         throw:{<<"InternalError">>, _} ->
             ok;
+        % gen_server may die before replying
+        exit:{noproc, {gen_server,call, _}} ->
+            ok;
+        % or it may die with an epipe if it crashes while we send/recv data to it
+        exit:{epipe, {gen_server, call, _}} ->
+            ok;
         % It may fail and just exit the process. That's expected as well
         throw:{os_process_error, _} ->
             ok


### PR DESCRIPTION
It's designed to crash and exit but depending when it does it exactly it may generate different errors. Add a few more clauses. Hopefully we don't have to completely remove it or comment it out.

