### PR TITLE
Another flaky couch_js fix

### DIFF
--- a/src/couch/test/eunit/couch_js_tests.erl
+++ b/src/couch/test/eunit/couch_js_tests.erl
@@ -274,9 +274,7 @@ should_exit_on_internal_error() ->
         % It may fail and just exit the process. That's expected as well
         throw:{os_process_error, _} ->
             ok
-    end,
-    % Expect the process to be dead
-    ?assertThrow({os_process_error, _}, couch_query_servers:proc_prompt(Proc, [<<"reset">>])).
+    end.
 
 trigger_oom(Proc) ->
     Status =


### PR DESCRIPTION
After the previous fix, now the flakiness moved on to the next line.

Remove the extra assertion to avoid it generating flaky tests. The main assertion is already checked above that we get a crash.

