### PR TITLE
fix ken_server:nouveau_updated

### DIFF
--- a/src/ken/src/ken_server.erl
+++ b/src/ken/src/ken_server.erl
@@ -371,7 +371,7 @@ st_updated(_Name, _Doc, _Seq, _State) ->
 -endif.
 
 nouveau_updated(Name, Doc, Seq, State) ->
-    case should_update(Doc, <<"indexes">>) of
+    case should_update(Doc, <<"nouveau">>) of
         true ->
             try nouveau_util:design_doc_to_indexes(Name, Doc) of
                 SIndexes -> update_ddoc_nouveau_indexes(Name, SIndexes, Seq, State)


### PR DESCRIPTION
cut-and-paste error. only appears to affect the ability to selectively disable autoupdate.