### PR TITLE
CVE-2023-2626 details doc update

### DIFF
--- a/src/docs/src/cve/2023-26268.rst
+++ b/src/docs/src/cve/2023-26268.rst
@@ -12,16 +12,50 @@
 
 .. _cve/2023-26268:
 
-===========================================================
-CVE-2023-26268: RESERVED
-===========================================================
+=========================================================================
+CVE-2023-26268: Apache CouchDB: Information sharing via couchjs processes
+=========================================================================
 
 :Date: 02.05.2023
 
-:Affected: 3.2.2 and below
+:Affected: 3.3.1 and below, 3.2.2 and below
 
 :Severity: Medium
 
 :Vendor: The Apache Software Foundation
 
-Details will be published on 2023-05-02
+Description
+===========
+
+Design documents with matching document IDs, from databases on the same
+cluster, may share a mutable Javascript environment when using these design
+document functions:
+
+  * validate_doc_update
+  * list
+  * filter
+  * filter views (using view functions as filters)
+  * rewrite
+  * update
+
+This doesn't affect map/reduce or search (Dreyfus) index functions.
+
+Mitigation
+==========
+
+CouchDB :ref:`3.3.2 <release/3.3.2>` and :ref:`3.2.3 <release/3.2.3>` and
+onwards matches Javascript execution processes by database names in addition to
+design document IDs when processing the affected design document functions.
+
+Workarounds
+===========
+
+Avoid using design documents from untrusted sources which may attempt to cache
+or store data in the Javascript environment.
+
+Credit
+======
+
+This issue was identified by `Nick Vatamaniuc`_
+
+.. _Nick Vatamaniuc: https://home.apache.org/phonebook.html?uid=vatamane


### PR DESCRIPTION
Backporting https://github.com/apache/couchdb/pull/4562 to 3.3.x