### PR TITLE
fix(`mango`): improve handling of unsatisfiable ranges in selectors

### DIFF
--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -406,6 +406,10 @@ range(_, _, LCmp, Low, HCmp, High) ->
 % operators but its all straight forward once you figure out how
 % we're basically just narrowing our logical ranges.
 
+range({[{<<"$lt">>, Arg}]}, '$eq', N, '$eq', N) when
+    (N >= Arg)
+->
+    empty;
 range({[{<<"$lt">>, Arg}]}, LCmp, Low, HCmp, High) ->
     case range_pos(Low, Arg, High) of
         min ->
@@ -466,6 +470,10 @@ range({[{<<"$gte">>, Arg}]}, LCmp, Low, HCmp, High) ->
         max ->
             empty
     end;
+range({[{<<"$gt">>, Arg}]}, '$eq', N, '$eq', N) when
+    (Arg >= N)
+->
+    empty;
 range({[{<<"$gt">>, Arg}]}, LCmp, Low, HCmp, High) ->
     case range_pos(Low, Arg, High) of
         min ->


### PR DESCRIPTION
Certain configurations of unsatisfiable field ranges could cause HTTP 500 because they are not handled, for example:

```json
{"$and": [{"field": {"$eq": N}}, {"field": {"$gt": N}}]}
```

This makes `mango_idx_view:end_key/1` fail because there is no clause to cover `[{'$gt',35,'$eq',35}]`, the value that the selector becomes mapped to.

Similar field ranges are somewhat already handled by being mapped to `empty` so this seems to be an oversight in the original implementation.  Consider the following case, which will not crash on the contrary:

```json
{"$and": [{"field": {"$gt": N}}, {"field": {"$eq": N}}]}
```

Add the missing function clauses to fix this problem.

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
