### PR TITLE
remove Content-MD5 header support

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1728,18 +1728,7 @@ db_attachment_req(#httpd{method = 'GET', mochi_req = MochiReq} = Req, Db, DocId,
                             {identity, Ranges} when is_list(Ranges) andalso length(Ranges) < 10 ->
                                 send_ranges_multipart(Req, Type, Len, Att, Ranges);
                             _ ->
-                                Headers1 =
-                                    Headers ++
-                                        if
-                                            Enc =:= identity orelse ReqAcceptsAttEnc =:= true ->
-                                                [
-                                                    {"Content-MD5",
-                                                        base64:encode(couch_att:fetch(md5, Att))}
-                                                ];
-                                            true ->
-                                                []
-                                        end,
-                                {ok, Resp} = start_response_length(Req, 200, Headers1, Len),
+                                {ok, Resp} = start_response_length(Req, 200, Headers, Len),
                                 AttFun(Att, fun(Seg, _) -> send(Resp, Seg) end, {ok, Resp})
                         end
                 end
@@ -1802,7 +1791,6 @@ db_attachment_req(#httpd{method = Method, user_ctx = Ctx} = Req, Db, DocId, File
                         {type, MimeType},
                         {data, Data},
                         {att_len, ContentLen},
-                        {md5, get_md5_header(Req)},
                         {encoding, Encoding}
                     ])
                 ]
@@ -1943,26 +1931,6 @@ parse_ranges([{From, To} | Rest], Len, Acc) ->
 
 make_content_range(From, To, Len) ->
     ?l2b(io_lib:format("bytes ~B-~B/~B", [From, To, Len])).
-
-get_md5_header(Req) ->
-    ContentMD5 = couch_httpd:header_value(Req, "Content-MD5"),
-    Length = couch_httpd:body_length(Req),
-    Trailer = couch_httpd:header_value(Req, "Trailer"),
-    case {ContentMD5, Length, Trailer} of
-        _ when is_list(ContentMD5) orelse is_binary(ContentMD5) ->
-            base64:decode(ContentMD5);
-        {_, chunked, undefined} ->
-            <<>>;
-        {_, chunked, _} ->
-            case re:run(Trailer, "\\bContent-MD5\\b", [caseless]) of
-                {match, _} ->
-                    md5_in_footer;
-                _ ->
-                    <<>>
-            end;
-        _ ->
-            <<>>
-    end.
 
 parse_doc_query(Req) ->
     lists:foldl(fun parse_doc_query/2, #doc_query_args{}, chttpd:qs(Req)).

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -567,14 +567,8 @@ flush_data(Db, Fun, Att) when is_function(Fun) ->
                     % Called with Length == 0 on the last time.
                     % WriterFun returns NewState.
                     fun
-                        ({0, Footers}, _Total) ->
-                            F = mochiweb_headers:from_binary(Footers),
-                            case mochiweb_headers:get_value("Content-MD5", F) of
-                                undefined ->
-                                    ok;
-                                Md5 ->
-                                    {md5, base64:decode(Md5)}
-                            end;
+                        ({0, _Footers}, _Total) ->
+                            ok;
                         ({Length, Chunk}, Total0) ->
                             Total = Total0 + Length,
                             validate_attachment_size(AttName, Total, MaxAttSize),

--- a/src/couch/test/eunit/couchdb_attachments_tests.erl
+++ b/src/couch/test/eunit/couchdb_attachments_tests.erl
@@ -106,9 +106,9 @@ attachments_md5_tests() ->
                 fun should_upload_attachment_with_valid_md5_header/1,
                 fun should_upload_attachment_by_chunks_with_valid_md5_header/1,
                 fun should_upload_attachment_by_chunks_with_valid_md5_trailer/1,
-                fun should_reject_attachment_with_invalid_md5/1,
-                fun should_reject_chunked_attachment_with_invalid_md5/1,
-                fun should_reject_chunked_attachment_with_invalid_md5_trailer/1
+                fun should_upload_attachment_with_invalid_md5/1,
+                fun should_upload_chunked_attachment_with_invalid_md5/1,
+                fun should_upload_chunked_attachment_with_invalid_md5_trailer/1
             ]
         }
     }.
@@ -261,7 +261,7 @@ should_upload_attachment_by_chunks_with_valid_md5_trailer({Host, DbName}) ->
         ?assertEqual(true, get_json(Json, [<<"ok">>]))
     end).
 
-should_reject_attachment_with_invalid_md5({Host, DbName}) ->
+should_upload_attachment_with_invalid_md5({Host, DbName}) ->
     ?_test(begin
         AttUrl = string:join(["", DbName, ?docid(), "readme.txt"], "/"),
         Body = "We all live in a yellow submarine!",
@@ -272,14 +272,11 @@ should_reject_attachment_with_invalid_md5({Host, DbName}) ->
             {"Host", Host}
         ],
         {ok, Code, Json} = request("PUT", AttUrl, Headers, Body),
-        ?assertEqual(400, Code),
-        ?assertEqual(
-            <<"content_md5_mismatch">>,
-            get_json(Json, [<<"error">>])
-        )
+        ?assertEqual(201, Code),
+        ?assertEqual(true, get_json(Json, [<<"ok">>]))
     end).
 
-should_reject_chunked_attachment_with_invalid_md5({Host, DbName}) ->
+should_upload_chunked_attachment_with_invalid_md5({Host, DbName}) ->
     ?_test(begin
         AttUrl = string:join(["", DbName, ?docid(), "readme.txt"], "/"),
         AttData = <<"We all live in a yellow submarine!">>,
@@ -292,14 +289,11 @@ should_reject_chunked_attachment_with_invalid_md5({Host, DbName}) ->
             {"Transfer-Encoding", "chunked"}
         ],
         {ok, Code, Json} = request("PUT", AttUrl, Headers, Body),
-        ?assertEqual(400, Code),
-        ?assertEqual(
-            <<"content_md5_mismatch">>,
-            get_json(Json, [<<"error">>])
-        )
+        ?assertEqual(201, Code),
+        ?assertEqual(true, get_json(Json, [<<"ok">>]))
     end).
 
-should_reject_chunked_attachment_with_invalid_md5_trailer({Host, DbName}) ->
+should_upload_chunked_attachment_with_invalid_md5_trailer({Host, DbName}) ->
     ?_test(begin
         AttUrl = string:join(["", DbName, ?docid(), "readme.txt"], "/"),
         AttData = <<"We all live in a yellow submarine!">>,
@@ -317,8 +311,8 @@ should_reject_chunked_attachment_with_invalid_md5_trailer({Host, DbName}) ->
             {"Transfer-Encoding", "chunked"}
         ],
         {ok, Code, Json} = request("PUT", AttUrl, Headers, Body),
-        ?assertEqual(400, Code),
-        ?assertEqual(<<"content_md5_mismatch">>, get_json(Json, [<<"error">>]))
+        ?assertEqual(201, Code),
+        ?assertEqual(true, get_json(Json, [<<"ok">>]))
     end).
 
 should_get_att_without_accept_gzip_encoding(_, {Data, {_, _, AttUrl}}) ->

--- a/test/elixir/test/attachments_test.exs
+++ b/test/elixir/test/attachments_test.exs
@@ -431,29 +431,6 @@ defmodule AttachmentsTest do
   end
 
   @tag :with_db
-  test "md5 header for attachments", context do
-    db_name = context[:db_name]
-    md5 = "MntvB0NYESObxH4VRDUycw=="
-
-    bin_data = "foo bar"
-
-    resp =
-      Couch.put(
-        "/#{db_name}/bin_doc8/attachment.txt",
-        body: bin_data,
-        headers: ["Content-Type": "application/octet-stream", "Content-MD5": md5],
-        query: %{w: 3}
-      )
-
-    assert resp.status_code in [201, 202]
-    assert resp.body["ok"]
-
-    resp = Couch.get("/#{db_name}/bin_doc8/attachment.txt")
-    assert resp.status_code == 200
-    assert md5 == resp.headers["Content-MD5"]
-  end
-
-  @tag :with_db
   test "attachment via multipart/form-data", context do
     db_name = context[:db_name]
 


### PR DESCRIPTION
Part of a series of changes to expunge MD5 entirely.
