### PR TITLE
TLS: add `{verify, verify_peer}` to enable verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,6 @@ dev/*.beam
 dev/devnode.*
 dev/lib/
 dev/logs/
-dev/erlserver.pem
-dev/couch_ssl_dist.conf
 ebin/
 erl_crash.dump
 erln8.config

--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ clean:
 	@rm -f src/couch/priv/couchspawnkillable
 	@rm -f src/couch/priv/couch_js/config.h
 	@rm -f dev/*.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
-	@rm -f dev/erlserver.pem dev/couch_ssl_dist.conf
+	@rm -f src/couch_dist/certs/out
 ifeq ($(with_nouveau), 1)
 	@cd nouveau && ./gradlew clean
 endif

--- a/configure
+++ b/configure
@@ -63,29 +63,9 @@ Options:
   --spidermonkey-version VSN  specify the version of SpiderMonkey to use (defaults to $SM_VSN)
   --skip-deps                 do not update erlang dependencies
   --rebar=PATH                use rebar by specified path (version >=2.6.0 && <3.0 required)
-  --generate-tls-dev-cert     generate a cert for TLS distribution (To enable TLS, change the vm.args file.)
   --rebar3=PATH               use rebar3 by specified path
   --erlfmt=PATH               use erlfmt by specified path
 EOF
-}
-
-# This is just an example to generate a certfile for TLS distribution.
-# This is not an endorsement of specific expiration limits, key sizes, or algorithms.
-generate_tls_dev_cert() {
-    if [ ! -e "${rootdir}/dev/erlserver.pem" ]; then
-        openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem
-        cat key.pem cert.pem > dev/erlserver.pem && rm key.pem cert.pem
-    fi
-
-    if [ ! -e "${rootdir}/dev/couch_ssl_dist.conf" ]; then
-        cat > "${rootdir}/dev/couch_ssl_dist.conf" << EOF
-[{server,
-  [{certfile, "${rootdir}/dev/erlserver.pem"},
-   {secure_renegotiate, true}]},
- {client,
-  [{secure_renegotiate, true}]}].
-EOF
-    fi
 }
 
 parse_opts() {
@@ -219,13 +199,6 @@ parse_opts() {
             --spidermonkey-version=)
                 printf 'ERROR: "--spidermonkey-version" requires a non-empty argument.\n' >&2
                 exit 1
-                ;;
-
-            --generate-tls-dev-cert)
-                echo "WARNING: To enable TLS distribution, don't forget to customize vm.args file."
-                generate_tls_dev_cert
-                shift
-                continue
                 ;;
 
             --) # End of options

--- a/dev/remsh-tls
+++ b/dev/remsh-tls
@@ -23,7 +23,11 @@ if [ -z $HOST ]; then
     HOST="127.0.0.1"
 fi
 
+if [ -z $OPTFILE ]; then
+    rootdir=`dirname "$(cd "${0%/*}" 2>/dev/null; echo "$PWD")"`
+    OPTFILE="$rootdir/src/couch_dist/certs/out/couch_dist.conf"
+fi
+
 NAME="remsh$$@$HOST"
 NODE="node$NODE@$HOST"
-rootdir="$(cd "${0%/*}" 2>/dev/null; echo "$PWD")"
-erl -name $NAME -remsh $NODE -hidden -proto_dist inet_tls -ssl_dist_optfile "${rootdir}/couch_ssl_dist.conf"
+erl -name $NAME -remsh $NODE -hidden -proto_dist inet_tls -ssl_dist_optfile $OPTFILE

--- a/dev/run
+++ b/dev/run
@@ -117,7 +117,7 @@ def setup_argparse():
 
 
 def get_args_parser():
-    parser = optparse.OptionParser(description="Runs CouchDB 2.0 dev cluster")
+    parser = optparse.OptionParser(description="Runs CouchDB dev cluster")
     parser.add_option(
         "-a",
         "--admin",
@@ -234,6 +234,20 @@ def get_args_parser():
         action="store_true",
         help="Start Nouveau server",
     )
+    parser.add_option(
+        "-t",
+        "--enable-tls",
+        dest="enable_tls",
+        default=False,
+        action="store_true",
+        help="Enable custom TLS distribution -- couch",
+    )
+    parser.add_option(
+        "--no-tls",
+        dest="no_tls",
+        default=None,
+        help="Use TCP for specified node when TLS distribution is enabled",
+    )
     return parser
 
 
@@ -264,6 +278,8 @@ def setup_context(opts, args):
         "auto_ports": opts.auto_ports,
         "locald_configs": opts.locald_configs,
         "with_nouveau": opts.with_nouveau,
+        "enable_tls": opts.enable_tls,
+        "no_tls": opts.no_tls,
     }
 
 
@@ -421,6 +437,8 @@ def cluster_port(ctx, n):
 def write_config(ctx, node, env):
     etc_src = os.path.join(ctx["rootdir"], "rel", "overlay", "etc")
     etc_tgt = ensure_dir_exists(ctx["devdir"], "lib", node, "etc")
+    if ctx["enable_tls"]:
+        sp.call(["./src/couch_dist/gen_certs"], cwd=ctx["rootdir"])
 
     for fname in glob.glob(os.path.join(etc_src, "*")):
         base = os.path.basename(fname)
@@ -440,6 +458,8 @@ def write_config(ctx, node, env):
             content = apply_config_overrides(ctx, content)
         elif base == "local.ini":
             content = hack_local_ini(ctx, content)
+        elif ctx["enable_tls"] and base == "vm.args":
+            content = hack_vm_args(ctx, node, content)
 
         with open(tgt, "w") as handle:
             handle.write(content)
@@ -522,6 +542,20 @@ def hack_local_ini(ctx, contents):
     contents = contents + "\n%s = %s" % (user, hashify(pswd))
 
     return contents + "\n\n[chttpd_auth]\nsecret = %s\n" % COMMON_SALT
+
+
+def hack_vm_args(ctx, node, contents):
+    contents += f"""
+-proto_dist couch
+-couch_dist no_tls '"clouseau{node[-1]}@127.0.0.1"'
+-ssl_dist_optfile {ctx["rootdir"]}/src/couch_dist/certs/out/couch_dist.conf
+    """
+    if ctx["no_tls"]:
+        no_tls_nodes = ctx["no_tls"].split(",")
+        for node_name in no_tls_nodes:
+            node_name = node_name if "@" in node_name else f"{node_name}@127.0.0.1"
+            contents += f"""\n-couch_dist no_tls '"{node_name}"'"""
+    return contents
 
 
 def gen_password():

--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -95,7 +95,7 @@ while getopts ":hn:c:l:mvt:" optionName; do
     t)
       TLSCONF=$OPTARG
       if [ ! -f "$TLSCONF" ]; then
-        echo "ERROR: Could't find the file \"$TLSCONF\"." >&2
+        echo "ERROR: Couldn't find the file \"$TLSCONF\"." >&2
         exit 1
       fi
       ;;

--- a/src/couch_dist/.gitignore
+++ b/src/couch_dist/.gitignore
@@ -1,0 +1,4 @@
+.rebar/
+certs/*.pem
+certs/out/
+ebin/

--- a/src/couch_dist/README.md
+++ b/src/couch_dist/README.md
@@ -1,0 +1,162 @@
+# couch_dist
+
+Erlang communicates with its own protocol over TCP (Transmission Control Protocol).
+It can also be configured to run its protocol over a TLS (Transport Layer Security)
+connection which itself is over TCP.
+
+`couch_dist` implements a custom distribution protocol -- `couch`, which allows
+using TLS for Erlang distribution between nodes, with the ability to connect to
+some nodes using TCP as well.
+
+`TLS` can provide extra verification and security, but requires proper
+certificates and configuration to set up the environment.
+
+## Set up a custom Erlang distribution
+
+1. Specify the distribution protocol in `vm.args`
+2. Specify some nodes to use TCP only in `vm.args` (optional)
+3. Generate certificates using `certs`
+4. Specify security and other SSL options in `couch_dist.conf`
+
+Examples:
+
+1. `vm.args`:
+
+      ```vm.args
+      -proto_dist couch
+      -couch_dist no_tls '"clouseau@127.0.0.1"'
+      -ssl_dist_optfile </absolute_path/to/couch_dist.conf>
+      ```
+
+2. `couch_dist.conf`:
+
+    - `erlserver.pem`: contains the certificate and its private key.
+    - `{fail_if_no_peer_cert, true}`: In previous OTP versions it could be specified on both server side and client
+      side, but in OTP 26 it can only be used on server side,
+      see [OTP 26 Highlights](https://www.erlang.org/blog/otp-26-highlights/#ssl-improved-checking-of-options).
+
+       ```couch_dist.conf
+       [
+         {server, [
+           {cacertfile, "</absolute_path/to/ca-cert.pem>"},
+           {certfile,   "</absolute_path/to/erlserver.pem>"},
+           {secure_renegotiate, true},
+           {verify, verify_peer},
+           {fail_if_no_peer_cert, true}
+         ]},
+         {client, [
+           {cacertfile, "</absolute_path/to/ca-cert.pem>"},
+           {certfile,   "</absolute_path/to/cert.pem>"},
+           {keyfile,    "</absolute_path/to/key.pem>"},
+           {secure_renegotiate, true},
+           {verify, verify_peer}
+         ]}
+       ].
+       ```
+
+## Generate Certificate
+
+This is an example of using `elixir-certs` to generate certificates, but it is
+not an endorsement of a specific expiration limit, key size or algorithm.
+
+```bash
+cd src/couch_dist/certs
+
+# Generate CA certificate and key
+./certs self-signed \
+  --out-cert ca-cert.pem --out-key ca-key.pem \
+  --template root-ca \
+  --subject "/CN=CouchDB Root CA"
+
+# Generate node certificate and key
+./certs create-cert \
+  --issuer-cert ca-cert.pem --issuer-key ca-key.pem \
+  --out-cert cert.pem --out-key key.pem \
+  --template server \
+  --subject "/CN=127.0.0.1"
+
+# Generate `erlserver.pem`
+cat key.pem cert.pem >erlserver.pem
+
+# Parse certificate to verify:
+# Certificate needs to match the node's hostname
+./parse_cert.escript cert.pem
+["127.0.0.1"]
+```
+
+Thanks to Roger Lipscombe for creating [`elixir-certs`](https://github.com/rlipscombe/elixir-certs)
+which simplifies the process of generating `X.509` certificates.
+
+Also, thanks to Robert Newson for finding `elixir-certs` and adding the feature
+to [easily pass `host` and `node` parameters to certificates](https://github.com/rnewson/elixir-certs/).
+
+## Development
+
+You can run CouchDB with `--enable-tls` mode, which will automatically generate
+vm.args, certificates, and configuration files.
+
+```bash
+./configure --dev --spidermonkey-version 91 && make && ./dev/run -t
+./configure --dev --spidermonkey-version 91 && make && ./dev/run --enable-tls
+
+./dev/remsh-tls
+(node1@127.0.0.1)1> net_kernel:nodes_info().
+{ok,[{'node3@127.0.0.1',
+         [{owner,<0.679.0>},
+          {state,up},
+          {address,
+              {net_address,{{127,0,0,1},55013},"127.0.0.1",tls,inet}},
+          {type,normal},
+          {in,150},
+          {out,147}]},
+     {'node2@127.0.0.1',
+         [{owner,<0.655.0>},
+          {state,up},
+          {address,
+              {net_address,{{127,0,0,1},55011},"127.0.0.1",tls,inet}},
+          {type,normal},
+          {in,181},
+          {out,196}]},
+     {'remsh14066@127.0.0.1',
+         [{owner,<0.8558.0>},
+          {state,up},
+          {address,
+              {net_address,{{127,0,0,1},55075},"127.0.0.1",tls,inet}},
+          {type,hidden},
+          {in,10},
+          {out,15}]}]}
+```
+
+You can also set specific nodes to use TCP:
+
+```bash
+./configure --dev --spidermonkey-version 91 && make && ./dev/run -t --no-tls node2@127.0.0.1
+./configure --dev --spidermonkey-version 91 && make && ./dev/run -t --no-tls node2,node3
+
+./dev/remsh-tls
+(node1@127.0.0.1)1> net_kernel:nodes_info().
+{ok,[{'node2@127.0.0.1',
+         [{owner,<0.456.0>},
+          {state,up},
+          {address,
+              {net_address,{{127,0,0,1},55170},"127.0.0.1",tcp,inet}},
+          {type,normal},
+          {in,145},
+          {out,164}]},
+     {'node3@127.0.0.1',
+         [{owner,<0.461.0>},
+          {state,up},
+          {address,
+              {net_address,{{127,0,0,1},55172},"127.0.0.1",tcp,inet}},
+          {type,normal},
+          {in,141},
+          {out,169}]},
+     {'remsh17312@127.0.0.1',
+         [{owner,<0.1418.0>},
+          {state,up},
+          {address,
+              {net_address,{{127,0,0,1},55203},"127.0.0.1",tls,inet}},
+          {type,hidden},
+          {in,10},
+          {out,15}]}]}
+```

--- a/src/couch_dist/certs/certs
+++ b/src/couch_dist/certs/certs
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Source code: https://github.com/rnewson/elixir-certs/
+# We want the keys to be u=rw,go=, but there's no way to do that in
+# Elixir without race conditions, afaict, so we use umask:
+umask 077
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+exec elixir "$SCRIPTPATH/certs.exs" "$@"

--- a/src/couch_dist/certs/certs.exs
+++ b/src/couch_dist/certs/certs.exs
@@ -1,0 +1,209 @@
+# Source code: https://github.com/rnewson/elixir-certs/
+# credo:disable-for-this-file
+# Important: run this with the wrapper script, so that umask is set correctly.
+
+Mix.install([{:x509, "~> 0.8.3"}, {:optimus, "~> 0.2"}])
+
+defmodule Certs do
+  def main(argv) do
+    Certs.Options.new!() |> Optimus.parse!(argv) |> run()
+  end
+
+  defp run(
+         {[:self_signed],
+          %Optimus.ParseResult{
+            options: %{subject: subject, out_cert: out_cert, out_key: out_key, template: template}
+          }}
+       ) do
+    ca_key = X509.PrivateKey.new_ec(:secp256r1)
+
+    ca_crt = X509.Certificate.self_signed(ca_key, subject, template: template(template, subject, "", ""))
+
+    File.write!(out_key, X509.PrivateKey.to_pem(ca_key), [:exclusive])
+    File.chmod!(out_key, 0o400)
+
+    File.write!(out_cert, X509.Certificate.to_pem(ca_crt), [:exclusive])
+    File.chmod!(out_cert, 0o444)
+  end
+
+  defp run(
+         {[:create_cert],
+          %Optimus.ParseResult{
+            options: %{
+              subject: subject,
+              host: host,
+              node: node,
+              issuer_cert: issuer_cert,
+              issuer_key: issuer_key,
+              out_cert: out_cert,
+              out_key: out_key,
+              template: template
+            }
+          }}
+       ) do
+    issuer_cert = File.read!(issuer_cert) |> X509.Certificate.from_pem!()
+    issuer_key = File.read!(issuer_key) |> X509.PrivateKey.from_pem!()
+
+    key = X509.PrivateKey.new_ec(:secp256r1)
+    pub = X509.PublicKey.derive(key)
+
+    crt =
+      X509.Certificate.new(pub, subject, issuer_cert, issuer_key,
+        template: template(template, subject, host, node)
+      )
+
+    File.write!(out_key, X509.PrivateKey.to_pem(key), [:exclusive])
+    File.chmod!(out_key, 0o400)
+
+    File.write!(out_cert, X509.Certificate.to_pem(crt), [:exclusive])
+    File.chmod!(out_cert, 0o444)
+  end
+
+  defp run(_) do
+    Certs.Options.new!() |> Optimus.help() |> IO.puts()
+  end
+
+  defp template("root-ca", _subject, _host, _node), do: :root_ca
+
+  defp template("server", subject, _host, _node) do
+    [commonName] =
+      X509.RDNSequence.new(subject)
+      |> X509.RDNSequence.get_attr(:commonName)
+
+    import X509.Certificate.Extension
+
+    %X509.Certificate.Template{
+      # 1 year, plus a 30 days grace period
+      validity: 365 + 30,
+      hash: :sha256,
+      extensions: [
+        basic_constraints: basic_constraints(false),
+        key_usage: key_usage([:digitalSignature, :keyEncipherment]),
+        ext_key_usage: ext_key_usage([:serverAuth, :clientAuth]),
+        subject_key_identifier: true,
+        authority_key_identifier: true,
+        subject_alt_name: subject_alt_name([commonName])
+      ]
+    }
+  end
+
+  defp template("node", _subject, host, node) do
+    import X509.Certificate.Extension
+
+    %X509.Certificate.Template{
+      # 1 year, plus a 30 days grace period
+      validity: 365 + 30,
+      hash: :sha256,
+      extensions: [
+        basic_constraints: basic_constraints(false),
+        key_usage: key_usage([:digitalSignature, :keyEncipherment]),
+        ext_key_usage: ext_key_usage([:serverAuth, :clientAuth]),
+        subject_key_identifier: true,
+        authority_key_identifier: true,
+        subject_alt_name: subject_alt_name([host]),
+        subject_alt_name: subject_alt_name([{:directoryName, X509.RDNSequence.new("CN=" <> node, :otp)}])
+      ]
+    }
+  end
+end
+
+defmodule Certs.Options do
+  def new!() do
+    Optimus.new!(
+      name: "certs",
+      description: "certs",
+      version: "0.2",
+      allow_unknown_args: false,
+      parse_double_dash: true,
+      subcommands: [
+        self_signed: [
+          name: "self-signed",
+          about: "Create a self-signed certificate",
+          options: [
+            subject: [
+              long: "--subject",
+              value_name: "SUBJECT",
+              required: true,
+              parser: :string
+            ],
+            out_cert: [
+              long: "--out-cert",
+              value_name: "OUT_CRT",
+              required: true,
+              parser: :string
+            ],
+            out_key: [
+              long: "--out-key",
+              value_name: "OUT_KEY",
+              required: true,
+              parser: :string
+            ],
+            template: [
+              long: "--template",
+              value_name: "TEMPLATE",
+              required: true,
+              parser: :string
+            ]
+          ]
+        ],
+        create_cert: [
+          name: "create-cert",
+          options: [
+            subject: [
+              long: "--subject",
+              value_name: "SUBJECT",
+              required: true,
+              parser: :string
+            ],
+            host: [
+              long: "--host",
+              value_name: "HOST",
+              required: false,
+              parser: :string
+            ],
+            node: [
+              long: "--node",
+              value_name: "NODE",
+              required: false,
+              parser: :string
+            ],
+            issuer_cert: [
+              long: "--issuer-cert",
+              value_name: "ISSUER_CRT",
+              required: true,
+              parser: :string
+            ],
+            issuer_key: [
+              long: "--issuer-key",
+              value_name: "ISSUER_KEY",
+              required: true,
+              parser: :string
+            ],
+            out_cert: [
+              long: "--out-cert",
+              value_name: "OUT_CRT",
+              required: true,
+              parser: :string
+            ],
+            out_key: [
+              long: "--out-key",
+              value_name: "OUT_KEY",
+              required: true,
+              parser: :string
+            ],
+            template: [
+              long: "--template",
+              value_name: "TEMPLATE",
+              required: true,
+              parser: :string
+            ]
+          ]
+        ]
+      ]
+    )
+  end
+end
+
+Certs.main(System.argv())
+
+# vim: set ft=elixir

--- a/src/couch_dist/certs/parse_cert.escript
+++ b/src/couch_dist/certs/parse_cert.escript
@@ -1,0 +1,8 @@
+#!/usr/bin/env escript
+-mode(compile).
+
+main(File) ->
+    {ok, PemBin} = file:read_file(File),
+    [{_, DerCert, _}] = public_key:pem_decode(PemBin),
+    OTPCert = public_key:pkix_decode_cert(DerCert, otp),
+    io:format("~p~n", [inet_tls_dist:cert_nodes(OTPCert)]).

--- a/src/couch_dist/gen_certs
+++ b/src/couch_dist/gen_certs
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -e
+
+certs_dir="$(cd "${0%/*}" 2>/dev/null; echo "${PWD}")/certs"
+cd "${certs_dir}"
+mkdir -p "${certs_dir}/out"
+
+if [ ! -e "${certs_dir}/out/ca-cert.pem" ]; then
+  ./certs self-signed \
+    --out-cert out/ca-cert.pem --out-key out/ca-key.pem \
+    --template root-ca \
+    --subject "/CN=CouchDB Root CA"
+fi
+
+if [ ! -e "${certs_dir}/out/cert.pem" ]; then
+  ./certs create-cert \
+    --issuer-cert out/ca-cert.pem --issuer-key out/ca-key.pem \
+    --out-cert out/cert.pem --out-key out/key.pem \
+    --template server \
+    --subject "/CN=127.0.0.1"
+fi
+
+if [ ! -e "${certs_dir}/out/couch_dist.conf" ]; then
+  cat <<EOF >"${certs_dir}/out/couch_dist.conf"
+[
+  {server, [
+    {cacertfile, "$(pwd)/out/ca-cert.pem"},
+    {certfile,   "$(pwd)/out/cert.pem"},
+    {keyfile,    "$(pwd)/out/key.pem"},
+    {secure_renegotiate, true},
+    {verify, verify_peer},
+    {fail_if_no_peer_cert, true}
+  ]},
+  {client, [
+    {cacertfile, "$(pwd)/out/ca-cert.pem"},
+    {certfile,   "$(pwd)/out/cert.pem"},
+    {keyfile,    "$(pwd)/out/key.pem"},
+    {secure_renegotiate, true},
+    {verify, verify_peer}
+  ]}
+].
+EOF
+fi


### PR DESCRIPTION
When the CouchDB custom (couch) distribution is enabled, OTP 24 and 25,
you will get a warning when using `remsh-tls` or `remsh -t`; but in OTP 26,
this is an error. Because the default value of the verify option is `verify_peer`
instead of `verify_none`. We need to provide the appropriate CA certificates to
pass the validation.

```bash
$ ./dev/remsh-tls
=WARNING REPORT==== 4-May-2023::12:43:28.893022 ===
Description: "Server authenticity is not verified since certificate path validation is not enabled"
     Reason: "The option {verify, verify_peer} and one of the options
              'cacertfile' or 'cacerts' are required to enable this."
```

```bash
$ ./dev/remsh-tls
Could not connect to "node1@127.0.0.1"
```

- Add `{verify, verify_peer}` to enable verification
- Add `certs` in `couch_dist` app to generate proper certificates
- Add `-t`/`--enable-tls` mode in ./dev/run to automatically generate
vm.args, certificates and configuration files
- Add `--no-tls <node>` option to specify node to use TCP only
- Add README and documentation
- Remove TLS certificate generation code from `configure`

Greate thanks to Robert Newson for figuring out how to generate the
correct certificates to pass verification!

Ref:
- https://www.erlang.org/doc/apps/ssl/ssl_distribution.html
- https://www.erlang.org/doc/man/ssl_app.html
- https://www.erlang.org/blog/otp-26-highlights/#ssl-safer-defaults
- https://github.com/rnewson/elixir-certs

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```bash
./configure --dev --spidermonkey-version 91 && make && ./dev/run --enable-tls
./configure --dev --spidermonkey-version 91 && make && ./dev/run --enable-tls --no-tls node2,node3

./dev/remsh-tls
(node1@127.0.0.1)1> net_kernel:nodes_info().
{ok,[{'node2@127.0.0.1',
         [{owner,<0.456.0>},
          {state,up},
          {address,
              {net_address,{{127,0,0,1},55170},"127.0.0.1",tcp,inet}},
          {type,normal},
          {in,145},
          {out,164}]},
     {'node3@127.0.0.1',
         [{owner,<0.461.0>},
          {state,up},
          {address,
              {net_address,{{127,0,0,1},55172},"127.0.0.1",tcp,inet}},
          {type,normal},
          {in,141},
          {out,169}]},
     {'remsh17312@127.0.0.1',
         [{owner,<0.1418.0>},
          {state,up},
          {address,
              {net_address,{{127,0,0,1},55203},"127.0.0.1",tls,inet}},
          {type,hidden},
          {in,10},
          {out,15}]}]}
```

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
