### PR TITLE
Encapsulate MD5 file checksums bits in couch_file

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -421,8 +421,7 @@ serialize_doc(#st{} = St, #doc{} = Doc) ->
     Body = Compress(Doc#doc.body),
     Atts = Compress(Doc#doc.atts),
     SummaryBin = ?term_to_bin({Body, Atts}),
-    Md5 = couch_hash:md5_hash(SummaryBin),
-    Data = couch_file:assemble_file_chunk(SummaryBin, Md5),
+    Data = couch_file:assemble_file_chunk_and_checksum(SummaryBin),
     % TODO: This is a terrible hack to get around the issues
     %       in COUCHDB-3255. We'll need to come back and figure
     %       out a better approach to handling the case when we

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -40,7 +40,7 @@
 -export([open/1, open/2, close/1, bytes/1, sync/1, truncate/2, set_db_pid/2]).
 -export([pread_term/2, pread_iolist/2, pread_binary/2]).
 -export([append_binary/2]).
--export([append_raw_chunk/2, assemble_file_chunk/2]).
+-export([append_raw_chunk/2, assemble_file_chunk_and_checksum/1]).
 -export([append_term/2, append_term/3]).
 -export([pread_terms/2]).
 -export([append_terms/2, append_terms/3]).
@@ -141,7 +141,8 @@ append_raw_chunk(Fd, Chunk) ->
 assemble_file_chunk(Bin) ->
     [<<0:1/integer, (iolist_size(Bin)):31/integer>>, Bin].
 
-assemble_file_chunk(Bin, Md5) ->
+assemble_file_chunk_and_checksum(Bin) ->
+    Md5 = couch_hash:md5_hash(Bin),
     [<<1:1/integer, (iolist_size(Bin)):31/integer>>, Md5, Bin].
 
 %%----------------------------------------------------------------------


### PR DESCRIPTION
Avoid leaking checksumming details into couch_bt_engine.
