### PR TITLE
Remove extra unused variable

### DIFF
--- a/src/couch_log/src/couch_log_writer_stderr.erl
+++ b/src/couch_log/src/couch_log_writer_stderr.erl
@@ -27,7 +27,7 @@ init() ->
 terminate(_, _St) ->
     ok.
 
-write(Entry, St) ->
+write(#log_entry{} = Entry, St) ->
     #log_entry{
         level = Level,
         pid = Pid,

--- a/src/couch_log/src/couch_log_writer_stderr.erl
+++ b/src/couch_log/src/couch_log_writer_stderr.erl
@@ -27,7 +27,7 @@ init() ->
 terminate(_, _St) ->
     ok.
 
-write(#log_entry{type = Type} = Entry, St) ->
+write(Entry, St) ->
     #log_entry{
         level = Level,
         pid = Pid,


### PR DESCRIPTION
Quick follow up to https://github.com/apache/couchdb/pull/4483 removing a variable that ended up not being used that is currently causing a compiler warning.