### PR TITLE
Use xxHash for couch_file checksums

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -95,6 +95,11 @@ view_index_dir = {{view_index_dir}}
 ; Sets the log level for informational compaction related entries.
 ;compaction_log_level = info
 
+; Enable writting xxHash checksums in .couch files. The current
+; default is false. When the value is false both xxHash and legacy
+; checksums can be read and verified.
+;write_xxhash_checksums = false
+
 [purge]
 ; Allowed maximum number of documents in one purge request
 ;max_document_id_number = 100

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -326,6 +326,10 @@
     {type, counter},
     {desc, <<"number of OS process prompt errors">>}
 ]}.
+{[couchdb, legacy_checksums], [
+    {type, counter},
+    {desc, <<"number of legacy checksums found in couch_file instances">>}
+]}.
 {[pread, exceed_eof], [
     {type, counter},
     {desc, <<"number of the attempts to read beyond end of db file">>}

--- a/src/docs/src/config/couchdb.rst
+++ b/src/docs/src/config/couchdb.rst
@@ -230,3 +230,20 @@ Base CouchDB Options
 
             [couchdb]
             view_index_dir = /var/lib/couchdb
+
+    .. config:option:: write_xxhash_checksums :: Enable writting xxHash checksums
+
+        .. versionadded:: 3.4
+
+        The default value in version 3.4 is ``false``. The legacy checksum
+        algorithm will be used for writing couch_file blocks. During reads,
+        both xxHash and the legacy checksum algorithm will be used to verify
+        data integrity. In a future version of CouchDB the default value will
+        become ``true``. However, it would still be possible to safely
+        downgrade to version 3.4, which would be able to verify both xxHash and
+        legacy checksums. If CouchDB version downgrade is not a concern,
+        enabling xxHash checksums can result in a measuralbe document read
+        performance, especially for larger document sizes::
+
+            [couchdb]
+            write_xxhash_checksums = false


### PR DESCRIPTION
Use the 128 bit variant of xxHash as it has the same output size as MD5, is non-cryptographic, and is quite a bit faster [1].

Writing xxHash checksums is disabled by default. This would allow us to make an intermediate release to which we can downgrade to as it can read both xxHash and MD5 checksums. In a future release writing xxHash checksums will flip to
`true`, but it would be possible to safely downgrade to the intermediate releases which would be aware of xxHash checksums and won't interpret them as corrupt data.

If downgrade is not a concern, using xxHash checksums can yield a noticeable speed improvement when reading larger documents (128KB+ or so).

There is metric which would indicate if any MD5 checksums are present after the xxHash has been enabled.

To avoid duplicating the verification logic for headers and blocks combined into one function with a check if it's for a header or not. This is to preserve previous behavior where or headers we don't want to emit emergency logs if they fail the check since we may be just reading left-over uncommitted data from the file end.

Add a stats counter to indicate if there are still any MD5 checksums found during normal cluster operation after it has been enabled.

During test coverage checks noticed we never actually tested block level corruption before so added a test for that as well for both xxHash and legacy cases.

[1] Comparison of hashing a 4KB block (units are microseconds).
```
(node1@127.0.0.1)20> f(T), {T, ok} = timer:tc(fun() -> lists:foreach(fun (_) -> do_nothing_overhead end, lists:seq(1, 1000000)) end), (T/1000000.0).
0.167425
(node1@127.0.0.1)21> f(T), {T, ok} = timer:tc(fun() -> lists:foreach(fun (_) -> exxhash:xxhash128(B) end, lists:seq(1, 1000000)) end), (T/1000000).
0.770687
(node1@127.0.0.1)22> f(T), {T, ok} = timer:tc(fun() -> lists:foreach(fun (_) -> crypto:hash(md5, B) end, lists:seq(1, 1000000)) end), (T/1000000).
6.205445
```
