### PR TITLE
Remove duplicate etag generation function

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -813,8 +813,7 @@ doc_etag(#doc{id = Id, body = Body, revs = {Start, [DiskRev | _]}}) ->
     couch_httpd:doc_etag(Id, Body, {Start, DiskRev}).
 
 make_etag(Term) ->
-    <<SigInt:128/integer>> = exxhash:xxhash128(term_to_binary(Term)),
-    list_to_binary(io_lib:format("\"~.36B\"", [SigInt])).
+    couch_httpd:make_etag(Term).
 
 etag_match(Req, CurrentEtag) when is_binary(CurrentEtag) ->
     etag_match(Req, binary_to_list(CurrentEtag));

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -745,8 +745,8 @@ rev_etag({Start, DiskRev}) ->
     <<$", Rev/binary, $">>.
 
 make_etag(Term) ->
-    <<SigInt:128/integer>> = couch_hash:md5_hash(term_to_binary(Term)),
-    iolist_to_binary([$", io_lib:format("~.36B", [SigInt]), $"]).
+    <<SigInt:128/integer>> = exxhash:xxhash128(?term_to_bin(Term)),
+    list_to_binary(io_lib:format("\"~.36B\"", [SigInt])).
 
 etag_match(Req, CurrentEtag) when is_binary(CurrentEtag) ->
     etag_match(Req, binary_to_list(CurrentEtag));

--- a/src/couch/test/eunit/couch_etag_tests.erl
+++ b/src/couch/test/eunit/couch_etag_tests.erl
@@ -16,12 +16,12 @@
 
 local_with_empty_body_test() ->
     Etag = couch_httpd:doc_etag(<<"_local/local-and-empty">>, {[]}, {0, <<"1">>}),
-    ?assertEqual(Etag, <<"\"5ZVXQYO7VLEOU0TL9VXDNP5PV\"">>).
+    ?assertEqual(<<"\"A4Q262OE0BOPODSYG6Z2A449\"">>, Etag).
 
 local_with_body_test() ->
     DocBody = {[{<<"hello">>, <<"world">>}, {<<"relax">>, true}]},
     Etag = couch_httpd:doc_etag(<<"_local/local-with-body">>, DocBody, {0, <<"1">>}),
-    ?assertEqual(Etag, <<"\"CEFXP6WH8OKYIWO1GLGBHKCCA\"">>).
+    ?assertEqual(<<"\"266X8HX6TVMBGQBJAGSY0JON\"">>, Etag).
 
 normal_doc_uses_rev_test() ->
     DocBody = {[{<<"hello">>, <<"world">>}, {<<"relax">>, true}]},


### PR DESCRIPTION
Use the couch_httpd one as it would be odd for couch_httpd to call chttpd.

Also fix the test assertion order: the first argument should be the expected value, the second one should be the test value [1]

[1] https://www.erlang.org/doc/apps/eunit/chapter.html#Assert_macros
