### PR TITLE
Add new configure option and restore --dev behavior

### DIFF
--- a/configure
+++ b/configure
@@ -129,6 +129,13 @@ parse_opts() {
             --dev)
                 WITH_DOCS=0
                 WITH_FAUXTON=0
+                shift
+                continue
+                ;;
+
+            --dev-with-nouveau)
+                WITH_DOCS=0
+                WITH_FAUXTON=0
                 WITH_NOUVEAU=1
                 shift
                 continue


### PR DESCRIPTION
Restore the old `--dev` configure option and add a new switch
for `--disable-docs --disable-fauxton --enable nouveau`.