### PR TITLE
Revert "fix(mango): GET invalid path under `_index` should not cause 500

### DIFF
--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -107,6 +107,8 @@ handle_index_req(#httpd{method = 'POST', path_parts = [_, _]} = Req, Db) ->
                 end
         end,
     chttpd:send_json(Req, {[{result, Status}, {id, Id}, {name, Name}]});
+handle_index_req(#httpd{path_parts = [_, _]} = Req, _Db) ->
+    chttpd:send_method_not_allowed(Req, "GET,POST");
 %% Essentially we just iterate through the list of ddoc ids passed in and
 %% delete one by one. If an error occurs, all previous documents will be
 %% deleted, but an error will be thrown for the current ddoc id.
@@ -187,9 +189,7 @@ handle_index_req(
             ?MANGO_ERROR({error_saving_ddoc, Error})
     end;
 handle_index_req(#httpd{path_parts = [_, _, _DDocId0, _Type, _Name]} = Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "DELETE");
-handle_index_req(#httpd{path_parts = [_, _ | _]} = Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST").
+    chttpd:send_method_not_allowed(Req, "DELETE").
 
 handle_explain_req(#httpd{method = 'POST'} = Req, Db) ->
     chttpd:validate_ctype(Req, "application/json"),

--- a/src/mango/test/01-index-crud-test.py
+++ b/src/mango/test/01-index-crud-test.py
@@ -88,10 +88,6 @@ class IndexCrudTests(mango.DbPerClass):
             else:
                 raise AssertionError("bad create index")
 
-    def test_bad_url(self):
-        r = self.db.sess.get(self.db.path("_index/foo"))
-        self.assertEqual(r.status_code, 405)
-
     def test_create_idx_01(self):
         fields = ["foo", "bar"]
         ret = self.db.create_index(fields, name="idx_01")


### PR DESCRIPTION
This reverts commit c1195e43c0b55f99892bb5d6b593de178499b969.

This wasn't quite right. handle_index_req has several separate resources handled within it which each support a different set of http methods.

We should send 405 for a resource that exists but doesn't support the request's method.
We should send 404 for a resource that doesn't exist at all.

Reverting this gives us a 500 / function_clause, which is at least honest (the server has made an error) but we should circle back and send better errors.

Noting that;

1) extra paths for _all_docs gives the desired 404 but for a silly reason (it matches the clause that looks for attachments, and you can't make a doc called _all_docs to attach anything to)
2) extra paths for _changes are ignored (and the _changes request works as expected) because handle_changes_req doesn't insist on a pattern for path_parts

In conclusion, we handle invalid paths in request handlers inconsistently, which ironically frees us to do the right thing in handle_index_req