### PR TITLE
fix(`mango`): missing parts of the `_index` API

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -1261,7 +1261,8 @@ it easier to take advantage of future improvements to query planning
     :synopsis: Delete an index.
 
     :param db: Database name.
-    :param design_doc: Design document name.
+    :param design_doc: Design document name.  The ``_design/`` prefix
+                       is not required.
     :param name: Index name.
 
     :>header Content-Type: - :mimetype:`application/json`
@@ -1295,6 +1296,80 @@ it easier to take advantage of future improvements to query planning
 
         {
             "ok": true
+        }
+
+.. _api/db/find/index-bulk-delete:
+
+.. http:post:: /{db}/_index/_bulk_delete
+   :synopsis: Delete indexes in bulk.
+
+   :param db: Database name
+
+   :<header Content-Type: - :mimetype:`application/json`
+
+   :<json array docids: List of names for indexes to be deleted.
+   :<json number w: Write quorum for each of the deletions.  Default
+      is ``2``. *Optional*
+
+   :>header Content-Type: - :mimetype:`application/json`
+
+   :>json array success: An array of objects that represent successful
+      deletions per index.  The ``id`` key contains the name of the
+      index, and ``ok`` reports if the operation has completed
+   :>json array fail: An array of object that describe failed
+      deletions per index.  The ``id`` key names the corresponding
+      index, and ``error`` describes the reason for the failure
+
+   :code 200: Success
+   :code 400: Invalid request
+   :code 404: Requested database not found
+   :code 500: Execution error
+
+   **Request**:
+
+   .. code-block:: http
+
+        POST /db/_index/_bulk_delete HTTP/1.1
+        Accept: application/json
+        Content-Type: application/json
+        Host: localhost:5984
+
+        {
+            "docids": [
+                "_design/example-ddoc",
+                "foo-index",
+                "nonexistent-index"
+            ]
+        }
+
+   **Response**:
+
+   .. code-block:: http
+
+        HTTP/1.1 200 OK
+        Cache-Control: must-revalidate
+        Content-Length: 94
+        Content-Type: application/json
+        Date: Thu, 01 Sep 2016 19:26:59 GMT
+        Server: CouchDB (Erlang OTP/18)
+
+        {
+            "success": [
+                {
+                    "id": "_design/example-ddoc",
+                    "ok": true
+                },
+                {
+                    "id": "foo-index",
+                    "ok": true
+                }
+            ],
+            "fail": [
+                {
+                    "id": "nonexistent-index",
+                    "error": "not_found"
+                }
+            ]
         }
 
 .. _api/db/find/explain:

--- a/src/mango/test/01-index-crud-test.py
+++ b/src/mango/test/01-index-crud-test.py
@@ -11,6 +11,7 @@
 # the License.
 
 import random
+from functools import partial
 
 import mango
 import copy
@@ -87,6 +88,56 @@ class IndexCrudTests(mango.DbPerClass):
                 self.assertEqual(e.response.status_code, 400)
             else:
                 raise AssertionError("bad create index")
+
+    def test_bad_urls(self):
+        # These are only the negative test cases because ideally the
+        # positive ones are implicitly tested by other ones.
+
+        all_methods = [
+            ("PUT", self.db.sess.put),
+            ("GET", self.db.sess.get),
+            ("POST", self.db.sess.post),
+            ("PATCH", self.db.sess.get),
+            ("DELETE", self.db.sess.delete),
+            ("HEAD", self.db.sess.head),
+            ("COPY", partial(self.db.sess.request, "COPY")),
+            ("OPTIONS", partial(self.db.sess.request, "OPTIONS")),
+            ("TRACE", partial(self.db.sess.request, "TRACE")),
+            ("CONNECT", partial(self.db.sess.request, "CONNECT")),
+        ]
+
+        def all_but(method):
+            return list(filter(lambda x: x[0] != method, all_methods))
+
+        # Three-element subpaths are used as a shorthand to delete
+        # indexes via design documents, see below.
+        for subpath in ["a", "a/b", "a/b/c/d", "a/b/c/d/e", "a/b/c/d/e/f"]:
+            path = self.db.path("_index/{}".format(subpath))
+            for method_name, method in all_methods:
+                with self.subTest(path=path, method=method_name):
+                    r = method(path)
+                    self.assertEqual(r.status_code, 404)
+
+        for method_name, method in all_but("POST"):
+            path = self.db.path("_index/_bulk_delete")
+            with self.subTest(path=path, method=method_name):
+                r = method(path)
+                self.assertEqual(r.status_code, 405)
+
+        fields = ["foo", "bar"]
+        ddoc = "dd"
+        idx = "idx_01"
+        ret = self.db.create_index(fields, name=idx, ddoc=ddoc)
+        assert ret is True
+        for subpath in [
+            "{}/json/{}".format(ddoc, idx),
+            "_design/{}/json/{}".format(ddoc, idx),
+        ]:
+            path = self.db.path("_index/{}".format(subpath))
+            for method_name, method in all_but("DELETE"):
+                r = method(path)
+                with self.subTest(path=path, method=method_name):
+                    self.assertEqual(r.status_code, 405)
 
     def test_create_idx_01(self):
         fields = ["foo", "bar"]


### PR DESCRIPTION
Many of the requests outside the scope of the `_index` endpoint are not handled gracefully but trigger an internal server error.  Enhance the `_index` handler logic to return proper answers for invalid queries and supply it with more exhaustive integration tests.

Provide documentation for the existing `_index/_bulk_delete` endpoint as it was missing, and mention that the `_design` prefix is not needed when deleting indexes.

This is a follow-up to #4584 and a revisited version of #4514.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Documentation changes were made in the `src/docs` folder
