### PR TITLE
Update default vm.args settings

### DIFF
--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -61,6 +61,18 @@
 # Dirty IO schedulers are used for file IO.
 +SDio 16
 
+# Increase distribution buffer size from default of 1MB to 32MB. The default is
+# usually a bit low on busy clusters. Has no effect for single-node setups.
+# The unit is in kilobytes.
++zdbbl 32768
+
+# When running on Docker, Kubernetes or an OS using CFS (Completely Fair
+# Scheduler) with CPU quota limits set, disable busy waiting for schedulers to
+# avoid busy waiting consuming too much of Erlang VM's CPU time-slice shares.
+#+sbwt none
+#+sbwtdcpu none
+#+sbwtdio none
+
 # Comment this line out to enable the interactive Erlang shell on startup
 +Bd -noinput
 


### PR DESCRIPTION
 * Increase distribution buffer size from 1MB to 32MB. We've been using this value at Cloudant for years in all the clusters. RabbitMQ defaults to 128MB, which is even higher. This might speed busy clusters with lots of distribution traffic.

 * Add a commented out example of scheduling flags to use in a Docker or Kube environment with CFS quotas (advice taken from https://erlangforums.com/t/vm-tuning-guide/1945/3).
