### PR TITLE
Optimize mem3:dbname/1 function

### DIFF
--- a/src/fabric/src/fabric_db_create.erl
+++ b/src/fabric/src/fabric_db_create.erl
@@ -62,8 +62,7 @@ validate_dbname(DbName, Options) ->
     end.
 
 generate_shard_map(DbName, Options) ->
-    {MegaSecs, Secs, _} = os:timestamp(),
-    Suffix = "." ++ integer_to_list(MegaSecs * 1000000 + Secs),
+    Suffix = mem3:generate_shard_suffix(),
     Shards = mem3:choose_shards(DbName, [{shard_suffix, Suffix} | Options]),
     case mem3_util:open_db_doc(DbName) of
         {ok, Doc} ->


### PR DESCRIPTION
`mem3:dbname/1` with a `<<"shard/...">>` binary is called quite a few times as
seen when profiling with fprof:
https://gist.github.com/nickva/38760462c1545bf55d98f4898ae1983d

In that case `mem3:dbname` is removing the timestamp suffix. However, because
it uses `filename:rootname/1` which handles cases pertaining to file system
paths and such, it ends up being a bit more expensive than necessary.

To optimize it assume it has a timestamp suffix and try to parse it out first,
and then verify can be parsed into an integer, if that fails fall back to using
`filename:rootname/1`.

To lower chance of the timestamp suffix changing and us not noticing move the
shard suffix generation function from fabric to mem3 so the generating and the
stripping functions are right next to each other.

A quick speed comparison test shows a 6x speedup or so:

```
shard_speed_test() ->
    Shard = <<"shards/80000000-9fffffff/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.1234567890">>,
    shard_speed_check(Shard, 10000).

shard_speed_check(Shard, N) ->
    T0 = erlang:monotonic_time(),
    do_dbname(Shard, N),
    Dt = erlang:monotonic_time() - T0,
    DtUsec = erlang:convert_time_unit(Dt, native, microsecond),
    DtUsec / N.

do_dbname(_, 0) ->
    ok;
do_dbname(Shard, N) ->
    _ = dbname(Shard),
    do_dbname(Shard, N - 1).
```

On main:
```
(node1@127.0.0.1)1> mem3:shard_speed_test().
1.3099
```

With PR:
```
(node1@127.0.0.1)1> mem3:shard_speed_test().
0.1959
```
