### PR TITLE
ARM64 worker went away.

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -65,13 +65,15 @@ meta = [
     image: "apache/couchdbci-debian:buster-erlang-${ERLANG_VERSION}"
   ],
 
-  'bullseye-arm64': [
-    name: 'Debian 11 ARM',
-    spidermonkey_vsn: '78',
-    enable_nouveau: true,
-    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
-    node_label: 'arm64v8'
-  ],
+  // ARM64 worker seems to have gone away. Disable it for now
+  // to unlock main CI runs
+  // 'bullseye-arm64': [
+  //   name: 'Debian 11 ARM',
+  //   spidermonkey_vsn: '78',
+  //   enable_nouveau: true,
+  //   image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+  //   node_label: 'arm64v8'
+  // ],
 
   'bullseye-ppc64': [
     name: 'Debian 11 POWER',


### PR DESCRIPTION
Disable it for now to unblock CI builds.

If it comes back, we'll re-enable it.
