### PR TITLE
Add a few more commit and query engine metrics

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -278,6 +278,18 @@
     {type, histogram},
     {desc, <<"length of a request inside CouchDB without MochiWeb">>}
 ]}.
+{[couchdb, commits], [
+    {type, counter},
+    {desc, <<"number of commits performed">>}
+]}.
+{[couchdb, coalesced_updates, interactive], [
+    {type, counter},
+    {desc, <<"number of coalesced interactive updates">>}
+]}.
+{[couchdb, coalesced_updates, replicated], [
+    {type, counter},
+    {desc, <<"number of coalesced replicated updates">>}
+]}.
 {[couchdb, couch_server, lru_skip], [
     {type, counter},
     {desc, <<"number of couch_server LRU operations skipped">>}
@@ -290,6 +302,30 @@
     {type, histogram},
     {desc, <<"duration of validate_doc_update function calls">>}
 ]}.
+{[couchdb, query_server, acquired_processes], [
+    {type, counter},
+    {desc, <<"number of acquired external processes">>}
+]}.
+{[couchdb, query_server, process_starts], [
+    {type, counter},
+    {desc, <<"number of OS process starts">>}
+]}.
+{[couchdb, query_server, process_exists], [
+    {type, counter},
+    {desc, <<"number of OS normal process exits">>}
+]}.
+{[couchdb, query_server, process_errors], [
+    {type, counter},
+    {desc, <<"number of OS error process exits">>}
+]}.
+{[couchdb, query_server, process_prompts], [
+    {type, counter},
+    {desc, <<"number of successful OS process prompts">>}
+]}.
+{[couchdb, query_server, process_prompt_errors], [
+    {type, counter},
+    {desc, <<"number of OS process prompt errors">>}
+]}.
 {[pread, exceed_eof], [
     {type, counter},
     {desc, <<"number of the attempts to read beyond end of db file">>}
@@ -297,6 +333,14 @@
 {[pread, exceed_limit], [
     {type, counter},
     {desc, <<"number of the attempts to read beyond set limit">>}
+]}.
+{[fsync, time], [
+    {type, histogram},
+    {desc, <<"microseconds to call fsync">>}
+]}.
+{[fsync, count], [
+    {type, counter},
+    {desc, <<"number of fsync calls">>}
 ]}.
 {[mango, unindexed_queries], [
     {type, counter},

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -570,6 +570,7 @@ commit_data(St) ->
             couch_file:sync(Fd),
             ok = couch_file:write_header(Fd, NewHeader),
             couch_file:sync(Fd),
+            couch_stats:increment_counter([couchdb, commits]),
             {ok, St#st{
                 header = NewHeader,
                 needs_commit = false

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -295,6 +295,10 @@ collect_updates(GroupedDocsAcc, ClientsAcc, MergeConflicts) ->
         % updaters than deal with their possible conflicts, and local docs
         % writes are relatively rare. Can be optmized later if really needed.
         {update_docs, Client, GroupedDocs, [], MergeConflicts} ->
+            case MergeConflicts of
+                true -> couch_stats:increment_counter([couchdb, coalesced_updates, replicated]);
+                false -> couch_stats:increment_counter([couchdb, coalesced_updates, interactive])
+            end,
             GroupedDocs2 = sort_and_tag_grouped_docs(Client, GroupedDocs),
             GroupedDocsAcc2 =
                 merge_updates(GroupedDocsAcc, GroupedDocs2),

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -81,13 +81,17 @@ get_proc(#doc{body = {Props}} = DDoc, DbKey, {_DDocId, _Rev} = DDocKey) ->
     Lang = couch_util:to_binary(LangStr),
     Client = #client{lang = Lang, ddoc = DDoc, db_key = DbKey, ddoc_key = DDocKey},
     Timeout = get_os_process_timeout(),
-    gen_server:call(?MODULE, {get_proc, Client}, Timeout).
+    Res = gen_server:call(?MODULE, {get_proc, Client}, Timeout),
+    couch_stats:increment_counter([couchdb, query_server, acquired_processes]),
+    Res.
 
 get_proc(LangStr) ->
     Lang = couch_util:to_binary(LangStr),
     Client = #client{lang = Lang},
     Timeout = get_os_process_timeout(),
-    gen_server:call(?MODULE, {get_proc, Client}, Timeout).
+    Res = gen_server:call(?MODULE, {get_proc, Client}, Timeout),
+    couch_stats:increment_counter([couchdb, query_server, acquired_processes]),
+    Res.
 
 ret_proc(#proc{} = Proc) ->
     gen_server:call(?MODULE, {ret_proc, Proc}, infinity).

--- a/src/couch/test/eunit/couch_js_tests.erl
+++ b/src/couch/test/eunit/couch_js_tests.erl
@@ -53,6 +53,11 @@ should_create_sandbox() ->
     ?assertMatch([[[true, <<_/binary>>]]], Result),
     [[[true, ErrMsg]]] = Result,
     ?assertNotEqual([], binary:matches(ErrMsg, <<"not defined">>)),
+    ?assert(couch_stats:sample([couchdb, query_server, process_starts]) > 0),
+    ?assert(couch_stats:sample([couchdb, query_server, process_prompts]) > 0),
+    ?assert(couch_stats:sample([couchdb, query_server, acquired_processes]) > 0),
+    ?assert(couch_stats:sample([couchdb, query_server, process_exists]) >= 0),
+    ?assert(couch_stats:sample([couchdb, query_server, process_errors]) >= 0),
     couch_query_servers:ret_os_process(Proc).
 
 %% erlfmt-ignore
@@ -274,7 +279,8 @@ should_exit_on_internal_error() ->
         % It may fail and just exit the process. That's expected as well
         throw:{os_process_error, _} ->
             ok
-    end.
+    end,
+    ?assert(couch_stats:sample([couchdb, query_server, process_errors]) > 0).
 
 trigger_oom(Proc) ->
     Status =

--- a/src/couch_pse_tests/src/cpse_test_read_write_docs.erl
+++ b/src/couch_pse_tests/src/cpse_test_read_write_docs.erl
@@ -43,6 +43,7 @@ cpse_write_one_doc(Db1) ->
     ?assertEqual(0, couch_db_engine:get_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db1)),
     ?assertEqual(0, couch_db_engine:get_update_seq(Db1)),
+    Commits = couch_stats:sample([couchdb, commits]),
 
     Actions = [
         {create, {<<"foo">>, {[{<<"vsn">>, 1}]}}}
@@ -57,7 +58,9 @@ cpse_write_one_doc(Db1) ->
     ?assertEqual(1, couch_db_engine:get_doc_count(Db3)),
     ?assertEqual(0, couch_db_engine:get_del_doc_count(Db3)),
     ?assertEqual(1, couch_db_engine:get_update_seq(Db3)),
-
+    ?assert(couch_stats:sample([couchdb, commits]) > Commits),
+    ?assert(couch_stats:sample([couchdb, coalesced_updates, interactive]) >= 0),
+    ?assert(couch_stats:sample([couchdb, coalesced_updates, replicated]) >= 0),
     [FDI] = couch_db_engine:open_docs(Db3, [<<"foo">>]),
     #rev_info{
         rev = {RevPos, PrevRevId},


### PR DESCRIPTION
fsync times can vary widely, especially on a remote block storage, so add a histogram and count for fsync calls. At a higher level, we can coalesce similar update doc requests from multiple clients, so add metrics to track that as well.

Improving couch_proc_manager, and experimenting with quickjs js engine [1], noticed we lacked metrics in that area. Add metrics to track query process acquires, start/stops (including crashes) as well as how many prompt and prompt errors we have. These should help gain some confidence when upgrading to a new engine version or engine type by comparing the before and after metrics output.

Trying to test some of these new metrics, noticed couch_file tests did most of the test logic in the setup part, which resulted in plenty of log noise during the test runs about started/stopped applications, so updated a few tests which were affected by this PR to use the ?TDEF_FE macro. That should make test output a bit smaller and neater.

[1] https://github.com/apache/couchdb/issues/4448#issuecomment-1447196423
