### PR TITLE
fix: missing stats description for Mango `keys_examined`

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -354,6 +354,10 @@
     {type, counter},
     {desc, <<"number of mango queries that generated an index scan warning">>}
 ]}.
+{[mango, keys_examined], [
+    {type, counter},
+    {desc, <<"number of keys examined by mango queries coordinated by this node">>}
+]}.
 {[mango, docs_examined], [
     {type, counter},
     {desc, <<"number of documents examined by mango queries coordinated by this node">>}


### PR DESCRIPTION
The stats description was probably not included for the `keys_examined` counter for Mango in #4569, which causes `unknown metric: [mango, keys_examined]` messages in the logs.  This change fixes the problem by providing the necessary item.