### PR TITLE
fix(mango): integration tests

### DIFF
--- a/src/mango/test/04-key-tests.py
+++ b/src/mango/test/04-key-tests.py
@@ -48,8 +48,7 @@ class KeyTests(mango.DbPerClass):
         super(KeyTests, klass).setUpClass()
         klass.db.save_docs(TEST_DOCS, w=3)
         klass.db.create_index(["type"], ddoc="view")
-        if mango.has_text_service():
-            klass.db.create_text_index(ddoc="text")
+        klass.db.create_text_index(ddoc="text")
 
     def run_check(self, query, check, fields=None, indexes=None):
         if indexes is None:

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -249,8 +249,7 @@ class TextIndexSelectionTests(mango.UserDocsTests):
     @classmethod
     def setUpClass(klass):
         super(TextIndexSelectionTests, klass).setUpClass()
-        if mango.has_text_service():
-            user_docs.add_text_indexes(klass.db, {})
+        user_docs.add_text_indexes(klass.db, {})
 
     def test_with_text(self):
         resp = self.db.find(
@@ -315,9 +314,8 @@ class MultiTextIndexSelectionTests(mango.UserDocsTests):
     @classmethod
     def setUpClass(klass):
         super(MultiTextIndexSelectionTests, klass).setUpClass()
-        if mango.has_text_service():
-            klass.db.create_text_index(ddoc="foo", analyzer="keyword")
-            klass.db.create_text_index(ddoc="bar", analyzer="email")
+        klass.db.create_text_index(ddoc="foo", analyzer="keyword")
+        klass.db.create_text_index(ddoc="bar", analyzer="email")
 
     def test_fallback_to_json_with_multi_text(self):
         resp = self.db.find(

--- a/src/mango/test/06-basic-text-test.py
+++ b/src/mango/test/06-basic-text-test.py
@@ -573,8 +573,7 @@ class NumStringTests(mango.DbPerClass):
     def setUpClass(klass):
         super(NumStringTests, klass).setUpClass()
         klass.db.recreate()
-        if mango.has_text_service():
-            klass.db.create_text_index()
+        klass.db.create_text_index()
 
     # not available for python 2.7.x
     def isFinite(num):

--- a/src/mango/test/10-disable-array-length-field-test.py
+++ b/src/mango/test/10-disable-array-length-field-test.py
@@ -17,7 +17,6 @@ import unittest
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class DisableIndexArrayLengthsTest(mango.UserDocsTextTests):
     def setUp(self):
-        self.db.recreate()
         self.db.create_text_index(
             ddoc="disable_index_array_lengths",
             analyzer="keyword",
@@ -33,12 +32,12 @@ class DisableIndexArrayLengthsTest(mango.UserDocsTextTests):
         docs = self.db.find(
             {"favorites": {"$size": 4}}, use_index="disable_index_array_lengths"
         )
-        for d in docs:
-            assert len(d["favorites"]) == 0
+        assert len(docs) == 0
 
     def test_enable_index_array_length(self):
         docs = self.db.find(
             {"favorites": {"$size": 4}}, use_index="explicit_enable_index_array_lengths"
         )
+        assert len(docs) > 0
         for d in docs:
             assert len(d["favorites"]) == 4


### PR DESCRIPTION
- Fix the faulty `index_array_length` tests:

    - They do not check the count of the returned documents but blindly
      assume that there will be results.  Add an explicit assertion about
      the expected number of documents in the response so it could be
      detected if something breaks.

    - The assertion on the document count revealed that the test database
      is actually empty because it is immediately wiped out after creation
      by a misplaced `recreate()` call.

    - When the indexing on the array lengths is disabled, there shall be no
      documents returned, and not the sizes of the `favorites` arrays in
      the results shall be zero.  That is because there is no information
      available on the sizes of the arrays.

- The result of the `mango.has_text_service()` checks is implicitly forecasted by the `@unittest.skipUnless` annotations in the head of the class declaration.  Hence they are not needed anymore.
