### PR TITLE
optionally suppress version info in server response header

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -197,6 +197,10 @@ bind_address = 127.0.0.1
 ; the old behavior.
 ;bulk_get_use_batches = true
 
+; Whether CouchDB should send CouchDB and Erlang/OTP version in the Server
+; response header.
+;server_header_versions = true
+
 ;[jwt_auth]
 ; List of claims to validate
 ; can be the name of a claim like "exp" or a tuple if the claim requires

--- a/src/couch/src/couch_httpd.erl
+++ b/src/couch/src/couch_httpd.erl
@@ -1202,11 +1202,16 @@ negotiate_content_type(_Req) ->
     end.
 
 server_header() ->
-    [
-        {"Server",
-            "CouchDB/" ++ couch_server:get_version() ++
-                " (Erlang OTP/" ++ erlang:system_info(otp_release) ++ ")"}
-    ].
+    case chttpd_util:get_chttpd_config_boolean("server_header_versions", true) of
+        false ->
+            [{"Server", "CouchDB"}];
+        true ->
+            [
+                {"Server",
+                    "CouchDB/" ++ couch_server:get_version() ++
+                        " (Erlang OTP/" ++ erlang:system_info(otp_release) ++ ")"}
+            ]
+    end.
 
 -record(mp, {boundary, buffer, data_fun, callback}).
 

--- a/src/docs/src/config/http.rst
+++ b/src/docs/src/config/http.rst
@@ -256,6 +256,16 @@ HTTP Server Options
             [chttpd]
             admin_only_all_dbs = true
 
+    .. config:option:: server_header_versions :: Whether to send version info Server header
+
+        .. versionadded:: 3.4
+
+        Set to false to remove the CouchDB and Erlang/OTP versions from the Server response
+        header. ::
+
+            [chttpd]
+            server_header_versions = true
+
 .. config:section:: httpd :: HTTP Server Options
 
     .. versionchanged:: 3.2 These options were moved to [chttpd] section:


### PR DESCRIPTION
Add an option to suppress including the CouchDB and OTP versions, defaulting to the current behaviour of including both.

note: If, instead, we omitted this line we would get Mochiweb's default server line rather than no server line.