### PR TITLE
Use milliseconds for fsync time histogram

### DIFF
--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -643,10 +643,13 @@ format_status(_Opt, [PDict, #file{} = File]) ->
     [{data, [{"State", File}, {"InitialFilePath", FilePath}]}].
 
 fsync(Fd) ->
+    % Our metrics histograms are in milliseconds so stick to that pattern.
+    % However we measure the time delta in microseconds so we get fractional
+    % microseconds for cases when the disk drives are faster.
     T0 = erlang:monotonic_time(microsecond),
     Res = file:sync(Fd),
-    Dt = erlang:monotonic_time(microsecond) - T0,
-    couch_stats:update_histogram([fsync, time], Dt),
+    DtUSec = erlang:monotonic_time(microsecond) - T0,
+    couch_stats:update_histogram([fsync, time], DtUSec / 1000),
     couch_stats:increment_counter([fsync, count]),
     Res.
 


### PR DESCRIPTION
Most of our histograms are in milliseconds. Don't deviate from that with the new fsync.time metric so make it use milliseconds as well. It turns out fractional histogram values are allowed, so we can still get the sub-millisecond precision for faster disks that way.

Example of usage during: `fabric_bench:go(#{docs=>50000, batch_size=>100}).`

```
couch_stats:sample([fsync, time]).
[{min,8.303},
 {max,134.124},
 {arithmetic_mean,49.3490064102564},
 {geometric_mean,42.939511193319994},
 {harmonic_mean,37.05011500299417},
 {median,43.198},
 {variance,654.1673972451199},
 {standard_deviation,25.57669637082006},
 {skewness,0.7276971171556265},
 {kurtosis,-0.021701320829371706},
 {percentile,[{50,43.198},
              {75,63.858},
              {90,81.22},
              {95,97.231},
              {99,114.86},
              {999,134.124}]},
 {histogram,[{25.303,48},
             {48.303,40},
             {68.303,38},
             {78.303,4},
             {98.303,18},
             {118.303,7},
             {128.303,0},
             {148.303,1}]},
 {n,156}]
```
