### PR TITLE
Use a faster sets implementation available since OTP 24

### DIFF
--- a/src/global_changes/src/global_changes_listener.erl
+++ b/src/global_changes/src/global_changes_listener.erl
@@ -55,7 +55,7 @@ init(_) ->
     State = #state{
         update_db = UpdateDb,
         pending_update_count = 0,
-        pending_updates = sets:new(),
+        pending_updates = sets:new([{version, 2}]),
         max_event_delay = MaxEventDelay,
         dbname = global_changes_util:get_dbname()
     },
@@ -99,7 +99,7 @@ handle_cast({set_update_db, Boolean}, State0) ->
             {false, true} ->
                 State0#state{
                     update_db = Boolean,
-                    pending_updates = sets:new(),
+                    pending_updates = sets:new([{version, 2}]),
                     pending_update_count = 0,
                     last_update_time = undefined
                 };
@@ -141,7 +141,7 @@ maybe_send_updates(#state{update_db = true} = State) ->
                         0
                     ),
                     State1 = State#state{
-                        pending_updates = sets:new(),
+                        pending_updates = sets:new([{version, 2}]),
                         pending_update_count = 0,
                         last_update_time = undefined
                     },

--- a/src/global_changes/src/global_changes_server.erl
+++ b/src/global_changes/src/global_changes_server.erl
@@ -69,7 +69,7 @@ init([]) ->
     State = #state{
         update_db = UpdateDb,
         pending_update_count = 0,
-        pending_updates = sets:new(),
+        pending_updates = sets:new([{version, 2}]),
         max_write_delay = MaxWriteDelay,
         dbname = GlobalChangesDbName,
         handler_ref = erlang:monitor(process, Handler)
@@ -106,7 +106,7 @@ handle_cast({set_update_db, Boolean}, State0) ->
             {false, true} ->
                 State0#state{
                     update_db = Boolean,
-                    pending_updates = sets:new(),
+                    pending_updates = sets:new([{version, 2}]),
                     pending_update_count = 0
                 };
             _ ->
@@ -177,7 +177,7 @@ flush_updates(State) ->
         0
     ),
     {noreply, State#state{
-        pending_updates = sets:new(),
+        pending_updates = sets:new([{version, 2}]),
         pending_update_count = 0
     }}.
 

--- a/src/mem3/src/mem3_sync_event_listener.erl
+++ b/src/mem3/src/mem3_sync_event_listener.erl
@@ -63,7 +63,7 @@ init(_) ->
     ok = subscribe_for_config(),
     Delay = config:get_integer("mem3", "sync_delay", 5000),
     Frequency = config:get_integer("mem3", "sync_frequency", 500),
-    Buckets = lists:duplicate(Delay div Frequency + 1, sets:new()),
+    Buckets = lists:duplicate(Delay div Frequency + 1, sets:new([{version, 2}])),
     St = #state{
         nodes = mem3_sync:nodes_db(),
         shards = mem3_sync:shards_db(),
@@ -163,7 +163,7 @@ rebucket_shards(Frequency, Delay, Buckets0) ->
             [sets:union([B | ToMerge]) | Buckets1];
         M ->
             %% Extend the number of buckets by M
-            lists:duplicate(M, sets:new()) ++ Buckets0
+            lists:duplicate(M, sets:new([{version, 2}])) ++ Buckets0
     end.
 
 %% To ensure that mem3_sync:push/2 is indeed called with roughly the frequency
@@ -180,7 +180,7 @@ maybe_push_shards(St) ->
     case Delta > Frequency of
         true ->
             {Buckets1, [ToPush]} = lists:split(length(Buckets0) - 1, Buckets0),
-            Buckets2 = [sets:new() | Buckets1],
+            Buckets2 = [sets:new([{version, 2}]) | Buckets1],
             %% There's no sets:map/2!
             sets:fold(
                 fun(ShardName, _) -> push_shard(ShardName) end,


### PR DESCRIPTION
Since OTP 24 a version of sets implemented using maps is available [1]

Replace a few case where we use sets with the new implementation.

[1] https://www.erlang.org/doc/man/sets.html
