### PR TITLE
Revert "Bump requests from 2.27.1 to 2.31.0 in /src/mango"

### DIFF
--- a/src/mango/requirements.txt
+++ b/src/mango/requirements.txt
@@ -1,4 +1,5 @@
 nose2==0.11.0
-requests==2.31.0
+# requests 2.27.1 is the highest supported version
+# on ubuntu 18 and centos 7 CI workers
+requests==2.27.1
 hypothesis==6.31.6
-


### PR DESCRIPTION
This reverts commit a4bad8d8e93eaa93a56465a082524f18fd736178.

Unfortunately 2.27.1 is the highest support version for python 3 on Ubuntu 18 and CentOS 7 workers. This is for a localhost CI test only and not part of our release artifact.
