### PR TITLE
Add extra assert in flaky couch_file test

### DIFF
--- a/src/couch/test/eunit/couch_file_tests.erl
+++ b/src/couch/test/eunit/couch_file_tests.erl
@@ -411,7 +411,7 @@ make_enable_recovery_test_case({RootDir, File}, EnableRecovery, Context) ->
         ("couchdb", "delete_after_rename", _) -> false
     end),
     FileExistsBefore = filelib:is_regular(File),
-    couch_file:delete(RootDir, File, [{context, Context}]),
+    DeleteResult = couch_file:delete(RootDir, File, [{context, Context}]),
     FileExistsAfter = filelib:is_regular(File),
     RenamedFiles = filelib:wildcard(filename:rootname(File) ++ "*.deleted.*"),
     DeletedFiles = filelib:wildcard(RootDir ++ "/.delete/*"),
@@ -421,6 +421,7 @@ make_enable_recovery_test_case({RootDir, File}, EnableRecovery, Context) ->
             true -> {0, 1}
         end,
     [
+        ?_assertEqual(ok, DeleteResult),
         ?_assert(FileExistsBefore),
         ?_assertNot(FileExistsAfter),
         ?_assertEqual(ExpectRenamedCount, length(RenamedFiles)),


### PR DESCRIPTION
The deletion test is flaky sometimes:

```
[2023-05-31T19:44:32.096Z]     File delete tests
[2023-05-31T19:44:32.096Z]       enable_database_recovery = false, context = delete
[2023-05-31T19:44:32.096Z]         couch_file_tests:424: make_enable_recovery_test_case...ok
[2023-05-31T19:44:32.096Z]         couch_file_tests:425: make_enable_recovery_test_case...ok
[2023-05-31T19:44:32.096Z]         couch_file_tests:426: make_enable_recovery_test_case...ok
[2023-05-31T19:44:32.096Z]         couch_file_tests:427: make_enable_recovery_test_case...*failed*
[2023-05-31T19:44:32.096Z] in function couch_file_tests:'-make_enable_recovery_test_case/3-fun-8-'/2 (test/eunit/couch_file_tests.erl, line 427)
[2023-05-31T19:44:32.096Z] in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
[2023-05-31T19:44:32.096Z] in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531)
[2023-05-31T19:44:32.096Z] in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356)
[2023-05-31T19:44:32.096Z] in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514)
[2023-05-31T19:44:32.096Z] in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456)
[2023-05-31T19:44:32.096Z] in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 346)
[2023-05-31T19:44:32.096Z] in call from eunit_proc:run_group/2 (eunit_proc.erl, line 570)
[2023-05-31T19:44:32.096Z] **error:{assertEqual,[{module,couch_file_tests},
[2023-05-31T19:44:32.096Z]               {line,427},
[2023-05-31T19:44:32.096Z]               {expression,"length ( DeletedFiles )"},
[2023-05-31T19:44:32.096Z]               {expected,1},
[2023-05-31T19:44:32.096Z]               {value,0}]}
[2023-05-31T19:44:32.096Z]   output:<<"">>
```

It seems the renamed files are not found in the $root/.delete directory, which is odd as renames are supposed to be atomic. Should we fsync dir entries themselves? We could also add a sleep, but on first attempt is to add and extra assert that file:name/2 actually returned an ok not some posix error.
