### PR TITLE
Clean up fabric_bench_test databases

### DIFF
--- a/src/fabric/test/eunit/fabric_bench_test.erl
+++ b/src/fabric/test/eunit/fabric_bench_test.erl
@@ -64,9 +64,11 @@ t_newer_db_deletion_doesnt_work(_Ctx) ->
     Db = <<"fabricbenchdb-", Suffix/binary>>,
     ok = fabric:create_db(Db, [{q, 1}, {n, 1}]),
     fabric_bench:delete_old_dbs(),
-    ?assertEqual({ok, 0}, fabric:get_doc_count(Db)).
+    ?assertEqual({ok, 0}, fabric:get_doc_count(Db)),
+    ok = fabric:delete_db(Db).
 
 t_db_deletion_ignores_other_dbs(_Ctx) ->
+    ok = delete_prefixed_dbs(<<"fabricbenchdb">>),
     Db1 = <<"fabricbenchdb-">>,
     Db2 = <<"fabricbenchdb">>,
     Db3 = <<"fabricbenchdb-xyz">>,
@@ -76,4 +78,14 @@ t_db_deletion_ignores_other_dbs(_Ctx) ->
     fabric_bench:delete_old_dbs(),
     ?assertEqual({ok, 0}, fabric:get_doc_count(Db1)),
     ?assertEqual({ok, 0}, fabric:get_doc_count(Db2)),
-    ?assertEqual({ok, 0}, fabric:get_doc_count(Db3)).
+    ?assertEqual({ok, 0}, fabric:get_doc_count(Db3)),
+    ok = delete_prefixed_dbs(<<"fabricbenchdb">>).
+
+delete_prefixed_dbs(Prefix) ->
+    {ok, Prefixed} = fabric:all_dbs(Prefix),
+    lists:foreach(
+        fun(Name) ->
+            ok = fabric:delete_db(Name)
+        end,
+        Prefixed
+    ).


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

In some cases, it's possible for databases created in previous test runs to cause test failures like this:
```
  fabric_bench_test:97: -with/1-fun-0- (t_db_deletion_ignores_other_dbs)...*failed*
in function fabric_bench_test:t_db_deletion_ignores_other_dbs/1 (test/eunit/fabric_bench_test.erl, line 76) in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71) in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531) in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356) in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514) in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456) in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 346) in call from eunit_proc:run_group/2 (eunit_proc.erl, line 570) **error:{badmatch,{error,file_exists}}
  output:<<"">>
```
This deletes databases created by the tests, and also preemptively deletes databases that might exist from previous test failures that were unable to clean up after themselves.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make eunit apps=fabric suites=fabric_bench_test
```
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
