### PR TITLE
fix(`mango`): remove duplicate elements from `indexable_fields/1` results

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2293,3 +2293,18 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Erlang/OTP
+Copyright Ericsson AB 1996-2023.  All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/couch/src/couch_lists.erl
+++ b/src/couch/src/couch_lists.erl
@@ -1,0 +1,40 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_lists).
+
+-export([uniq/1]).
+
+%% uniq/1: return a new list with the unique elements of the given list
+
+-spec uniq(List1) -> List2 when
+    List1 :: [T],
+    List2 :: [T],
+    T :: term().
+
+-if((?OTP_RELEASE) >= 25).
+uniq(L) ->
+    lists:uniq(L).
+-else.
+uniq(L) ->
+    uniq_1(L, #{}).
+
+uniq_1([X | Xs], M) ->
+    case is_map_key(X, M) of
+        true ->
+            uniq_1(Xs, M);
+        false ->
+            [X | uniq_1(Xs, M#{X => true})]
+    end;
+uniq_1([], _) ->
+    [].
+-endif.

--- a/src/couch/test/eunit/couch_lists_tests.erl
+++ b/src/couch/test/eunit/couch_lists_tests.erl
@@ -1,0 +1,30 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_lists_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+uniq_test_() ->
+    [
+        ?_assertEqual([], couch_lists:uniq([])),
+        ?_assertEqual(lists:seq(1, 100), couch_lists:uniq(lists:seq(1, 100))),
+        ?_assertEqual(lists:seq(100, 1, -1), couch_lists:uniq(lists:seq(100, 1, -1))),
+        ?_assertEqual(
+            [1, 2, 3, 4],
+            couch_lists:uniq([1, 2, 2, 3, 3, 3, 4, 4, 4, 4])
+        ),
+        ?_assertEqual(
+            [5, 1, 3, 2, 8],
+            couch_lists:uniq([5, 1, 1, 5, 5, 3, 2, 5, 3, 3, 2, 3, 8, 2, 2, 8])
+        )
+    ].

--- a/src/mango/src/mango_idx_nouveau.erl
+++ b/src/mango/src/mango_idx_nouveau.erl
@@ -307,7 +307,7 @@ construct_analyzer({Props}) ->
 
 indexable_fields(Selector) ->
     TupleTree = mango_selector_text:convert([], Selector),
-    indexable_fields([], TupleTree).
+    couch_lists:uniq(indexable_fields([], TupleTree)).
 
 indexable_fields(Fields, {op_and, Args}) when is_list(Args) ->
     lists:foldl(

--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -316,7 +316,7 @@ construct_analyzer({Props}) ->
     Fields :: [binary()].
 indexable_fields(Selector) ->
     TupleTree = mango_selector_text:convert([], Selector),
-    indexable_fields([], TupleTree).
+    couch_lists:uniq(indexable_fields([], TupleTree)).
 
 -spec indexable_fields(Fields, abstract_text_selector()) -> Fields when
     Fields :: [binary()].
@@ -505,6 +505,24 @@ indexable_fields_test() ->
                     <<"$not">> => #{<<"f5">> => <<"v5">>}
                 }
             )
+        )
+    ),
+    ?assertEqual(
+        [<<"f2:string">>, <<"f3:string">>, <<"f1:string">>],
+        indexable(
+            #{
+                <<"$and">> =>
+                    [
+                        #{<<"f2">> => <<"v1">>},
+                        #{<<"f2">> => <<"v2">>}
+                    ],
+                <<"$not">> => #{<<"f3">> => <<"v5">>},
+                <<"$or">> =>
+                    [
+                        #{<<"f1">> => <<"v3">>},
+                        #{<<"f1">> => <<"v4">>}
+                    ]
+            }
         )
     ),
     ?assertEqual(


### PR DESCRIPTION
Indexable fields from selectors are not de-duplicated when collected.  This means that every time when the same field is referenced in the selector, it will be added to the result.  This does not sound like a good practice in general, but addressing it would also make the implementation consistent with that of the view indexes.

In addition to all these, the change could help with exposing this information more cleanly when guiding the user in composing better queries.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
