### PR TITLE
fix(`mango`): chase `idx_text` changes for Nouveau

### DIFF
--- a/src/mango/src/mango_idx_nouveau.erl
+++ b/src/mango/src/mango_idx_nouveau.erl
@@ -346,8 +346,6 @@ indexable_fields(Fields, {op_not, {ExistsQuery, Arg}}) when is_tuple(Arg) ->
 % forces "$exists" : false to use _all_docs
 indexable_fields(_, {op_not, {_, false}}) ->
     [];
-indexable_fields(Fields, {op_insert, Arg}) when is_binary(Arg) ->
-    Fields;
 %% fieldname.[]:length is not a user defined field.
 indexable_fields(Fields, {op_field, {[_, <<":length">>], _}}) ->
     Fields;
@@ -362,6 +360,8 @@ indexable_fields(Fields, {op_fieldname, {_, _}}) ->
 %% Similar idea to op_fieldname but with fieldname:null
 indexable_fields(Fields, {op_null, {_, _}}) ->
     Fields;
+indexable_fields(Fields, {op_regex, Name}) ->
+    [iolist_to_binary([Name, ":string"]) | Fields];
 indexable_fields(Fields, {op_default, _}) ->
     [<<"$default">> | Fields].
 


### PR DESCRIPTION
Commit f40147b2 was not added for the Nouveau index module.  This could lead to a failure when `indexable_fields/1` is called with a selector that contains the `$regex` operator.