### PR TITLE
chore(`mango`): simplify implementation of empty selector tests

### DIFF
--- a/src/mango/test/21-empty-selector-tests.py
+++ b/src/mango/test/21-empty-selector-tests.py
@@ -10,82 +10,75 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-import json
 import mango
 import unittest
 import user_docs
-import math
 
 
-def make_empty_selector_suite(klass):
-    class EmptySelectorTestCase(klass):
-        def test_empty(self):
-            resp = self.db.find({}, explain=True)
-            self.assertEqual(resp["index"]["type"], "special")
+class EmptySelectorTests:
+    def test_empty(self):
+        resp = self.db.find({}, explain=True)
+        self.assertEqual(resp["index"]["type"], "special")
 
-        def test_empty_array_or(self):
-            resp = self.db.find({"$or": []}, explain=True)
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"$or": []})
-            assert len(docs) == 0
+    def test_empty_array_or(self):
+        resp = self.db.find({"$or": []}, explain=True)
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"$or": []})
+        assert len(docs) == 0
 
-        def test_empty_array_or_with_age(self):
-            resp = self.db.find({"age": 22, "$or": []}, explain=True)
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"age": 22, "$or": []})
-            assert len(docs) == 1
+    def test_empty_array_or_with_age(self):
+        resp = self.db.find({"age": 22, "$or": []}, explain=True)
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"age": 22, "$or": []})
+        assert len(docs) == 1
 
-        def test_empty_array_in_with_age(self):
-            resp = self.db.find({"age": 22, "company": {"$in": []}}, explain=True)
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"age": 22, "company": {"$in": []}})
-            assert len(docs) == 0
+    def test_empty_array_in_with_age(self):
+        resp = self.db.find({"age": 22, "company": {"$in": []}}, explain=True)
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"age": 22, "company": {"$in": []}})
+        assert len(docs) == 0
 
-        def test_empty_array_and_with_age(self):
-            resp = self.db.find({"age": 22, "$and": []}, explain=True)
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"age": 22, "$and": []})
-            assert len(docs) == 1
+    def test_empty_array_and_with_age(self):
+        resp = self.db.find({"age": 22, "$and": []}, explain=True)
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"age": 22, "$and": []})
+        assert len(docs) == 1
 
-        def test_empty_array_all_age(self):
-            resp = self.db.find({"age": 22, "company": {"$all": []}}, explain=True)
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"age": 22, "company": {"$all": []}})
-            assert len(docs) == 0
+    def test_empty_array_all_age(self):
+        resp = self.db.find({"age": 22, "company": {"$all": []}}, explain=True)
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"age": 22, "company": {"$all": []}})
+        assert len(docs) == 0
 
-        def test_empty_array_nested_all_with_age(self):
-            resp = self.db.find(
-                {"age": 22, "$and": [{"company": {"$all": []}}]}, explain=True
-            )
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"age": 22, "$and": [{"company": {"$all": []}}]})
-            assert len(docs) == 0
+    def test_empty_array_nested_all_with_age(self):
+        resp = self.db.find(
+            {"age": 22, "$and": [{"company": {"$all": []}}]}, explain=True
+        )
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"age": 22, "$and": [{"company": {"$all": []}}]})
+        assert len(docs) == 0
 
-        def test_empty_arrays_complex(self):
-            resp = self.db.find({"$or": [], "a": {"$in": []}}, explain=True)
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"$or": [], "a": {"$in": []}})
-            assert len(docs) == 0
+    def test_empty_arrays_complex(self):
+        resp = self.db.find({"$or": [], "a": {"$in": []}}, explain=True)
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"$or": [], "a": {"$in": []}})
+        assert len(docs) == 0
 
-        def test_empty_nin(self):
-            resp = self.db.find({"favorites": {"$nin": []}}, explain=True)
-            self.assertEqual(resp["index"]["type"], klass.INDEX_TYPE)
-            docs = self.db.find({"favorites": {"$nin": []}})
-            assert len(docs) == len(user_docs.DOCS)
-
-    return EmptySelectorTestCase
+    def test_empty_nin(self):
+        resp = self.db.find({"favorites": {"$nin": []}}, explain=True)
+        self.assertEqual(resp["index"]["type"], self.INDEX_TYPE)
+        docs = self.db.find({"favorites": {"$nin": []}})
+        assert len(docs) == len(user_docs.DOCS)
 
 
-class EmptySelectorNoIndexTests(
-    make_empty_selector_suite(mango.UserDocsTestsNoIndexes)
-):
+class EmptySelectorNoIndexTests(mango.UserDocsTestsNoIndexes, EmptySelectorTests):
     pass
 
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
-class EmptySelectorTextTests(make_empty_selector_suite(mango.UserDocsTextTests)):
+class EmptySelectorTextTests(mango.UserDocsTextTests, EmptySelectorTests):
     pass
 
 
-class EmptySelectorUserDocTests(make_empty_selector_suite(mango.UserDocsTests)):
+class EmptySelectorUserDocTests(mango.UserDocsTests, EmptySelectorTests):
     pass


### PR DESCRIPTION
Remove unused imports and make the definition of test suites less handcrafted via multiple inheritance.  This representation makes it possible for developers to add tests as class-specific methods when required, much like it happened for `03-operator-test`.