### PR TITLE
fix(config): updating values

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -112,16 +112,21 @@ handle_node_req(#httpd{path_parts = [_, _Node, <<"_config">>, _Section]} = Req) 
 % "value"
 handle_node_req(#httpd{method = 'PUT', path_parts = [_, Node, <<"_config">>, Section, Key]} = Req) ->
     couch_util:check_config_blacklist(Section),
-    Value = couch_util:trim(chttpd:json_body(Req)),
-    Persist = chttpd:header_value(Req, "X-Couch-Persist") /= "false",
-    OldValue = call_node(Node, config, get, [Section, Key, ""]),
-    IsSensitive = Section == <<"admins">>,
-    Opts = #{persist => Persist, sensitive => IsSensitive},
-    case call_node(Node, config, set, [Section, Key, ?b2l(Value), Opts]) of
-        ok ->
-            send_json(Req, 200, list_to_binary(OldValue));
-        {error, Reason} ->
-            chttpd:send_error(Req, {bad_request, Reason})
+    case chttpd:json_body(Req) of
+        JSONValue when is_binary(JSONValue) ->
+            Value = couch_util:trim(JSONValue),
+            Persist = chttpd:header_value(Req, "X-Couch-Persist") /= "false",
+            OldValue = call_node(Node, config, get, [Section, Key, ""]),
+            IsSensitive = Section == <<"admins">>,
+            Opts = #{persist => Persist, sensitive => IsSensitive},
+            case call_node(Node, config, set, [Section, Key, ?b2l(Value), Opts]) of
+                ok ->
+                    send_json(Req, 200, list_to_binary(OldValue));
+                {error, Reason} ->
+                    chttpd:send_error(Req, {bad_request, Reason})
+            end;
+        _ ->
+            chttpd:send_error(Req, {bad_request, <<"a JSON string expected">>})
     end;
 % GET /_node/$node/_config/Section/Key
 handle_node_req(#httpd{method = 'GET', path_parts = [_, Node, <<"_config">>, Section, Key]} = Req) ->

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -143,7 +143,8 @@
     "Reload config",
     "Server-side password hashing, and raw updates disabling that",
     "Settings can be altered with undefined whitelist allowing any change",
-    "Standard config options are present"
+    "Standard config options are present",
+    "Only JSON strings are accepted"
   ],
   "CookieAuthTest": [
     "cookie auth"

--- a/test/elixir/test/config_test.exs
+++ b/test/elixir/test/config_test.exs
@@ -181,4 +181,16 @@ defmodule ConfigTest do
 
     assert resp.status_code == 200
   end
+
+  # Those are negative test cases.  The positive cases are implicitly
+  # tested by other ones.
+  test "Only JSON strings are accepted", context do
+    url = "#{context[:config_url]}/a/b"
+    values = ["true", "11", "{}", "{\"testing\": [1, 2, 3]}"]
+
+    Enum.each(values, fn value ->
+      resp = Couch.put(url, body: value)
+      assert resp.status_code == 400
+    end)
+  end
 end


### PR DESCRIPTION
Configuration values could be updated by sending JSON strings as the body.  But there is no safeguard in place to stop users from submitting values of arbitrary JSON type, including objects. Violating this assumption silently triggers a HTTP 500 response. Fill in this hole and provide users with a cause of rejection.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
