### PR TITLE
split all

### DIFF
--- a/src/couch_replicator/src/couch_replicator_parse.erl
+++ b/src/couch_replicator/src/couch_replicator_parse.erl
@@ -283,7 +283,7 @@ cfg_atoms(Cfg, Default) ->
         undefined ->
             Default;
         V when is_list(V) ->
-            [list_to_atom(string:strip(S)) || S <- string:split(V, ",")]
+            [list_to_atom(string:strip(S)) || S <- string:split(V, ",", all)]
     end.
 
 cfg_sock_opts() ->


### PR DESCRIPTION
It is not currently possible to override `[replicator] valid_socket_options` with more than two items as we call `string:split/2`, which splits the string at the first occurrence of the separator. We need to call `string:split/3` with third argument of `all` to split out all the fields.