### PR TITLE
Conditionally exclude nouveau from elixir make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,11 @@ python-black-update: .venv/bin/black
 		--exclude="build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.nox/|\.tox/|\.venv/|src/rebar/pr2relnotes.py|src/fauxton" \
 		build-aux/*.py dev/run src/mango/test/*.py src/docs/src/conf.py src/docs/ext/*.py .
 
+-include install.mk
+ifeq ($(with_nouveau), 0)
+  exclude_nouveau=--exclude nouveau
+endif
+
 .PHONY: elixir
 elixir: export MIX_ENV=integration
 elixir: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
@@ -243,7 +248,7 @@ elixir: elixir-init devclean
 	@dev/run "$(TEST_OPTS)" -a adm:pass -n 1 \
 		--enable-erlang-views \
 		--locald-config test/elixir/test/config/test-config.ini \
-		--no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(EXUNIT_OPTS)'
+		--no-eval 'mix test --trace --exclude without_quorum_test --exclude with_quorum_test $(exclude_nouveau) $(EXUNIT_OPTS)'
 
 .PHONY: elixir-init
 elixir-init: MIX_ENV=integration
@@ -405,7 +410,6 @@ dist: all derived
 
 .PHONY: release
 # target: release - Create an Erlang release including CouchDB!
--include install.mk
 release: all
 	@echo "Installing CouchDB into rel/couchdb/ ..."
 	@rm -rf rel/couchdb

--- a/test/elixir/test/nouveau_test.exs
+++ b/test/elixir/test/nouveau_test.exs
@@ -1,7 +1,7 @@
 defmodule NouveauTest do
   use CouchTestCase
 
-  @moduletag :search
+  @moduletag :nouveau
 
   @moduledoc """
   Test search


### PR DESCRIPTION
Only run nouveau tests if configured with `--enable-nouveau`

sidebar: is it appropriate to move the `-include install.mk` directive? Its original placement was just before the install targets, but it seems necessary to know `with_nouveau = X` elsewhere.

A similar switch is needed for dreyfus. `make elixir` still fails if you are not running a clouseau jvm. this predates the nouveau work.
