### PR TITLE
Build Nouveau on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -98,7 +98,7 @@ TEST_OPTS=-c startup_jitter=0 -c default_security=admin_local
 
 .PHONY: all
 # target: all - Build everything
-all: couch fauxton docs
+all: couch fauxton docs nouveau
 
 
 .PHONY: help
@@ -140,9 +140,11 @@ fauxton: share\www
 .PHONY: check
 # target: check - Test everything
 check: all
+	@$(MAKE) exunit
 	@$(MAKE) eunit
 	@$(MAKE) mango-test
 	@$(MAKE) elixir-suite
+	@$(MAKE) nouveau-test
 
 ifdef apps
 subdirs = $(apps)
@@ -270,6 +272,10 @@ elixir-source-checks: elixir-init
 # target: build-report - Generate a build report
 build-report:
 	@$(PYTHON) build-aux/show-test-results.py --suites=10 --tests=10 > test-results.log
+	cat .\dev\logs\node1.log || true
+	cat .\dev\logs\nouveau.log || true
+	cat .\tmp\couch.log || true
+	cat test-results.log || true
 
 .PHONY: check-qs
 # target: check-qs - Run query server tests (ruby and rspec required!)
@@ -383,6 +389,12 @@ else
 endif
 endif
 
+ifeq ($(with_nouveau), 1)
+	-@mkdir -p rel\couchdb\nouveau
+	@cp nouveau\build\libs\server-*-dist.jar rel\couchdb\nouveau
+	@cp nouveau\nouveau.yaml rel\couchdb\nouveau
+endif
+
 	@echo ... done
 	@echo .
 	@echo     You can now copy the rel\couchdb directory anywhere on your system.
@@ -423,7 +435,9 @@ clean:
 	-@rmdir /s/q src\mango\.venv
 	-@del /f/q src\couch\priv\couch_js\config.h
 	-@del /f/q dev\boot_node.beam dev\pbkdf2.pyc log\crash.log
-
+ifeq ($(with_nouveau), 1)
+	@cd nouveau && .\gradlew clean
+endif
 
 .PHONY: distclean
 # target: distclean - Remove build and release artifacts
@@ -489,3 +503,35 @@ derived:
 	@echo "ON_TAG:                 $(ON_TAG)"
 	@echo "REL_TAG:                $(REL_TAG)"
 	@echo "SUB_VSN:                $(SUB_VSN)"
+
+
+################################################################################
+# Nouveau
+################################################################################
+
+.PHONY: nouveau
+# target: nouveau - Build nouveau
+nouveau:
+ifeq ($(with_nouveau), 1)
+	@cd nouveau && .\gradlew build -x test
+endif
+
+.PHONY: nouveau-test
+# target: nouveau-test - Run nouveau tests
+nouveau-test: nouveau-test-gradle nouveau-test-elixir
+
+.PHONY: nouveau-test-gradle
+nouveau-test-gradle: couch nouveau
+ifeq ($(with_nouveau), 1)
+	@cd nouveau && .\gradlew test
+endif
+
+.PHONY: nouveau-test-elixir
+nouveau-test-elixir: export MIX_ENV=integration
+nouveau-test-elixir: elixir-init devclean
+nouveau-test-elixir: couch nouveau
+ifeq ($(with_nouveau), 1)
+	@dev\run -n 1 -q -a adm:pass --with-nouveau \
+		--locald-config test/elixir/test/config/test-config.ini \
+		--no-eval 'mix test --trace --include test/elixir/test/config/nouveau.elixir'
+endif

--- a/configure.ps1
+++ b/configure.ps1
@@ -7,6 +7,7 @@
 
   -DisableFauxton            request build process skip building Fauxton (default false)
   -DisableDocs               request build process skip building documentation (default false)
+  -EnableNouveau             enable the new experiemtal search module (default false)
   -SkipDeps                  do not update Erlang dependencies (default false)
   -CouchDBUser USER          set the username to run as (defaults to current user)
   -SpiderMonkeyVersion VSN   select the version of SpiderMonkey to use (default 91)
@@ -43,6 +44,7 @@ Param(
     [switch]$Test = $false,
     [switch]$DisableFauxton = $false, # do not build Fauxton
     [switch]$DisableDocs = $false, # do not build any documentation or manpages
+    [switch]$EnableNouveau = $false, # dont use new search module by default
     [switch]$SkipDeps = $false, # do not update erlang dependencies
     [switch]$DisableProper = $false, # a compilation pragma. proper is a kind of automated test suite
     [switch]$EnableErlangMD5 = $false, # don't use Erlang for md5 hash operations by default
@@ -127,6 +129,7 @@ $InstallDir="$LibDir\couchdb"
 $LogFile="$LogDir\couch.log"
 $BuildFauxton = [int](-not $DisableFauxton)
 $BuildDocs = [int](-not $DisableDocs)
+$BuildNouveau = $(If ($EnableNouveau) {1} else {0})
 $Hostname = [System.Net.Dns]::GetHostEntry([string]"localhost").HostName
 $WithProper = (-not $DisableProper).ToString().ToLower()
 $ErlangMD5 = ($EnableErlangMD5).ToString().ToLower()
@@ -151,11 +154,12 @@ $CouchDBConfig = @"
 {prefix, "."}.
 {data_dir, "./data"}.
 {view_index_dir, "./data"}.
+{state_dir, "./data"}.
 {log_file, ""}.
 {fauxton_root, "./share/www"}.
 {user, "$CouchDBUser"}.
 {spidermonkey_version, "$SpiderMonkeyVersion"}.
-{node_name, "-name couchdb@localhost"}.
+{node_name, "-name couchdb@127.0.0.1"}.
 {cluster_port, 5984}.
 {backend_port, 5986}.
 {prometheus_port, 17986}.
@@ -196,6 +200,7 @@ man_dir = $ManDir
 
 with_fauxton = $BuildFauxton
 with_docs = $BuildDocs
+with_nouveau = $BuildNouveau
 
 user = $CouchDBUser
 spidermonkey_version = $SpiderMonkeyVersion

--- a/nouveau/.gitattributes
+++ b/nouveau/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/nouveau/.gitignore
+++ b/nouveau/.gitignore
@@ -5,3 +5,4 @@
 .vscode/
 .gradle/
 build/
+target/


### PR DESCRIPTION
Porting Nouveau to build on Windows.

Commands:

```
.\make.cmd
.\make.cmd nouveau-test
.\make.cmd clean
```

The clean target ends with the following error:
```
PS C:\Users\couchdb\Documents\couchdb> .\make.cmd clean
==> snappy (clean)
==> bear (clean)
==> meck (clean)
==> folsom (clean)
==> hyper (clean)
==> ibrowse (clean)
==> jiffy (clean)
==> mochiweb (clean)
==> recon (clean)
==> proper (clean)
==> couch_epi (clean)
==> config (clean)
==> couch_log (clean)
==> khash (clean)
WARN:  Missing plugins: [pc]
==> b64url (clean)
WARN:  Missing plugins: [pc]
==> exxhash (clean)
==> ets_lru (clean)
==> chttpd (clean)
==> couch (clean)
==> couch_event (clean)
==> mem3 (clean)
==> couch_index (clean)
==> couch_mrview (clean)
==> couch_replicator (clean)
==> couch_pse_tests (clean)
==> couch_stats (clean)
==> couch_peruser (clean)
==> couch_tests (clean)
==> couch_dist (clean)
==> custodian (clean)
==> ddoc_cache (clean)
==> dreyfus (clean)
==> nouveau (clean)
==> fabric (clean)
==> global_changes (clean)
==> ioq (clean)
==> jwtf (clean)
==> ken (clean)
==> mango (clean)
==> rexi (clean)
==> setup (clean)
==> smoosh (clean)
==> weatherreport (clean)
==> couch_prometheus (clean)
==> rel (clean)
==> couchdb (clean)
The system cannot find the file specified.
make: [Makefile.win:424: clean] Error 2 (ignored)
The filename, directory name, or volume label syntax is incorrect.
make: [Makefile.win:426: clean] Error 123 (ignored)
The filename, directory name, or volume label syntax is incorrect.
make: [Makefile.win:427: clean] Error 123 (ignored)
Could Not Find C:\Users\couchdb\Documents\couchdb\src\*.dll
Could Not Find C:\Users\couchdb\Documents\couchdb\src\couch\priv\*.exe
The system cannot find the file specified.
make: [Makefile.win:431: clean] Error 2 (ignored)
The system cannot find the file specified.
make: [Makefile.win:432: clean] Error 2 (ignored)
dev\logs\nouveau.log - The process cannot access the file because it is being used by another process.
The system cannot find the file specified.
make: [Makefile.win:435: clean] Error 2 (ignored)
Could Not Find C:\Users\couchdb\Documents\couchdb\src\couch\priv\couch_js\config.h
The system cannot find the file specified.
make: [Makefile.win:437: clean] Error 1 (ignored)
> Task :clean FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':clean'.
> java.io.IOException: Unable to delete directory 'C:\Users\couchdb\Documents\couchdb\nouveau\build'
    Failed to delete some children. This might happen because a process has files open or has its working directory set in the target directory.
    - C:\Users\couchdb\Documents\couchdb\nouveau\build\libs\server-1.0-SNAPSHOT-dist.jar
    - C:\Users\couchdb\Documents\couchdb\nouveau\build\libs

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
1 actionable task: 1 executed
make: *** [Makefile.win:438: clean] Error 1
```

It seems, nouveau isn't shutting down properly by our `dev/run` script. Needs additional investigation.