### PR TITLE
[shard splitting] allow resumption of failed jobs & make timeout configurable

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -373,6 +373,8 @@ hash_algorithms = sha256, sha
 ;buffer_count = 2000
 ;server_per_node = true
 ;stream_limit = 5
+;shard_split_timeout_msec = 600000
+;shard_split_topoff_batch_size = 500
 
 ; Use a single message to kill a group of remote workers. This feature is
 ; available starting with 3.0. When performing a rolling upgrade from 2.x to

--- a/src/mem3/src/mem3_reshard.erl
+++ b/src/mem3/src/mem3_reshard.erl
@@ -266,7 +266,7 @@ handle_call({resume_job, _}, _From, #state{state = stopped} = State) ->
 handle_call({resume_job, Id}, _From, State) ->
     couch_log:notice("~p resume_job call ~p", [?MODULE, Id]),
     case job_by_id(Id) of
-        #job{job_state = stopped} = Job ->
+        #job{job_state = JobState} = Job when JobState == stopped; JobState == failed ->
             case start_job_int(Job, State) of
                 ok ->
                     {reply, ok, State};

--- a/src/mem3/src/mem3_rpc.erl
+++ b/src/mem3/src/mem3_rpc.erl
@@ -18,6 +18,7 @@
     find_common_seq/4,
     get_missing_revs/4,
     update_docs/4,
+    update_docs/5,
     pull_replication/1,
     load_checkpoint/4,
     load_checkpoint/5,
@@ -61,6 +62,8 @@ get_missing_revs(Node, DbName, IdsRevs, Options) ->
 
 update_docs(Node, DbName, Docs, Options) ->
     rexi_call(Node, {fabric_rpc, update_docs, [DbName, Docs, Options]}).
+update_docs(Node, DbName, Docs, Options, Timeout) ->
+    rexi_call(Node, {fabric_rpc, update_docs, [DbName, Docs, Options]}, Timeout).
 
 load_checkpoint(Node, DbName, SourceNode, SourceUUID, <<>>) ->
     % Upgrade clause for a mixed cluster for old nodes that don't have


### PR DESCRIPTION
failed jobs should be restartable, and with the ioq downgrade of reshard jobs, we need to make the timeout configurable, so busy clusters do not fail for no good reason.