### PR TITLE
Introduce optional countermeasures as we run out of disk space

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -898,3 +898,9 @@ port = {{prometheus_port}}
 
 [nouveau]
 enable = {{with_nouveau}}
+
+[disk_monitor]
+;enable = false
+;background_view_indexing_threshold = 80
+;interactive_view_indexing_threshold = 90
+;interactive_database_writes_threshold = 90

--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -122,3 +122,15 @@
 # in the features list.
 #
 #-crypto fips_mode true
+
+# OS Mon Settings
+
+# only start disksup
+-os_mon start_cpu_sup false
+-os_mon start_memsup false
+
+# Check disk space every 5 minutes
+-os_mon disk_space_check_interval 5
+
+# don't let disksup send alerts
+-os_mon disk_almost_full_threshold 1.0

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -23,6 +23,7 @@
         sasl,
         ssl,
         stdlib,
+        os_mon,
         syntax_tools,
         xmerl,
         %% couchdb
@@ -84,6 +85,7 @@
     {app, sasl, [{incl_cond, include}]},
     {app, ssl, [{incl_cond, include}]},
     {app, stdlib, [{incl_cond, include}]},
+    {app, os_mon, [{incl_cond, include}]},
     {app, syntax_tools, [{incl_cond, include}]},
     {app, xmerl, [{incl_cond, include}]},
 

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1138,6 +1138,8 @@ error_info(timeout) ->
     >>};
 error_info({service_unavailable, Reason}) ->
     {503, <<"service unavailable">>, Reason};
+error_info({insufficient_storage, Reason}) ->
+    {507, <<"insufficent_storage">>, Reason};
 error_info({timeout, _Reason}) ->
     error_info(timeout);
 error_info({'EXIT', {Error, _Stack}}) ->

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -266,6 +266,10 @@
     {type, counter},
     {desc, <<"number of HTTP 503 Service unavailable responses">>}
 ]}.
+{[couchdb, httpd_status_codes, 507], [
+    {type, counter},
+    {desc, <<"number of HTTP 507 Insufficient Storage responses">>}
+]}.
 {[couchdb, open_databases], [
     {type, counter},
     {desc,  <<"number of open databases">>}

--- a/src/couch/src/couch.app.src
+++ b/src/couch/src/couch.app.src
@@ -33,6 +33,7 @@
         sasl,
         inets,
         ssl,
+        os_mon,
 
         % Upstream deps
         ibrowse,

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1338,6 +1338,15 @@ update_docs(Db, Docs0, Options, ?REPLICATED_CHANGES) ->
     ),
     {ok, DocErrors};
 update_docs(Db, Docs0, Options, ?INTERACTIVE_EDIT) ->
+    BlockInteractiveDatabaseWrites = couch_disk_monitor:block_interactive_database_writes(),
+    if
+        BlockInteractiveDatabaseWrites ->
+            {ok, [{insufficient_storage, <<"database_dir is too full">>} || _ <- Docs0]};
+        true ->
+            update_docs_interactive(Db, Docs0, Options)
+    end.
+
+update_docs_interactive(Db, Docs0, Options) ->
     Docs = tag_docs(Docs0),
 
     AllOrNothing = lists:member(all_or_nothing, Options),

--- a/src/couch/src/couch_disk_monitor.erl
+++ b/src/couch/src/couch_disk_monitor.erl
@@ -1,0 +1,241 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_disk_monitor).
+-behaviour(gen_server).
+
+% public api
+-export([
+    block_background_view_indexing/0,
+    block_interactive_view_indexing/0,
+    block_interactive_database_writes/0
+]).
+
+% testing
+-export([
+    set_database_dir_percent_used/1,
+    set_view_index_dir_percent_used/1
+]).
+
+% gen_server callbacks
+-export([
+    start_link/0,
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-include_lib("kernel/include/file.hrl").
+
+-define(SECTION, "disk_monitor").
+
+-record(st, {
+    timer
+}).
+
+block_background_view_indexing() ->
+    Enabled = enabled(),
+    if
+        Enabled ->
+            view_index_dir_percent_used() > background_view_indexing_threshold();
+        true ->
+            false
+    end.
+
+block_interactive_view_indexing() ->
+    Enabled = enabled(),
+    if
+        Enabled -> view_index_dir_percent_used() > interactive_view_indexing_threshold();
+        true -> false
+    end.
+
+block_interactive_database_writes() ->
+    Enabled = enabled(),
+    if
+        Enabled -> database_dir_percent_used() > interactive_database_writes_threshold();
+        true -> false
+    end.
+
+set_database_dir_percent_used(PercentUsed) when PercentUsed >= 0, PercentUsed =< 100 ->
+    gen_server:call(?MODULE, {set_database_dir_percent_used, PercentUsed}).
+
+set_view_index_dir_percent_used(PercentUsed) when PercentUsed >= 0, PercentUsed =< 100 ->
+    gen_server:call(?MODULE, {set_view_index_dir_percent_used, PercentUsed}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init(_Args) ->
+    ets:new(?MODULE, [named_table, {read_concurrency, true}]),
+    ets:insert(?MODULE, {database_dir, 0}),
+    ets:insert(?MODULE, {view_index_dir, 0}),
+    update_disk_data(),
+    TRef = erlang:send_after(timer_interval(), self(), update_disk_data),
+    {ok, #st{timer = TRef}}.
+
+handle_call({set_database_dir_percent_used, PercentUsed}, _From, St) ->
+    ets:insert(?MODULE, {database_dir, PercentUsed}),
+    {reply, ok, St};
+handle_call({set_view_index_dir_percent_used, PercentUsed}, _From, St) ->
+    ets:insert(?MODULE, {view_index_dir, PercentUsed}),
+    {reply, ok, St};
+handle_call(_Msg, _From, St) ->
+    {reply, {error, unknown_msg}, St}.
+
+handle_cast(_Msg, St) ->
+    {noreply, St}.
+
+handle_info(update_disk_data, St) ->
+    erlang:cancel_timer(St#st.timer),
+    update_disk_data(),
+    TRef = erlang:send_after(timer_interval(), self(), update_disk_data),
+    {noreply, St#st{timer = TRef}};
+handle_info(_Msg, St) ->
+    {noreply, St}.
+
+update_disk_data() ->
+    DiskData = disksup:get_disk_data(),
+    update_disk_data(DiskData).
+
+update_disk_data([]) ->
+    ok;
+update_disk_data([{Id, _, PercentUsed} | Rest]) ->
+    IsDatabaseDir = is_database_dir(Id),
+    IsViewIndexDir = is_view_index_dir(Id),
+    if
+        IsDatabaseDir ->
+            ets:insert(?MODULE, {database_dir, PercentUsed});
+        true ->
+            ok
+    end,
+    if
+        IsViewIndexDir ->
+            ets:insert(?MODULE, {view_index_dir, PercentUsed});
+        true ->
+            ok
+    end,
+    update_disk_data(Rest).
+
+is_database_dir(MntOn) ->
+    same_device(config:get("couchdb", "database_dir"), MntOn).
+
+is_view_index_dir(MntOn) ->
+    same_device(config:get("couchdb", "view_index_dir"), MntOn).
+
+same_device(DirA, DirB) ->
+    case {device_id(DirA), device_id(DirB)} of
+        {{ok, DeviceId}, {ok, DeviceId}} ->
+            true;
+        _Else ->
+            false
+    end.
+
+device_id(Dir) ->
+    case file:read_file_info(Dir) of
+        {ok, FileInfo} ->
+            {ok, {FileInfo#file_info.minor_device, FileInfo#file_info.major_device}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+database_dir_percent_used() ->
+    [{database_dir, PercentUsed}] = ets:lookup(?MODULE, database_dir),
+    PercentUsed.
+
+view_index_dir_percent_used() ->
+    [{view_index_dir, PercentUsed}] = ets:lookup(?MODULE, view_index_dir),
+    PercentUsed.
+
+background_view_indexing_threshold() ->
+    config:get_integer(?SECTION, "background_view_indexing_threshold", 80).
+
+interactive_view_indexing_threshold() ->
+    config:get_integer(?SECTION, "interactive_view_indexing_threshold", 90).
+
+interactive_database_writes_threshold() ->
+    config:get_integer(?SECTION, "interactive_database_writes_threshold", 90).
+
+enabled() ->
+    config:get_boolean(?SECTION, "enable", false).
+
+%% Align our refresh with the os_mon refresh
+timer_interval() ->
+    disksup:get_check_interval().
+
+-ifdef(TEST).
+-include_lib("couch/include/couch_eunit.hrl").
+
+not_enabled_by_default_test() ->
+    ?assertEqual(false, enabled()),
+    ?assertEqual(false, block_background_view_indexing()),
+    ?assertEqual(false, block_interactive_view_indexing()),
+    ?assertEqual(false, block_interactive_database_writes()).
+
+setup_all() ->
+    Ctx = test_util:start_couch(),
+    config:set_boolean("disk_monitor", "enable", true, _Persist = false),
+    Ctx.
+
+teardown_all(Ctx) ->
+    test_util:stop_couch(Ctx).
+
+setup() ->
+    ok.
+
+teardown(_) ->
+    ok.
+
+enabled_test_() ->
+    {
+        setup,
+        fun setup_all/0,
+        fun teardown_all/1,
+        {
+            foreach,
+            fun setup/0,
+            fun teardown/1,
+            [
+                ?TDEF_FE(block_background_view_indexing_test),
+                ?TDEF_FE(block_interactive_view_indexing_test),
+                ?TDEF_FE(block_interactive_database_writes_test),
+                ?TDEF_FE(update_disk_data_test)
+            ]
+        }
+    }.
+
+block_background_view_indexing_test(_) ->
+    ?assert(enabled()),
+    set_view_index_dir_percent_used(80),
+    ?assertEqual(false, block_background_view_indexing()),
+    set_view_index_dir_percent_used(81),
+    ?assertEqual(true, block_background_view_indexing()).
+
+block_interactive_view_indexing_test(_) ->
+    ?assert(enabled()),
+    set_view_index_dir_percent_used(90),
+    ?assertEqual(false, block_interactive_view_indexing()),
+    set_view_index_dir_percent_used(91),
+    ?assertEqual(true, block_interactive_view_indexing()).
+
+block_interactive_database_writes_test(_) ->
+    ?assert(enabled()),
+    set_database_dir_percent_used(90),
+    ?assertEqual(false, block_interactive_database_writes()),
+    set_database_dir_percent_used(91),
+    ?assertEqual(true, block_interactive_database_writes()).
+
+update_disk_data_test(_) ->
+    whereis(?MODULE) ! update_disk_data,
+    ?assertEqual({error, unknown_msg}, gen_server:call(?MODULE, foo)).
+
+-endif.

--- a/src/couch/src/couch_secondary_sup.erl
+++ b/src/couch/src/couch_secondary_sup.erl
@@ -26,7 +26,8 @@ init([]) ->
         [
             {query_servers, {couch_proc_manager, start_link, []}},
             {vhosts, {couch_httpd_vhost, start_link, []}},
-            {uuids, {couch_uuids, start, []}}
+            {uuids, {couch_uuids, start, []}},
+            {disk_manager, {couch_disk_monitor, start_link, []}}
         ] ++ couch_index_servers(),
 
     MaybeHttp =

--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -291,8 +291,8 @@ query_view(Db, DDoc, VName, Args0, Callback, Acc0) ->
                     _ -> {ok, Acc0}
                 end,
             query_view(Db, VInfo, Args, Callback, Acc1);
-        ddoc_updated ->
-            Callback(ok, ddoc_updated)
+        Error when Error == ddoc_updated; Error == insufficient_storage ->
+            Callback(ok, Error)
     end.
 
 get_view_index_pid(Db, DDoc, ViewName, Args0) ->
@@ -752,8 +752,8 @@ default_cb({final, Info}, []) ->
     {ok, [Info]};
 default_cb({final, _}, Acc) ->
     {ok, Acc};
-default_cb(ok, ddoc_updated) ->
-    {ok, ddoc_updated};
+default_cb(ok, Error) when Error == ddoc_updated; Error == insufficient_storage ->
+    {ok, Error};
 default_cb(Row, Acc) ->
     {ok, [Row | Acc]}.
 

--- a/src/docs/src/config/disk-monitor.rst
+++ b/src/docs/src/config/disk-monitor.rst
@@ -1,0 +1,76 @@
+.. Licensed under the Apache License, Version 2.0 (the "License"); you may not
+.. use this file except in compliance with the License. You may obtain a copy of
+.. the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+.. WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+.. License for the specific language governing permissions and limitations under
+.. the License.
+
+.. default-domain:: config
+.. highlight:: ini
+
+==========================
+Disk Monitor Configuration
+==========================
+
+Apache CouchDB can react proactively when disk space gets low.
+
+.. _config/disk_monitor:
+
+Disk Monitor Options
+====================
+
+.. config:section:: disk_monitor :: Disk Monitor Options
+
+  .. versionadded:: 3.4
+
+    .. config:option:: background_view_indexing_threshold
+
+        The percentage of used disk space on the ``view_index_dir`` above
+        which CouchDB will no longer start background view indexing jobs.
+        Defaults to ``80``. ::
+
+            [disk_monitor]
+            background_view_indexing_threshold = 80
+
+    .. config:option:: interactive_database_writes_threshold
+
+        The percentage of used disk space on the ``database_dir`` above
+        which CouchDB will no longer allow interactive document updates
+        (writes or deletes).
+
+        Replicated updates and database deletions are still permitted.
+
+        In a clustered write an error will be returned if
+        enough nodes are above the ``interactive_database_writes_threshold``.
+
+        Defaults to ``90``. ::
+
+            [disk_monitor]
+            interactive_database_writes_threshold = 90
+
+    .. config:option:: enable :: enable disk monitoring
+
+        Enable disk monitoring subsystem. Defaults to ``false``. ::
+
+            [disk_monitor]
+            enable = false
+
+    .. config:option:: interactive_view_indexing_threshold
+
+        The percentage of used disk space on the ``view_index_dir`` above
+        which CouchDB will no longer update stale view indexes when queried.
+
+        View indexes that are already up to date can still be queried, and stale
+        view indexes can be queried if either ``stale=ok`` or ``update=false`` are
+        set.
+
+        Attempts to query a stale index without either parameter will yield a
+        ``507 Insufficient Storage`` error. Defaults to ``90``. ::
+
+            [disk_monitor]
+            interactive_view_indexing_threshold = 90

--- a/src/docs/src/config/index.rst
+++ b/src/docs/src/config/index.rst
@@ -23,6 +23,7 @@ Configuration
     couchdb
     cluster
     couch-peruser
+    disk-monitor
     http
     auth
     compaction

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -493,7 +493,9 @@ view_cb(complete, Acc) ->
     ok = rexi:stream_last(complete),
     {ok, Acc};
 view_cb(ok, ddoc_updated) ->
-    rexi:reply({ok, ddoc_updated}).
+    rexi:reply({ok, ddoc_updated});
+view_cb(ok, insufficient_storage) ->
+    rexi:reply({ok, insufficient_storage}).
 
 reduce_cb({meta, Meta}, Acc) ->
     % Map function starting
@@ -511,7 +513,9 @@ reduce_cb(complete, Acc) ->
     ok = rexi:stream_last(complete),
     {ok, Acc};
 reduce_cb(ok, ddoc_updated) ->
-    rexi:reply({ok, ddoc_updated}).
+    rexi:reply({ok, ddoc_updated});
+reduce_cb(ok, insufficient_storage) ->
+    rexi:reply({ok, insufficient_storage}).
 
 changes_enumerator(#full_doc_info{} = FDI, Acc) ->
     changes_enumerator(couch_doc:to_doc_info(FDI), Acc);

--- a/src/fabric/src/fabric_streams.erl
+++ b/src/fabric/src/fabric_streams.erl
@@ -144,11 +144,11 @@ handle_stream_start(rexi_STREAM_INIT, {Worker, From}, St) ->
                     {stop, St#stream_acc{workers = [], ready = Ready1}}
             end
     end;
-handle_stream_start({ok, ddoc_updated}, _, St) ->
+handle_stream_start({ok, Error}, _, St) when Error == ddoc_updated; Error == insufficient_storage ->
     WaitingWorkers = [W || {W, _} <- St#stream_acc.workers],
     ReadyWorkers = [W || {W, _} <- St#stream_acc.ready],
     cleanup(WaitingWorkers ++ ReadyWorkers),
-    {stop, ddoc_updated};
+    {stop, Error};
 handle_stream_start(Else, _, _) ->
     exit({invalid_stream_start, Else}).
 

--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -419,7 +419,14 @@ maybe_update_others(
     ViewName,
     #mrargs{update = lazy} = Args
 ) ->
-    ShardsNeedUpdated = mem3:shards(DbName) -- ShardsInvolved,
+    BlockInteractiveIndexing = couch_disk_monitor:block_interactive_view_indexing(),
+    ShardsNeedUpdated =
+        case BlockInteractiveIndexing of
+            true ->
+                [];
+            false ->
+                mem3:shards(DbName) -- ShardsInvolved
+        end,
     lists:foreach(
         fun(#shard{node = Node, name = ShardName}) ->
             rpc:cast(Node, fabric_rpc, update_mrview, [ShardName, DDoc, ViewName, Args])

--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -56,6 +56,10 @@ go(Db, Options, DDoc, View, Args0, Callback, Acc, VInfo) ->
         of
             {ok, ddoc_updated} ->
                 Callback({error, ddoc_updated}, Acc);
+            {ok, insufficient_storage} ->
+                Callback(
+                    {error, {insufficient_storage, <<"not enough room to update index">>}}, Acc
+                );
             {ok, Workers} ->
                 try
                     go(DbName, Workers, VInfo, CoordArgs, Callback, Acc)
@@ -207,6 +211,8 @@ handle_message({execution_stats, _} = Msg, {_, From}, St) ->
     rexi:stream_ack(From),
     {Go, St#collector{user_acc = Acc}};
 handle_message(ddoc_updated, _Worker, State) ->
+    {stop, State};
+handle_message(insufficient_storage, _Worker, State) ->
     {stop, State}.
 
 merge_row(Dir, Collation, undefined, Row, Rows0) ->

--- a/src/fabric/src/fabric_view_reduce.erl
+++ b/src/fabric/src/fabric_view_reduce.erl
@@ -47,6 +47,8 @@ go(Db, DDoc, VName, Args, Callback, Acc, VInfo) ->
         of
             {ok, ddoc_updated} ->
                 Callback({error, ddoc_updated}, Acc);
+            {ok, insufficient_storage} ->
+                Callback({error, insufficient_storage}, Acc);
             {ok, Workers} ->
                 try
                     go2(DbName, Workers, VInfo, CoordArgs, Callback, Acc)
@@ -175,6 +177,8 @@ handle_message(complete, Worker, #collector{counters = Counters0} = State) ->
     C1 = fabric_dict:update_counter(Worker, 1, Counters0),
     fabric_view:maybe_send_row(State#collector{counters = C1});
 handle_message(ddoc_updated, _Worker, State) ->
+    {stop, State};
+handle_message(insufficient_storage, _Worker, State) ->
     {stop, State}.
 
 os_proc_needed(<<"_", _/binary>>) -> false;

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -194,6 +194,11 @@
     "design doc options - include_desing=true",
     "design doc options - local_seq=true"
   ],
+  "DiskMonitorTest": [
+    "block background view indexing",
+    "block interactive view indexing",
+    "block interactive database writes"
+  ],
   "DesignPathTest": [
     "design doc path",
     "design doc path with slash in db name"

--- a/test/elixir/test/disk_monitor.exs
+++ b/test/elixir/test/disk_monitor.exs
@@ -1,0 +1,55 @@
+defmodule DiskMonitorTest do
+  use CouchTestCase
+
+  @moduletag :disk_monitor
+
+  setup_all do
+    set_config({"disk_monitor", "enable", "true"})
+    :ok
+  end
+
+  @tag :with_db
+  test "block background view indexing", context do
+    set_config({"disk_monitor", "background_view_indexing_threshold", "0"})
+    set_config({"disk_monitor", "interactive_view_indexing_threshold", "100"})
+
+    db_name = context[:db_name]
+    resp = Couch.post("/#{db_name}", body: %{:_id => "foo"})
+    assert resp.status_code == 201
+
+    map_doc = %{:views => %{:bar => %{:map => "function(doc) { emit(); }"}}}
+    assert Couch.put("/#{db_name}/_design/foo", body: map_doc).body["ok"]
+    :timer.sleep(500)
+    resp = Couch.get("/#{db_name}/_design/foo/_view/bar?stale=ok")
+    assert resp.body["total_rows"] == 0
+    resp = Couch.get("/#{db_name}/_design/foo/_view/bar")
+    assert resp.body["total_rows"] == 1
+  end
+
+  @tag :with_db
+  test "block interactive view indexing", context do
+    set_config({"disk_monitor", "background_view_indexing_threshold", "100"})
+    set_config({"disk_monitor", "interactive_view_indexing_threshold", "0"})
+
+    db_name = context[:db_name]
+    resp = Couch.post("/#{db_name}", body: %{:_id => "foo"})
+    assert resp.status_code == 201
+
+    map_doc = %{:views => %{:bar => %{:map => "function(doc) { emit(); }"}}}
+    assert Couch.put("/#{db_name}/_design/foo", body: map_doc).body["ok"]
+    resp = Couch.get("/#{db_name}/_design/foo/_view/bar")
+    assert resp.status_code == 507
+    resp = Couch.get("/#{db_name}/_design/foo/_view/bar?stale=ok")
+    assert resp.status_code == 200
+  end
+
+  @tag :with_db
+  test "block interactive database writes", context do
+    set_config({"disk_monitor", "interactive_database_writes_threshold", "0"})
+
+    db_name = context[:db_name]
+    resp = Couch.post("/#{db_name}", body: %{:_id => "foo"})
+    assert resp.status_code == 507
+  end
+
+end


### PR DESCRIPTION
## Overview

Add some opt-in countermeasures if disk space gets critically low, with the aim of avoiding hitting end of disk.

## Testing recommendations

Enable the disk monitor, run a CouchDB node on a small disk, and add lots of data. You should find that background indexing stops (at 80% full) and then stale view queries and database updates are blocked. Reduce disk usage (allow compaction to run to completion, or delete databases) and see both interventions automatically unlock. 

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
