### PR TITLE
fix(`mango`): tweak the formatting of option r in the _explain output

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -1472,9 +1472,7 @@ it easier to take advantage of future improvements to query planning
                     "year",
                     "title"
                 ],
-                "r": [
-                    49
-                ],
+                "r": 1,
                 "conflicts": false,
                 "execution_stats": false,
                 "partition": "",

--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -65,7 +65,17 @@ explain(#cursor{} = Cursor) ->
         fields = Fields
     } = Cursor,
     Mod = mango_idx:cursor_mod(Idx),
-    Opts = lists:keydelete(user_ctx, 1, Opts0),
+    Opts1 = lists:keydelete(user_ctx, 1, Opts0),
+    % The value of `r` needs to be translated to an integer
+    % otherwise `jiffy:encode/1` will render it as an array.
+    RValue = lists:keyfind(r, 1, Opts1),
+    Opts =
+        case RValue of
+            {r, R} ->
+                lists:keyreplace(r, 1, Opts1, {r, list_to_integer(R)});
+            false ->
+                Opts1
+        end,
     {
         [
             {dbname, mango_idx:dbname(Idx)},

--- a/src/mango/test/02-basic-find-test.py
+++ b/src/mango/test/02-basic-find-test.py
@@ -294,6 +294,23 @@ class BasicFindTests(mango.UserDocsTests):
         assert explain["mrargs"]["end_key"] == ["<MAX>"]
         assert explain["mrargs"]["include_docs"] == True
 
+    def test_explain_options(self):
+        explain = self.db.find({"age": {"$gt": 0}}, fields=["manager"], explain=True)
+        opts = explain["opts"]
+        assert opts["r"] == 1
+        assert opts["limit"] == 25
+        assert opts["skip"] == 0
+        assert opts["fields"] == ["manager"]
+        assert opts["sort"] == {}
+        assert opts["bookmark"] == "nil"
+        assert opts["conflicts"] == False
+        assert opts["execution_stats"] == False
+        assert opts["partition"] == ""
+        assert opts["stable"] == False
+        assert opts["stale"] == False
+        assert opts["update"] == True
+        assert opts["use_index"] == []
+
     def test_sort_with_all_docs(self):
         explain = self.db.find(
             {"_id": {"$gt": 0}, "age": {"$gt": 0}}, sort=["_id"], explain=True


### PR DESCRIPTION
Currently, the `r` query option (for read quorum) is formatted in an awkward way when added to the `_explain` JSON response (excerpt, `r` is set to `1` in the query object):

```json
 ...
 "opts": {
    ...
    "r": [
      49
    ],
    ...
  },
 ...
```

The value there is the ASCII code of `1` and the nesting list denotes the string.  That is because `r` is stored as a list internally and when it comes to rendering, `jiffy` will interpret the contents as an array.  Treat this issue locally, in the `_explain` code, by turning it an integer.

Thanks @ricellis for spotting this bug!

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Documentation changes were made in the `src/docs` folder
