### PR TITLE
allow locale setting for number detection

### DIFF
--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/SearchRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/SearchRequest.java
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.couchdb.nouveau.core.ser.PrimitiveWrapper;
 
@@ -30,6 +31,8 @@ public class SearchRequest {
 
     @NotNull
     private String query;
+
+    private Locale locale;
 
     private String partition;
 
@@ -59,6 +62,15 @@ public class SearchRequest {
     @JsonProperty
     public String getQuery() {
         return query;
+    }
+
+    public void setLocale(final Locale locale) {
+        this.locale = locale;
+    }
+
+    @JsonProperty
+    public Locale getLocale() {
+        return locale;
     }
 
     public void setPartition(final String partition) {
@@ -142,7 +154,7 @@ public class SearchRequest {
 
     @Override
     public String toString() {
-        return "SearchRequest [query=" + query + ", sort=" + sort + ", limit=" + limit + ", after=" + after
-                + ", counts=" + counts + ", ranges=" + ranges + "]";
+        return "SearchRequest [query=" + query + ", locale=" + locale + ", sort=" + sort + ", limit=" + limit
+                + ", after=" + after + ", counts=" + counts + ", ranges=" + ranges + "]";
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9Index.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9Index.java
@@ -489,7 +489,7 @@ public class Lucene9Index extends Index {
     }
 
     private Query parse(final SearchRequest request) {
-        var queryParser = new NouveauQueryParser(analyzer);
+        var queryParser = new NouveauQueryParser(analyzer, request.getLocale());
         Query result;
         try {
             result = queryParser.parse(request.getQuery(), "default");

--- a/nouveau/src/test/java/org/apache/couchdb/nouveau/lucene9/NouveauQueryParserTest.java
+++ b/nouveau/src/test/java/org/apache/couchdb/nouveau/lucene9/NouveauQueryParserTest.java
@@ -15,6 +15,7 @@ package org.apache.couchdb.nouveau.lucene9;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Locale;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.index.Term;
@@ -34,7 +35,7 @@ public class NouveauQueryParserTest {
 
     @BeforeAll
     public static void setup() {
-        qp = new NouveauQueryParser(new StandardAnalyzer());
+        qp = new NouveauQueryParser(new StandardAnalyzer(), Locale.US);
     }
 
     @Test
@@ -99,5 +100,17 @@ public class NouveauQueryParserTest {
     public void testOpenRightPointRangeQueryLegacy() throws Exception {
         assertThat(qp.parse("foo:[1.0 TO Infinity]", DEFAULT_FIELD))
                 .isEqualTo(DoublePoint.newRangeQuery("foo", new double[] {1}, new double[] {Double.POSITIVE_INFINITY}));
+    }
+
+    @Test
+    public void testLocales() throws Exception {
+        var us = new NouveauQueryParser(new StandardAnalyzer(), Locale.US);
+        var de = new NouveauQueryParser(new StandardAnalyzer(), Locale.GERMAN);
+
+        assertThat(us.parse("foo:[10.0 TO 20.0]", DEFAULT_FIELD))
+                .isEqualTo(DoublePoint.newRangeQuery("foo", new double[] {10}, new double[] {20}));
+
+        assertThat(de.parse("foo:[10.0 TO 20.0]", DEFAULT_FIELD))
+                .isEqualTo(DoublePoint.newRangeQuery("foo", new double[] {100}, new double[] {200}));
     }
 }

--- a/src/docs/src/api/ddoc/nouveau.rst
+++ b/src/docs/src/api/ddoc/nouveau.rst
@@ -46,6 +46,9 @@
         name among the documents that match the search query.
     :query boolean include_docs: Include the full content of the documents in the
         response.
+    :query string locale: The (Java) locale used to parse numbers in range queries.
+        Defaults to the JDK default locale if not specified. Some examples are ``de``
+        , ``us``, ``gb``.
     :query number limit: Limit the number of the returned documents to the specified
         number. For a grouped search, this parameter limits the number of documents per
         group.

--- a/src/nouveau/src/nouveau_httpd.erl
+++ b/src/nouveau/src/nouveau_httpd.erl
@@ -65,6 +65,7 @@ handle_search_req_int(#httpd{method = 'GET', path_parts = [_, _, _, _, IndexName
     DbName = couch_db:name(Db),
     QueryArgs = validate_query_args(#{
         query => chttpd:qs_value(Req, "q"),
+        locale => chttpd:qs_value(Req, "locale"),
         partition => chttpd:qs_value(Req, "partition"),
         limit => chttpd:qs_value(Req, "limit"),
         sort => chttpd:qs_value(Req, "sort"),
@@ -83,6 +84,7 @@ handle_search_req_int(
     ReqBody = chttpd:json_body(Req, [return_maps]),
     QueryArgs = validate_query_args(#{
         query => maps:get(<<"q">>, ReqBody, undefined),
+        locale => maps:get(<<"locale">>, ReqBody, undefined),
         partition => chttpd:qs_value(Req, "partition"),
         limit => maps:get(<<"limit">>, ReqBody, undefined),
         sort => json_or_undefined(<<"sort">>, ReqBody),
@@ -176,6 +178,10 @@ validate_query_args(#{} = QueryArgs) ->
 validate_query_arg(query, undefined) ->
     throw({query_parse_error, <<"q parameter is mandatory">>});
 validate_query_arg(query, Val) when is_list(Val); is_binary(Val) ->
+    couch_util:to_binary(Val);
+validate_query_arg(locale, undefined) ->
+    null;
+validate_query_arg(locale, Val) when is_list(Val); is_binary(Val) ->
     couch_util:to_binary(Val);
 validate_query_arg(partition, undefined) ->
     null;

--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -6,6 +6,7 @@
     "search returns all items for POST",
     "search returns all items (paginated)",
     "search for foo:bar",
+    "search for numeric ranges with locales",
     "sort by string field (asc)",
     "sort by string field (desc)",
     "sort by numeric field (asc)",

--- a/test/elixir/test/nouveau_test.exs
+++ b/test/elixir/test/nouveau_test.exs
@@ -183,6 +183,25 @@ defmodule NouveauTest do
   end
 
   @tag :with_db
+  test "search for numeric ranges with locales", context do
+    db_name = context[:db_name]
+    create_search_docs(db_name)
+    create_ddoc(db_name)
+
+    url = "/#{db_name}/_design/foo/_nouveau/bar"
+    resp = Couch.post(url, body: %{q: "bar:[10.0 TO 20.0]", locale: "us", include_docs: true})
+    assert_status_code(resp, 200)
+    ids = get_ids(resp)
+    assert ids == ["doc3"]
+
+    url = "/#{db_name}/_design/foo/_nouveau/bar"
+    resp = Couch.post(url, body: %{q: "bar:[10.0 TO 20.0]", locale: "de", include_docs: true})
+    assert_status_code(resp, 200)
+    ids = get_ids(resp)
+    assert ids == ["doc2"]
+  end
+
+  @tag :with_db
   test "sort by string field (asc)", context do
     db_name = context[:db_name]
     create_search_docs(db_name)


### PR DESCRIPTION
## Overview

The expected format for numbers varies by region. Allow a query to specify its locale with a new parameter (e.g, `?locale=de` or `?locale=us`) and apply the appropriate rules. If not specified the default locale for the JVM is used.

## Testing recommendations

run the test suite

## Related Issues or Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
