### PR TITLE
Add "CouchDB-Replicator/..." user agent to replicator /_session requests

### DIFF
--- a/src/couch_replicator/include/couch_replicator_api_wrap.hrl
+++ b/src/couch_replicator/include/couch_replicator_api_wrap.hrl
@@ -11,13 +11,14 @@
 % the License.
 
 
+-define(COUCH_REPLICATOR_USER_AGENT, "CouchDB-Replicator/" ++ couch_server:get_version()).
 
 -record(httpdb, {
     url,
     auth_props = [],
     headers = [
         {"Accept", "application/json"},
-        {"User-Agent", "CouchDB-Replicator/" ++ couch_server:get_version()}
+        {"User-Agent", ?COUCH_REPLICATOR_USER_AGENT}
     ],
     timeout,            % milliseconds
     ibrowse_options = [],


### PR DESCRIPTION
User the same user agent as we do for all the other replicator requests.
