### PR TITLE
fix(`dreyfus`): make faceting produce maps on empty results

### DIFF
--- a/src/dreyfus/src/dreyfus_httpd.erl
+++ b/src/dreyfus/src/dreyfus_httpd.erl
@@ -673,8 +673,8 @@ group_to_json(DbName, IncludeDocs, {Name, TotalHits, Hits}, UseNewApi) ->
 facets_to_json(Facets) ->
     {[facet_to_json(F) || F <- Facets]}.
 
-facet_to_json({K, V, []}) ->
-    {hd(K), V};
+facet_to_json({K, 0, []}) ->
+    {hd(K), {[]}};
 facet_to_json({K0, _V0, C0}) ->
     C2 = [{tl(K1), V1, C1} || {K1, V1, C1} <- C0],
     {hd(K0), facets_to_json(C2)}.

--- a/test/elixir/test/config/search.elixir
+++ b/test/elixir/test/config/search.elixir
@@ -27,6 +27,10 @@
     "drilldown single key single value for POST",
     "drilldown three keys single values for POST",
     "search returns all items for GET",
-    "search returns all items for POST"
+    "search returns all items for POST",
+    "facet counts, non-empty",
+    "facet counts, empty",
+    "facet ranges, empty",
+    "facet ranges, non-empty"
   ]
 }


### PR DESCRIPTION
Facet results are rendered inconsistently in the JSON response because a single zero-valued scalar is added to the place of the object which would otherwise represent the detailed statistics.

For example, a "no match" search with counts faceting, such as

```
/{db}/_design/{ddoc}/_search/{idx}?limit=0&q=city1:London*&counts=["city2"]
```

(where there are no documents matching the query, i.e. no `city1` field has a value `London`) results in the following JSON:

```json
"counts": {
  "city2": 0.0
}
```

but it should be like this instead:

```json
"counts": {
  "city2": {}
}
```

That is because the expectation is that `city2` would contain a map of other city counts (if there were matches), e.g.

```json
"counts": {
  "city2": {
    "Aberystwyth": 1004,
    "Bristol": 1019
  }
}
```

There is a similar impact for ranges.  Although the following one is a meaningless query (because there is no range defined), it manifests the same issue:

```
/{db}/_design/{ddoc}/_search/{idx}?q=*:*&limit=0&ranges={"code":{"high":""}}
```

Response:

```json
{
  "total_rows": 5095,
  "bookmark": "g2o",
  "rows": [],
  "ranges": {
    "code": 0
  }
}
```

which should be:

```json
{
  "total_rows": 5095,
  "bookmark": "g2o",
  "rows": [],
  "ranges": {
    "code": {}
  }
}
```

That is because the expectation is that the value for the field code should be the mapping of ranges to counts, not a count itself, viz.

```
/{db}/_design/{ddoc}/_search/{idx}?q=*:*&limit=0&ranges={"code":{"low":"[0%20TO%2010]","high":"[11%20TO%20Infinity]"}}
```

returns

```json
{
  "total_rows": 5095,
  "bookmark": "g2o",
  "rows": [],
  "ranges": {
    "code": {
      "high": 0,
      "low": 5095
    }
  }
}
```

This makes hard to properly capture the schema of the respective API and complicates the development of the SDK.

Thanks @ricellis for the detailed analysis of the problem, the examples, and his proposal about the solution.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
