### PR TITLE
feat(`mango`): strict index selection

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -496,6 +496,12 @@ authentication_db = _users
 ; the warning.
 ;index_scan_warning_threshold = 10
 
+; Set to true to make index selection strict.  Indexes always have to be
+; specified by the use_index parameter, they are not selected automatically
+; for the query.  An error is returned if the user-specified index is not
+; found.  This can be overridden (inverted) ad-hoc by the query parameters.
+;strict_index_selection = false
+
 [indexers]
 couch_mrview = true
 

--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -45,6 +45,10 @@
     :<json string|array use_index: Instruct a query to use a specific index.
         Specified either as ``"<design_document>"`` or
         ``["<design_document>", "<index_name>"]``. *Optional*
+    :<json boolean use_index_strict: Do not perform the query unless
+       the index specified by ``use_index`` is found and suitable.
+       The use of this parameter implies the use of
+       ``use_index``. *Optional*
     :<json boolean conflicts: Include conflicted documents if ``true``.
         Intended use is to easily find conflicted documents, without an
         index or view. Default is ``false``. *Optional*
@@ -1479,7 +1483,8 @@ it easier to take advantage of future improvements to query planning
                 "stable": false,
                 "stale": false,
                 "update": true,
-                "use_index": []
+                "use_index": [],
+                "use_index_strict": false
             },
             "mrargs": {
                 "conflicts": "undefined",
@@ -1512,7 +1517,9 @@ Index selection
 ===============
 
 :ref:`_find <api/db/_find>` chooses which index to use for responding
-to a query, unless you specify an index at query time.
+to a query, unless you specify an index at query time.  Note that this
+is just a hint for the query planner and as such it might be ignored
+if the named index is not suitable for performing the query.
 
 The query planner looks at the selector section and finds the index with the
 closest match to operators and fields used in the query. If there are two
@@ -1525,3 +1532,8 @@ the index with the first alphabetical name is chosen.
     It is good practice to specify indexes explicitly in your queries. This
     prevents existing queries being affected by new indexes that might get added
     in a production environment.
+
+Setting the ``use_index_strict`` parameter to ``true`` disables the
+automated query planning.  In that case, one must specify an index
+which will be checked for usability and an error is return when it is
+not specified or it is not usable.

--- a/src/docs/src/config/query-servers.rst
+++ b/src/docs/src/config/query-servers.rst
@@ -309,3 +309,20 @@ Mango is the Query Engine that services the :ref:`_find <api/db/_find>`, endpoin
 
             [mango]
             index_scan_warning_threshold = 10
+
+    .. config:option:: strict_index_selection :: Strict index selection.
+
+        .. versionadded:: 3.4
+
+        Make the index selection strict.  The query planner will not
+        try to find a suitable index automatically but use the
+        user-specified index and give up immediately in case of
+        failure.  This implictly makes the use of the ``use_index``
+        query parameter mandatory.  Using the ``use_index_strict``
+        Boolean parameter, this behavior may be adjusted per query.
+
+        Defaults to ``false``.
+        ::
+
+            [mango]
+            strict_index_selection = false

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -48,6 +48,28 @@ info(mango_json_bookmark, {invalid_bookmark, BadBookmark}) ->
         <<"invalid_bookmark">>,
         fmt("Invalid bookmark value: ~s", [?JSON_ENCODE(BadBookmark)])
     };
+info(mango_cursor, {invalid_index, []}) ->
+    {
+        400,
+        <<"invalid_index">>,
+        <<"You must specify an index with the `use_index` parameter.">>
+    };
+info(mango_cursor, {invalid_index, [DDocName]}) ->
+    {
+        400,
+        <<"invalid_index">>,
+        fmt("_design/~s specified by `use_index` could not be found or it is not suitable.", [
+            DDocName
+        ])
+    };
+info(mango_cursor, {invalid_index, [DDocName, ViewName]}) ->
+    {
+        400,
+        <<"invalid_index">>,
+        fmt("_design/~s, ~s specified by `use_index` could not be found or it is not suitable.", [
+            DDocName, ViewName
+        ])
+    };
 info(mango_cursor_text, {invalid_bookmark, BadBookmark}) ->
     {
         400,

--- a/src/mango/src/mango_opts.erl
+++ b/src/mango/src/mango_opts.erl
@@ -91,6 +91,12 @@ validate_find({Props}) ->
             {default, []},
             {validator, fun validate_use_index/1}
         ]},
+        {<<"use_index_strict">>, [
+            {tag, use_index_strict},
+            {optional, true},
+            {default, false},
+            {validator, fun mango_opts:is_boolean/1}
+        ]},
         {<<"bookmark">>, [
             {tag, bookmark},
             {optional, true},

--- a/src/mango/test/02-basic-find-test.py
+++ b/src/mango/test/02-basic-find-test.py
@@ -311,6 +311,7 @@ class BasicFindTests(mango.UserDocsTests):
         assert opts["stale"] == False
         assert opts["update"] == True
         assert opts["use_index"] == []
+        assert opts["use_index_strict"] == False
 
     def test_sort_with_all_docs(self):
         explain = self.db.find(

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -211,6 +211,25 @@ class IndexSelectionTests:
         )
         self.assertEqual(resp_explain["index"]["type"], "json")
 
+    def test_strict_index_selection(self):
+        with self.subTest(with_use_index=True):
+            try:
+                self.db.find(
+                    {"manager": True}, use_index="invalid", use_index_strict=True
+                )
+            except Exception as e:
+                self.assertEqual(e.response.status_code, 400)
+            else:
+                raise AssertionError("did not fail on invalid index")
+
+        with self.subTest(with_use_index=False):
+            try:
+                self.db.find({"manager": True}, use_index_strict=True)
+            except Exception as e:
+                self.assertEqual(e.response.status_code, 400)
+            else:
+                raise AssertionError("did not fail due to missing use_index")
+
 
 class JSONIndexSelectionTests(mango.UserDocsTests, IndexSelectionTests):
     @classmethod

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -248,6 +248,7 @@ class Database(object):
         update=True,
         executionStats=False,
         partition=None,
+        use_index_strict=None,
     ):
         body = {
             "selector": selector,
@@ -267,6 +268,8 @@ class Database(object):
             body["update"] = False
         if executionStats == True:
             body["execution_stats"] = True
+        if use_index_strict is not None:
+            body["use_index_strict"] = use_index_strict
         body = json.dumps(body)
         if partition:
             ppath = "_partition/{}/".format(partition)


### PR DESCRIPTION
It is not always beneficial for the performance if the Mango query planner tries to assign an index to the selector.  User-specified indexes may save the day, but since they are only hints for the planner, automated overrides can still happen.

Introduce the concept of "strict index selection" (h/t @willholley) which lets the user to request the exclusive use of a specific index.  When it is not possible, give up on planning and return an HTTP 400 response right away.  This way the user has the chance to learn about the missing index, request its creation and try again later.

The feature comes with a configuration toggle.  By default, the feature is disabled to maintain backward compatibility, but the user may ask for this behavior via the new `use_index_strict` query parameter for a specific query.  Note that, similarly, `use_index_strict` could be used to disable strict index selection temporarily when it is enabled on the server.

Fixes #4511

## Checklist for the review

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
