### PR TITLE
Upgrade sphinx-rtd-theme

### DIFF
--- a/src/docs/requirements.txt
+++ b/src/docs/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx==5.3.0
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.2.2
 sphinxcontrib-httpdomain==1.8.0


### PR DESCRIPTION
Upgrade to the latest version 1.2.2 of sphinx-rtd-theme.

Fixes #4701.