### PR TITLE
fix(`docs`): minor fixes for Mango

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -1441,13 +1441,12 @@ it easier to take advantage of future improvements to query planning
         Transfer-Encoding: chunked
 
         {
-            "covered": false,
             "dbname": "movies",
             "index": {
                 "ddoc": "_design/0d61d9177426b1e2aa8d0fe732ec6e506f5d443c",
                 "name": "0d61d9177426b1e2aa8d0fe732ec6e506f5d443c",
-                "partitioned": false,
                 "type": "json",
+                "partitioned": false,
                 "def": {
                     "fields": [
                         {
@@ -1456,12 +1455,14 @@ it easier to take advantage of future improvements to query planning
                     ]
                 }
             },
+            "partitioned": false,
             "selector": {
                 "year": {
                     "$gt": 2010
                 }
             },
             "opts": {
+                "use_index": [],
                 "bookmark": "nil",
                 "limit": 2,
                 "skip": 0,
@@ -1472,30 +1473,13 @@ it easier to take advantage of future improvements to query planning
                     "year",
                     "title"
                 ],
+                "partition": "",
                 "r": 1,
                 "conflicts": false,
-                "execution_stats": false,
-                "partition": "",
-                "stable": false,
                 "stale": false,
                 "update": true,
-                "use_index": []
-            },
-            "mrargs": {
-                "conflicts": "undefined",
-                "direction": "fwd",
-                "end_key": [
-                    "<MAX>"
-                ],
-                "include_docs": true,
-                "partition": null,
-                "reduce": false,
                 "stable": false,
-                "start_key": [
-                    2010
-                ],
-                "update": true,
-                "view_type": "map"
+                "execution_stats": false
             },
             "limit": 2,
             "skip": 0,
@@ -1505,7 +1489,23 @@ it easier to take advantage of future improvements to query planning
                 "year",
                 "title"
             ],
-            "partitioned": false
+            "mrargs": {
+                "include_docs": true,
+                "view_type": "map",
+                "reduce": false,
+                "partition": null,
+                "start_key": [
+                    2010
+                ],
+                "end_key": [
+                    "<MAX>"
+                ],
+                "direction": "fwd",
+                "stable": false,
+                "update": true,
+                "conflicts": "undefined"
+            },
+            "covered": false
         }
 
 Index selection

--- a/src/docs/src/config/query-servers.rst
+++ b/src/docs/src/config/query-servers.rst
@@ -282,7 +282,8 @@ Mango is the Query Engine that services the :ref:`_find <api/db/_find>`, endpoin
 
         Set to ``true`` to disable the "index all fields" text index. This can lead
         to out of memory issues when there are documents with nested array fields.
-        Defaults to ``false``.::
+        Defaults to ``false``.
+        ::
 
             [mango]
             index_all_disabled = false
@@ -292,7 +293,8 @@ Mango is the Query Engine that services the :ref:`_find <api/db/_find>`, endpoin
         Sets the default number of results that will be returned in a
         :ref:`_find <api/db/_find>` response. Individual requests can override this
         by setting ``limit`` directly in the query parameters.
-        Defaults to ``25``.::
+        Defaults to ``25``.
+        ::
 
             [mango]
             default_limit = 25
@@ -305,7 +307,8 @@ Mango is the Query Engine that services the :ref:`_find <api/db/_find>`, endpoin
         requires reading 100 documents to return 10 rows, a warning will be
         generated if this value is ``10``.
 
-        Defaults to ``10``. Setting the value to ``0`` disables the warning.::
+        Defaults to ``10``. Setting the value to ``0`` disables the warning.
+        ::
 
             [mango]
             index_scan_warning_threshold = 10


### PR DESCRIPTION
Fix minor problems with the CouchDB documentation, related to Mango:

- Formatting issues with the description of the configuration options
- Adjust order of fields in the sample `_explain` JSON response for better readability