### PR TITLE
Add extra nouveau purge tests with conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,6 +547,7 @@ derived:
 # Build nouveau
 nouveau:
 ifeq ($(with_nouveau), 1)
+	@cd nouveau && ./gradlew spotlessApply
 	@cd nouveau && ./gradlew build -x test
 endif
 

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentDeleteRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentDeleteRequest.java
@@ -24,15 +24,18 @@ public class DocumentDeleteRequest {
     @Positive
     private long seq;
 
+    private boolean purge;
+
     public DocumentDeleteRequest() {
         // Jackson deserialization
     }
 
-    public DocumentDeleteRequest(long seq) {
+    public DocumentDeleteRequest(long seq, final boolean purge) {
         if (seq < 1) {
             throw new IllegalArgumentException("seq must be 1 or greater");
         }
         this.seq = seq;
+        this.purge = purge;
     }
 
     @JsonProperty
@@ -40,8 +43,13 @@ public class DocumentDeleteRequest {
         return seq;
     }
 
+    @JsonProperty
+    public boolean isPurge() {
+        return purge;
+    }
+
     @Override
     public String toString() {
-        return "DocumentDeleteRequest [seq=" + seq + "]";
+        return "DocumentDeleteRequest [seq=" + seq + ", purge=" + purge + "]";
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/IndexInfo.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/IndexInfo.java
@@ -19,42 +19,50 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.PositiveOrZero;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class IndexInfo {
+public final class IndexInfo {
 
     @PositiveOrZero
-    private long updateSeq;
+    private final long updateSeq;
 
     @PositiveOrZero
-    private int numDocs;
+    private final long purgeSeq;
 
     @PositiveOrZero
-    private long diskSize;
+    private final int numDocs;
 
-    public IndexInfo() {}
+    @PositiveOrZero
+    private final long diskSize;
 
-    public IndexInfo(final long updateSeq, final int numDocs, final long diskSize) {
+    public IndexInfo(
+            @JsonProperty("update_seq") final long updateSeq,
+            @JsonProperty("purge_seq") final long purgeSeq,
+            @JsonProperty("num_docs") final int numDocs,
+            @JsonProperty("disk_size") final long diskSize) {
         this.updateSeq = updateSeq;
+        this.purgeSeq = purgeSeq;
         this.numDocs = numDocs;
         this.diskSize = diskSize;
     }
 
-    @JsonProperty
     public int getNumDocs() {
         return numDocs;
     }
 
-    @JsonProperty
     public long getDiskSize() {
         return diskSize;
     }
 
-    @JsonProperty
     public long getUpdateSeq() {
         return updateSeq;
     }
 
+    public long getPurgeSeq() {
+        return purgeSeq;
+    }
+
     @Override
     public String toString() {
-        return "IndexInfo [updateSeq=" + updateSeq + ", numDocs=" + numDocs + ", diskSize=" + diskSize + "]";
+        return "IndexInfo [updateSeq=" + updateSeq + ", purgeSeq=" + purgeSeq + ", numDocs=" + numDocs + ", diskSize="
+                + diskSize + "]";
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9Index.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9Index.java
@@ -25,7 +25,6 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,8 +103,9 @@ public class Lucene9Index extends Index {
             final Analyzer analyzer,
             final IndexWriter writer,
             final long updateSeq,
+            final long purgeSeq,
             final SearcherManager searcherManager) {
-        super(updateSeq);
+        super(updateSeq, purgeSeq);
         this.analyzer = Objects.requireNonNull(analyzer);
         this.writer = Objects.requireNonNull(writer);
         this.searcherManager = Objects.requireNonNull(searcherManager);
@@ -144,12 +144,12 @@ public class Lucene9Index extends Index {
     }
 
     @Override
-    public boolean doCommit(final long updateSeq) throws IOException {
+    public boolean doCommit(final long updateSeq, final long purgeSeq) throws IOException {
         if (!writer.hasUncommittedChanges()) {
             return false;
         }
-        writer.setLiveCommitData(
-                Collections.singletonMap("update_seq", Long.toString(updateSeq)).entrySet());
+        writer.setLiveCommitData(Map.of("update_seq", Long.toString(updateSeq), "purge_seq", Long.toString(purgeSeq))
+                .entrySet());
         writer.commit();
         return true;
     }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/resources/IndexResource.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/resources/IndexResource.java
@@ -126,19 +126,20 @@ public final class IndexResource {
             final IndexWriterConfig config = new IndexWriterConfig(analyzer);
             config.setUseCompoundFile(false);
             final IndexWriter writer = new IndexWriter(dir, config);
-            final long updateSeq = getUpdateSeq(writer);
+            final long updateSeq = getSeq(writer, "update_seq");
+            final long purgeSeq = getSeq(writer, "purge_seq");
             final SearcherManager searcherManager = new SearcherManager(writer, searcherFactory);
-            return new Lucene9Index(analyzer, writer, updateSeq, searcherManager);
+            return new Lucene9Index(analyzer, writer, updateSeq, purgeSeq, searcherManager);
         };
     }
 
-    private static long getUpdateSeq(final IndexWriter writer) throws IOException {
+    private static long getSeq(final IndexWriter writer, final String key) throws IOException {
         final Iterable<Map.Entry<String, String>> commitData = writer.getLiveCommitData();
         if (commitData == null) {
             return 0L;
         }
         for (Map.Entry<String, String> entry : commitData) {
-            if (entry.getKey().equals("update_seq")) {
+            if (entry.getKey().equals(key)) {
                 return Long.parseLong(entry.getValue());
             }
         }

--- a/src/nouveau/src/nouveau_api.erl
+++ b/src/nouveau/src/nouveau_api.erl
@@ -24,6 +24,7 @@
     delete_path/1,
     delete_path/2,
     delete_doc/3,
+    purge_doc/3,
     update_doc/5,
     search/2
 ]).
@@ -97,7 +98,17 @@ delete_path(Path, Exclusions) when
 delete_doc(#index{} = Index, DocId, UpdateSeq) when
     is_binary(DocId), is_integer(UpdateSeq)
 ->
-    ReqBody = {[{<<"seq">>, UpdateSeq}]},
+    delete_doc(Index, DocId, UpdateSeq, false).
+
+purge_doc(#index{} = Index, DocId, PurgeSeq) when
+    is_binary(DocId), is_integer(PurgeSeq)
+->
+    delete_doc(Index, DocId, PurgeSeq, true).
+
+delete_doc(#index{} = Index, DocId, Seq, IsPurge) when
+    is_binary(DocId), is_integer(Seq), is_boolean(IsPurge)
+->
+    ReqBody = #{seq => Seq, purge => IsPurge},
     Resp = send_if_enabled(
         doc_url(Index, DocId), [?JSON_CONTENT_TYPE], delete, jiffy:encode(ReqBody)
     ),

--- a/src/nouveau/src/nouveau_epi.erl
+++ b/src/nouveau/src/nouveau_epi.erl
@@ -31,7 +31,10 @@ app() ->
     nouveau.
 
 providers() ->
-    [{chttpd_handlers, nouveau_httpd_handlers}].
+    [
+        {couch_db, nouveau_plugin_couch_db},
+        {chttpd_handlers, nouveau_httpd_handlers}
+    ].
 
 services() ->
     [].

--- a/src/nouveau/src/nouveau_plugin_couch_db.erl
+++ b/src/nouveau/src/nouveau_plugin_couch_db.erl
@@ -1,0 +1,24 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(nouveau_plugin_couch_db).
+
+-export([
+    is_valid_purge_client/2,
+    on_compact/2
+]).
+
+is_valid_purge_client(DbName, Props) ->
+    nouveau_util:verify_index_exists(DbName, Props).
+
+on_compact(DbName, DDocs) ->
+    nouveau_util:ensure_local_purge_docs(DbName, DDocs).

--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -23,6 +23,7 @@
     "search POST (partitioned)",
     "mango (partitioned)",
     "delete",
-    "purge"
+    "purge",
+    "purge with conflicts"
   ]
 }

--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -21,6 +21,8 @@
     "mango sort by string",
     "search GET (partitioned)",
     "search POST (partitioned)",
-    "mango (partitioned)"
+    "mango (partitioned)",
+    "delete",
+    "purge"
   ]
 }


### PR DESCRIPTION
Purge requests can take a few different code paths so this is trying to exercise more of them. Specifically cases when we purge some revisions but not others from the same doc, purging non-winning revisions (no-ops for nouveau), etc.
