### PR TITLE
Unlock build using Elixir 1.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,11 +461,14 @@ install: release
 # target: clean - Remove build artifacts
 clean:
 	@$(REBAR) -r clean
+	@mix clean --deps
 	@rm -rf .rebar/
+	@rm -rf _build
 	@rm -f bin/couchjs
 	@rm -f bin/weatherreport
 	@rm -rf src/*/ebin
 	@rm -rf src/*/.rebar
+	@rm -rf src/*/_build
 	@rm -rf src/*/priv/*.so
 	@rm -rf src/couch/priv/{couchspawnkillable,couchjs}
 	@rm -rf share/server/main.js share/server/main-ast-bypass.js share/server/main-coffee.js

--- a/Makefile.win
+++ b/Makefile.win
@@ -418,10 +418,13 @@ install: release
 # target: clean - Remove build artifacts
 clean:
 	@$(REBAR) -r clean
+	-@mix clean --deps
 	-@rmdir /s/q .rebar
+	-@rmdir /s/q _build
 	-@del /f/q bin\couchjs.exe
 	-@rmdir /s/q src\*\ebin
 	-@rmdir /s/q src\*\.rebar
+	-@rmdir /s/q src\*\_build
 	-@del /f/q/s src\*.dll
 	-@del /f/q src\couch\priv\*.exe
 	-@del /f/q share\server\main.js share\server\main-ast-bypass.js share\server\main-coffee.js

--- a/mix.exs
+++ b/mix.exs
@@ -61,6 +61,7 @@ defmodule CouchDBTest.Mixfile do
       consolidate_protocols: Mix.env() not in [:test, :dev, :integration],
       test_paths: get_test_paths(Mix.env()),
       elixirc_paths: elixirc_paths(Mix.env()),
+      prune_code_paths: false,
       test_coverage: [
         tool: CoverTool,
         dirs: get_coverage_paths(),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Elixir 1.5 introduces some changes in the compilation process tha affects to the execution of our test suite. The problem has been reported here #4706

It seems that we are facing one of the incompatibility problems documented in the Elixir 1.15 release notes

> Potential incompatibilities
Due to the code path pruning, if you have an application or dependency that does not specify its dependencies on Erlang and Elixir application, it may no longer compile successfully in Elixir v1.15. You can temporarily disable code path pruning by setting prune_code_paths: false in your mix.exs, although doing so may lead to runtime bugs that are only manifested inside a [mix release](https://hexdocs.pm/mix/1.15/Mix.Tasks.Release.html).

Previous to this PR, if we try to run the elixir test suite with Elixir 1.15, the following error appears in any test that uses `jiffy`.

```
> make clean couch elixir

 1) test Basic reduce functions (ReduceTest)
     test/elixir/test/reduce_test.exs:16
     ** (UndefinedFunctionError) function :jiffy.decode/2 is undefined (module :jiffy is not available)
     stacktrace:
       (jiffy 1.0.9) :jiffy.decode("{\"ok\":true}\n", [:return_maps])
```

This PR indroduces the suggested temporary fix in the `mix.exs` by adding `prune_code_paths: false` to the build config. With this change we can use Elixir 1.15 in our build process. I've tried to find the problem with our dependency declaration without sucess. This should be a temporary solution until we find the root of the problem.

This PR introduces a second change in the Makefile clean target by adding aditional cleanup for elixir build artifacts. 

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

- Install Erlang >= 24
- Install Elixir 1.15
- `make clean couch elixir`

The elixir test suite should run without problems. Then check the cleanup.

- `make clean`
- `find . -name "_build"` (No _build folder should be found)
- `MIX_ENV=integration mix deps` (should inform that every dependency needs to be compiled/updated)

## Related Issues or Pull Requests
<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->
This PR proposes a temporary solution for #4706

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
