### PR TITLE
Fabric stream coordinators should exit if idle for a long period

### DIFF
--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -278,6 +278,7 @@ convert_to_design_id(DDocId) ->
     end.
 
 start_find_resp(Req) ->
+    fabric_streams:enable_watchdog(),
     chttpd:start_delayed_json_response(Req, 200, [], "{\"docs\":[").
 
 end_find_resp(Acc0) ->
@@ -310,6 +311,7 @@ handle_doc({add_key, Key, Value}, Acc0) ->
     NewKVs = lists:keystore(Key, 1, KVs, {Key, Value}),
     {ok, Acc0#vacc{kvs = NewKVs}};
 handle_doc({row, Doc}, Acc0) ->
+    fabric_streams:kick_watchdog(),
     #vacc{prepend = Prepend} = Acc0,
     Chunk = [Prepend, ?JSON_ENCODE(Doc)],
     maybe_flush_response(Acc0, Chunk, iolist_size(Chunk)).


### PR DESCRIPTION
## Overview

A `_find` request can run for a very long time (on large databases when the selector matches no index) and this continues even if the client disconnects.

We want to stop the fabric work when there is no client to receive the result. `fabric_streams` already kills the workers if the coordinating process dies but in this circumstance it does not.

this PR enhances (and renames) the existing cleanup process to be a watchdog. If enabled, the watchdog needs to be kicked regularly (by whatever activity we think indicates its worth continuing) or it will terminate the process it is watching, and kill the worker processes also.

Currently only `mango_httpd:handle_find_req` enables the watchdog and it only kicks the watchdog when it enqueues a row to be returned (i.e, only on selector matches).

Further work is being considered to directly detect a client disconnect and that might replace this approach. The reason detecting client disconnect is difficult is because the socket is in passive mode (and thus `monitor(port, MochiSocket)` and other ideas do not work).

## Testing recommendations

* start dev/run with log level debug
* make a database with millions of empty documents
* change `[fabric] idle_stream_timeout` to some low number of seconds
* in a terminal run `curl -i 'foo:bar@localhost:15984/db1/_find' -H content-type:application/json -d '{"selector":{"foo":"bar"}}'`

I intend to add automated tests for this but wanted to get the diff in front of the team first.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
