### PR TITLE
feat(`mango`): rolling execution statistics (exploration)

### DIFF
--- a/src/mango/src/mango_execution_stats.erl
+++ b/src/mango/src/mango_execution_stats.erl
@@ -26,8 +26,8 @@
     log_stats/1,
     maybe_add_stats/4,
     shard_init/0,
-    shard_incr_keys_examined/0,
-    shard_incr_docs_examined/0,
+    shard_incr_keys_examined/1,
+    shard_incr_docs_examined/1,
     shard_get_stats/0
 ]).
 
@@ -123,19 +123,19 @@ shard_init() ->
     InitialState = #{docs_examined => 0, keys_examined => 0},
     put(?SHARD_STATS_KEY, InitialState).
 
--spec shard_incr_keys_examined() -> any().
-shard_incr_keys_examined() ->
-    incr(keys_examined).
+-spec shard_incr_keys_examined(integer()) -> any().
+shard_incr_keys_examined(N) ->
+    incr(keys_examined, N).
 
--spec shard_incr_docs_examined() -> any().
-shard_incr_docs_examined() ->
-    incr(docs_examined).
+-spec shard_incr_docs_examined(integer()) -> any().
+shard_incr_docs_examined(N) ->
+    incr(docs_examined, N).
 
--spec incr(atom()) -> any().
-incr(Key) ->
+-spec incr(atom(), integer()) -> any().
+incr(Key, N) ->
     case get(?SHARD_STATS_KEY) of
         #{} = Stats0 ->
-            Stats = maps:update_with(Key, fun(X) -> X + 1 end, Stats0),
+            Stats = maps:update_with(Key, fun(X) -> X + N end, Stats0),
             put(?SHARD_STATS_KEY, Stats);
         _ ->
             ok

--- a/src/mango/test/15-execution-stats-test.py
+++ b/src/mango/test/15-execution-stats-test.py
@@ -73,6 +73,19 @@ class ExecutionStatsTests(mango.UserDocsTests):
         self.assertEqual(resp["execution_stats"]["total_quorum_docs_examined"], 0)
         self.assertEqual(resp["execution_stats"]["results_returned"], 3)
 
+    def test_reporting_consistency(self):
+        resp = self.db.find(
+            {"age": {"$lte": 42}},
+            fields=["name", "email", "age"],
+            limit=3,
+            return_raw=True,
+            executionStats=True,
+        )
+        executionStats = resp["execution_stats"]
+        self.assertEqual(executionStats["total_keys_examined"], 3)
+        self.assertEqual(executionStats["total_docs_examined"], 3)
+        self.assertEqual(executionStats["results_returned"], 3)
+
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class ExecutionStatsTests_Text(mango.UserDocsTextTests):


### PR DESCRIPTION
## Overview

In case of map-reduce views, the arrival of the `complete` message is not guaranteed for the view callback (at the shard) when a `stop` is issued during the aggregation (at the coordinator).  Due to that, internally collected shard-level statistics may not be fed back to the coordinator which can cause data loss hence inaccuracy in the overall execution statistics.

Address this issue by switching to a "rolling" model where row-level statistics are immediately streamed back to the coordinator.  Support mixed-version cluster upgrades by activating this model only if requested through the map-reduce arguments and the given shard supports that.

This is only a proposal, a way explore the approach, comments and feedback are welcome.  Remarks:
- It clearly uses more bandwidth as it will send more `execution_stats` messages.  Is this acceptable?
- It does not require changes in fabric itself, the whole logic is kept on the Mango side and it is compatible with the previous solution.
- Are there other ways to stop the aggregation as soon as the limit is reached?
- Are there other kind of messages coming from the shards that could be reliably used to signal the end of statistics collection (alternatives to capturing `complete`)? 

## Testing recommendations

Running the respective Mango unit and integration test suites might suffice (which is done by the CI):

```shell
make eunit apps=mango
make mango-test MANGO_TEST_OPTS="15-execution-stats-test"
```

But there is a detailed description in related the ticket (see below) on how to trigger the problem.  Feel free to kick the tires.

## Related Issues or Pull Requests

Fixes #4560

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
