### PR TITLE
Stop client process and clean up if client disconnects

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -206,6 +206,14 @@ bind_address = 127.0.0.1
 ; response header.
 ;server_header_versions = true
 
+; How often to check for client disconnects while processing streaming
+; requests such as _all_docs, _find, _changes and views
+;disconnect_check_msec = 30000
+
+; The amount of jitter to apply to the disconnect_check_msec. That's to avoid a
+; stampede in case when there are lot of concurrent clients connecting.
+;disconnect_check_jitter_msec = 15000
+
 ;[jwt_auth]
 ; List of claims to validate
 ; can be the name of a claim like "exp" or a tuple if the claim requires

--- a/src/chttpd/priv/stats_descriptions.cfg
+++ b/src/chttpd/priv/stats_descriptions.cfg
@@ -18,6 +18,10 @@
     {type, counter},
     {desc, <<"number of aborted requests">>}
 ]}.
+{[couchdb, httpd, abandoned_streaming_requests], [
+    {type, counter},
+    {desc, <<"number of abandoned streaming requests">>}
+]}.
 {[couchdb, dbinfo], [
     {type, histogram},
     {desc, <<"distribution of latencies for calls to retrieve DB info">>}

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -320,6 +320,9 @@ handle_request_int(MochiReq) ->
     erlang:put(dont_log_request, true),
     erlang:put(dont_log_response, true),
 
+    % Save client socket so that it can be monitored for disconnects
+    chttpd_util:mochiweb_socket_set(MochiReq:get(socket)),
+
     {HttpReq2, Response} =
         case before_request(HttpReq0) of
             {ok, HttpReq1} ->
@@ -327,6 +330,8 @@ handle_request_int(MochiReq) ->
             {error, Response0} ->
                 {HttpReq0, Response0}
         end,
+
+    chttpd_util:mochiweb_socket_clean(),
 
     {Status, Code, Reason, Resp} = split_response(Response),
 

--- a/src/chttpd/src/chttpd_util.erl
+++ b/src/chttpd/src/chttpd_util.erl
@@ -22,8 +22,17 @@
     get_chttpd_auth_config_integer/2,
     get_chttpd_auth_config_boolean/2,
     maybe_add_csp_header/3,
-    get_db_info/1
+    get_db_info/1,
+    mochiweb_socket_set/1,
+    mochiweb_socket_clean/0,
+    mochiweb_socket_get/0,
+    mochiweb_socket_check_msec/0,
+    stop_client_process_if_disconnected/2
 ]).
+
+-define(MOCHIWEB_SOCKET, mochiweb_connection_socket).
+-define(DISCONNECT_CHECK_MSEC, 30000).
+-define(DISCONNECT_CHECK_JITTER_MSEC, 15000).
 
 get_chttpd_config(Key) ->
     config:get("chttpd", Key, config:get("httpd", Key)).
@@ -110,3 +119,117 @@ get_db_info(DbName) ->
     catch
         _Tag:Error -> {error, Error}
     end.
+
+mochiweb_socket_set(Sock) ->
+    put(?MOCHIWEB_SOCKET, Sock).
+
+mochiweb_socket_clean() ->
+    erase(?MOCHIWEB_SOCKET).
+
+mochiweb_socket_get() ->
+    get(?MOCHIWEB_SOCKET).
+
+mochiweb_socket_check_msec() ->
+    MSec = config:get_integer(
+        "chttpd", "disconnect_check_msec", ?DISCONNECT_CHECK_MSEC
+    ),
+    JitterMSec = config:get_integer(
+        "chttpd", "disconnect_check_jitter_msec", ?DISCONNECT_CHECK_JITTER_MSEC
+    ),
+    max(100, MSec + rand:uniform(max(1, JitterMSec))).
+
+stop_client_process_if_disconnected(Pid, Sock) ->
+    case is_mochiweb_socket_closed(Sock) of
+        true ->
+            exit(Pid, {shutdown, client_disconnected}),
+            couch_stats:increment_counter([couchdb, httpd, abandoned_streaming_requests]),
+            ok;
+        false ->
+            ok
+    end.
+
+is_mochiweb_socket_closed(undefined) ->
+    false;
+is_mochiweb_socket_closed(Sock) ->
+    OsType = os:type(),
+    case tcp_info_opt(OsType) of
+        {raw, _, _, _} = InfoOpt ->
+            case mochiweb_socket:getopts(Sock, [InfoOpt]) of
+                {ok, [{raw, _, _, <<State:8/native, _/binary>>}]} ->
+                    tcp_is_closed(State, OsType);
+                {ok, []} ->
+                    false;
+                {error, einval} ->
+                    % Already cleaned up
+                    true;
+                {error, _} ->
+                    false
+            end;
+        undefined ->
+            false
+    end.
+
+% All OS-es have the tcpi_state (uint8) as first member of tcp_info struct
+
+tcp_info_opt({unix, linux}) ->
+    %% netinet/in.h
+    %%   IPPROTO_TCP = 6
+    %%
+    %% netinet/tcp.h
+    %%   #define TCP_INFO 11
+    %%
+    {raw, 6, 11, 1};
+tcp_info_opt({unix, darwin}) ->
+    %% netinet/in.h
+    %%   #define IPPROTO_TCP   6
+    %%
+    %% netinet/tcp.h
+    %%   #define TCP_CONNECTION_INFO  0x106
+    %%
+    {raw, 6, 16#106, 1};
+tcp_info_opt({unix, freebsd}) ->
+    %% sys/netinet/in.h
+    %%   #define  IPPROTO_TCP  6
+    %%
+    %% sys/netinet/tcp.h
+    %%   #define  TCP_INFO    32
+    %%
+    {raw, 6, 32, 1};
+tcp_info_opt({_, _}) ->
+    undefined.
+
+tcp_is_closed(State, {unix, linux}) ->
+    %% netinet/tcp.h
+    %%   enum
+    %%   {
+    %%     TCP_ESTABLISHED = 1,
+    %%     TCP_SYN_SENT,
+    %%     TCP_SYN_RECV,
+    %%     TCP_FIN_WAIT1,
+    %%     TCP_FIN_WAIT2,
+    %%     TCP_TIME_WAIT,
+    %%     TCP_CLOSE,
+    %%     TCP_CLOSE_WAIT,
+    %%     TCP_LAST_ACK,
+    %%     TCP_LISTEN,
+    %%     TCP_CLOSING
+    %%   }
+    %%
+    lists:member(State, [4, 5, 6, 7, 8, 9, 11]);
+tcp_is_closed(State, {unix, Type}) when Type =:= darwin; Type =:= freebsd ->
+    %% tcp_fsm.h states are the same on macos and freebsd
+    %%
+    %% netinet/tcp_fsm.h
+    %%   #define TCPS_CLOSED             0       /* closed */
+    %%   #define TCPS_LISTEN             1       /* listening for connection */
+    %%   #define TCPS_SYN_SENT           2       /* active, have sent syn */
+    %%   #define TCPS_SYN_RECEIVED       3       /* have send and received syn */
+    %%   #define TCPS_ESTABLISHED        4       /* established */
+    %%   #define TCPS_CLOSE_WAIT         5       /* rcvd fin, waiting for close */
+    %%   #define TCPS_FIN_WAIT_1         6       /* have closed, sent fin */
+    %%   #define TCPS_CLOSING            7       /* closed xchd FIN; await FIN ACK */
+    %%   #define TCPS_LAST_ACK           8       /* had fin and close; await FIN ACK */
+    %%   #define TCPS_FIN_WAIT_2         9       /* have closed, fin is acked */
+    %%   #define TCPS_TIME_WAIT          10      /* in 2*msl quiet wait after close */
+    %%
+    lists:member(State, [0, 5, 6, 7, 8, 9, 10]).

--- a/src/docs/src/config/http.rst
+++ b/src/docs/src/config/http.rst
@@ -266,6 +266,28 @@ HTTP Server Options
             [chttpd]
             server_header_versions = true
 
+    .. config:option:: disconnect_check_msec :: Client disconnection check interval
+
+        .. versionadded:: 3.4
+
+        How often, in milliseconds, to check for client disconnects while
+        processing streaming requests such as _all_docs, _find, _changes and
+        views. ::
+
+            [chttpd]
+            disconnect_check_msec = 30000
+
+    .. config:option:: disconnect_check_jitter_msec :: Client disconnection check jitter
+
+        .. versionadded:: 3.4
+
+        How much random jitter to apply to the ``disconnect_check_msec``
+        period. This is to avoid stampede in case of a large number of
+        concurrent clients. ::
+
+            [chttpd]
+            disconnect_check_jitter_msec = 15000
+
 .. config:section:: httpd :: HTTP Server Options
 
     .. versionchanged:: 3.2 These options were moved to [chttpd] section:

--- a/src/fabric/src/fabric_view_changes.erl
+++ b/src/fabric/src/fabric_view_changes.erl
@@ -39,11 +39,12 @@ go(DbName, Feed, Options, Callback, Acc0) when
             {Timeout, _} = couch_changes:get_changes_timeout(Args, Callback),
             Ref = make_ref(),
             Parent = self(),
+            ClientSock = chttpd_util:mochiweb_socket_get(),
             UpdateListener = {
                 spawn_link(
                     fabric_db_update_listener,
                     go,
-                    [Parent, Ref, DbName, Timeout]
+                    [Parent, Ref, DbName, Timeout, ClientSock]
                 ),
                 Ref
             },


### PR DESCRIPTION
Previously, when processing long running streaming requests, such as _find with a highly selective selector, when no rows are emitted for a while, the client could disconnect but the request process, and all the associated workers on remote nodes would continue running, consuming server resources.

We already handle remote (RPC) process cleanup if the coordinator crashes, we just need a way to kill that coordinator if the connection is closed in the case when no data may be emitted for a long time. This is what the current commit accomplishes.

It turns out there is no simple way to detect passive mode socket disconnects in current versions of Erlang/OTP. The socket at the kernel level may be closed (in close_wait state), however `inet:info/1` will continue reporting it as `connected`. The only ways to obtain an accurate connection state is to try to write, read, or query the TCP info state.

Here we attempt to query the state with tcp_info. Unfortunately, not all versions of supported OTP platforms have this option, so it probably never became an officially supported inet socket option, so we use `raw` socket option for it. However, it turns out most of CouchDB supported platforms do have that option. The only platform this is not working currently is Windows. In that case, or future platform cases we default to the previous behavior, assuming the socket is still open.
