### PR TITLE
Update mochiweb to 3.2.0

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -155,7 +155,7 @@ DepDescs = [
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
 {jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-2"}},
-{mochiweb,         "mochiweb",         {tag, "v3.1.1"}},
+{mochiweb,         "mochiweb",         {tag, "v3.2.0"}},
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.3"}}
 ].

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -321,7 +321,7 @@ handle_request_int(MochiReq) ->
     erlang:put(dont_log_response, true),
 
     % Save client socket so that it can be monitored for disconnects
-    chttpd_util:mochiweb_socket_set(MochiReq:get(socket)),
+    chttpd_util:mochiweb_client_req_set(MochiReq),
 
     {HttpReq2, Response} =
         case before_request(HttpReq0) of
@@ -331,7 +331,7 @@ handle_request_int(MochiReq) ->
                 {HttpReq0, Response0}
         end,
 
-    chttpd_util:mochiweb_socket_clean(),
+    chttpd_util:mochiweb_client_req_clean(),
 
     {Status, Code, Reason, Resp} = split_response(Response),
 

--- a/src/fabric/src/fabric_view_changes.erl
+++ b/src/fabric/src/fabric_view_changes.erl
@@ -39,12 +39,12 @@ go(DbName, Feed, Options, Callback, Acc0) when
             {Timeout, _} = couch_changes:get_changes_timeout(Args, Callback),
             Ref = make_ref(),
             Parent = self(),
-            ClientSock = chttpd_util:mochiweb_socket_get(),
+            ClientReq = chttpd_util:mochiweb_client_req_get(),
             UpdateListener = {
                 spawn_link(
                     fabric_db_update_listener,
                     go,
-                    [Parent, Ref, DbName, Timeout, ClientSock]
+                    [Parent, Ref, DbName, Timeout, ClientReq]
                 ),
                 Ref
             },


### PR DESCRIPTION
Mochiweb [3.2.0](https://github.com/mochi/mochiweb/releases/tag/v3.2.0) has a `mochiweb_request:is_closed/1` function which we can use instead of our socket check in `chttpd_util`.

Since `mochiweb_request:is_closed/1` takes a request object, switch the client request monitoring code and tests to use requests instead of sockets. That involves doing a bunch of renames mostly which makes the PR a bit long, but otherwise, everything should work as before.
