### PR TITLE
Increase timeout in mango_cursor tests

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -558,9 +558,9 @@ create_test_() ->
             meck:unload()
         end,
         [
-            ?TDEF_FE(t_create_regular),
-            ?TDEF_FE(t_create_user_specified_index),
-            ?TDEF_FE(t_create_invalid_user_specified_index)
+            ?TDEF_FE(t_create_regular, 10),
+            ?TDEF_FE(t_create_user_specified_index, 10),
+            ?TDEF_FE(t_create_invalid_user_specified_index, 10)
         ]
     }.
 


### PR DESCRIPTION
Noticed two consecutive failures there on ppc64le platform. That's usually the slowest executor so it's probalby just a timeout. Let's try bumping it from 5 sec to 10 sec.

Re: https://github.com/apache/couchdb/pull/4662#issuecomment-1703174645