### PR TITLE
Increase timeout in mango_cursor tests

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -558,9 +558,9 @@ create_test_() ->
             meck:unload()
         end,
         [
-            ?TDEF_FE(t_create_regular),
-            ?TDEF_FE(t_create_user_specified_index),
-            ?TDEF_FE(t_create_invalid_user_specified_index)
+            ?TDEF_FE(t_create_regular, 10),
+            ?TDEF_FE(t_create_user_specified_index, 10),
+            ?TDEF_FE(t_create_invalid_user_specified_index, 10)
         ]
     }.
 


### PR DESCRIPTION
Noticed two consecutive failures there on ppc64le platform. That's usually the slowest executor so it's probalby just a timeout. Let's try bumping it from 5 sec to 10 sec.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
