### PR TITLE
Nouveau ibrowse improvements

### DIFF
--- a/nouveau/gradle/wrapper/gradle-wrapper.properties
+++ b/nouveau/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentDeleteRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentDeleteRequest.java
@@ -15,20 +15,36 @@ package org.apache.couchdb.nouveau.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public final class DocumentDeleteRequest {
+
+    @PositiveOrZero
+    private final long matchSeq;
 
     @Positive
     private final long seq;
 
     private final boolean purge;
 
-    public DocumentDeleteRequest(@JsonProperty("seq") final long seq, @JsonProperty("purge") final boolean purge) {
+    public DocumentDeleteRequest(
+            @JsonProperty("match_seq") final long matchSeq,
+            @JsonProperty("seq") final long seq,
+            @JsonProperty("purge") final boolean purge) {
+        if (matchSeq < 0) {
+            throw new IllegalArgumentException("matchSeq must be 0 or greater");
+        }
+
         if (seq < 1) {
             throw new IllegalArgumentException("seq must be 1 or greater");
         }
+        this.matchSeq = matchSeq;
         this.seq = seq;
         this.purge = purge;
+    }
+
+    public long getMatchSeq() {
+        return matchSeq;
     }
 
     public long getSeq() {
@@ -41,6 +57,6 @@ public final class DocumentDeleteRequest {
 
     @Override
     public String toString() {
-        return "DocumentDeleteRequest [seq=" + seq + ", purge=" + purge + "]";
+        return "DocumentDeleteRequest [matchSeq=" + matchSeq + ", seq=" + seq + ", purge=" + purge + "]";
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentDeleteRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentDeleteRequest.java
@@ -14,23 +14,16 @@
 package org.apache.couchdb.nouveau.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.Positive;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class DocumentDeleteRequest {
+public final class DocumentDeleteRequest {
 
     @Positive
-    private long seq;
+    private final long seq;
 
-    private boolean purge;
+    private final boolean purge;
 
-    public DocumentDeleteRequest() {
-        // Jackson deserialization
-    }
-
-    public DocumentDeleteRequest(long seq, final boolean purge) {
+    public DocumentDeleteRequest(@JsonProperty("seq") final long seq, @JsonProperty("purge") final boolean purge) {
         if (seq < 1) {
             throw new IllegalArgumentException("seq must be 1 or greater");
         }
@@ -38,12 +31,10 @@ public class DocumentDeleteRequest {
         this.purge = purge;
     }
 
-    @JsonProperty
     public long getSeq() {
         return seq;
     }
 
-    @JsonProperty
     public boolean isPurge() {
         return purge;
     }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentUpdateRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentUpdateRequest.java
@@ -17,9 +17,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.Collection;
 
 public final class DocumentUpdateRequest {
+
+    @PositiveOrZero
+    private final long matchSeq;
 
     @Positive
     private final long seq;
@@ -31,12 +35,18 @@ public final class DocumentUpdateRequest {
     private final Collection<Field> fields;
 
     public DocumentUpdateRequest(
+            @JsonProperty("match_seq") final long matchSeq,
             @JsonProperty("seq") final long seq,
             @JsonProperty("partition") final String partition,
             @JsonProperty("fields") final Collection<Field> fields) {
+        this.matchSeq = matchSeq;
         this.seq = seq;
         this.partition = partition;
         this.fields = fields;
+    }
+
+    public long getMatchSeq() {
+        return matchSeq;
     }
 
     public long getSeq() {
@@ -57,6 +67,7 @@ public final class DocumentUpdateRequest {
 
     @Override
     public String toString() {
-        return "DocumentUpdateRequest [seq=" + seq + ", partition=" + partition + ", fields=" + fields + "]";
+        return "DocumentUpdateRequest [matchSeq=" + matchSeq + ", seq=" + seq + ", partition=" + partition + ", fields="
+                + fields + "]";
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentUpdateRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/DocumentUpdateRequest.java
@@ -14,41 +14,35 @@
 package org.apache.couchdb.nouveau.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
 import java.util.Collection;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class DocumentUpdateRequest {
+public final class DocumentUpdateRequest {
 
     @Positive
-    private long seq;
+    private final long seq;
 
-    private String partition;
+    private final String partition;
 
     @NotEmpty
     @Valid
-    private Collection<Field> fields;
+    private final Collection<Field> fields;
 
-    public DocumentUpdateRequest() {
-        // Jackson deserialization
-    }
-
-    public DocumentUpdateRequest(long seq, String partition, Collection<Field> fields) {
+    public DocumentUpdateRequest(
+            @JsonProperty("seq") final long seq,
+            @JsonProperty("partition") final String partition,
+            @JsonProperty("fields") final Collection<Field> fields) {
         this.seq = seq;
         this.partition = partition;
         this.fields = fields;
     }
 
-    @JsonProperty
     public long getSeq() {
         return seq;
     }
 
-    @JsonProperty
     public String getPartition() {
         return partition;
     }
@@ -57,7 +51,6 @@ public class DocumentUpdateRequest {
         return partition != null;
     }
 
-    @JsonProperty
     public Collection<Field> getFields() {
         return fields;
     }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/IndexInfoRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/IndexInfoRequest.java
@@ -19,13 +19,13 @@ import java.util.OptionalLong;
 
 public final class IndexInfoRequest {
 
-    private OptionalLong updateSeq;
+    private final OptionalLong updateSeq;
 
-    private OptionalLong purgeSeq;
+    private final OptionalLong purgeSeq;
 
     public IndexInfoRequest(
-            @JsonProperty("update_seq") @Positive OptionalLong updateSeq,
-            @JsonProperty("purge_seq") @Positive OptionalLong purgeSeq) {
+            @JsonProperty("update_seq") @Positive final OptionalLong updateSeq,
+            @JsonProperty("purge_seq") @Positive final OptionalLong purgeSeq) {
         this.updateSeq = updateSeq;
         this.purgeSeq = purgeSeq;
     }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/IndexInfoRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/IndexInfoRequest.java
@@ -19,19 +19,35 @@ import java.util.OptionalLong;
 
 public final class IndexInfoRequest {
 
+    private final OptionalLong matchUpdateSeq;
+
     private final OptionalLong updateSeq;
+
+    private final OptionalLong matchPurgeSeq;
 
     private final OptionalLong purgeSeq;
 
     public IndexInfoRequest(
+            @JsonProperty("match_update_seq") @Positive final OptionalLong matchUpdateSeq,
             @JsonProperty("update_seq") @Positive final OptionalLong updateSeq,
+            @JsonProperty("match_purge_seq") @Positive final OptionalLong matchPurgeSeq,
             @JsonProperty("purge_seq") @Positive final OptionalLong purgeSeq) {
+        this.matchUpdateSeq = matchUpdateSeq;
         this.updateSeq = updateSeq;
+        this.matchPurgeSeq = matchPurgeSeq;
         this.purgeSeq = purgeSeq;
+    }
+
+    public OptionalLong getMatchUpdateSeq() {
+        return matchUpdateSeq;
     }
 
     public OptionalLong getUpdateSeq() {
         return updateSeq;
+    }
+
+    public OptionalLong getMatchPurgeSeq() {
+        return matchPurgeSeq;
     }
 
     public OptionalLong getPurgeSeq() {
@@ -40,6 +56,7 @@ public final class IndexInfoRequest {
 
     @Override
     public String toString() {
-        return "IndexInfoRequest [updateSeq=" + updateSeq + ", purgeSeq=" + purgeSeq + "]";
+        return "IndexInfoRequest [matchUpdateSeq=" + matchUpdateSeq + ", updateSeq=" + updateSeq + ", matchPurgeSeq="
+                + matchPurgeSeq + ", purgeSeq=" + purgeSeq + "]";
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/core/UpdatesOutOfOrderException.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/core/UpdatesOutOfOrderException.java
@@ -18,11 +18,12 @@ import jakarta.ws.rs.core.Response.Status;
 
 public final class UpdatesOutOfOrderException extends WebApplicationException {
 
-    public UpdatesOutOfOrderException(final long currentSeq, final long attemptedSeq) {
+    public UpdatesOutOfOrderException(
+            final boolean purge, final long currentSeq, final long matchSeq, final long attemptedSeq) {
         super(
                 String.format(
-                        "Updates applied in the wrong order (current seq: %d, attempted seq: %d)",
-                        currentSeq, attemptedSeq),
-                Status.BAD_REQUEST);
+                        "%s updates applied in the wrong order (current seq: %d, match seq: %d, attempted seq: %d)",
+                        purge ? "Purge" : "Index", currentSeq, matchSeq, attemptedSeq),
+                Status.CONFLICT);
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/health/IndexHealthCheck.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/health/IndexHealthCheck.java
@@ -42,7 +42,7 @@ public final class IndexHealthCheck extends HealthCheck {
         indexResource.createIndex(name, new IndexDefinition("standard", null));
         try {
             final DocumentUpdateRequest documentUpdateRequest =
-                    new DocumentUpdateRequest(1, null, Collections.emptyList());
+                    new DocumentUpdateRequest(0, 1, null, Collections.emptyList());
             indexResource.updateDoc(name, "foo", documentUpdateRequest);
 
             final SearchRequest searchRequest = new SearchRequest();

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/resources/IndexResource.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/resources/IndexResource.java
@@ -102,11 +102,16 @@ public final class IndexResource {
     public void setIndexInfo(@PathParam("name") String name, @NotNull @Valid IndexInfoRequest request)
             throws Exception {
         indexManager.with(name, indexLoader(), (index) -> {
-            if (request.getUpdateSeq().isPresent()) {
-                index.setUpdateSeq(request.getUpdateSeq().getAsLong());
+            if (request.getMatchUpdateSeq().isPresent()
+                    && request.getUpdateSeq().isPresent()) {
+                index.setUpdateSeq(
+                        request.getMatchUpdateSeq().getAsLong(),
+                        request.getUpdateSeq().getAsLong());
             }
-            if (request.getPurgeSeq().isPresent()) {
-                index.setPurgeSeq(request.getPurgeSeq().getAsLong());
+            if (request.getMatchPurgeSeq().isPresent() && request.getPurgeSeq().isPresent()) {
+                index.setPurgeSeq(
+                        request.getMatchPurgeSeq().getAsLong(),
+                        request.getPurgeSeq().getAsLong());
             }
             return null;
         });

--- a/src/nouveau/src/nouveau_index_manager.erl
+++ b/src/nouveau/src/nouveau_index_manager.erl
@@ -152,10 +152,10 @@ configure_ibrowse(URL) ->
     ibrowse:set_max_sessions(
         Host,
         Port,
-        config:get_integer("nouveau", "max_sessions", 100)
+        nouveau_util:max_sessions()
     ),
     ibrowse:set_max_pipeline_size(
         Host,
         Port,
-        config:get_integer("nouveau", "max_pipeline_size", 1000)
+        nouveau_util:max_pipeline_size()
     ).

--- a/src/nouveau/src/nouveau_util.erl
+++ b/src/nouveau/src/nouveau_util.erl
@@ -27,7 +27,9 @@
     maybe_create_local_purge_doc/2,
     get_local_purge_doc_id/1,
     get_local_purge_doc_body/3,
-    nouveau_url/0
+    nouveau_url/0,
+    max_sessions/0,
+    max_pipeline_size/0
 ]).
 
 index_name(Path) when is_binary(Path) ->
@@ -196,3 +198,9 @@ get_local_purge_doc_body(LocalDocId, PurgeSeq, Index) ->
 
 nouveau_url() ->
     config:get("nouveau", "url", "http://127.0.0.1:8080").
+
+max_sessions() ->
+    config:get_integer("nouveau", "max_sessions", 100).
+
+max_pipeline_size() ->
+    config:get_integer("nouveau", "max_pipeline_size", 1000).

--- a/test/elixir/test/nouveau_test.exs
+++ b/test/elixir/test/nouveau_test.exs
@@ -524,8 +524,9 @@ defmodule NouveauTest do
 
     resp = Couch.get("/#{db_name}/_design/foo/_nouveau_info/bar")
     assert_status_code(resp, 200)
-    assert resp.body["search_index"]["update_seq"] == 6
-    assert resp.body["search_index"]["purge_seq"] == 1
+    db_info = info(db_name)
+    assert seq(db_info["update_seq"]) == resp.body["search_index"]["update_seq"]
+    assert seq(db_info["purge_seq"]) == resp.body["search_index"]["purge_seq"]
   end
 
   @tag :with_db
@@ -593,7 +594,13 @@ defmodule NouveauTest do
 
     resp = Couch.get("/#{db_name}/_design/foo/_nouveau_info/bar")
     assert_status_code(resp, 200)
-    assert resp.body["search_index"]["update_seq"] == 8
-    assert resp.body["search_index"]["purge_seq"] == 4
+    db_info = info(db_name)
+    assert seq(db_info["update_seq"]) == resp.body["search_index"]["update_seq"]
+    assert seq(db_info["purge_seq"]) == resp.body["search_index"]["purge_seq"]
   end
+
+  def seq(str) do
+    String.to_integer(hd(Regex.run(~r/^[0-9]+/, str)))
+  end
+
 end


### PR DESCRIPTION
## Overview

This is a performance only pull request, but a complicated one.

I benchmarked nouveau against clouseau for the same database and found it was slower (2-4x slower depending on how large the documents were, the smaller the docs the bigger the difference).

This is fundamentally because clouseau's overhead between erlang and the jvm is much lower, as they are exchanging messages over an established, dedicated connection.

To improve nouveau performance I have adopted a similar approach, while ensuring index consistency.

1) nouveau on the jvm side requires each index update request (whether a document update, delete or purge, or a request to advance update_seq or purge_seq independently from an index change) to pass the current update_seq or purge_seq of the index. This is critical in detecting missed updates in the events of failure.
2) nouveau_index_updater spawns its own ibrowse worker (and, thus, its own dedicated http connection) when it starts to update an index. This ensures that all requests issued from the erlang side are received in the same order on the jvm side. Using the ibrowse pool would have allowed for a reordering.
3) finally, the performance improvement itself. nouveau_index_updater sets the `[{stream_to, self()}]` option, so does not wait for the response, successful or otherwise, before making the next one. This is why item 1 is critical. If there is a failure for one update, all subsequent updates will also fail, as the update/purge sequence on the jvm side will not have advanced. At the start of each loop of the callback fun we do a selective receive to collect any and all async responses we might have received. If any are errors, we terminate the update process with that error. We also check after the callback fun is finished but this time we block to receive all the outstanding responses, to ensure the index is in the state we require before issuing the request.

I've separated out these changes across multiple commits for readability.

## Testing recommendations

covered by the test suite

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
