### PR TITLE
fix(`mango`): correct behavior of `fields` on `_explain`

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -1401,7 +1401,9 @@ it easier to take advantage of future improvements to query planning
     :>json object mrargs: Arguments passed to the underlying view.
     :>json number limit: Limit parameter used.
     :>json number skip: Skip parameter used.
-    :>json array fields: Fields to be returned by the query.
+    :>json array fields: Fields to be returned by the query.  The `[]`
+       value here means all the fields, since there is no projection
+       happening in that case.
     :>json boolean partitioned: The database is partitioned or not.
     :>json array index_candidates: The list of all indexes that were
        found but not selected for serving the query.  See :ref:`the


### PR DESCRIPTION
The `fields` attribute on `_explain` might have the string value `"all_fields"` when the respective query parameter (`fields`) is not set by the user.  This is to express that no projection of fields would happen on the returned documents.

The current behavior contradicts with the current contract, because by documentation, `fields` is an array of strings instead to provide information on the projected fields.  The discrepancy here makes it hard to formalize this in OpenAPI which leads to problems in the development of SDKs, among others.

Change `_explain` to return `[]` for `fields` when it was not set through the query parameters. This is thought to be semantically equivalent to `"all_fields"` therefore this would not cause problems while preserving the promised type.

Thanks @ricellis for reporting this problem!

## Testing recommendations

```
make eunit apps=mango
```

Users who based their solution on utilizing the `"all_fields"` response explicitly might need to change it to use `[]` instead. Otherwise they will not affected by the change.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Documentation changes were made in the `src/docs` folder
