### PR TITLE
Revert "print peer port in http log"

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -250,7 +250,7 @@ handle_request_int(MochiReq) ->
                 P
         end,
 
-    Peer = peer(MochiReq),
+    Peer = MochiReq:get(peer),
 
     Method1 =
         case MochiReq:get(method) of
@@ -1477,23 +1477,6 @@ get_user(#httpd{user_ctx = #user_ctx{name = User}}) ->
     couch_util:url_encode(User);
 get_user(#httpd{user_ctx = undefined}) ->
     "undefined".
-
-peer(MochiReq) ->
-    Socket = MochiReq:get(socket),
-    case mochiweb_socket:peername(Socket) of
-        {ok, {{O1, O2, O3, O4}, Port}} ->
-            io_lib:format(
-                "~B.~B.~B.~B:~B",
-                [O1, O2, O3, O4, Port]
-            );
-        {ok, {{O1, O2, O3, O4, O5, O6, O7, O8}, Port}} ->
-            io_lib:format(
-                "~B.~B.~B.~B.~B.~B.~B.~B:~B",
-                [O1, O2, O3, O4, O5, O6, O7, O8, Port]
-            );
-        {error, _Reason} ->
-            MochiReq:get(peer)
-    end.
 
 -ifdef(TEST).
 


### PR DESCRIPTION
## Overview

This reverts commit 139ac9c05148b4c97c848bbe8d4d5abdf8e7fff5.

I, very belatedly, realised this breaks the X-Forwarded-For feature from mochiweb. That's more important than the port number. Reverting for now but will attempt again later (but without altering `peer` value).

## Testing recommendations

N/A

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
