### PR TITLE
fix(`mango`): align `opts.fields` with `fields` on `_explain`

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -325,7 +325,7 @@ explain(#cursor{} = Cursor) ->
     % The value of `r` needs to be translated to an integer
     % otherwise `jiffy:encode/1` will render it as an array.
     RValue = lists:keyfind(r, 1, Opts1),
-    Opts =
+    Opts2 =
         case RValue of
             {r, R} ->
                 lists:keyreplace(r, 1, Opts1, {r, list_to_integer(R)});
@@ -336,6 +336,14 @@ explain(#cursor{} = Cursor) ->
         case Fields0 of
             all_fields -> [];
             Value -> Value
+        end,
+    OptsFields = lists:keyfind(fields, 1, Opts2),
+    Opts =
+        case OptsFields of
+            {fields, all_fields} ->
+                lists:keyreplace(fields, 1, Opts2, {fields, []});
+            _ ->
+                Opts2
         end,
     CandidateIndexes = extract_candidate_indexes(Cursor),
     SelectorHints = extract_selector_hints(Selector),
@@ -1111,7 +1119,7 @@ t_explain_empty(_) ->
             db = db,
             index = none,
             selector = Selector,
-            opts = [{user_ctx, user_ctx}],
+            opts = [{user_ctx, user_ctx}, {fields, all_fields}],
             limit = limit,
             skip = skip,
             fields = all_fields,
@@ -1124,7 +1132,7 @@ t_explain_empty(_) ->
             {index, null},
             {partitioned, db_partitioned},
             {selector, Selector},
-            {opts, {[]}},
+            {opts, {[{fields, []}]}},
             {limit, limit},
             {skip, skip},
             {fields, []},
@@ -1160,7 +1168,7 @@ t_explain_regular(_) ->
             db = db,
             index = Index,
             selector = Selector,
-            opts = [{user_ctx, user_ctx}],
+            opts = [{user_ctx, user_ctx}, {fields, Fields}],
             limit = limit,
             skip = skip,
             fields = Fields,
@@ -1173,7 +1181,7 @@ t_explain_regular(_) ->
             {index, index},
             {partitioned, db_partitioned},
             {selector, Selector},
-            {opts, {[]}},
+            {opts, {[{fields, Fields}]}},
             {limit, limit},
             {skip, skip},
             {fields, Fields},


### PR DESCRIPTION
This is a follow-up to 83e39b6d where the `all_fields` value was replaced for `[]` to preserve the JSON array type.  The same has to be done for `fields` in the `opts` nesting object as well — these two attributes should behave alike.

## Testing recommendations

```shell
make eunit apps=mango
```

Similarly to #4751, users who based their solution on utilizing the `"all_fields"` response explicitly might need to change it to use `[]` instead. Otherwise they are not affected by the change.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
