### PR TITLE
Use HTTP rules for hostname verification

### DIFF
--- a/src/couch_replicator/src/couch_replicator_parse.erl
+++ b/src/couch_replicator/src/couch_replicator_parse.erl
@@ -489,7 +489,11 @@ ssl_params(Url) ->
 -spec ssl_verify_options(true | false) -> [_].
 ssl_verify_options(true) ->
     CAFile = cfg("ssl_trusted_certificates_file"),
-    [{verify, verify_peer}, {cacertfile, CAFile}];
+    [
+        {verify, verify_peer},
+        {customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]},
+        {cacertfile, CAFile}
+    ];
 ssl_verify_options(false) ->
     [{verify, verify_none}].
 

--- a/src/couch_replicator/src/couch_replicator_utils.erl
+++ b/src/couch_replicator/src/couch_replicator_utils.erl
@@ -335,6 +335,9 @@ check_ssl_certificates(#rep{} = Rep, Type) ->
                     {ssl_options, [
                         {cacertfile, CACertFile},
                         {verify, verify_peer},
+                        {customize_hostname_check, [
+                            {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+                        ]},
                         {verify_fun, check_certificate_fun(Rep, Url, Type)}
                     ]}
                 ])


### PR DESCRIPTION
## Overview

By default, erlang does not recognise wildcards in Server Name Indication fields (which is bizarre but they seem committed to this error).

Fortunately they also ship a function that does validate them, you just have to hook it up.

So here we do that hooking up.

## Testing recommendations

We are following the published advice at https://www.erlang.org/doc/man/ssl.html#type-customize_hostname_check;

> Customizes the hostname verification of the peer certificate, as different protocols that use TLS such as HTTP or LDAP may want to do it differently. For example the get standard HTTPS handling provide the already implememnted fun from the public_key application for HTTPS. `{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]}`

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
