### PR TITLE
Add new HTTP endpoint `/_node/_local/_smoosh/status`

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -39,6 +39,12 @@ handle_node_req(#httpd{path_parts = [_, <<"_local">>]} = Req) ->
     send_json(Req, 200, {[{name, node()}]});
 handle_node_req(#httpd{path_parts = [A, <<"_local">> | Rest]} = Req) ->
     handle_node_req(Req#httpd{path_parts = [A, node()] ++ Rest});
+% GET /_node/$node/_smoosh/status
+handle_node_req(#httpd{method = 'GET', path_parts = [_, _Node, <<"_smoosh">>, <<"status">>]} = Req) ->
+    {ok, Status} = smoosh:status(),
+    send_json(Req, 200, Status);
+handle_node_req(#httpd{path_parts = [_, _Node, <<"_smoosh">>, <<"status">>]} = Req) ->
+    send_method_not_allowed(Req, "GET");
 % GET /_node/$node/_versions
 handle_node_req(#httpd{method = 'GET', path_parts = [_, _Node, <<"_versions">>]} = Req) ->
     IcuVer = couch_ejson_compare:get_icu_version(),

--- a/src/docs/src/api/server/common.rst
+++ b/src/docs/src/api/server/common.rst
@@ -1902,6 +1902,116 @@ See :ref:`Configuration of Prometheus Endpoint <config/prometheus>` for details.
         Accept: text/plain
         Host: localhost:17986
 
+.. _api/server/smoosh/status:
+
+=====================================
+``/_node/{node-name}/_smoosh/status``
+=====================================
+
+.. versionadded:: 3.4
+
+.. http:get:: /_node/{node-name}/_smoosh/status
+    :synopsis: Returns metrics of the CouchDB's auto-compaction daemon
+
+    This prints the state of each channel, how many jobs they are
+    currently running and how many jobs are enqueued (as well as the
+    lowest and highest priority of those enqueued items). The idea is to
+    provide, at a glance, sufficient insight into ``smoosh`` that an operator
+    can assess whether ``smoosh`` is adequately targeting the reclaimable
+    space in the cluster.
+
+    In general, a healthy status output will have
+    items in the ``ratio_dbs`` and ``ratio_views`` channels. Owing to the default
+    settings, the ``slack_dbs`` and ``slack_views`` will almost certainly have
+    items in them. Historically, we've not found that the slack channels,
+    on their own, are particularly adept at keeping things well compacted.
+
+    :code 200: Request completed successfully
+    :code 401: CouchDB Server Administrator privileges required
+
+    **Request**:
+
+    .. code-block:: http
+
+        GET /_node/_local/_smoosh/status HTTP/1.1
+        Host: 127.0.0.1:5984
+        Accept: */*
+
+    **Response**:
+
+    .. code-block:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+            "channels": {
+                "slack_dbs": {
+                    "starting": 0,
+                    "waiting": {
+                        "size": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "active": 0
+                },
+                "ratio_dbs": {
+                    "starting": 0,
+                    "waiting": {
+                        "size": 56,
+                        "min": 1.125,
+                        "max": 11.0625
+                    },
+                    "active": 0
+                },
+                "ratio_views": {
+                    "starting": 0,
+                    "waiting": {
+                        "size": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "active": 0
+                },
+                "upgrade_dbs": {
+                    "starting": 0,
+                    "waiting": {
+                        "size": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "active": 0
+                },
+                "slack_views": {
+                    "starting": 0,
+                    "waiting": {
+                        "size": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "active": 0
+                },
+                "upgrade_views": {
+                    "starting": 0,
+                    "waiting": {
+                        "size": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "active": 0
+                },
+                "index_cleanup": {
+                    "starting": 0,
+                    "waiting": {
+                        "size": 0,
+                        "min": 0,
+                        "max": 0
+                    },
+                    "active": 0
+                }
+            }
+        }
+
 .. _api/server/system:
 
 ==============================

--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -77,10 +77,10 @@ enqueue(ServerRef, Object, Priority) ->
 get_status(StatusTab) when is_reference(StatusTab) ->
     try ets:lookup(StatusTab, status) of
         [{status, Status}] -> Status;
-        [] -> []
+        [] -> #{}
     catch
         error:badarg ->
-            []
+            #{}
     end.
 
 close(ServerRef) ->
@@ -235,11 +235,11 @@ unpersist(Name) ->
 %
 set_status(#state{} = State) ->
     #state{active = Active, starting = Starting, waiting = Waiting} = State,
-    Status = [
-        {active, map_size(Active)},
-        {starting, map_size(Starting)},
-        {waiting, smoosh_priority_queue:info(Waiting)}
-    ],
+    Status = #{
+        active => map_size(Active),
+        starting => map_size(Starting),
+        waiting => smoosh_priority_queue:info(Waiting)
+    },
     true = ets:insert(State#state.stab, {status, Status}),
     State.
 

--- a/src/smoosh/src/smoosh_persist.erl
+++ b/src/smoosh/src/smoosh_persist.erl
@@ -225,7 +225,7 @@ t_persist_unpersist_disabled(_) ->
 
     Q2 = unpersist(Name),
     ?assertEqual(Name, smoosh_priority_queue:name(Q2)),
-    ?assertEqual([{size, 0}], smoosh_priority_queue:info(Q2)).
+    ?assertEqual(#{max => 0, min => 0, size => 0}, smoosh_priority_queue:info(Q2)).
 
 t_persist_unpersist_enabled(_) ->
     Name = "chan2",
@@ -241,7 +241,7 @@ t_persist_unpersist_enabled(_) ->
     Q2 = unpersist(Name),
     ?assertEqual(Name, smoosh_priority_queue:name(Q2)),
     Info2 = smoosh_priority_queue:info(Q2),
-    ?assertEqual([{size, 3}, {min, 1.0}, {max, infinity}], Info2),
+    ?assertEqual(#{max => infinity, min => 1.0, size => 3}, Info2),
     ?assertEqual(Keys, drain_q(Q2)),
 
     % Try to persist the already unpersisted queue
@@ -249,7 +249,7 @@ t_persist_unpersist_enabled(_) ->
     Q3 = unpersist(Name),
     ?assertEqual(Name, smoosh_priority_queue:name(Q3)),
     Info3 = smoosh_priority_queue:info(Q2),
-    ?assertEqual([{size, 3}, {min, 1.0}, {max, infinity}], Info3),
+    ?assertEqual(#{max => infinity, min => 1.0, size => 3}, Info3),
     ?assertEqual(Keys, drain_q(Q3)).
 
 t_persist_unpersist_errors(_) ->
@@ -267,7 +267,7 @@ t_persist_unpersist_errors(_) ->
 
     Q2 = unpersist(Name),
     ?assertEqual(Name, smoosh_priority_queue:name(Q2)),
-    ?assertEqual([{size, 0}], smoosh_priority_queue:info(Q2)),
+    ?assertEqual(#{max => 0, min => 0, size => 0}, smoosh_priority_queue:info(Q2)),
 
     Dir = state_dir(),
     ok = file:make_dir(Dir),
@@ -278,7 +278,7 @@ t_persist_unpersist_errors(_) ->
 
     Q3 = unpersist(Name),
     ?assertEqual(Name, smoosh_priority_queue:name(Q3)),
-    ?assertEqual([{size, 0}], smoosh_priority_queue:info(Q3)),
+    ?assertEqual(#{max => 0, min => 0, size => 0}, smoosh_priority_queue:info(Q3)),
 
     ok = file:del_dir_r(Dir).
 


### PR DESCRIPTION
Adding the status of the CouchDB auto-compaction daemon to the HTTP API.

Old behavior / result if called from `remsh`:

```
smoosh:status().
{ok,[{"upgrade_dbs",
      [{active,0},{starting,0},{waiting,[{size,0}]}]},
     {"slack_dbs",[{active,0},{starting,0},{waiting,[{size,0}]}]},
     {"slack_views",
      [{active,0},{starting,0},{waiting,[{size,0}]}]},
     {"upgrade_views",
      [{active,0},{starting,0},{waiting,[{size,0}]}]},
     {"index_cleanup",
      [{active,0},{starting,0},{waiting,[{size,0}]}]},
     {"ratio_views",
      [{active,0},{starting,0},{waiting,[{size,0}]}]},
     {"ratio_dbs",
      [{active,0},{starting,0},{waiting,[{size,0}]}]}]}
```

The function `smoosh:status/1` returns now an Erlang map, so that it can be used directly with `send_json/3`.
Calling it from a `remsh` session, the result is the following:

```
(node1@127.0.0.1)1> smoosh:status().
{ok,#{channels =>
          #{index_cleanup =>
                #{active => 0,
                  waiting => #{max => 0,min => 0,size => 0},
                  starting => 0},
            upgrade_views =>
                #{active => 0,
                  waiting => #{max => 0,min => 0,size => 0},
                  starting => 0},
            slack_views =>
                #{active => 0,
                  waiting => #{max => 0,min => 0,size => 0},
                  starting => 0},
            upgrade_dbs =>
                #{active => 0,
                  waiting => #{max => 0,min => 0,size => 0},
                  starting => 0},
            ratio_views =>
                #{active => 0,
                  waiting => #{max => 0,min => 0,size => 0},
                  starting => 0},
            ratio_dbs =>
                #{active => 0,
                  waiting => #{max => 0,min => 0,size => 0},
                  starting => 0},
            slack_dbs =>
                #{active => 0,
                  waiting => #{max => 0,min => 0,size => 0},
                  starting => 0}}}}
```

Calling the new API endpoint `_node/{node-name}/_smoosh/status` will give the following result:

```
curl http://127.0.0.1:15984/_node/_local/_smoosh/status
```

```json
{
    "channels": {
        "slack_dbs": {
            "waiting": {
                "size": 0,
                "min": 0,
                "max": 0
            },
            "starting": 0,
            "active": 0
        },
        "ratio_dbs": {
            "waiting": {
                "size": 0,
                "min": 0,
                "max": 0
            },
            "starting": 0,
            "active": 0
        },
        "ratio_views": {
            "waiting": {
                "size": 0,
                "min": 0,
                "max": 0
            },
            "starting": 0,
            "active": 0
        },
        "upgrade_dbs": {
            "waiting": {
                "size": 0,
                "min": 0,
                "max": 0
            },
            "starting": 0,
            "active": 0
        },
        "slack_views": {
            "waiting": {
                "size": 0,
                "min": 0,
                "max": 0
            },
            "starting": 0,
            "active": 0
        },
        "upgrade_views": {
            "waiting": {
                "size": 0,
                "min": 0,
                "max": 0
            },
            "starting": 0,
            "active": 0
        },
        "index_cleanup": {
            "waiting": {
                "size": 0,
                "min": 0,
                "max": 0
            },
            "starting": 0,
            "active": 0
        }
    }
}
```

Closes #4705.