### PR TITLE
remsh extract wrong NODE name from ERL_FLAGS

### DIFF
--- a/rel/overlay/bin/remsh
+++ b/rel/overlay/bin/remsh
@@ -39,7 +39,7 @@ ARGS_FILE="${COUCHDB_ARGS_FILE:-$ROOTDIR/etc/vm.args}"
 
 # If present, extract cookie from ERL_FLAGS
 # This is used by the CouchDB Dockerfile and Helm chart
-NODE=$(echo "$ERL_FLAGS" | sed 's/^.*name \([^ ][^ ]*\).*$/\1/g')
+NODE=$(echo "$ERL_FLAGS" | sed -n 's/^.*name \([^ ][^ ]*\).*$/\1/p')
 if test -f "$ARGS_FILE"; then
 # else attempt to extract from vm.args
   ARGS_FILE_COOKIE=$(awk '$1=="-name"{print $2}' "$ARGS_FILE")


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Fixed #4783 remsh extract wrong NODE name from ERL_FLAGS

There is bug sed regex `echo "$ERL_FLAGS" | sed 's/^.*name \([^ ][^ ]*\).*$/\1/g'`. If there are no `-name ` in env ERL_FLAGS will get whole string. 

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [x] Documentation changes were backported (separated PR) to affected branches
