### PR TITLE
Add extra timing stats for couch_js engine commands

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -330,6 +330,46 @@
     {type, counter},
     {desc, <<"number of OS process prompt errors">>}
 ]}.
+{[couchdb, query_server, time, spawn_proc], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent spawning os query processes">>}
+]}.
+{[couchdb, query_server, time, map], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing map_doc requests">>}
+]}.
+{[couchdb, query_server, time, reduce], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing reduce requests">>}
+]}.
+{[couchdb, query_server, time, reset], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing reset requests">>}
+]}.
+{[couchdb, query_server, time, add_fun], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing add_fun requests">>}
+]}.
+{[couchdb, query_server, time, ddoc_new], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing ddoc new requests">>}
+]}.
+{[couchdb, query_server, time, ddoc_vdu], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing vdu requests">>}
+]}.
+{[couchdb, query_server, time, ddoc_filter], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing filter requests">>}
+]}.
+{[couchdb, query_server, time, ddoc_other], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing other ddoc requests">>}
+]}.
+{[couchdb, query_server, time, other], [
+    {type, counter},
+    {desc, <<"accumulated number of microseconds spent processing other requests">>}
+]}.
 {[couchdb, legacy_checksums], [
     {type, counter},
     {desc, <<"number of legacy checksums found in couch_file instances">>}


### PR DESCRIPTION
When evaluating various JS engine versions it's useful to track not just error metrics, but also how fast commands execute. To avoid creating a large number of histograms, and keep the metrics count reasonable, keep track of the total accumulated time spent on  some of the more frequently used commands.

To reduce counting json serialization into the JS processing time, move the writejson/2 and writeline/2 logic into the `prompt` callback. The time delta, is then taken after the data is serialized, and after it's deserialized from readjson/1. The reason for the asymmetry is that response data could be streamed back byte-by-byte, so in that case to keep it simpler, opt to record the times after json had already been parsed.

Take advantage of updating couch_js_module and switch it to use the more common ?TDEF macro. Also, take the opportinity to expand the coverage of the couch_js_module so it also tests reduces, add_lib and some ddoc operations like vdu, filter, and updates.
