### PR TITLE
Add calls counts to couch_js engine time stats

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -370,6 +370,46 @@
     {type, counter},
     {desc, <<"accumulated number of microseconds spent processing other requests">>}
 ]}.
+{[couchdb, query_server, calls, spawn_proc], [
+    {type, counter},
+    {desc, <<"number of spawned query processes">>}
+]}.
+{[couchdb, query_server, calls, map], [
+    {type, counter},
+    {desc, <<"number of map_doc requests">>}
+]}.
+{[couchdb, query_server, calls, reduce], [
+    {type, counter},
+    {desc, <<"number of reduce requests">>}
+]}.
+{[couchdb, query_server, calls, reset], [
+    {type, counter},
+    {desc, <<"number of reset requests">>}
+]}.
+{[couchdb, query_server, calls, add_fun], [
+    {type, counter},
+    {desc, <<"number of add_fun requests">>}
+]}.
+{[couchdb, query_server, calls, ddoc_new], [
+    {type, counter},
+    {desc, <<"number of ddoc new requests">>}
+]}.
+{[couchdb, query_server, calls, ddoc_vdu], [
+    {type, counter},
+    {desc, <<"number of vdu requests">>}
+]}.
+{[couchdb, query_server, calls, ddoc_filter], [
+    {type, counter},
+    {desc, <<"number of filter requests">>}
+]}.
+{[couchdb, query_server, calls, ddoc_other], [
+    {type, counter},
+    {desc, <<"number of other ddoc requests">>}
+]}.
+{[couchdb, query_server, calls, other], [
+    {type, counter},
+    {desc, <<"number of other requests">>}
+]}.
 {[couchdb, legacy_checksums], [
     {type, counter},
     {desc, <<"number of legacy checksums found in couch_file instances">>}

--- a/src/couch/src/couch_os_process.erl
+++ b/src/couch/src/couch_os_process.erl
@@ -254,4 +254,5 @@ bump_cmd_time_stat(Cmd, USec) when is_list(Cmd), is_integer(USec) ->
     end.
 
 bump_time_stat(Stat, USec) when is_atom(Stat), is_integer(USec) ->
+    couch_stats:increment_counter([couchdb, query_server, calls, Stat]),
     couch_stats:increment_counter([couchdb, query_server, time, Stat], USec).


### PR DESCRIPTION
Just tracking total time spent in each individual query prompt may be ambiguous, unless we also keep track of the number of calls of each prompt type.

For instance, if we notice the total time spent per some call increasing, it could be because the JS engine got slower, or, because some other bottleneck was removed and now we can run more total map calls per unit of time. To disambiguate between these cases let's also track the total number of calls. This way users would be able to estimate the average time spent per call more accurately.
