### PR TITLE
feat(`mango`): add `allow_fallback` to control falling back to other indexes on `_find`

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -50,6 +50,12 @@
         is attempted. Therefore that is more like a hint. When
         fallback occurs, the details are given in the ``warning``
         field of the response. *Optional*
+    :<json boolean allow_fallback: Tell if it is allowed to fall back
+        to a valid index when requesting a query to use a specific
+        index that is not deemed usable.  Default is ``true``.  This
+        is meant to be used in combination with ``use_index`` and
+        setting ``allow_fallback`` to ``false`` can make the query
+        fail if the user-specified index is not suitable.  *Optional*
     :<json boolean conflicts: Include conflicted documents if ``true``.
         Intended use is to easily find conflicted documents, without an
         index or view. Default is ``false``. *Optional*
@@ -1498,7 +1504,8 @@ it easier to take advantage of future improvements to query planning
                 "stale": false,
                 "update": true,
                 "stable": false,
-                "execution_stats": false
+                "execution_stats": false,
+                "allow_fallback": true
             },
             "limit": 2,
             "skip": 0,

--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -19,11 +19,11 @@
 .. http:post:: /{db}/_find
     :synopsis: Find documents within a given database.
 
-    Find documents using a declarative JSON querying syntax.
-    Queries will use custom indexes, specified using the :ref:`_index <api/db/find/index>`
-    endpoint, if available.
-    Otherwise, they use the built-in :ref:`_all_docs <api/db/all_docs>` index, which
-    can be arbitrarily slow.
+    Find documents using a declarative JSON querying syntax.  Queries
+    will use custom indexes, specified using the :ref:`_index
+    <api/db/find/index>` endpoint, if available.  Otherwise, when
+    allowed, they use the built-in :ref:`_all_docs <api/db/all_docs>`
+    index, which can be arbitrarily slow.
 
     :param db: Database name
 
@@ -51,11 +51,13 @@
         fallback occurs, the details are given in the ``warning``
         field of the response. *Optional*
     :<json boolean allow_fallback: Tell if it is allowed to fall back
-        to a valid index when requesting a query to use a specific
-        index that is not deemed usable.  Default is ``true``.  This
-        is meant to be used in combination with ``use_index`` and
-        setting ``allow_fallback`` to ``false`` can make the query
-        fail if the user-specified index is not suitable.  *Optional*
+        to another valid index.  This can happen on running a query
+        with an index specified by ``use_index`` which is not deemed
+        usable, or when only the built-in :ref:`_all_docs
+        <api/db/all_docs>` index would be picked in lack of indexes
+        available to support the query.  Disabling this fallback logic
+        causes the endpoint immediately return an error in such cases.
+        Default is ``true``. *Optional*
     :<json boolean conflicts: Include conflicted documents if ``true``.
         Intended use is to easily find conflicted documents, without an
         index or view. Default is ``false``. *Optional*

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -253,6 +253,12 @@ info(mango_opts, {invalid_bulk_docs, Val}) ->
             [Val]
         )
     };
+info(mango_opts, {invalid_index_name, Val}) ->
+    {
+        400,
+        <<"invalid_index_name">>,
+        fmt("Invalid index name: ~w", [Val])
+    };
 info(mango_opts, {invalid_ejson, Val}) ->
     {
         400,

--- a/src/mango/src/mango_error.erl
+++ b/src/mango/src/mango_error.erl
@@ -48,6 +48,28 @@ info(mango_json_bookmark, {invalid_bookmark, BadBookmark}) ->
         <<"invalid_bookmark">>,
         fmt("Invalid bookmark value: ~s", [?JSON_ENCODE(BadBookmark)])
     };
+info(mango_cursor, {invalid_index, []}) ->
+    {
+        400,
+        <<"invalid_index">>,
+        <<"You must specify an index with the `use_index` parameter.">>
+    };
+info(mango_cursor, {invalid_index, [DDocName]}) ->
+    {
+        400,
+        <<"invalid_index">>,
+        fmt("_design/~s specified by `use_index` could not be found or it is not suitable.", [
+            DDocName
+        ])
+    };
+info(mango_cursor, {invalid_index, [DDocName, ViewName]}) ->
+    {
+        400,
+        <<"invalid_index">>,
+        fmt("_design/~s, ~s specified by `use_index` could not be found or it is not suitable.", [
+            DDocName, ViewName
+        ])
+    };
 info(mango_cursor_text, {invalid_bookmark, BadBookmark}) ->
     {
         400,

--- a/src/mango/src/mango_opts.erl
+++ b/src/mango/src/mango_opts.erl
@@ -262,7 +262,7 @@ validate_bulk_docs(Else) ->
     ?MANGO_ERROR({invalid_bulk_docs, Else}).
 
 validate_use_index(IndexName) when is_binary(IndexName) ->
-    case binary:split(IndexName, <<"/">>) of
+    case binary:split(IndexName, <<"/">>, [global]) of
         [DesignId] ->
             {ok, [DesignId]};
         [<<"_design">>, DesignId] ->

--- a/src/mango/src/mango_opts.erl
+++ b/src/mango/src/mango_opts.erl
@@ -162,6 +162,12 @@ validate_find({Props}) ->
             {optional, true},
             {default, false},
             {validator, fun mango_opts:is_boolean/1}
+        ]},
+        {<<"allow_fallback">>, [
+            {tag, allow_fallback},
+            {optional, true},
+            {default, true},
+            {validator, fun mango_opts:is_boolean/1}
         ]}
     ],
     validate(Props, Opts).

--- a/src/mango/test/02-basic-find-test.py
+++ b/src/mango/test/02-basic-find-test.py
@@ -311,6 +311,7 @@ class BasicFindTests(mango.UserDocsTests):
         assert opts["stale"] == False
         assert opts["update"] == True
         assert opts["use_index"] == []
+        assert opts["allow_fallback"] == True
 
     def test_sort_with_all_docs(self):
         explain = self.db.find(

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -211,6 +211,31 @@ class IndexSelectionTests:
         )
         self.assertEqual(resp_explain["index"]["type"], "json")
 
+    def test_use_index_without_fallback(self):
+        with self.subTest(use_index="valid"):
+            docs = self.db.find(
+                {"manager": True}, use_index="manager", allow_fallback=False
+            )
+            assert len(docs) > 0
+
+        with self.subTest(use_index="invalid"):
+            try:
+                self.db.find(
+                    {"manager": True}, use_index="invalid", allow_fallback=False
+                )
+            except Exception as e:
+                self.assertEqual(e.response.status_code, 400)
+            else:
+                raise AssertionError("did not fail on invalid index")
+
+        with self.subTest(use_index="empty"):
+            try:
+                self.db.find({"manager": True}, use_index=[], allow_fallback=False)
+            except Exception as e:
+                self.assertEqual(e.response.status_code, 400)
+            else:
+                raise AssertionError("did not fail due to missing use_index")
+
 
 class JSONIndexSelectionTests(mango.UserDocsTests, IndexSelectionTests):
     @classmethod

--- a/src/mango/test/05-index-selection-test.py
+++ b/src/mango/test/05-index-selection-test.py
@@ -211,6 +211,16 @@ class IndexSelectionTests:
         )
         self.assertEqual(resp_explain["index"]["type"], "json")
 
+    def test_use_index_with_invalid_name(self):
+        for index in ["foo/bar/baz", ["foo", "bar", "baz"]]:
+            with self.subTest(index=index):
+                try:
+                    self.db.find({"manager": True}, use_index=index)
+                except Exception as e:
+                    self.assertEqual(e.response.status_code, 400)
+                else:
+                    raise AssertionError("did not fail on invalid index name")
+
     def test_use_index_without_fallback(self):
         with self.subTest(use_index="valid"):
             docs = self.db.find(

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -282,6 +282,7 @@ class Database(object):
         update=True,
         executionStats=False,
         partition=None,
+        allow_fallback=None,
     ):
         body = {
             "selector": selector,
@@ -301,6 +302,8 @@ class Database(object):
             body["update"] = False
         if executionStats == True:
             body["execution_stats"] = True
+        if allow_fallback is not None:
+            body["allow_fallback"] = allow_fallback
         body = json.dumps(body)
         if partition:
             ppath = "_partition/{}/".format(partition)


### PR DESCRIPTION
*This is an alternative to #4710 based on the results of the related discussion.*

It is not always beneficial for the performance if the Mango query planner tries to assign an index to the selector.  User-specified indexes may save the day, but since they are only hints for the planner, fallbacks may still happen.

Introduce the `allow_fallback` flag which can be used to tell if falling back to other indexes is acceptable when an index is explicitly specified by the user or when only the "catch-all" `all_docs` index could be picked.  When set to `false`, give up on planning and return an HTTP 400 response right away.  This way the user has the chance to learn about the requested but missing index, optionally create it and try again.

By default, fallbacks are allowed to maintain backwards compatibility.  It is possible to set `allow_fallback` to `true` but currently it coincides with the default behavior hence becomes a no-op in practice.

Fixes #4511

## Testing recommendations

The changes could be verified by the following commands:

```shell
make eunit apps=mango
make mango-test
```

This is a non-breaking change, so there should be no observable difference in the behavior for the users.  When `allow_fallback` is set to `false` and `use_index` is set to some index, it may return HTTP 400 depending on the suitability of the given index.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Documentation changes were made in the `src/docs` folder
