### PR TITLE
Fix incorrect raising of database_does_not_exist error

### DIFF
--- a/src/custodian/src/custodian_util.erl
+++ b/src/custodian/src/custodian_util.erl
@@ -187,7 +187,7 @@ load_shards(Db, #full_doc_info{id = Id} = FDI) ->
         {ok, #doc{body = {Props}}} ->
             mem3_util:build_shards(Id, Props);
         {not_found, _} ->
-            erlang:error(database_does_not_exist, ?b2l(Id))
+            erlang:error(database_does_not_exist, [Id])
     end.
 
 maybe_redirect(Nodes) ->

--- a/src/fabric/src/fabric_db_create.erl
+++ b/src/fabric/src/fabric_db_create.erl
@@ -227,7 +227,7 @@ db_exists_for_existing_db() ->
 
 db_exists_for_missing_db() ->
     Mock = fun(DbName) ->
-        erlang:error(database_does_not_exist, DbName)
+        erlang:error(database_does_not_exist, [DbName])
     end,
     ok = meck:expect(mem3, shards, Mock),
     ?assertEqual(false, db_exists(<<"foobar">>)),

--- a/src/fabric/src/fabric_db_delete.erl
+++ b/src/fabric/src/fabric_db_delete.erl
@@ -29,7 +29,7 @@ go(DbName, _Options) ->
         {ok, accepted} ->
             accepted;
         {ok, not_found} ->
-            erlang:error(database_does_not_exist, DbName);
+            erlang:error(database_does_not_exist, [DbName]);
         Error ->
             Error
     after

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -53,7 +53,7 @@ opts_for_db(DbName0) ->
         {ok, #doc{body = {Props}}} ->
             mem3_util:get_shard_opts(Props);
         {not_found, _} ->
-            erlang:error(database_does_not_exist, ?b2l(DbName))
+            erlang:error(database_does_not_exist, [DbName])
     end.
 
 for_db(DbName) ->
@@ -427,7 +427,7 @@ load_shards_from_db(ShardDb, DbName) ->
             end,
             Shards;
         {not_found, _} ->
-            erlang:error(database_does_not_exist, ?b2l(DbName))
+            erlang:error(database_does_not_exist, [DbName])
     end.
 
 load_shards_from_disk(DbName, DocId) ->


### PR DESCRIPTION
When we're raising the error with the args list [1], the format for the args is a list of arguments not a single arg. So the previous invocations of `erlang:error(database_does_not_exist, ?b2l(Id))` would produce a args list of individual database name characters [2].

[1] https://www.erlang.org/doc/man/erlang#error-2

[2] > mem3_shards:opts_for_db(<<"doesnotexit">>).
```
** exception error: database_does_not_exist
     in function  mem3_shards:opts_for_db/11
        called as mem3_shards:opts_for_db(100,111,101,115,110,111,116,101,120,105,116)
```
