### PR TITLE
Configure hex, gradle, pip and npm caches.

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -65,13 +65,16 @@ meta = [
     image: "apache/couchdbci-debian:buster-erlang-${ERLANG_VERSION}"
   ],
 
-  'bullseye-arm64': [
-    name: 'Debian 11 ARM',
-    spidermonkey_vsn: '78',
-    enable_nouveau: true,
-    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
-    node_label: 'arm64v8'
-  ],
+  // Exclude temporarily until we can fix package cache directory
+  // permissions
+  //
+  // 'bullseye-arm64': [
+  //   name: 'Debian 11 ARM',
+  //   spidermonkey_vsn: '78',
+  //   enable_nouveau: true,
+  //   image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+  //   node_label: 'arm64v8'
+  // ],
 
   'bullseye-ppc64': [
     name: 'Debian 11 POWER',
@@ -81,13 +84,15 @@ meta = [
     node_label: 'ppc64le'
   ],
 
-  'bullseye-s390x': [
-    name: 'Debian 11 s390x',
-    spidermonkey_vsn: '78',
-    enable_nouveau: true,
-    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
-    node_label: 's390x'
-  ],
+  // Exclude until hex.pm downloads are resolved
+  //   https://github.com/linuxone-community-cloud/tickets/issues/58
+  // 'bullseye-s390x': [
+  //   name: 'Debian 11 s390x',
+  //   spidermonkey_vsn: '78',
+  //   enable_nouveau: true,
+  //   image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+  //   node_label: 's390x'
+  // ],
 
   'bullseye': [
     name: 'Debian 11',
@@ -282,7 +287,7 @@ pipeline {
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly
     // inside the image
-    DOCKER_ARGS = '-e npm_config_cache=npm-cache -e HOME=. -v=/etc/passwd:/etc/passwd -v /etc/group:/etc/group -v /root/.gradle:/root/.gradle'
+    DOCKER_ARGS = '-e npm_config_cache=/home/jenkins/.npm -e HOME=. -e MIX_HOME=/home/jenkins/.mix -e HEX_HOME=/home/jenkins/.hex -e PIP_CACHE_DIR=/home/jenkins/.cache/pip -v=/etc/passwd:/etc/passwd -v /etc/group:/etc/group -v /home/jenkins/.gradle:/home/jenkins/.gradle:rw,z -v /home/jenkins/.hex:/home/jenkins/.hex:rw,z -v /home/jenkins/.npm:/home/jenkins/.npm:rw,z -v /home/jenkins/.cache/pip:/home/jenkins/.cache/pip:rw,z -v /home/jenkins/.mix:/home/jenkins/.mix:rw,z'
   }
 
   options {

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -44,7 +44,7 @@ pipeline {
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly
     // inside the image
-    DOCKER_ARGS = '-e npm_config_cache=npm-cache -e HOME=. -v=/etc/passwd:/etc/passwd -v /etc/group:/etc/group'
+    DOCKER_ARGS = '-e npm_config_cache=/home/jenkins/.npm -e HOME=. -e MIX_HOME=/home/jenkins/.mix -e HEX_HOME=/home/jenkins/.hex -e PIP_CACHE_DIR=/home/jenkins/.cache/pip -v=/etc/passwd:/etc/passwd -v /etc/group:/etc/group -v /home/jenkins/.gradle:/home/jenkins/.gradle:rw,z -v /home/jenkins/.hex:/home/jenkins/.hex:rw,z -v /home/jenkins/.npm:/home/jenkins/.npm:rw,z -v /home/jenkins/.cache/pip:/home/jenkins/.cache/pip:rw,z -v /home/jenkins/.mix:/home/jenkins/.mix:rw,z'
 
     // *** BE SURE TO ALSO CHANGE THE ERLANG VERSIONS FARTHER DOWN ***
     // Search for ERLANG_VERSION


### PR DESCRIPTION
We saw repeated failures on some CI nodes, possibly from them being throttled
by hex.pm. To mitigate it, try to setup package caches for hex, gradle, pip and
npm.

So far it works with Docker builder only but requires that cache directories in
/home/jenkins are owned by the `jenkins` user. That has to happen as part of
the Jenkins node setup. Nodes controlled from couchdb-infra-cm have been
updated to have those directories and permission however the ARM64 one doesn't
yet, so we're excluding it temporarily.