### PR TITLE
fix(`mango`): correct the fix for the duplicated `text` results

### DIFF
--- a/src/mango/src/mango_cursor_nouveau.erl
+++ b/src/mango/src/mango_cursor_nouveau.erl
@@ -176,17 +176,17 @@ handle_hit(CAcc0, Hit, Doc) ->
         execution_stats = Stats,
         documents_seen = Seen
     } = CAcc0,
+    CAcc1 = update_bookmark(CAcc0, Hit),
     Stats1 = mango_execution_stats:incr_docs_examined(Stats),
     couch_stats:increment_counter([mango, docs_examined]),
-    CAcc1 = CAcc0#cacc{execution_stats = Stats1},
-    case mango_selector:match(CAcc1#cacc.selector, Doc) of
+    CAcc2 = CAcc1#cacc{execution_stats = Stats1},
+    case mango_selector:match(CAcc2#cacc.selector, Doc) of
         true ->
             DocId = mango_doc:get_field(Doc, <<"_id">>),
             case sets:is_element(DocId, Seen) of
                 true ->
-                    CAcc1;
+                    CAcc2;
                 false ->
-                    CAcc2 = update_bookmark(CAcc1, Hit),
                     CAcc3 = CAcc2#cacc{
                         documents_seen = sets:add_element(DocId, Seen)
                     },
@@ -207,7 +207,7 @@ handle_hit(CAcc0, Hit, Doc) ->
                     end
             end;
         false ->
-            CAcc1
+            CAcc2
     end.
 
 apply_user_fun(CAcc, Doc) ->

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -184,17 +184,17 @@ handle_hit(CAcc0, Sort, Doc) ->
         execution_stats = Stats,
         documents_seen = Seen
     } = CAcc0,
+    CAcc1 = update_bookmark(CAcc0, Sort),
     Stats1 = mango_execution_stats:incr_docs_examined(Stats),
     couch_stats:increment_counter([mango, docs_examined]),
-    CAcc1 = CAcc0#cacc{execution_stats = Stats1},
-    case mango_selector:match(CAcc1#cacc.selector, Doc) of
+    CAcc2 = CAcc1#cacc{execution_stats = Stats1},
+    case mango_selector:match(CAcc2#cacc.selector, Doc) of
         true ->
             DocId = mango_doc:get_field(Doc, <<"_id">>),
             case sets:is_element(DocId, Seen) of
                 true ->
-                    CAcc1;
+                    CAcc2;
                 false ->
-                    CAcc2 = update_bookmark(CAcc1, Sort),
                     CAcc3 = CAcc2#cacc{
                         documents_seen = sets:add_element(DocId, Seen)
                     },
@@ -216,7 +216,7 @@ handle_hit(CAcc0, Sort, Doc) ->
                     end
             end;
         false ->
-            CAcc1
+            CAcc2
     end.
 
 apply_user_fun(CAcc, Doc) ->
@@ -765,8 +765,8 @@ t_execute_limit_cutoff_unique(_) ->
                         Hit2 = #sortable{item = #hit{fields = [{<<"_id">>, {id, 2}}]}},
                         Hit3 = #sortable{item = #hit{fields = [{<<"_id">>, {id, 3}}]}},
                         {[bookmark, 4], [Hit3, Hit2, Hit1]};
-                    [bookmark, 4] ->
-                        {[bookmark, 5], []}
+                    [bookmark, 7] ->
+                        {[bookmark, 8], []}
                 end,
             {ok, Bookmark, undefined, Hits, undefined, undefined}
         end
@@ -857,8 +857,8 @@ t_execute_limit_unique(_) ->
                         Hit2 = #sortable{item = #hit{fields = [{<<"_id">>, {id, 2}}]}},
                         Hit3 = #sortable{item = #hit{fields = [{<<"_id">>, {id, 3}}]}},
                         {[bookmark, 4], [Hit3, Hit2, Hit1]};
-                    [bookmark, 4] ->
-                        {[bookmark, 5], []}
+                    [bookmark, 7] ->
+                        {[bookmark, 8], []}
                 end,
             {ok, Bookmark, undefined, Hits, undefined, undefined}
         end


### PR DESCRIPTION
This is a follow-up to #4782.  Commits d6d4ad97 and ce2607a5 missed out on the necessity of keeping the bookmark updated all the time.  Otherwise the same hits might be returned which can lead to an infinite loop at the processing and make the integration test suite hang, for example.

This change is covered by the existing unit and integration tests.