### PR TITLE
mango: do not skip json tests when clouseau installed

### DIFF
--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -14,62 +14,164 @@ import mango
 import unittest
 
 
-class OperatorTests:
-    def assertUserIds(self, user_ids, docs):
-        user_ids_returned = list(d["user_id"] for d in docs)
-        user_ids.sort()
-        user_ids_returned.sort()
-        self.assertEqual(user_ids, user_ids_returned)
+class BaseOperatorTests:
+    class Common(object):
+        def assertUserIds(self, user_ids, docs):
+            user_ids_returned = list(d["user_id"] for d in docs)
+            user_ids.sort()
+            user_ids_returned.sort()
+            self.assertEqual(user_ids, user_ids_returned)
 
-    def test_all(self):
-        docs = self.db.find(
-            {"manager": True, "favorites": {"$all": ["Lisp", "Python"]}}
-        )
-        self.assertEqual(len(docs), 3)
-        user_ids = [2, 12, 9]
+        def test_all(self):
+            docs = self.db.find(
+                {"manager": True, "favorites": {"$all": ["Lisp", "Python"]}}
+            )
+            self.assertEqual(len(docs), 3)
+            user_ids = [2, 12, 9]
+            self.assertUserIds(user_ids, docs)
+
+        def test_all_non_array(self):
+            docs = self.db.find({"manager": True, "location": {"$all": ["Ohai"]}})
+            self.assertEqual(len(docs), 0)
+
+        def test_elem_match(self):
+            emdocs = [
+                {"user_id": "a", "bang": [{"foo": 1, "bar": 2}]},
+                {"user_id": "b", "bang": [{"foo": 2, "bam": True}]},
+            ]
+            self.db.save_docs(emdocs, w=3)
+            docs = self.db.find(
+                {
+                    "_id": {"$gt": None},
+                    "bang": {"$elemMatch": {"foo": {"$gte": 1}, "bam": True}},
+                }
+            )
+            self.assertEqual(len(docs), 1)
+            self.assertEqual(docs[0]["user_id"], "b")
+
+        def test_all_match(self):
+            amdocs = [
+                {"user_id": "a", "bang": [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]},
+                {"user_id": "b", "bang": [{"foo": 1, "bar": 2}, {"foo": 4, "bar": 4}]},
+            ]
+            self.db.save_docs(amdocs, w=3)
+            docs = self.db.find(
+                {
+                    "bang": {
+                        "$allMatch": {"foo": {"$mod": [2, 1]}, "bar": {"$mod": [2, 0]}}
+                    }
+                }
+            )
+            self.assertEqual(len(docs), 1)
+            self.assertEqual(docs[0]["user_id"], "a")
+
+        def test_empty_all_match(self):
+            amdocs = [{"bad_doc": "a", "emptybang": []}]
+            self.db.save_docs(amdocs, w=3)
+            docs = self.db.find({"emptybang": {"$allMatch": {"foo": {"$eq": 2}}}})
+            self.assertEqual(len(docs), 0)
+
+        def test_in_operator_array(self):
+            docs = self.db.find(
+                {"manager": True, "favorites": {"$in": ["Ruby", "Python"]}}
+            )
+            self.assertUserIds([2, 6, 7, 9, 11, 12], docs)
+
+        def test_nin_operator_array(self):
+            docs = self.db.find(
+                {"manager": True, "favorites": {"$nin": ["Erlang", "Python"]}}
+            )
+            self.assertEqual(len(docs), 4)
+            for doc in docs:
+                if isinstance(doc["favorites"], list):
+                    self.assertNotIn("Erlang", doc["favorites"])
+                    self.assertNotIn("Python", doc["favorites"])
+
+        def test_regex(self):
+            docs = self.db.find(
+                {"age": {"$gt": 40}, "location.state": {"$regex": "(?i)new.*"}}
+            )
+            self.assertEqual(len(docs), 2)
+            self.assertUserIds([2, 10], docs)
+
+        def test_exists_false(self):
+            docs = self.db.find({"age": {"$gt": 0}, "twitter": {"$exists": False}})
+            user_ids = [2, 3, 5, 6, 7, 8, 10, 11, 12, 14]
+            self.assertUserIds(user_ids, docs)
+            for d in docs:
+                self.assertNotIn("twitter", d)
+
+        def test_eq_null_does_not_include_missing(self):
+            docs = self.db.find({"age": {"$gt": 0}, "twitter": None})
+            user_ids = [9]
+            self.assertUserIds(user_ids, docs)
+            for d in docs:
+                self.assertEqual(d["twitter"], None)
+
+        def test_ne_includes_null_but_not_missing(self):
+            docs = self.db.find({"twitter": {"$ne": "notamatch"}})
+            user_ids = [0, 1, 4, 9, 13]
+            self.assertUserIds(user_ids, docs)
+            for d in docs:
+                self.assertIn("twitter", d)
+
+        def test_lte_null_includes_null_but_not_missing(self):
+            docs = self.db.find({"twitter": {"$lte": None}})
+            user_ids = [9]
+            self.assertUserIds(user_ids, docs)
+            for d in docs:
+                self.assertEqual(d["twitter"], None)
+
+        def test_lte_at_z_except_null_excludes_null_and_missing(self):
+            docs = self.db.find({"twitter": {"$and": [{"$lte": "@z"}, {"$ne": None}]}})
+            user_ids = [0, 1, 4, 13]
+            self.assertUserIds(user_ids, docs)
+            for d in docs:
+                self.assertNotEqual(d["twitter"], None)
+
+        def test_range_gte_null_includes_null_but_not_missing(self):
+            docs = self.db.find({"twitter": {"$gte": None}})
+            self.assertGreater(len(docs), 0)
+            for d in docs:
+                self.assertIn("twitter", d)
+
+        def test_exists_false_returns_missing_but_not_null(self):
+            docs = self.db.find({"twitter": {"$exists": False}})
+            self.assertGreater(len(docs), 0)
+            for d in docs:
+                self.assertNotIn("twitter", d)
+
+
+class OperatorJSONTests(mango.UserDocsTests, BaseOperatorTests.Common):
+    # START: text indexes do not support range queries across type boundaries so only
+    # test this for JSON indexes
+    def test_lt_includes_null_but_not_missing(self):
+        docs = self.db.find({"twitter": {"$lt": 1}})
+        user_ids = [9]
+        self.assertUserIds(user_ids, docs)
+        for d in docs:
+            self.assertEqual(d["twitter"], None)
+
+    def test_lte_includes_null_but_not_missing(self):
+        docs = self.db.find({"twitter": {"$lte": 1}})
+        user_ids = [9]
+        self.assertUserIds(user_ids, docs)
+        for d in docs:
+            self.assertEqual(d["twitter"], None)
+
+    def test_lte_respects_unicode_collation(self):
+        docs = self.db.find({"ordered": {"$lte": "a"}})
+        user_ids = [7, 8, 9, 10, 11, 12]
         self.assertUserIds(user_ids, docs)
 
-    def test_all_non_array(self):
-        docs = self.db.find({"manager": True, "location": {"$all": ["Ohai"]}})
-        self.assertEqual(len(docs), 0)
+    def test_gte_respects_unicode_collation(self):
+        docs = self.db.find({"ordered": {"$gte": "a"}})
+        user_ids = [12, 13, 14]
+        self.assertUserIds(user_ids, docs)
 
-    def test_elem_match(self):
-        emdocs = [
-            {"user_id": "a", "bang": [{"foo": 1, "bar": 2}]},
-            {"user_id": "b", "bang": [{"foo": 2, "bam": True}]},
-        ]
-        self.db.save_docs(emdocs, w=3)
-        docs = self.db.find(
-            {
-                "_id": {"$gt": None},
-                "bang": {"$elemMatch": {"foo": {"$gte": 1}, "bam": True}},
-            }
-        )
-        self.assertEqual(len(docs), 1)
-        self.assertEqual(docs[0]["user_id"], "b")
+    # END
 
-    def test_all_match(self):
-        amdocs = [
-            {"user_id": "a", "bang": [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]},
-            {"user_id": "b", "bang": [{"foo": 1, "bar": 2}, {"foo": 4, "bar": 4}]},
-        ]
-        self.db.save_docs(amdocs, w=3)
-        docs = self.db.find(
-            {"bang": {"$allMatch": {"foo": {"$mod": [2, 1]}, "bar": {"$mod": [2, 0]}}}}
-        )
-        self.assertEqual(len(docs), 1)
-        self.assertEqual(docs[0]["user_id"], "a")
-
-    def test_empty_all_match(self):
-        amdocs = [{"bad_doc": "a", "emptybang": []}]
-        self.db.save_docs(amdocs, w=3)
-        docs = self.db.find({"emptybang": {"$allMatch": {"foo": {"$eq": 2}}}})
-        self.assertEqual(len(docs), 0)
-
-    @unittest.skipUnless(
-        not mango.has_text_service(),
-        "text indexes do not support the $keyMapMatch operator",
-    )
+    # $keyMapMatch operator is only supported for JSON indexes
     def test_keymap_match(self):
         amdocs = [
             {"foo": {"aa": "bar", "bb": "bang"}},
@@ -79,126 +181,13 @@ class OperatorTests:
         docs = self.db.find({"foo": {"$keyMapMatch": {"$eq": "aa"}}})
         self.assertEqual(len(docs), 1)
 
-    def test_in_operator_array(self):
-        docs = self.db.find({"manager": True, "favorites": {"$in": ["Ruby", "Python"]}})
-        self.assertUserIds([2, 6, 7, 9, 11, 12], docs)
-
-    def test_nin_operator_array(self):
-        docs = self.db.find(
-            {"manager": True, "favorites": {"$nin": ["Erlang", "Python"]}}
-        )
-        self.assertEqual(len(docs), 4)
-        for doc in docs:
-            if isinstance(doc["favorites"], list):
-                self.assertNotIn("Erlang", doc["favorites"])
-                self.assertNotIn("Python", doc["favorites"])
-
-    def test_regex(self):
-        docs = self.db.find(
-            {"age": {"$gt": 40}, "location.state": {"$regex": "(?i)new.*"}}
-        )
-        self.assertEqual(len(docs), 2)
-        self.assertUserIds([2, 10], docs)
-
-    def test_exists_false(self):
-        docs = self.db.find({"age": {"$gt": 0}, "twitter": {"$exists": False}})
-        user_ids = [2, 3, 5, 6, 7, 8, 10, 11, 12, 14]
-        self.assertUserIds(user_ids, docs)
-        for d in docs:
-            self.assertNotIn("twitter", d)
-
-    def test_eq_null_does_not_include_missing(self):
-        docs = self.db.find({"age": {"$gt": 0}, "twitter": None})
-        user_ids = [9]
-        self.assertUserIds(user_ids, docs)
-        for d in docs:
-            self.assertEqual(d["twitter"], None)
-
-    def test_ne_includes_null_but_not_missing(self):
-        docs = self.db.find({"twitter": {"$ne": "notamatch"}})
-        user_ids = [0, 1, 4, 9, 13]
-        self.assertUserIds(user_ids, docs)
-        for d in docs:
-            self.assertIn("twitter", d)
-
-    # ideally this work be consistent across index types but, alas, it is not
-    @unittest.skipUnless(
-        not mango.has_text_service(),
-        "text indexes do not support range queries across type boundaries",
-    )
-    def test_lt_includes_null_but_not_missing(self):
-        docs = self.db.find({"twitter": {"$lt": 1}})
-        user_ids = [9]
-        self.assertUserIds(user_ids, docs)
-        for d in docs:
-            self.assertEqual(d["twitter"], None)
-
-    @unittest.skipUnless(
-        not mango.has_text_service(),
-        "text indexes do not support range queries across type boundaries",
-    )
-    def test_lte_includes_null_but_not_missing(self):
-        docs = self.db.find({"twitter": {"$lt": 1}})
-        user_ids = [9]
-        self.assertUserIds(user_ids, docs)
-        for d in docs:
-            self.assertEqual(d["twitter"], None)
-
-    def test_lte_null_includes_null_but_not_missing(self):
-        docs = self.db.find({"twitter": {"$lte": None}})
-        user_ids = [9]
-        self.assertUserIds(user_ids, docs)
-        for d in docs:
-            self.assertEqual(d["twitter"], None)
-
-    def test_lte_at_z_except_null_excludes_null_and_missing(self):
-        docs = self.db.find({"twitter": {"$and": [{"$lte": "@z"}, {"$ne": None}]}})
-        user_ids = [0, 1, 4, 13]
-        self.assertUserIds(user_ids, docs)
-        for d in docs:
-            self.assertNotEqual(d["twitter"], None)
-
-    def test_range_gte_null_includes_null_but_not_missing(self):
-        docs = self.db.find({"twitter": {"$gte": None}})
-        self.assertGreater(len(docs), 0)
-        for d in docs:
-            self.assertIn("twitter", d)
-
-    def test_exists_false_returns_missing_but_not_null(self):
-        docs = self.db.find({"twitter": {"$exists": False}})
-        self.assertGreater(len(docs), 0)
-        for d in docs:
-            self.assertNotIn("twitter", d)
-
-    @unittest.skipUnless(
-        not mango.has_text_service(),
-        "text indexes do not support range queries across type boundaries",
-    )
-    def test_lte_respsects_unicode_collation(self):
-        docs = self.db.find({"ordered": {"$lte": "a"}})
-        user_ids = [7, 8, 9, 10, 11, 12]
-        self.assertUserIds(user_ids, docs)
-
-    @unittest.skipUnless(
-        not mango.has_text_service(),
-        "text indexes do not support range queries across type boundaries",
-    )
-    def test_gte_respsects_unicode_collation(self):
-        docs = self.db.find({"ordered": {"$gte": "a"}})
-        user_ids = [12, 13, 14]
-        self.assertUserIds(user_ids, docs)
-
-
-class OperatorJSONTests(mango.UserDocsTests, OperatorTests):
-    pass
-
 
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
-class OperatorTextTests(mango.UserDocsTextTests, OperatorTests):
+class OperatorTextTests(mango.UserDocsTextTests, BaseOperatorTests.Common):
     pass
 
 
-class OperatorAllDocsTests(mango.UserDocsTestsNoIndexes, OperatorTests):
+class OperatorAllDocsTests(mango.UserDocsTestsNoIndexes, OperatorJSONTests):
     def test_range_id_eq(self):
         doc_id = "8e1c90c0-ac18-4832-8081-40d14325bde0"
         r = self.db.find({"_id": doc_id}, explain=True, return_raw=True)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Previously, Mango tests which only apply to JSON indexes were being skipped if the clouseau (text index) service was enabled for the CouchDB instance being tested against, resulting in tests being skipped in some CI cases.

This refactors the tests so that we execute these tests on JSON / all_docs indexes regardless of whether clouseau is present or not.

## Testing recommendations

`make mango-test` with / without clouseau enabled.

Note that `nose2` will report skipped tests in the `Ran N tests` output. With this change, we see the same number of tests executed when `clouseau` is not enabled:

Before:
```
Ran 373 tests in 11.328s

OK (skipped=146)
```

After:
```
Ran 368 tests in 12.104s

OK (skipped=141)
```

With `clouseau` enabled we see fewer skipped tests after this change (so more overall):

Before:
```
Ran 373 tests in 37.748s

OK (skipped=16)
```

After:
```
Ran 368 tests in 35.741s

OK (skipped=1)
```

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
