### PR TITLE
Fix a few couch_os_process metrics

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -314,21 +314,21 @@
     {type, counter},
     {desc, <<"number of OS process starts">>}
 ]}.
-{[couchdb, query_server, process_exists], [
+{[couchdb, query_server, process_exits], [
     {type, counter},
-    {desc, <<"number of OS normal process exits">>}
+    {desc, <<"number of normal OS process exits">>}
+]}.
+{[couchdb, query_server, process_error_exits], [
+    {type, counter},
+    {desc, <<"number of error OS process exits">>}
 ]}.
 {[couchdb, query_server, process_errors], [
     {type, counter},
-    {desc, <<"number of OS error process exits">>}
+    {desc, <<"number of OS process errors">>}
 ]}.
 {[couchdb, query_server, process_prompts], [
     {type, counter},
     {desc, <<"number of successful OS process prompts">>}
-]}.
-{[couchdb, query_server, process_prompt_errors], [
-    {type, counter},
-    {desc, <<"number of OS process prompt errors">>}
 ]}.
 {[couchdb, query_server, time, spawn_proc], [
     {type, counter},

--- a/src/couch/test/eunit/couch_js_tests.erl
+++ b/src/couch/test/eunit/couch_js_tests.erl
@@ -57,8 +57,9 @@ should_create_sandbox(_) ->
     ?assert(couch_stats:sample([couchdb, query_server, process_starts]) > 0),
     ?assert(couch_stats:sample([couchdb, query_server, process_prompts]) > 0),
     ?assert(couch_stats:sample([couchdb, query_server, acquired_processes]) > 0),
-    ?assert(couch_stats:sample([couchdb, query_server, process_exists]) >= 0),
+    ?assert(couch_stats:sample([couchdb, query_server, process_exits]) >= 0),
     ?assert(couch_stats:sample([couchdb, query_server, process_errors]) >= 0),
+    ?assert(couch_stats:sample([couchdb, query_server, process_error_exits]) >= 0),
     couch_query_servers:ret_os_process(Proc).
 
 %% erlfmt-ignore


### PR DESCRIPTION
Some were misnamed:
  * exists -> exits
  * process_prompt_errors is just errors
  * description of process_errors was incorrect

Some were missing:
  * process_error_exits was not defined in the cfg file
