### PR TITLE
mango: add $beginsWith operator

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -673,68 +673,74 @@ In addition, some 'meta' condition operators are available. Some condition
 operators accept any valid JSON content as the argument.  Other condition
 operators require the argument to be in a specific JSON format.
 
-+---------------+-------------+------------+-----------------------------------+
-| Operator type | Operator    | Argument   | Purpose                           |
-+===============+=============+============+===================================+
-| (In)equality  | ``$lt``     | Any JSON   | The field is less than the        |
-|               |             |            | argument.                         |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$lte``    | Any JSON   | The field is less than or equal to|
-|               |             |            | the argument.                     |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$eq``     | Any JSON   | The field is equal to the argument|
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$ne``     | Any JSON   | The field is not equal to the     |
-|               |             |            | argument.                         |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$gte``    | Any JSON   | The field is greater than or equal|
-|               |             |            | to the argument.                  |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$gt``     | Any JSON   | The field is greater than the     |
-|               |             |            | to the argument.                  |
-+---------------+-------------+------------+-----------------------------------+
-| Object        | ``$exists`` | Boolean    | Check whether the field exists or |
-|               |             |            | not, regardless of its value.     |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$type``   | String     | Check the document field's type.  |
-|               |             |            | Valid values are ``"null"``,      |
-|               |             |            | ``"boolean"``, ``"number"``,      |
-|               |             |            | ``"string"``, ``"array"``, and    |
-|               |             |            | ``"object"``.                     |
-+---------------+-------------+------------+-----------------------------------+
-| Array         | ``$in``     | Array of   | The document field must exist in  |
-|               |             | JSON values| the list provided.                |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$nin``    | Array of   | The document field not must exist |
-|               |             | JSON values| in the list provided.             |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$size``   | Integer    | Special condition to match the    |
-|               |             |            | length of an array field in a     |
-|               |             |            | document. Non-array fields cannot |
-|               |             |            | match this condition.             |
-+---------------+-------------+------------+-----------------------------------+
-| Miscellaneous | ``$mod``    | [Divisor,  | Divisor is a non-zero integer,    |
-|               |             | Remainder] | Remainder is any integer.         |
-|               |             |            | Non-integer values result in a    |
-|               |             |            | 404. Matches documents where      |
-|               |             |            | ``field % Divisor == Remainder``  |
-|               |             |            | is true, and only when the        |
-|               |             |            | document field is an integer.     |
-+---------------+-------------+------------+-----------------------------------+
-|               | ``$regex``  | String     | A regular expression pattern to   |
-|               |             |            | match against the document field. |
-|               |             |            | Only matches when the field is a  |
-|               |             |            | string value and matches the      |
-|               |             |            | supplied regular expression. The  |
-|               |             |            | matching algorithms are based on  |
-|               |             |            | the Perl Compatible Regular       |
-|               |             |            | Expression (PCRE) library. For    |
-|               |             |            | more information about what is    |
-|               |             |            | implemented, see the see the      |
-|               |             |            | `Erlang Regular Expression        |
-|               |             |            | <http://erlang.org/doc            |
-|               |             |            | /man/re.html>`_.                  |
-+---------------+-------------+------------+-----------------------------------+
++---------------+-----------------+-------------+------------------------------------+
+| Operator type |    Operator     |  Argument   |              Purpose               |
++===============+=================+=============+====================================+
+| (In)equality  | ``$lt``         | Any JSON    | The field is less than the         |
+|               |                 |             | argument.                          |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$lte``        | Any JSON    | The field is less than or equal to |
+|               |                 |             | the argument.                      |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$eq``         | Any JSON    | The field is equal to the argument |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$ne``         | Any JSON    | The field is not equal to the      |
+|               |                 |             | argument.                          |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$gte``        | Any JSON    | The field is greater than or equal |
+|               |                 |             | to the argument.                   |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$gt``         | Any JSON    | The field is greater than the      |
+|               |                 |             | to the argument.                   |
++---------------+-----------------+-------------+------------------------------------+
+| Object        | ``$exists``     | Boolean     | Check whether the field exists or  |
+|               |                 |             | not, regardless of its value.      |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$type``       | String      | Check the document field's type.   |
+|               |                 |             | Valid values are ``"null"``,       |
+|               |                 |             | ``"boolean"``, ``"number"``,       |
+|               |                 |             | ``"string"``, ``"array"``, and     |
+|               |                 |             | ``"object"``.                      |
++---------------+-----------------+-------------+------------------------------------+
+| Array         | ``$in``         | Array of    | The document field must exist in   |
+|               |                 | JSON values | the list provided.                 |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$nin``        | Array of    | The document field not must exist  |
+|               |                 | JSON values | in the list provided.              |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$size``       | Integer     | Special condition to match the     |
+|               |                 |             | length of an array field in a      |
+|               |                 |             | document. Non-array fields cannot  |
+|               |                 |             | match this condition.              |
++---------------+-----------------+-------------+------------------------------------+
+| Miscellaneous | ``$mod``        | [Divisor,   | Divisor is a non-zero integer,     |
+|               |                 | Remainder]  | Remainder is any integer.          |
+|               |                 |             | Non-integer values result in a     |
+|               |                 |             | 404. Matches documents where       |
+|               |                 |             | ``field % Divisor == Remainder``   |
+|               |                 |             | is true, and only when the         |
+|               |                 |             | document field is an integer.      |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$regex``      | String      | A regular expression pattern to    |
+|               |                 |             | match against the document field.  |
+|               |                 |             | Only matches when the field is a   |
+|               |                 |             | string value and matches the       |
+|               |                 |             | supplied regular expression. The   |
+|               |                 |             | matching algorithms are based on   |
+|               |                 |             | the Perl Compatible Regular        |
+|               |                 |             | Expression (PCRE) library. For     |
+|               |                 |             | more information about what is     |
+|               |                 |             | implemented, see the see the       |
+|               |                 |             | `Erlang Regular Expression         |
+|               |                 |             | <http://erlang.org/doc             |
+|               |                 |             | /man/re.html>`_.                   |
++---------------+-----------------+-------------+------------------------------------+
+|               | ``$beginsWith`` | String      | Matches where the document field   |
+|               |                 |             | begins with the specified prefix   |
+|               |                 |             | (case-sensitive). If the document  |
+|               |                 |             | field contains a non-string value, |
+|               |                 |             | the document is not matched.       |
++---------------+-----------------+-------------+------------------------------------+
 
 .. warning::
     Regular expressions do not work with indexes, so they should not be used to
@@ -754,8 +760,10 @@ can itself be another operator with arguments of its own. This enables us to
 build up more complex selector expressions.
 
 However, only equality operators such as ``$eq``, ``$gt``, ``$gte``, ``$lt``,
-and ``$lte`` (but not ``$ne``) can be used as the basis of a query. You should
-include at least one of these in a selector.
+``$lte`` and ``$beginsWith`` (but not ``$ne``) can be used as the basis
+of a query that can make efficient use of a ``json`` index. You should
+include at least one of these in a selector, or consider using
+a ``text`` index if more flexibility is required.
 
 For example, if you try to perform a query that attempts to match all documents
 that have a field called `afieldname` containing a value that begins with the

--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -200,8 +200,9 @@ A simple selector, inspecting specific fields:
 
 You can create more complex selector expressions by combining operators.
 For best performance, it is best to combine 'combination' or
-'array logical' operators, such as ``$regex``, with an equality
-operators such as ``$eq``, ``$gt``, ``$gte``, ``$lt``, and ``$lte``
+'array logical' operators, such as ``$regex``, with an operator
+that defines a contiguous range of keys such as ``$eq``,
+``$gt``, ``$gte``, ``$lt``, ``$lte``, and ``$beginsWith``
 (but not ``$ne``). For more information about creating complex
 selector expressions, see :ref:`creating selector expressions
 <find/expressions>`.
@@ -759,11 +760,12 @@ In general, whenever you have an operator that takes an argument, that argument
 can itself be another operator with arguments of its own. This enables us to
 build up more complex selector expressions.
 
-However, only equality operators such as ``$eq``, ``$gt``, ``$gte``, ``$lt``,
-``$lte`` and ``$beginsWith`` (but not ``$ne``) can be used as the basis
+However, only operators that define a contiguous range of values
+such as ``$eq``, ``$gt``, ``$gte``, ``$lt``, ``$lte``,
+and ``$beginsWith`` (but not ``$ne``) can be used as the basis
 of a query that can make efficient use of a ``json`` index. You should
 include at least one of these in a selector, or consider using
-a ``text`` index if more flexibility is required.
+a ``text`` index if greater flexibility is required.
 
 For example, if you try to perform a query that attempts to match all documents
 that have a field called `afieldname` containing a value that begins with the

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -306,6 +306,8 @@ indexable({[{<<"$gt">>, _}]}) ->
     true;
 indexable({[{<<"$gte">>, _}]}) ->
     true;
+indexable({[{<<"$beginsWith">>, _}]}) ->
+    true;
 % This is required to improve index selection for covering indexes.
 % Making `$exists` indexable should not cause problems in other cases.
 indexable({[{<<"$exists">>, _}]}) ->
@@ -412,6 +414,10 @@ range(_, _, LCmp, Low, HCmp, High) ->
 % operators but its all straight forward once you figure out how
 % we're basically just narrowing our logical ranges.
 
+% beginsWith requires both a high and low bound
+range({[{<<"$beginsWith">>, Arg}]}, LCmp, Low, HCmp, High) ->
+    {LCmp0, Low0, HCmp0, High0} = range({[{<<"$gte">>, Arg}]}, LCmp, Low, HCmp, High),
+    range({[{<<"$lte">>, <<Arg/binary, 16#10FFFF>>}]}, LCmp0, Low0, HCmp0, High0);
 range({[{<<"$lt">>, Arg}]}, LCmp, Low, HCmp, High) ->
     case range_pos(Low, Arg, High) of
         min ->

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -142,8 +142,9 @@ convert(Path, {[{<<"$exists">>, ShouldExist}]}) ->
         true -> FieldExists;
         false -> {op_not, {FieldExists, false}}
     end;
-convert(Path, {[{<<"$beginsWith">>, Arg}]}) ->
-    PrefixSearch = [value_str(Arg), <<"*">>],
+convert(Path, {[{<<"$beginsWith">>, Arg}]}) when is_binary(Arg) ->
+    Suffix = <<"*">>,
+    PrefixSearch = value_str(<<Arg/binary,  Suffix/binary>>),
     {op_field, {make_field(Path, Arg), PrefixSearch}};
 % We're not checking the actual type here, just looking for
 % anything that has a possibility of matching by checking
@@ -822,6 +823,12 @@ convert_nor_test() ->
         convert_selector(#{
             <<"$nor">> => [#{<<"field1">> => <<"value1">>}, #{<<"field2">> => <<"value2">>}]
         })
+    ).
+
+convert_beginswith_test() ->
+    ?assertEqual(
+        {op_field, {[[<<"field">>], <<":">>, <<"string">>],<<"\"foo\\*\"">>}},
+        convert_selector(#{<<"field">> => #{<<"$beginsWith">> => <<"foo">>}})
     ).
 
 to_query_test() ->

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -144,7 +144,7 @@ convert(Path, {[{<<"$exists">>, ShouldExist}]}) ->
     end;
 convert(Path, {[{<<"$beginsWith">>, Arg}]}) when is_binary(Arg) ->
     Suffix = <<"*">>,
-    PrefixSearch = value_str(<<Arg/binary,  Suffix/binary>>),
+    PrefixSearch = value_str(<<Arg/binary, Suffix/binary>>),
     {op_field, {make_field(Path, Arg), PrefixSearch}};
 % We're not checking the actual type here, just looking for
 % anything that has a possibility of matching by checking
@@ -827,7 +827,7 @@ convert_nor_test() ->
 
 convert_beginswith_test() ->
     ?assertEqual(
-        {op_field, {[[<<"field">>], <<":">>, <<"string">>],<<"\"foo\\*\"">>}},
+        {op_field, {[[<<"field">>], <<":">>, <<"string">>], <<"\"foo\\*\"">>}},
         convert_selector(#{<<"field">> => #{<<"$beginsWith">> => <<"foo">>}})
     ).
 

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -143,8 +143,9 @@ convert(Path, {[{<<"$exists">>, ShouldExist}]}) ->
         false -> {op_not, {FieldExists, false}}
     end;
 convert(Path, {[{<<"$beginsWith">>, Arg}]}) when is_binary(Arg) ->
+    Prefix = mango_util:lucene_escape_query_value(Arg),
     Suffix = <<"*">>,
-    PrefixSearch = value_str(<<Arg/binary, Suffix/binary>>),
+    PrefixSearch = <<Prefix/binary, Suffix/binary>>,
     {op_field, {make_field(Path, Arg), PrefixSearch}};
 % We're not checking the actual type here, just looking for
 % anything that has a possibility of matching by checking

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -828,7 +828,7 @@ convert_nor_test() ->
 
 convert_beginswith_test() ->
     ?assertEqual(
-        {op_field, {[[<<"field">>], <<":">>, <<"string">>], <<"\"foo\\*\"">>}},
+        {op_field, {[[<<"field">>], <<":">>, <<"string">>], <<"foo*">>}},
         convert_selector(#{<<"field">> => #{<<"$beginsWith">> => <<"foo">>}})
     ).
 

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -142,6 +142,9 @@ convert(Path, {[{<<"$exists">>, ShouldExist}]}) ->
         true -> FieldExists;
         false -> {op_not, {FieldExists, false}}
     end;
+convert(Path, {[{<<"$beginsWith">>, Arg}]}) ->
+    PrefixSearch = [value_str(Arg), <<"*">>],
+    {op_field, {make_field(Path, Arg), PrefixSearch}};
 % We're not checking the actual type here, just looking for
 % anything that has a possibility of matching by checking
 % for the field name. We use the same logic for $exists on

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -10,7 +10,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from requests.exceptions import HTTPError
 import mango
 import unittest
 

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -143,19 +143,19 @@ class BaseOperatorTests:
                 self.assertNotIn("twitter", d)
 
         def test_beginswith(self):
+            self.db.save_docs(
+                [
+                    {"user_id": 99, "location": {"state": ":Bar"}},
+                ]
+            )
+
             cases = [
                 {"prefix": "New", "user_ids": [2, 10]},
-                {
-                    # test escaped characters - note the space in the test string
-                    "prefix": "New ",
-                    "user_ids": [2, 10],
-                },
-                {
-                    # non-string values in documents should not match the prefix,
-                    # but should not error
-                    "prefix": "Foo",
-                    "user_ids": [],
-                },
+                # test characters that require escaping
+                {"prefix": "New ", "user_ids": [2, 10]},
+                {"prefix": ":", "user_ids": [99]},
+                {"prefix": "Foo", "user_ids": []},
+                {"prefix": '"Foo', "user_ids": []},
                 {"prefix": " New", "user_ids": []},
             ]
 

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -171,8 +171,12 @@ class BaseOperatorTests:
             cases = [123, True, [], {}]
             for prefix in cases:
                 with self.subTest(prefix=prefix):
-                    with self.assertRaises(HTTPError):
+                    try:
                         self.db.find({"location.state": {"$beginsWith": prefix}})
+                    except Exception as e:
+                        self.assertEqual(e.response.status_code, 400)
+                    else:
+                        raise AssertionError("expected request to fail")
 
 
 class OperatorJSONTests(mango.UserDocsTests, BaseOperatorTests.Common):

--- a/src/mango/test/03-operator-test.py
+++ b/src/mango/test/03-operator-test.py
@@ -141,6 +141,22 @@ class BaseOperatorTests:
             for d in docs:
                 self.assertNotIn("twitter", d)
 
+        def test_beginswith(self):
+            docs = self.db.find({"location.state": {"$beginsWith": "New"}})
+            self.assertEqual(len(docs), 2)
+            self.assertUserIds([2, 10], docs)
+
+        # non-string prefixes should return an error
+        def test_beginswith_invalid_prefix(self):
+            docs = self.db.find({"location.state": {"$beginsWith": 123}})
+            self.assertEqual(len(docs), 2)
+
+        # non-string values in documents should not match the prefix,
+        # but should not error
+        def test_beginswith_invalid_prefix(self):
+            docs = self.db.find({"user_id": {"$beginsWith": "Foo"}})
+            self.assertEqual(len(docs), 0)
+
 
 class OperatorJSONTests(mango.UserDocsTests, BaseOperatorTests.Common):
     # START: text indexes do not support range queries across type boundaries so only

--- a/src/mango/test/25-beginswith-test.py
+++ b/src/mango/test/25-beginswith-test.py
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import copy
+import mango
+
+DOCS = [
+    {"_id": "aaa", "name": "Jimi", "location": "AUS", "age": 27},
+    {"_id": "abc", "name": "Eddie", "location": "AND", "age": 65},
+    {"_id": "bbb", "name": "Harry", "location": "CAN", "age": 21},
+    {"_id": "ccc", "name": "Eddie", "location": "DEN", "age": 37},
+    {"_id": "ddd", "name": "Jones", "location": "ETH", "age": 49},
+]
+
+
+def to_utf8_bytes(list):
+    return [x.encode() for x in list]
+
+
+class BeginsWithOperator(mango.DbPerClass):
+    def setUp(self):
+        self.db.recreate()
+        self.db.save_docs(copy.deepcopy(DOCS))
+        self.db.create_index(["location"])
+        self.db.create_index(["name", "location"])
+
+    def assertDocIds(self, user_ids, docs):
+        user_ids_returned = list(d["_id"] for d in docs)
+        user_ids.sort()
+        user_ids_returned.sort()
+        self.assertEqual(user_ids, user_ids_returned)
+
+    def test_basic(self):
+        docs = self.db.find({"location": {"$beginsWith": "A"}})
+
+        self.assertEqual(len(docs), 2)
+        self.assertDocIds(["aaa", "abc"], docs)
+
+    def test_json_range(self):
+        explain = self.db.find({"location": {"$beginsWith": "A"}}, explain=True)
+        self.assertEqual(explain["mrargs"]["start_key"], ["A"])
+        end_key_bytes = to_utf8_bytes(explain["mrargs"]["end_key"])
+        self.assertEqual(end_key_bytes, [b"A\xef\xbf\xbd", b"<MAX>"])
+
+    def test_compound_key(self):
+        selector = {"name": "Eddie", "location": {"$beginsWith": "A"}}
+        explain = self.db.find(selector, explain=True)
+
+        self.assertEqual(explain["mrargs"]["start_key"], ["Eddie", "A"])
+        end_key_bytes = to_utf8_bytes(explain["mrargs"]["end_key"])
+        self.assertEqual(end_key_bytes, [b"Eddie", b"A\xef\xbf\xbd", b"<MAX>"])
+
+        docs = self.db.find(selector)
+        self.assertEqual(len(docs), 1)
+        self.assertDocIds(["abc"], docs)
+
+    def test_sort_asc(self):
+        selector = {"location": {"$beginsWith": "A"}}
+        explain = self.db.find(selector, sort=["location"], explain=True)
+
+        self.assertEqual(explain["mrargs"]["start_key"], ["A"])
+        end_key_bytes = to_utf8_bytes(explain["mrargs"]["end_key"])
+        self.assertEqual(end_key_bytes, [b"A\xef\xbf\xbd", b"<MAX>"])
+        self.assertEqual(explain["mrargs"]["direction"], "fwd")
+
+    def test_sort_desc(self):
+        selector = {"location": {"$beginsWith": "A"}}
+        explain = self.db.find(selector, sort=[{"location": "desc"}], explain=True)
+
+        start_key_bytes = to_utf8_bytes(explain["mrargs"]["end_key"])
+        self.assertEqual(start_key_bytes, [b"A"])
+        self.assertEqual(explain["mrargs"]["end_key"], ["A"])
+        self.assertEqual(explain["mrargs"]["direction"], "rev")
+
+    def test_all_docs_range(self):
+        explain = self.db.find({"_id": {"$beginsWith": "a"}}, explain=True)
+        self.assertEqual(explain["mrargs"]["start_key"], "a")
+        end_key_bytes = to_utf8_bytes(explain["mrargs"]["end_key"])
+        self.assertEqual(end_key_bytes, [b"a", b"\xef\xbf\xbd"])
+
+    def test_no_index(self):
+        selector = {"foo": {"$beginsWith": "a"}}
+        resp_explain = self.db.find(selector, explain=True)
+
+        self.assertEqual(resp_explain["index"]["type"], "special")
+        self.assertEqual(resp_explain["mrargs"]["start_key"], None)
+        self.assertEqual(resp_explain["mrargs"]["end_key"], "<MAX>")
+
+    def test_invalid_operand(self):
+        try:
+            self.db.find({"_id": {"$beginsWith": True}})
+        except Exception as e:
+            self.assertEqual(e.response.status_code, 400)
+            resp = e.response.json()
+            self.assertEqual(resp["error"], "invalid_operator")
+        else:
+            raise AssertionError("expected find error")
+
+    def test_does_not_match_non_string_value(self):
+        selector = {"age": {"$beginsWith": "a"}}
+        docs = self.db.find(selector)
+
+        self.assertEqual(len(docs), 0)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Adds a `$beginsWith` operator to selectors, with json and text index support. This is a compliment / precursor to optimising `$regex` support as proposed in https://github.com/apache/couchdb/pull/4776.

For `json` indexes, a $beginsWith operator translates into a key range query, as is common practice for _view queries. For example, to find all rows with a key beginning with "W", we can use a range `start_key="W", end_key="W\ufff0"`. Given Mango uses compound keys, this is slightly more complex in practice, but the idea is the same. As with other range operators (`$gt`, `$gte`, etc), `$beginsWith` can be used in combination with equality operators and result sorting but must result in a contiguous key range. That is, a range of `start_key=[10, "W"], end_key=[10, "W\ufff0", {}]` would be valid, but `start_key=["W", 10], end_key=["W\ufff0", 10, {}]` would not, because the second element of the key may result in a non-contiguous range.

For text indexes, `$beginsWith` translates to a Lucene query on the specified field of `W*`.

If a non-string operand is provided to `$beginsWith`, the request will fail with a 400 / `invalid_operator` error.

## Testing recommendations

I've only tested this with json indexes so far because the dev container doesn't have `text` index support.

A basic eunit test is added for the new `selector` support. You can run these using `make eunit apps=mango`.

Integration tests are added to the Mango test suite, which can be run via `make mango-test`.

## Related Issues or Pull Requests

n/a

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
