### PR TITLE
PoC Couch Stats Resource Tracker for tracking process local resource usage

### DIFF
--- a/src/chttpd/src/chttpd_httpd_handlers.erl
+++ b/src/chttpd/src/chttpd_httpd_handlers.erl
@@ -20,6 +20,7 @@ url_handler(<<"_utils">>) -> fun chttpd_misc:handle_utils_dir_req/1;
 url_handler(<<"_all_dbs">>) -> fun chttpd_misc:handle_all_dbs_req/1;
 url_handler(<<"_dbs_info">>) -> fun chttpd_misc:handle_dbs_info_req/1;
 url_handler(<<"_active_tasks">>) -> fun chttpd_misc:handle_task_status_req/1;
+url_handler(<<"_active_resources">>) -> fun chttpd_misc:handle_resource_status_req/1;
 url_handler(<<"_scheduler">>) -> fun couch_replicator_httpd:handle_scheduler_req/1;
 url_handler(<<"_node">>) -> fun chttpd_node:handle_node_req/1;
 url_handler(<<"_reload_query_servers">>) -> fun chttpd_misc:handle_reload_query_servers_req/1;

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -414,6 +414,11 @@
     {type, counter},
     {desc, <<"number of legacy checksums found in couch_file instances">>}
 ]}.
+%% CSRT (couch_stats_resource_tracker) stats
+{[couchdb, csrt, delta_missing_t0], [
+    {type, counter},
+    {desc, <<"number of csrt contexts without a proper startime">>}
+]}.
 {[pread, exceed_eof], [
     {type, counter},
     {desc, <<"number of the attempts to read beyond end of db file">>}

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -297,6 +297,7 @@ open_doc(Db, IdOrDocInfo) ->
     open_doc(Db, IdOrDocInfo, []).
 
 open_doc(Db, Id, Options) ->
+    %% TODO: wire in csrt tracking
     increment_stat(Db, [couchdb, database_reads]),
     case open_doc_int(Db, Id, Options) of
         {ok, #doc{deleted = true} = Doc} ->
@@ -1982,6 +1983,7 @@ increment_stat(#db{options = Options}, Stat, Count) when
 ->
     case lists:member(sys_db, Options) of
         true ->
+            %% TODO: we shouldn't leak resource usage just because it's a sys_db
             ok;
         false ->
             couch_stats:increment_counter(Stat, Count)

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -97,6 +97,8 @@ sup_start_link(N) ->
     gen_server:start_link({local, couch_server(N)}, couch_server, [N], []).
 
 open(DbName, Options) ->
+    %% TODO: wire in csrt tracking
+    couch_stats:increment_counter([couchdb, couch_server, open]),
     try
         validate_open_or_create(DbName, Options),
         open_int(DbName, Options)

--- a/src/couch_stats/src/couch_stats_resource_tracker.erl
+++ b/src/couch_stats/src/couch_stats_resource_tracker.erl
@@ -1,0 +1,607 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_stats_resource_tracker).
+
+-behaviour(gen_server).
+
+-export([
+    start_link/0,
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+]).
+
+-export([
+    inc/1, inc/2,
+    maybe_inc/2,
+    get_pid_ref/0,
+    accumulate_delta/1
+]).
+
+-export([
+    create_context/0, create_context/1, create_context/3,
+    track/1,
+    should_track/1
+]).
+
+-export([
+    active/0
+]).
+
+-export([
+    make_delta/0
+]).
+
+%% Singular increment operations
+-export([
+    db_opened/0,
+    doc_read/0,
+    row_read/0,
+    change_processed/0,
+    ioq_called/0,
+    js_evaled/0,
+    js_filtered/0,
+    js_filtered_error/0,
+    js_filtered_doc/0,
+    mango_match_evaled/0,
+    get_kv_node/0,
+    get_kp_node/0
+]).
+
+%% Plural increment operations
+-export([
+    js_filtered_docs/1,
+    io_bytes_read/1,
+    io_bytes_written/1
+]).
+
+-include_lib("couch/include/couch_db.hrl").
+
+%% Use these for record upgrades over the wire and in ETS tables
+%% TODO: alternatively, just delete these. Currently using a map
+%% for shipping deltas over the wire, avoiding much of the
+%% problem here. We'll likely still need to handle upgrades to
+%% map format over time, so let's decide a course of action here.
+-define(RCTX_V1, rctx_v1).
+-define(RCTX, ?RCTX_V1).
+
+-define(MANGO_EVAL_MATCH, mango_eval_match).
+-define(DB_OPEN_DOC, docs_read).
+
+-define(FRPC_CHANGES_ROW, changes_processed).
+
+%% Module pdict markers
+-define(DELTA_TA, csrt_delta_ta).
+-define(DELTA_TZ, csrt_delta_tz). %% T Zed instead of T0
+-define(PID_REF, csrt_pid_ref). %% track local ID
+
+
+-record(st, {
+    eviction_delay = 10000, %% How many ms dead processes are visible
+    tracking = #{} %% track active processes for eventual eviction
+}).
+
+
+%% TODO: switch to:
+%% -record(?RCTX, {
+-record(rctx, {
+    updated_at = os:timestamp(),
+    exited_at,
+    pid_ref,
+    mfa,
+    nonce,
+    from,
+    type = unknown, %% unknown/background/system/rpc/coordinator/fabric_rpc/etc_rpc/etc
+    db_open = 0,
+    docs_read = 0,
+    rows_read = 0,
+    changes_processed = 0,
+    ioq_calls = 0,
+    io_bytes_read = 0,
+    io_bytes_written = 0,
+    js_evals = 0,
+    js_filter = 0,
+    js_filter_error = 0,
+    js_filtered_docs = 0,
+    mango_eval_match = 0,
+    get_kv_node = 0,
+    get_kp_node = 0,
+    state = alive
+}).
+
+db_opened() -> inc(db_open).
+doc_read() -> inc(docs_read).
+row_read() -> inc(rows_read).
+change_processed() -> inc(changes_processed).
+ioq_called() -> inc(ioq_calls).
+js_evaled() -> inc(js_evals).
+js_filtered() -> inc(js_filter).
+js_filtered_error() -> inc(js_filter_error).
+js_filtered_doc() -> inc(js_filtered_docs).
+mango_match_evaled() -> inc(mango_eval_match).
+get_kv_node() -> inc(get_kv_node).
+get_kp_node() -> inc(get_kp_node).
+
+js_filtered_docs(N) -> inc(js_filtered_docs, N).
+io_bytes_read(N) -> inc(io_bytes_read, N).
+io_bytes_written(N) -> inc(io_bytes_written, N).
+
+inc(db_open) ->
+    inc(db_open, 1);
+inc(docs_read) ->
+    inc(docs_read, 1);
+inc(rows_read) ->
+    inc(rows_read, 1);
+inc(changes_processed) ->
+    inc(changes_processed, 1);
+inc(ioq_calls) ->
+    inc(ioq_calls, 1);
+inc(io_bytes_read) ->
+    inc(io_bytes_read, 1);
+inc(io_bytes_written) ->
+    inc(io_bytes_written, 1);
+inc(js_evals) ->
+    inc(js_evals, 1);
+inc(js_filter) ->
+    inc(js_filter, 1);
+inc(js_filter_error) ->
+    inc(js_filter_error, 1);
+inc(js_filtered_docs) ->
+    inc(js_filtered_docs, 1);
+inc(?MANGO_EVAL_MATCH) ->
+    inc(?MANGO_EVAL_MATCH, 1);
+inc(get_kv_node) ->
+    inc(get_kv_node, 1);
+inc(get_kp_node) ->
+    inc(get_kp_node, 1);
+inc(_) ->
+    0.
+
+
+inc(db_open, N) ->
+    update_counter(#rctx.db_open, N);
+inc(rows_read, N) ->
+    update_counter(#rctx.rows_read, N);
+inc(ioq_calls, N) ->
+    update_counter(#rctx.ioq_calls, N);
+inc(io_bytes_read, N) ->
+    update_counter(#rctx.io_bytes_read, N);
+inc(io_bytes_written, N) ->
+    update_counter(#rctx.io_bytes_written, N);
+inc(js_evals, N) ->
+    update_counter(#rctx.js_evals, N);
+inc(js_filter, N) ->
+    update_counter(#rctx.js_filter, N);
+inc(js_filter_error, N) ->
+    update_counter(#rctx.js_filter_error, N);
+inc(js_filtered_docs, N) ->
+    update_counter(#rctx.js_filtered_docs, N);
+inc(?MANGO_EVAL_MATCH, N) ->
+    update_counter(#rctx.?MANGO_EVAL_MATCH, N);
+inc(?DB_OPEN_DOC, N) ->
+    update_counter(#rctx.?DB_OPEN_DOC, N);
+inc(?FRPC_CHANGES_ROW, N) ->
+    update_counter(#rctx.?FRPC_CHANGES_ROW, N);
+inc(get_kv_node, N) ->
+    update_counter(#rctx.get_kv_node, N);
+inc(get_kp_node, N) ->
+    update_counter(#rctx.get_kp_node, N);
+inc(_, _) ->
+    0.
+
+maybe_inc([mango, evaluate_selector], Val) ->
+    inc(?MANGO_EVAL_MATCH, Val);
+maybe_inc([couchdb, database_reads], Val) ->
+    inc(?DB_OPEN_DOC, Val);
+maybe_inc([fabric_rpc, changes, rows_read], Val) ->
+    inc(?FRPC_CHANGES_ROW, Val);
+maybe_inc(_, _) ->
+    0.
+
+
+%% TODO: update stats_descriptions.cfg for relevant apps
+should_track([fabric_rpc, all_docs, spawned]) ->
+    true;
+should_track([fabric_rpc, changes, spawned]) ->
+    true;
+should_track([fabric_rpc, map_view, spawned]) ->
+    true;
+should_track([fabric_rpc, reduce_view, spawned]) ->
+    true;
+should_track([fabric_rpc, get_all_security, spawned]) ->
+    true;
+should_track([fabric_rpc, open_doc, spawned]) ->
+    true;
+should_track([fabric_rpc, update_docs, spawned]) ->
+    true;
+should_track([fabric_rpc, open_shard, spawned]) ->
+    true;
+should_track([mango_cursor, view, all_docs]) ->
+    true;
+should_track([mango_cursor, view, idx]) ->
+    true;
+should_track(_) ->
+    false.
+
+%% TODO: update coordinator stats from worker deltas
+accumulate_delta(_Delta) ->
+    ok.
+
+update_counter(Field, Count) ->
+    update_counter(get_pid_ref(), Field, Count).
+
+
+update_counter({_Pid,_Ref}=Key, Field, Count) ->
+    ets:update_counter(?MODULE, Key, {Field, Count}, #rctx{pid_ref=Key}).
+
+
+active() ->
+    lists:map(fun to_json/1, ets:tab2list(?MODULE)).
+
+
+to_json(#rctx{}=Rctx) ->
+    #rctx{
+        updated_at = TP,
+        pid_ref = {_Pid, _Ref} = PidRef,
+        mfa = MFA0,
+        nonce = Nonce0,
+        from = From0,
+        docs_read = DocsRead,
+        rows_read = RowsRead,
+        state = State0,
+        type = Type,
+        changes_processed = ChangesProcessed
+    } = Rctx,
+    %%io:format("TO_JSON_MFA: ~p~n", [MFA0]),
+    MFA = case MFA0 of
+        {M, F, A} ->
+            [M, F, A];
+        undefined ->
+            null;
+        Other ->
+            throw({error, {unexpected, Other}})
+    end,
+    From = case From0 of
+        {Parent, ParentRef} ->
+            [pid_to_list(Parent), ref_to_list(ParentRef)];
+        undefined ->
+            null
+    end,
+    State = case State0 of
+        alive ->
+            alive;
+        {down, Reason} when is_atom(Reason) ->
+            [down, Reason];
+        Unknown ->
+            [unknown, io_lib:format("~w", [Unknown])]
+    end,
+    Nonce = case Nonce0 of
+        undefined ->
+            null;
+        Nonce0 ->
+            list_to_binary(Nonce0)
+    end,
+    #{
+        updated_at => term_to_json(TP),
+        %%pid_ref => [pid_to_list(Pid), ref_to_list(Ref)],
+        pid_ref => term_to_json(PidRef),
+        mfa => term_to_json(MFA),
+        nonce => term_to_json(Nonce),
+        %%from => From,
+        from => term_to_json(From),
+        docs_read => DocsRead,
+        rows_read => RowsRead,
+        state => State,
+        type => term_to_json(Type),
+        changes_processed => ChangesProcessed
+    }.
+
+term_to_json({Pid, Ref}) when is_pid(Pid), is_reference(Ref) ->
+    [?l2b(pid_to_list(Pid)), ?l2b(ref_to_list(Ref))];
+term_to_json({A, B, C}) ->
+    [A, B, C];
+term_to_json(undefined) ->
+    null;
+term_to_json(T) ->
+    T.
+
+term_to_flat_json(Tuple) when is_tuple(Tuple) ->
+    ?l2b(io_lib:format("~w", [Tuple]));
+term_to_flat_json(undefined) ->
+    null;
+term_to_flat_json(T) ->
+    T.
+
+to_flat_json(#rctx{}=Rctx) ->
+    #rctx{
+        updated_at = TP,
+        pid_ref = {_Pid, _Ref} = PidRef,
+        mfa = MFA0,
+        nonce = Nonce0,
+        from = From0,
+        docs_read = DocsRead,
+        rows_read = RowsRead,
+        state = State0,
+        type = Type,
+        changes_processed = ChangesProcessed
+    } = Rctx,
+    io:format("TO_JSON_MFA: ~p~n", [MFA0]),
+    MFA = case MFA0 of
+        {_M, _F, _A} ->
+            ?l2b(io_lib:format("~w", [MFA0]));
+        undefined ->
+            null;
+        Other ->
+            throw({error, {unexpected, Other}})
+    end,
+    From = case From0 of
+        {_Parent, _ParentRef} ->
+            ?l2b(io_lib:format("~w", [From0]));
+        undefined ->
+            null
+    end,
+    State = case State0 of
+        alive ->
+            alive;
+        State0 ->
+            ?l2b(io_lib:format("~w", [State0]))
+    end,
+    Nonce = case Nonce0 of
+        undefined ->
+            null;
+        Nonce0 ->
+            list_to_binary(Nonce0)
+    end,
+    #{
+        %%updated_at => ?l2b(io_lib:format("~w", [TP])),
+        updated_at => term_to_flat_json(TP),
+        %%pid_ref => [pid_to_list(Pid), ref_to_list(Ref)],
+        pid_ref => ?l2b(io_lib:format("~w", [PidRef])),
+        mfa => MFA,
+        nonce => Nonce,
+        from => From,
+        docs_read => DocsRead,
+        rows_read => RowsRead,
+        state => State,
+        type => term_to_flat_json(Type),
+        changes_processed => ChangesProcessed
+    }.
+
+get_pid_ref() ->
+    case get(?PID_REF) of
+        undefined ->
+            Ref = make_ref(),
+            set_pid_ref({self(), Ref});
+        PidRef ->
+            PidRef
+    end.
+
+
+create_context() ->
+    create_context(self()).
+
+
+create_context(Pid) ->
+    Ref = make_ref(),
+    Rctx = make_record(Pid, Ref),
+    track(Rctx),
+    ets:insert(?MODULE, Rctx),
+    Rctx.
+
+%% add type to disnguish coordinator vs rpc_worker
+create_context(From, {M,F,_A} = MFA, Nonce) ->
+    io:format("CREAT_CONTEXT MFA[~p]: {~p}: ~p~n", [From, MFA, Nonce]),
+    Ref = make_ref(),
+    %%Rctx = make_record(self(), Ref),
+    %% TODO: extract user_ctx and db/shard from 
+    Rctx = #rctx{
+        pid_ref = {self(), Ref},
+        from = From,
+        mfa = MFA,
+        type = {worker, M, F},
+        nonce = Nonce
+    },
+    track(Rctx),
+    erlang:put(?DELTA_TZ, Rctx),
+    ets:insert(?MODULE, Rctx),
+    Rctx.
+
+track(#rctx{}=Rctx) ->
+    %% TODO: should this block or not? If no, what cleans up zombies?
+    %% gen_server:call(?MODULE, {track, PR}).
+    gen_server:cast(?MODULE, {track, Rctx}).
+
+
+make_delta() ->
+    TA = case get(?DELTA_TA) of
+        undefined ->
+            %% Need to handle this better, can't just make a new T0 at T' as
+            %% the timestamps will be identical causing a divide by zero error.
+            %%
+            %% Realistically need to ensure that all invocations of database
+            %% operations sets T0 appropriately. Perhaps it's possible to do
+            %% this is the couch_db:open chain, and then similarly, in
+            %% couch_server, and uhhhh... couch_file, and...
+            %%
+            %% I think we need some type of approach for establishing a T0 that
+            %% doesn't result in outrageous deltas. For now zero out the
+            %% microseconds field, or subtract a second on the off chance that
+            %% microseconds is zero. I'm not uptodate on the latest Erlang time
+            %% libraries and don't remember how to easily get an
+            %% `os:timestamp()` out of now() - 100ms or some such.
+            %%
+            %% I think it's unavoidable that we'll have some codepaths that do
+            %% not properly instantiate the T0 at spawn resulting in needing to
+            %% do some time of "time warp" or ignoring the timing collection
+            %% entirely. Perhaps if we hoisted out the stats collection into
+            %% the primary flow of the database and funnel that through all the
+            %% function clauses we could then utilize Dialyzer to statically
+            %% analyze and assert all code paths that invoke database
+            %% operations have properly instantinated a T0 at the appropriate
+            %% start time such that we don't have to "fudge" deltas with a
+            %% missing start point, but we're a long ways from that happening
+            %% so I feel it necessary to address the NULL start time.
+
+            %% Track how often we fail to initiate T0 correctly
+            %% Perhaps somewhat naughty we're incrementing stats from within
+            %% couch_stats itself? Might need to handle this differently
+            %% TODO: determine appropriate course of action here
+            couch_stats:increment_counter(
+                [couchdb, csrt, delta_missing_t0]),
+                %%[couch_stats_resource_tracker, delta_missing_t0]),
+
+            case erlang:get(?DELTA_TZ) of
+                undefined ->
+                    TA0 = make_delta_base(),
+                    %% TODO: handline missing deltas, otherwise divide by zero
+                    set_delta_a(TA0),
+                    TA0;
+                TA0 ->
+                    TA0
+            end;
+        %%?RCTX{} = TA0 ->
+        #rctx{} = TA0 ->
+            TA0
+    end,
+    TB = get_resource(),
+    make_delta(TA, TB).
+
+
+make_delta(#rctx{}=TA, #rctx{}=TB) ->
+    Delta = #{
+        docs_read => TB#rctx.docs_read - TA#rctx.docs_read,
+        rows_read => TB#rctx.rows_read - TA#rctx.rows_read,
+        changes_processed => TB#rctx.changes_processed - TA#rctx.changes_processed,
+        dt => timer:now_diff(TB#rctx.updated_at, TA#rctx.updated_at)
+    },
+    %% TODO: reevaluate this decision
+    %% Only return non zero (and also positive) delta fields
+    maps:filter(fun(_K,V) -> V > 0 end, Delta);
+make_delta(_, #rctx{}) ->
+    #{error => missing_beg_rctx};
+make_delta(#rctx{}, _) ->
+    #{error => missing_fin_rctx}.
+
+make_delta_base() ->
+    Ref = make_ref(),
+    %%Rctx = make_record(self(), Ref),
+    %% TODO: extract user_ctx and db/shard from request
+    TA0 = #rctx{
+        pid_ref = {self(), Ref}
+    },
+    case TA0#rctx.updated_at of
+        {Me, S, Mi} when Mi > 0 ->
+            TA0#rctx{updated_at = {Me, S, 0}};
+        {Me, S, Mi} when S > 0 ->
+            TA0#rctx{updated_at = {Me, S - 1, Mi}}
+    end.
+
+set_delta_a(TA) ->
+    erlang:put(?DELTA_TA, TA).
+
+set_pid_ref(PidRef) ->
+    erlang:put(?PID_REF, PidRef),
+    PidRef.
+
+get_resource() ->
+    get_resource(get_pid_ref()).
+
+get_resource(PidRef) ->
+    case ets:lookup(?MODULE, PidRef) of
+        [#rctx{}=TP] ->
+            TP;
+        [] ->
+            undefined
+    end.
+
+make_record(Pid, Ref) ->
+    #rctx{pid_ref = {Pid, Ref}}.
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    ets:new(?MODULE, [
+        named_table,
+        public,
+        {decentralized_counters, true}, %% TODO: test impact of this
+        {write_concurrency, true},
+        {read_concurrency, true},
+        {keypos, #rctx.pid_ref}
+    ]),
+    {ok, #st{}}.
+
+handle_call(fetch, _from, #st{} = St) ->
+    {reply, {ok, St}, St};
+handle_call({track, _}, _From, St) ->
+    {reply, ok, St};
+handle_call(Msg, _From, St) ->
+    {stop, {unknown_call, Msg}, error, St}.
+
+handle_cast({track, #rctx{pid_ref={Pid,_}=PidRef}}, #st{tracking=AT0} = St0) ->
+    St = case maps:is_key(PidRef, AT0) of
+        true -> %% noop, we're already tracking this PidRef
+            St0;
+        false -> %% setup new monitor and double bookkeep refs
+            Mon = erlang:monitor(process, Pid),
+            AT = maps:put(Mon, PidRef, maps:put(PidRef, Mon, AT0)),
+            St0#st{tracking=AT}
+    end,
+    {noreply, St};
+handle_cast(Msg, St) ->
+    {stop, {unknown_cast, Msg}, St}.
+
+handle_info({'DOWN', MonRef, Type, DPid, Reason}, #st{tracking=AT0} = St0) ->
+    io:format("CSRT:HI(~p)~n", [{'DOWN', MonRef, Type, DPid, Reason}]),
+    St = case maps:get(MonRef, AT0, undefined) of
+        undefined ->
+            io:format("ERROR: UNEXPECTED MISSING MONITOR IN TRACKING TABLE: {~p, ~p}~n", [MonRef, DPid]),
+            St0;
+        {RPid, _Ref} = PidRef ->
+            if
+                RPid =:= DPid -> ok;
+                true -> erlang:halt(io_lib:format("CSRT:HI PID MISMATCH ABORT: ~p =/= ~p~n", [DPid, RPid]))
+            end,
+            %% remove double bookkeeping
+            AT = maps:remove(MonRef, maps:remove(PidRef, AT0)),
+            %% TODO: Assert Pid matches Object
+            %% update process state in live table
+            %% TODO: decide whether we want the true match to crash this process on failure
+            true = ets:update_element(?MODULE, PidRef,
+                [{#rctx.state, {down, Reason}}, {#rctx.updated_at, os:timestamp()}]),
+            log_process_lifetime_report(PidRef),
+            %% Delay eviction to allow human visibility on short lived pids
+            erlang:send_after(St0#st.eviction_delay, self(), {evict, PidRef}),
+            St0#st{tracking=AT}
+    end,
+    {noreply, St};
+handle_info({evict, {_Pid, _Ref}=PidRef}, #st{}=St) ->
+    ets:delete(?MODULE, PidRef),
+    {noreply, St};
+handle_info(Msg, St) ->
+    {stop, {unknown_info, Msg}, St}.
+
+terminate(_Reason, _St) ->
+    ok.
+
+code_change(_OldVsn, St, _Extra) ->
+    {ok, St}.
+
+log_process_lifetime_report(PidRef) ->
+    %% More safely assert this can't ever be undefined
+    #rctx{} = Rctx = get_resource(PidRef),
+    %% TODO: catch error out of here, report crashes on depth>1 json
+    couch_log:report("csrt-pid-usage-lifetime", to_flat_json(Rctx)).

--- a/src/couch_stats/src/couch_stats_sup.erl
+++ b/src/couch_stats/src/couch_stats_sup.erl
@@ -29,6 +29,7 @@ init([]) ->
         {
             {one_for_one, 5, 10}, [
                 ?CHILD(couch_stats_server, worker),
+                ?CHILD(couch_stats_resource_tracker, worker),
                 ?CHILD(couch_stats_process_tracker, worker)
             ]
         }}.

--- a/src/fabric/priv/stats_descriptions.cfg
+++ b/src/fabric/priv/stats_descriptions.cfg
@@ -26,3 +26,29 @@
     {type, counter},
     {desc, <<"number of write quorum errors">>}
 ]}.
+
+
+%% fabric_rpc worker stats
+%% TODO: decide on which naming scheme:
+%% {[fabric_rpc, get_all_security, spawned], [
+%% {[fabric_rpc, spawned, get_all_security], [
+{[fabric_rpc, get_all_security, spawned], [
+    {type, counter},
+    {desc, <<"number of fabric_rpc worker get_all_security spawns">>}
+]}.
+{[fabric_rpc, open_doc, spawned], [
+    {type, counter},
+    {desc, <<"number of fabric_rpc worker open_doc spawns">>}
+]}.
+{[fabric_rpc, all_docs, spawned], [
+    {type, counter},
+    {desc, <<"number of fabric_rpc worker all_docs spawns">>}
+]}.
+{[fabric_rpc, open_shard, spawned], [
+    {type, counter},
+    {desc, <<"number of fabric_rpc worker open_shard spawns">>}
+]}.
+{[fabric_rpc, changes, spawned], [
+    {type, counter},
+    {desc, <<"number of fabric_rpc worker changes spawns">>}
+]}.

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -492,6 +492,11 @@ view_cb({meta, Meta}, Acc) ->
     ok = rexi:stream2({meta, Meta}),
     {ok, Acc};
 view_cb({row, Row}, Acc) ->
+    %% TODO: distinguish between rows and docs
+    %% TODO: wire in csrt tracking
+    %% TODO: distinguish between all_docs vs view call
+    couch_stats:increment_counter([fabric_rpc, view, row_processed]),
+    %%couch_stats_resource_tracker:inc(rows_read),
     % Adding another row
     ViewRow = #view_row{
         id = couch_util:get_value(id, Row),
@@ -535,6 +540,7 @@ changes_enumerator(#full_doc_info{} = FDI, Acc) ->
 changes_enumerator(#doc_info{id = <<"_local/", _/binary>>, high_seq = Seq}, Acc) ->
     {ok, Acc#fabric_changes_acc{seq = Seq, pending = Acc#fabric_changes_acc.pending - 1}};
 changes_enumerator(DocInfo, Acc) ->
+    couch_stats:increment_counter([fabric_rpc, changes, rows_read]),
     #fabric_changes_acc{
         db = Db,
         args = #changes_args{

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -229,9 +229,11 @@ execute(#cursor{db = Db, index = Idx, execution_stats = Stats} = Cursor0, UserFu
             Result =
                 case mango_idx:def(Idx) of
                     all_docs ->
+                        couch_stats:increment_counter([mango_cursor, view, all_docs]),
                         CB = fun ?MODULE:handle_all_docs_message/2,
                         fabric:all_docs(Db, DbOpts, CB, Cursor, Args);
                     _ ->
+                        couch_stats:increment_counter([mango_cursor, view, idx]),
                         CB = fun ?MODULE:handle_message/2,
                         % Normal view
                         DDoc = ddocid(Idx),

--- a/src/mango/src/mango_selector.erl
+++ b/src/mango/src/mango_selector.erl
@@ -50,6 +50,7 @@ normalize(Selector) ->
 % This assumes that the Selector has been normalized.
 % Returns true or false.
 match(Selector, D) ->
+    %% TODO: wire in csrt tracking
     couch_stats:increment_counter([mango, evaluate_selector]),
     match_int(Selector, D).
 

--- a/src/rexi/src/rexi.erl
+++ b/src/rexi/src/rexi.erl
@@ -129,7 +129,8 @@ async_server_call(Server, Caller, Request) ->
 -spec reply(any()) -> any().
 reply(Reply) ->
     {Caller, Ref} = get(rexi_from),
-    erlang:send(Caller, {Ref, Reply}).
+    Delta = couch_stats_resource_tracker:make_delta(),
+    erlang:send(Caller, {Ref, Reply, {delta, Delta}}).
 
 %% @equiv sync_reply(Reply, 300000)
 sync_reply(Reply) ->
@@ -214,7 +215,8 @@ stream(Msg, Limit, Timeout) ->
         {ok, Count} ->
             put(rexi_unacked, Count + 1),
             {Caller, Ref} = get(rexi_from),
-            erlang:send(Caller, {Ref, self(), Msg}),
+            Delta = couch_stats_resource_tracker:make_delta(),
+            erlang:send(Caller, {Ref, self(), Msg, {delta, Delta}}),
             ok
     catch
         throw:timeout ->

--- a/src/rexi/src/rexi_server.erl
+++ b/src/rexi/src/rexi_server.erl
@@ -136,9 +136,12 @@ init_p(From, MFA) ->
     string() | undefined
 ) -> any().
 init_p(From, {M, F, A}, Nonce) ->
+    MFA = {M, F, length(A)},
     put(rexi_from, From),
-    put('$initial_call', {M, F, length(A)}),
+    put('$initial_call', MFA),
     put(nonce, Nonce),
+    couch_stats:create_context(From, MFA, Nonce),
+    couch_stats:maybe_track_rexi_init_p(MFA),
     try
         apply(M, F, A)
     catch


### PR DESCRIPTION
# Couch Stats Resource Tracker Overview

We currently lack visibility into the types of operations that are inducing
system resource usage in CouchDB. We can see in the IOQ stats the raw
quantities of IO operations being induced, at categories of essentially "normal
database reads", "database writes", "view index writes", "internal
replication", and "compaction". The problem is connecting the dots between the
data in IOQ and the corresponding database operation types inducing the work,
and going a step further, connecting that with individual requests to identify
the actual operations inducing all of the work.

In particular, I believe this is especially pronounced in aggregate
database read operations that perform a fold over the `id_tree` or `seq_tree` of
the underlying `.couch` file. We do not currently instrument `couch_btree.erl`
with `couch_stats` to track operations, so we do not have any data to correlate
`couch_btree:fold*` operations with the volume of IOQ traffic flowing through
the system. A basic first step would be to add counters for the amount of btree
fold reads performed, however, that would still be insufficient as it would not
allow us to distinguish between `_all_docs`, `_view`, `_find`, and `_changes`
unless we track which type of fold operation is being induced.

Ideally, we should be able to correlate the overall IOQ throughput with the
different types of API operations being induced. Beyond that, it would be
fantastic if we can extend CouchDB's introspection capabilities such that we
can track the types of operations being performed at the user/db/request level,
allowing users to understand what operations and requests are utilizing system
resources.

This writeup proposes an approach to alleviate these introspection blindspots by
collecting additional cluster level metrics at the RPC operation level providing
context about the overall volume of requests, the magnitude of data processed,
and the response payload magnitude. By extending the global stats collection
logic we can allow for process local tracking of stats and build a system for
tracking and exposing that data at the RPC level, the node local level, and at
an HTTP API level. I think it's essential we target cluster level workloads in
addition to request level so we can correlate resource usage with individual
requests. Given how variable API operations are in CouchDB (eg single doc read
reads one doc from 3 shard replicas, whereas a `_find` query failing to find an
index will do a full database scan _every time_), I think it's important  to be
able to easily see what types of operations are consuming cluster resources, and
then readily identify the heavy hitting requests.

This data can be tracked in records in ETS tables allowing for realtime
introspection of active resource consumption across all operations. We can focus
on monotonically increasing counters for tracking core operations and avoid an
assortment of complexity from negative values and dealing with histograms. We
can leave histograms to other stacks by tracking start/etc/stop timestamps. By
only focusing on monotonically increasing values as a function of resource
consumption we can take a delta between any two timestamps and get a precise
rate of consumption for this process/coordinator during the given time window.
This also allows us to iteratively track stats between any start and stop point.
The simple case is from process start to process finish, but anywhere any
between is a valid delta and we can distinguish between live snapshots and final
full process workload. By having RPC worker processes store data to the node
local ETS tables in addition to sending resouce usage deltas in rexi
replies we can track node local RPC worker resource usage in addition to node
local coordinator processes and how much work they've induced across the
cluster. This provides both insight into the active heavy operations in the
cluster but also provides users with easy access to identify heavy hitter
requests for further optimization.

By focusing on only tracking monotonically increasing counters about core
resource usage we can utilize a delta based system allowing for resource
tracking on the desired stat. Essentially this allows us to create
`recon:proc_window` but `couchdb:proc_window` and identify the most active
processes by account or docs reads or IOQ calls or rows read or JS filter
invocations or by data volume or whatever else we choose to track.

The delta based approach allows us to decouple from any particular time
interval based collection approach and instead focus on what provides the most
insight in any particular context. This allows at the base case to collect
stats time start to time end, but also provides intermediate values at whtaever
intervals/rates we desire. This also allows us to use the same stats collection
logic for both streaming and non streaming API endpoints as we can handle full
deltas or partials. It's key we support delta operations as we need to see long
running processes live, not when they're completed potentially hours later, so
delta updates are essential to live tracking on long running operations. (In
practice, long running `_find` query RPC workers can induce work for
potentially hours, so it's inappropriate to wait until the worker completes to
stream the resource usage, as otherwise it'll be hours behind when it actually
happened).

With the idea of using the existing `couch_stats:increment_counter` logic to
handle resource tracking, we can extend that `increment_counter` logic so that
in addition to the normal global tracking of the desired metric, we also begin
tracking a process local set of statistics allowing us so isolate resources
utilized to individual requests and even rpc workers.

This is straightforward to accomplish from within
`couch_stats:increment_counter` as we have the exact stats being recorded but
also we're still in the process that invoked those stats, so this draft PR also
has the local process performing operations update an ets table entry for its
own usage levels. This results in all worker processes concurrently updating
ETS tables in realtime as a function of resource usage. Unlike our normal stats
collection where we have many processes writing to a small number of keys
creating lock contention, for process local stats each process only writes to a
singular key corresponding to the process ID, so there is no overlapping stats
collection across keys, allowing us to take full advantage of ETS
`write_concurrency`.

Each process updates in realtime its process usage stats as the normal
`couch_stats:increment_counter` code paths are exercised. We utilize a
timestamp based approach to track when each update occurs, and given we're only
interacting with monotonically increasing counters, we can take the delta
between any two time points and that will give us a reasonably accurate rate of
change. This allows us to create the equivalent of `recon:proc_window` but for
`couch_db:proc_window` to find busiest
processes/requests/databases/shards/users/etc.

The timestamp delta approach also allows us to send deltas from rpc worker back
to coordinator during the normally desired `rexi:reply` occurances by embedding
the resource delta into the rexi reply, allowing us to incrementally send back
worker usage stats to be aggregated at the coordinator level so we can find
runaway processes prior to seeing them in the report logs. This approach also
allows us extend `rexi:ping` with the same logic so we can keep resource usage
stats streaming independently of when rows are streamed back to the coodinator
(a major issue we've encountered with long running bad `_find` queries).

This also allows us to create watchdog processes that kill a cluster process
chain in the event it has surpassed certain thresholds. This would be easily
achievable at the node local level or coordinator cluster level. We'll also
likely want some type of watchdog process to clear our old entries in the ETS
cache. The process being tracked itself shouldn't be accountable for the
longevity in the stats table, as we want to leave a small buffer of time so we
don't lose info about the processes the second they exit. This is a common
problem when using `recon:proc_window` where if you try and `process_info` a
process you found with `proc_window` it could be dead by the end of the proc
window, losing any potential insights. By having say a 10 second buffer on
letting processes remained completed in the stats table we can see more easily
track and interact with live work.

This system also allows us to generate a per process report of resources
consumed both for local processes invoked by way of `fabric_rpc` and also
cluster wide aggregations at the coordinator level allowing for realtime usage
reporting of active requests utilizing the new report engine. For example:

> [report] 2023-10-06T23:24:35.974642Z node1@127.0.0.1 <0.296.0> -------- [csrt-pid-usage-lifetime changes_processed=0 docs_read=0 mfa="{fabric_rpc,open_doc,3}" nonce="null" pid_ref="<0.1558.0>#Ref<0.1796228611.1272446977.134363>" rows_read=0 state="{down,noproc}" updated_at="{1696,634675,974598}"]


# Core Tasks

* extend stats collection into `fabric_rpc` (or `mango_httpd` `dreyfus_rpc`, etc)
  - target core streaming API operations; changes feed as first step
  - each operation should include _at least_ metrics for:
    1) number of rpc invocations
    2) number of documents processed (request magnitude)
    3) number of documents streamed out (response magnitude)
  - for example, changes feed should do:
    1) `couch_stats:increment_counter([fabric_rpc, changes_feed])`
      - on rpc invocation
    2) `couch_stats:increment_counter([fabric_rpc, changes_feed, row_processed])`
      - on rows read; perhaps also for docs read
    3) `couch_stats:increment_counter([fabric_rpc, changes_feed, rows_returned])`
      - when streaming rows back to the client
    4) we should also include JS filter invocations for relevant API operations 
  - somewhat awkward with rows vs docs and needing js filters
  - we'll likely need to play around with what all to collect here, but in
    general we need direct visibility into core operations induced and what is
    performing them; Cluster level metrics give us the former, and reports/real
    time reporting gives us the latter

* Extend `couch_stats` to do local process stat tracking
  - when we do `couch_stats:increment_counter`, do something like
    `maybe_track_local_stat(StatOp)` where we can track local process stats for
    the subset of stats we're interested in having reports and real time stats
    available for
  - this is the key second step from tracking the additional RPC data. Basically
    we start tracking the core data we want so we can use that for cluster
    status introspection and usage levels, then we gather the local stats for
    identifying which requests are heaviest
  - this provides a mechanism to track any additional stats on RPC we want
    without having to immediately introduce new metrics for all RPC operations we
    want, while skipping undesired operations

* Store local stats into ETS backend
  - several counters backend options available. I believe an ETS table (or
    shared set of ETS tables like we do with `couch_server(N)` and others) that
    utilizies a combination of `read_concurrency`, `write_concurrency`, and
    `distributed_counters` will provide us with a performant system that allows
    for isolated tracking of per process stats in a way that allows for
    concurrent writers with no overlapping writers in addition to read
    concurrency and distributed counters to minimize impact of writing to the
    shared table across processes. Each process will be its only writer,
    minimizing concurrency issues, yet we can still do a more expensive read
    operation over the ETS table(s) to allow for aggregate real time tooling to
    expose at the `remsh` and HTTP API (eg `couch_debug` functions for finding
    heaviest requests or similar exposing of data over http to end up in a
    Fauxton interface providing real time stats
  - key off of `{self(), make_ref()}` to ensure uniqueness in stats table
  - also can store:
    - user
    - db/shard
    - request type
    - coordinator vs rpc vs background task
    - these are specifically for introspection and grouping on with ets queries
  - use records for tracking data
    - this allows for use of atomic `ets:update_counter` operations
    - easily interact with particular fields
    - also allows for `ets:match` and `ets:select` to perform aggregate queries
      about overal system load. I think this is only possible with records in
      ETS, I don't think we could use counters and select with maps?

* Extend `rexi:{reply,stream,etc}` to send usage deltas
  - we can take the current stats record for the process and delta with that
    since a `T0` stats record and provide a delta. We we make that delta we
    store the stats at the time of the delta `TDelta1`, then afterwards we 
    perform our deltas against the last record snapshot and then we can continue
    to send deltas over time and still return a full workload usage if desired.
  - key thing here is we need to stream the stats back, we can't wait until the
    RPC worker is done because sometimes that takes hours. Need to be able to get
    iterative stats so we can find problematic processes live
  - need to address related issue where responses coming in from other shards
    are not accounted for in the usage as those responses are dropped, eg when
    limit is reached in Mango find at the coordinator level before shard level
  - alternative is specifically sending stats lines, but I think we'll be far
    better served by always sending deltas with every rpc line

* Introduce watchdog process around stats collection

This has two core jobs:

  1) clear out old process stats after desired delay
    - we want to have data about recent processes that just exited to faciliate
      human interaction with busy yet fast lived processes
  2) provide an automated mechanism for killing processes
    - I think this is an important initial feature, at the very least we should
      be able to tell a cluster to kill find requests that are still going after
      an hour, for example.
    - can easily find long running processes or heavy processes using ets:select
    - can also key on user to find most active users
    - I think with a bit of thought and a few configuration options we can make
      this usable for helping out with problematic specific workflows on a per
      user/request basis
    - for example:
      - "automatically kill all find requests that have processed a million docs
        yet returned none"

* Introduce remsh/http level introspection tooling
  - eg make `couchdb:proc_window` and some other tools for filtering and sorting
    the stats collection tables. This tooling should be readily available by way
    of remsh but we should also expose the same introspection APIs over http
    from the get go so that this can be utilized directly by users with curl and
    end up in a nice Fauxton dashboard showing realtime usage levels.
  - this doesn't have to be complicated, but should easily be able to query the
    local rpc node, all cluster rpc nodes, and all cluster coordinators. It
    should be easy to get a cluster level view of overall usage, grouped by the
    desired set of stats.
  - provide tooling to teardown RPC workers and coordinators with full worker
    teardown. Once we make it easy to find the heavy hitters, we need to make it
    easy to take action against them. Obviously being able to kill the processes
    is essential, but I could see providing additional functionality like
    perhaps allowing for lowering the IOQ priority for the given request if it's
    a request that genuinely needs to complete but is impacting the system.

I've got a hacked together http API to demonstrate being able to query the stats
collection across the cluster directly over http:

<img width="1719" alt="Screenshot 2023-10-06 at 3 29 50 PM" src="https://github.com/apache/couchdb/assets/5326/1aebe0f7-ec8a-4f36-8a0f-f92385d8a96b">


# Overall Approach

The key task here is to build out the mechanisms for collecting/tracking stats
locally, shipping them back over the wire to the coordinator for aggregation,
handling the deltas, exposing them realtime stats, and then generating reports
with the data. I believe this to be the core work at hand, where afterwards
extending out the API operations to collect the data is fairly straightforward;
for instance, once the functionality is in place, adding changes feed reports
is simply adding the new stats to collect to the relevant `fabric_rpc`
functions and then ensuring we've flagged those new stats as desired fields to
expose in our resource usage tracking. We could easily extend compactions or
indexing with similar stats and reporting logic. Once we have a system in place
for tracking process local metrics, sending and aggregating the deltas, then
exposing the data over querying interfaces, we can easily extend this level of
introspection to any operations in the system, and in my opinion, we should
extend this coverage to 100% of database operations such that all resource
usage is accounted for and tracked.

This is still a bit rough in a few areas, and not everything is fully
operational, but essentially the core framework is operational and demonstrates
a working version of what I've detailed out. I believe this to be a viable
approach and that the proof of concept provides a clear path forward on how to
deliver this.
