### PR TITLE
Remove support for delete markers and improve config consistency

### DIFF
--- a/src/chttpd/test/eunit/chttpd_auth_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_auth_tests.erl
@@ -41,11 +41,11 @@ setup_proxy_auth() ->
     {{StartCtx, ProxyCfgFile}, HashesShouldWork, HashesShouldFail, SupportedHashAlgorithms}.
 
 teardown_proxy_auth({{Ctx, ProxyCfgFile}, _, _, _}) ->
-    ok = file:delete(ProxyCfgFile),
     config:delete("chttpd_auth", "hash_algorithms", false),
     config:delete("chttpd_auth", "secret", false),
     config:delete("chttpd_auth", "proxy_use_secret", false),
     config:delete("chttpd", "require_valid_user", false),
+    ok = file:delete(ProxyCfgFile),
     test_util:stop_couch(Ctx).
 
 require_valid_user_exception_test_() ->

--- a/src/config/src/config.erl
+++ b/src/config/src/config.erl
@@ -34,7 +34,6 @@
 
 -export([listen_for_changes/2]).
 -export([subscribe_for_changes/1]).
--export([parse_ini_file/1]).
 
 -export([init/1]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
@@ -50,7 +49,6 @@
 -define(DELETE, delete).
 
 -record(config, {
-    notify_funs = [],
     ini_files = undefined,
     write_filename = undefined
 }).

--- a/src/config/src/config.hrl
+++ b/src/config/src/config.hrl
@@ -1,0 +1,13 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-define(DELETE, delete).

--- a/src/config/test/config_tests.erl
+++ b/src/config/test/config_tests.erl
@@ -19,7 +19,6 @@
 ]).
 
 -include_lib("couch/include/couch_eunit.hrl").
--include_lib("couch/include/couch_db.hrl").
 
 -define(TIMEOUT, 4000).
 -define(RESTART_TIMEOUT_IN_MILLISEC, 3000).
@@ -55,9 +54,6 @@
     ok = file:close(Fd),
     FileName
 end).
-
--define(T(F), {erlang:fun_to_list(F), F}).
--define(FEXT(F), fun(_, _) -> F() end).
 
 setup() ->
     setup(?CONFIG_CHAIN).
@@ -441,7 +437,7 @@ should_write_changes(_, _) ->
         ?assertEqual("5986", config:get("httpd", "port")),
         ?assertEqual(ok, config:set("httpd", "port", "8080")),
         ?assertEqual("8080", config:get("httpd", "port")),
-        ?assertEqual(ok, config:delete("httpd", "bind_address", "8080")),
+        ?assertEqual(ok, config:delete("httpd", "bind_address")),
         ?assertEqual(undefined, config:get("httpd", "bind_address"))
     end).
 
@@ -461,16 +457,12 @@ should_ensure_that_no_ini_files_loaded() ->
     ?assertEqual(0, length(config:all())).
 
 should_create_non_persistent_option() ->
-    ?_test(begin
-        ?assertEqual(ok, config:set("httpd", "port", "80", false)),
-        ?assertEqual("80", config:get("httpd", "port"))
-    end).
+    ?assertEqual(ok, config:set("httpd", "port", "80", false)),
+    ?assertEqual("80", config:get("httpd", "port")).
 
 should_create_persistent_option() ->
-    ?_test(begin
-        ?assertEqual(ok, config:set("httpd", "bind_address", "127.0.0.1")),
-        ?assertEqual("127.0.0.1", config:get("httpd", "bind_address"))
-    end).
+    ?assertEqual(ok, config:set("httpd", "bind_address", "127.0.0.1")),
+    ?assertEqual("127.0.0.1", config:get("httpd", "bind_address")).
 
 should_handle_value_change({_Apps, Pid}) ->
     ?_test(begin

--- a/src/config/test/config_tests.erl
+++ b/src/config/test/config_tests.erl
@@ -111,6 +111,35 @@ handle_config_terminate(Self, Reason, {Pid, State}) ->
     Pid ! {config_msg, {Self, Reason, State}},
     ok.
 
+setup_ini() ->
+    Chain = [write_ini(F) || F <- ["default.ini", "local.ini"]],
+    {Chain, setup(Chain)}.
+
+teardown_ini({Chain, Apps}) ->
+    lists:foreach(
+        fun(Path) -> ok = file:delete(Path) end,
+        Chain
+    ),
+    teardown(Apps).
+
+write_ini(FileName) ->
+    Path = filename:join([?TEMPDIR, FileName]),
+    Data = io_lib:format("[section]\nfile = ~s\n", [FileName]),
+    ok = file:write_file(Path, Data),
+    Path.
+
+config_delete_reload_restart_test_() ->
+    {
+        "Test consistency after set, delete, reload, and restart",
+        foreach,
+        fun setup_ini/0,
+        fun teardown_ini/1,
+        [
+            fun non_persistent_set_delete_reload_restart/0,
+            fun persistent_set_delete_reload_restart/0
+        ]
+    }.
+
 config_get_test_() ->
     {
         "Config get tests",
@@ -140,7 +169,8 @@ config_set_test_() ->
             [
                 fun should_update_option/0,
                 fun should_create_new_section/0,
-                fun should_fail_to_set_binary_value/0
+                fun should_fail_to_set_binary_value/0,
+                fun should_fail_to_set_invalid_sensitive_key/0
             ]
         }
     }.
@@ -386,6 +416,16 @@ should_fail_to_set_binary_value() ->
         config:set(<<"a">>, <<"b">>, <<"c">>, false)
     ).
 
+should_fail_to_set_invalid_sensitive_key() ->
+    ?assertEqual(
+        {error, <<"Invalid configuration key">>},
+        config:set("admins", "[]", "val")
+    ),
+    ?assertEqual(
+        "'****'",
+        lists:nth(4, meck:capture(first, couch_log, error, ['_', '_'], 2))
+    ).
+
 should_return_undefined_atom_after_option_deletion() ->
     ?assertEqual(ok, config:delete("mock_log", "level", false)),
     ?assertEqual(undefined, config:get("mock_log", "level")).
@@ -438,7 +478,7 @@ should_write_changes(_, _) ->
         ?assertEqual(ok, config:set("httpd", "port", "8080")),
         ?assertEqual("8080", config:get("httpd", "port")),
         ?assertEqual(ok, config:delete("httpd", "bind_address")),
-        ?assertEqual(undefined, config:get("httpd", "bind_address"))
+        ?assertEqual("127.0.0.1", config:get("httpd", "bind_address"))
     end).
 
 should_ensure_default_wasnt_modified(_, _) ->
@@ -705,6 +745,44 @@ should_notify_on_config_reload_flush(Subscription, {_Apps, Pid}) ->
             ok
         end)
     }.
+
+persistent_set_delete_reload_restart() ->
+    Persist = true,
+    ?assertEqual("local.ini", config:get("section", "file")),
+    ?assertEqual(ok, config:set("section", "file", "memory", Persist)),
+    ?assertEqual("memory", config:get("section", "file")),
+    ?assertEqual(ok, config:delete("section", "file", Persist)),
+    ?assertEqual("default.ini", config:get("section", "file")),
+    ?assertEqual(ok, config:reload()),
+    ?assertEqual("default.ini", config:get("section", "file")),
+    with_process_restart(config),
+    % Avoid race with config loading .ini files
+    wait_config_get("section", "file", "default.ini"),
+    ?assertEqual("default.ini", config:get("section", "file")).
+
+non_persistent_set_delete_reload_restart() ->
+    Persist = false,
+    ?assertEqual("local.ini", config:get("section", "file")),
+    ?assertEqual(ok, config:set("section", "file", "memory", Persist)),
+    ?assertEqual("memory", config:get("section", "file")),
+    ?assertEqual(ok, config:delete("section", "file", Persist)),
+    ?assertEqual("local.ini", config:get("section", "file")),
+    ?assertEqual(ok, config:reload()),
+    ?assertEqual("local.ini", config:get("section", "file")),
+    with_process_restart(config),
+    % Avoid race with config loading .ini files
+    wait_config_get("section", "file", "local.ini"),
+    ?assertEqual("local.ini", config:get("section", "file")).
+
+wait_config_get(Sec, Key, Val) ->
+    test_util:wait(
+        fun() ->
+            case config:get(Sec, Key) of
+                V when V =:= Val -> ok;
+                _ -> wait
+            end
+        end
+    ).
 
 spawn_config_listener() ->
     Self = self(),

--- a/src/docs/src/config/intro.rst
+++ b/src/docs/src/config/intro.rst
@@ -125,17 +125,6 @@ the parameter and value are separated `` = ``, i.e. the equal sign is surrounded
 by at least one space on each side. This might be useful in the ``[jwt_keys]``
 section, where base64 encoded keys may contain some ``=`` characters.
 
-.. note::
-    In case when you'd like to remove some parameter from the `default.ini`
-    without modifying that file, you may override in `local.ini`, but without
-    any value::
-
-        [compactions]
-        _default =
-
-    This could be read as: "remove the `_default` parameter from the
-    `compactions` section if it was ever set before".
-
 The semicolon (``;``) signals the start of a comment. Everything after this
 character is ignored by CouchDB.
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Remove support for delete markers, and improve consistency of config values following deletion.

Calling the persistent variation of `config:delete("section", "key")` writes `key =` to the most significant `.ini` file, internally referred to as a "delete marker" which, [according to the docs](https://docs.couchdb.org/en/stable/config/intro.html#setting-parameters-via-the-configuration-file), should cause all previous values of `key` in the `.ini` file chain to be ignored, and sets the value to the atom `undefined`.

Currently, `config:reload` [ignores delete markers](https://github.com/apache/couchdb/issues/4892). Also, since `config:delete` doesn't reload values from `.ini` files at all, using the persistent variation may result in temporarily returning an inconsistent value until the `config` server is restarted.

This change removes support for delete markers. A persistent call to `config:delete` no longer writes a delete marker, but instead deletes the entire line. When parsing `.ini` files, any existing  delete markers are ignored.

Additionally, this change improves consistency after `config:delete` by loading any values from `.ini` files into the `ets` table subsequent to the deletion.

Additionally, this PR:
- Simplifies logging of sensitive values by introducing the `maybe_conceal/2` function.
- Cleans up the config application:
  - Removes an unused record field, export, include, and some defines.
  - Removes a deletion "reason" that was probably a copy/pasta error.
  - Fixes `should_create_non_persistent_option` and `should_create_persistent_option` tests so that they will run.
- Improves test coverage:

Before:
```
  All 59 tests passed.
Code Coverage:
config              :  84%
config_app          :  87%
config_listener     :  66%
config_listener_mon :  65%
config_notifier     :  93%
config_sup          : 100%
config_util         :   4%
config_writer       : 100%

Total               : 80%
```
After:
```
  All 63 tests passed.
Code Coverage:
config              :  87%
config_app          :  87%
config_listener     :  66%
config_listener_mon :  65%
config_notifier     :  93%
config_sup          : 100%
config_util         :  52%
config_writer       :  95%

Total               : 85%
```
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make check
```

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
