### PR TITLE
Wait for compacted indexes to flip.

### DIFF
--- a/src/couch_index/src/couch_index_compactor.erl
+++ b/src/couch_index/src/couch_index_compactor.erl
@@ -112,7 +112,7 @@ compact(Idx, Mod, IdxState, Opts) ->
         Mod:compact(Db, IdxState, Opts)
     end),
     ok = Mod:commit(NewIdxState),
-    case gen_server:call(Idx, {compacted, NewIdxState}) of
+    case gen_server:call(Idx, {compacted, NewIdxState}, infinity) of
         recompact ->
             couch_log:info("Compaction restarting for db: ~s idx: ~s", Args),
             compact(Idx, Mod, NewIdxState, [recompact]);


### PR DESCRIPTION
Noticed on a few production instances, we run a potentially long compaction, and when done, the call to commit the compacted state times out after 5 seconds. That, in turn, triggers are a `compaction_failed` call, which also may timeout and the whole thing crashes.

Since we have the ioq scheduler running and we're doing disk IO, compaction swap may be delayed in the background, and take longer than 5 seconds. Opt to wait however long it takes or crash for some other reason. gen_server calls already auto-monitor and check for called process's exits.

