### PR TITLE
Update proper

### DIFF
--- a/configure
+++ b/configure
@@ -241,6 +241,11 @@ if [ "${ERLANG_OS}" = "unix" ]; then
     fi
 fi
 
+# If we're in a release tarball and we don't have proper, then mark it as skipped
+if [ ! -d .git ] && [ "$WITH_PROPER" = "true" ] && [ ! -d src/proper ]; then
+    WITH_PROPER="false"
+fi
+
 echo "==> configuring couchdb in rel/couchdb.config"
 cat > rel/couchdb.config << EOF
 % Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -164,7 +164,7 @@ WithProper = lists:keyfind(with_proper, 1, CouchConfig) == {with_proper, true}.
 
 OptionalDeps = case WithProper of
     true ->
-        [{proper, {url, "https://github.com/proper-testing/proper"}, "def84f172df92635cc62f3356e3e7ad054638eb4"}];
+        [{proper, {url, "https://github.com/proper-testing/proper"}, "a5ae5669f01143b0828fc21667d4f5e344aa760b"}];
     false ->
         []
 end.

--- a/src/couch/test/eunit/couch_ejson_compare_tests.erl
+++ b/src/couch/test/eunit/couch_ejson_compare_tests.erl
@@ -163,6 +163,10 @@ zero_width_list() ->
 zero_width_chars() ->
     oneof([16#200B, 16#200C, 16#200D]).
 
+-else.
+
+-include_lib("couch/include/couch_eunit.hrl").
+
 -endif.
 
 % Regular EUnit tests


### PR DESCRIPTION
A few updates to prepare for the next release

 * Bump proper to the latest commit sha
 * Simplify release configure option so it can automatically figure out with/without-proper
 * Fix running an eunit test without proper.
