### PR TITLE
docs(`find`): add missing negation on talking about field mismatch

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -1675,8 +1675,8 @@ reason code.
 |                                |            | specify the index.                       |
 +--------------------------------+------------+------------------------------------------+
 | ``field_mismatch``             | any        | Fields in ``"selector"`` of the query do |
-|                                |            | match with the fields available in the   |
-|                                |            | index.                                   |
+|                                |            | not match with the fields available in   |
+|                                |            | the index.                               |
 +--------------------------------+------------+------------------------------------------+
 | ``is_partial``                 | json, text | Partial indexes can be selected only     |
 |                                |            | manually.                                |


### PR DESCRIPTION
The description of the `field_mismatch` reason code is missing a "not" in the documentation of the `/{db}/_explain` endpoint hence it has the opposite meaning.
