### PR TITLE
mango: fix $beginsWith range

### DIFF
--- a/src/mango/test/25-beginswith-test.py
+++ b/src/mango/test/25-beginswith-test.py
@@ -54,7 +54,7 @@ class BeginsWithOperator(mango.DbPerClass):
 
         self.assertEqual(mrargs["start_key"], ["A"])
         end_key_bytes = to_utf8_bytes(mrargs["end_key"])
-        self.assertEqual(end_key_bytes, [b"A\xef\xbf\xbd", b"<MAX>"])
+        self.assertEqual(end_key_bytes, [b"A\xef\xbf\xbf", b"<MAX>"])
 
     def test_compound_key(self):
         selector = {"name": "Eddie", "location": {"$beginsWith": "A"}}
@@ -62,7 +62,7 @@ class BeginsWithOperator(mango.DbPerClass):
 
         self.assertEqual(mrargs["start_key"], ["Eddie", "A"])
         end_key_bytes = to_utf8_bytes(mrargs["end_key"])
-        self.assertEqual(end_key_bytes, [b"Eddie", b"A\xef\xbf\xbd", b"<MAX>"])
+        self.assertEqual(end_key_bytes, [b"Eddie", b"A\xef\xbf\xbf", b"<MAX>"])
 
         docs = self.db.find(selector)
         self.assertEqual(len(docs), 1)
@@ -74,12 +74,12 @@ class BeginsWithOperator(mango.DbPerClass):
             {
                 "sort": ["location"],
                 "start_key": [b"A"],
-                "end_key": [b"A\xef\xbf\xbd", b"<MAX>"],
+                "end_key": [b"A\xef\xbf\xbf", b"<MAX>"],
                 "direction": "fwd",
             },
             {
                 "sort": [{"location": "desc"}],
-                "start_key": [b"A\xef\xbf\xbd", b"<MAX>"],
+                "start_key": [b"A\xef\xbf\xbf", b"<MAX>"],
                 "end_key": [b"A"],
                 "direction": "rev",
             },
@@ -97,7 +97,7 @@ class BeginsWithOperator(mango.DbPerClass):
 
         self.assertEqual(mrargs["start_key"], "a")
         end_key_bytes = to_utf8_bytes(mrargs["end_key"])
-        self.assertEqual(end_key_bytes, [b"a", b"\xef\xbf\xbd"])
+        self.assertEqual(end_key_bytes, [b"a", b"\xef\xbf\xbf"])
 
     def test_no_index(self):
         selector = {"foo": {"$beginsWith": "a"}}


### PR DESCRIPTION
## Overview
In the initial implementation of `$beginsWith`, the range calculation for view indexes mistakenly appends an integer with the size of 8 bits which gets maxed out at FF, rather than building a binary with an extra 3 bytes at the end.

This PR fixes the `mango_idx_view:range/5` by correctly appending the `U+FFFF` code point to create a utf-8 encoded binary. Additionally, the Erlang `utf8` binary type ensures the result is a valid utf8 string. If `Arg` is not a utf8 binary, this will throw a badarg error.

`U+FFFF` is used instead of `U+10FFFF` as it's the highest sorting code point according to the collator rules.

We expect `Arg` strings to be a valid utf8 but, to be safe, `mango_selector:norm_ops/1` is enhanced to verify that any argument to `$beginsWith` is a utf8 string.

## Testing recommendations

`make mango-test`

## Related Issues or Pull Requests

Initial implementation: #4810 

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
