### PR TITLE
add eviction for idleness to ets_lru

### DIFF
--- a/src/ets_lru/test/ets_lru_test.erl
+++ b/src/ets_lru/test/ets_lru_test.erl
@@ -181,7 +181,10 @@ lru_good_options_test_() ->
                 {[{max_size, 2342923423942309423094}], fun test_good_opts/2},
                 {[{max_lifetime, 1}], fun test_good_opts/2},
                 {[{max_lifetime, 5}], fun test_good_opts/2},
-                {[{max_lifetime, 1244209909180928348}], fun test_good_opts/2}
+                {[{max_lifetime, 1244209909180928348}], fun test_good_opts/2},
+                {[{max_idle, 1}], fun test_good_opts/2},
+                {[{max_idle, 5}], fun test_good_opts/2},
+                {[{max_idle, 1244209909180928348}], fun test_good_opts/2}
             ]}
     }.
 
@@ -215,7 +218,8 @@ lru_limits_test_() ->
             [
                 {[{max_objects, 25}], fun test_limits/2},
                 {[{max_size, 1024}], fun test_limits/2},
-                {[{max_lifetime, 100}], fun test_limits/2}
+                {[{max_lifetime, 100}], fun test_limits/2},
+                {[{max_idle, 100}], fun test_limits/2}
             ]}
     }.
 
@@ -306,7 +310,7 @@ test_limits([{max_size, N}], {ok, LRU}) ->
         "Max size ok",
         ?_assert(insert_kvs(memory, LRU, 10 * N, N))
     };
-test_limits([{max_lifetime, N}], {ok, LRU}) ->
+test_limits([{Max, N}], {ok, LRU}) when Max == max_lifetime; Max == max_idle ->
     [
         {
             "Expire leaves new entries",


### PR DESCRIPTION
## Overview

add `max_idle` option, which evicts items by last access time (as opposed to `max_lifetime` which evicts based on creation time).

## Testing recommendations

N/A

## Related Issues or Pull Requests

Will be used by https://github.com/apache/couchdb/pull/4814

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
