### PR TITLE
Replace unique_integer with a ref in ets_lru

### DIFF
--- a/src/ets_lru/src/ets_lru.erl
+++ b/src/ets_lru/src/ets_lru.erl
@@ -366,4 +366,4 @@ table_name(Name, Ext) ->
 
 -spec strict_monotonic_time(atom()) -> strict_monotonic_time().
 strict_monotonic_time(TimeUnit) ->
-    {erlang:monotonic_time(TimeUnit), erlang:unique_integer([monotonic])}.
+    {erlang:monotonic_time(TimeUnit), make_ref()}.


### PR DESCRIPTION
We don't really need a strictly monotonic integer, just a unique key for each atime and ctime entry. `unique_integer([monotonic])` is also a concurrency bottleneck as indicated the warning in [1].

Even in a sequential context, it's slower:

```
> timer:tc(fun() -> [erlang:unique_integer([monotonic]) || _ <- lists:seq(1,1000000)], ok end).
{434637,ok}

> timer:tc(fun() -> [make_ref() || _ <- lists:seq(1,1000000)], ok end).
{322988,ok}
```

[1] https://www.erlang.org/docs/21/man/erlang#unique_integer-1