### PR TITLE
Optimize _active_tasks

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -219,14 +219,8 @@ handle_dbs_info_req(Req) ->
 
 handle_task_status_req(#httpd{method = 'GET'} = Req) ->
     ok = chttpd:verify_is_server_admin(Req),
-    {Replies, _BadNodes} = gen_server:multi_call(couch_task_status, all),
-    Response = lists:flatmap(
-        fun({Node, Tasks}) ->
-            [{[{node, Node} | Task]} || Task <- Tasks]
-        end,
-        Replies
-    ),
-    send_json(Req, lists:sort(Response));
+    TaskList = chttpd_util:get_active_tasks(nodes([visible, this])),
+    send_json(Req, lists:sort(TaskList));
 handle_task_status_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 

--- a/src/chttpd/test/eunit/chttpd_util_test.erl
+++ b/src/chttpd/test/eunit/chttpd_util_test.erl
@@ -226,3 +226,125 @@ tcp_info_works() ->
         {_, _} ->
             false
     end.
+
+chttpd_util_get_active_tasks_test_() ->
+    {
+        "chttpd util get_active_tasks() tests",
+        {
+            setup,
+            fun test_util:start_couch/0,
+            fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    ?TDEF_FE(t_empty_tasks),
+                    ?TDEF_FE(t_one_task),
+                    ?TDEF_FE(t_multiple_tasks),
+                    ?TDEF_FE(t_ignore_errors),
+                    ?TDEF_FE(t_rolling_upgrade_test)
+                ]
+            }
+        }
+    }.
+
+t_empty_tasks(_) ->
+    Tasks = chttpd_util:get_active_tasks(nodes([visible, this])),
+    ?assert(is_list(Tasks)),
+    ?assertEqual([], Tasks).
+
+t_one_task(_) ->
+    [Pid] = spawn_link_some_tasks(1),
+    [Task] = chttpd_util:get_active_tasks(nodes([visible, this])),
+    ThisNode = node(),
+    ?assertMatch({[{node, ThisNode}, {pid, <<_/binary>>}, {_, _} | _]}, Task),
+    kill_tasks([Pid]).
+
+t_multiple_tasks(_) ->
+    N = 1000,
+    Pids = spawn_link_some_tasks(N),
+    Tasks = chttpd_util:get_active_tasks(nodes([visible, this])),
+    ?assert(is_list(Tasks)),
+    ?assertEqual(N, length(Tasks)),
+    ThisNode = node(),
+    lists:map(
+        fun(T) ->
+            ?assertMatch({[{node, ThisNode}, {pid, <<_/binary>>}, {_, _} | _]}, T)
+        end,
+        Tasks
+    ),
+    kill_tasks(Pids).
+
+t_ignore_errors(_) ->
+    [Pid] = spawn_link_some_tasks(1),
+    ThisNode = node(),
+    Nodes = [node(), 'bad@foobar'],
+    [Task] = chttpd_util:get_active_tasks(Nodes),
+    ?assertMatch({[{node, ThisNode}, {pid, <<_/binary>>}, {_, _} | _]}, Task),
+    kill_tasks([Pid]).
+
+t_rolling_upgrade_test(_) ->
+    % Previously, in releases =< 3.3.2, we used to fetch active tasks with:
+    %   gen_server:multi_call(couch_task_status, all)
+    % Here we test the rolling upgrade case when old nodes would call the
+    % the new nodes which were just upgraded. This test should be removed
+    % in the future when rolling upgrades from before =< 3.3.2 is not a
+    % concern any longer.
+    N = 1000,
+    Pids = spawn_link_some_tasks(N),
+    Tasks = chttpd_util:get_active_tasks(nodes([visible, this])),
+    OldTasks = compat_get_active_stats(),
+    % There should be no difference between the two
+    ?assertEqual(lists:sort(Tasks), lists:sort(OldTasks)),
+    kill_tasks(Pids).
+
+compat_get_active_stats() ->
+    {Replies, _BadNodes} = gen_server:multi_call(couch_task_status, all),
+    lists:flatmap(
+        fun({Node, Tasks}) ->
+            [{[{node, Node} | Task]} || Task <- Tasks]
+        end,
+        Replies
+    ).
+
+spawn_link_some_tasks(N) ->
+    Pids = [spawn_link(fun rand_task_proc/0) || _ <- lists:seq(1, N)],
+    [
+        begin
+            Pid ! {add_task, self()},
+            receive
+                task_added -> ok
+            end
+        end
+     || Pid <- Pids
+    ],
+    Pids.
+
+kill_tasks(Pids) ->
+    [
+        begin
+            unlink(Pid),
+            exit(Pid, kill)
+        end
+     || Pid <- Pids
+    ],
+    ok.
+
+rand_task_proc() ->
+    receive
+        {add_task, From} ->
+            couch_task_status:add_task(rand_task_props()),
+            From ! task_added,
+            rand_task_proc()
+    end.
+
+rand_task_props() ->
+    [
+        {type, indexer},
+        {database, binary:encode_hex(rand:bytes(10))},
+        {design_document, binary:encode_hex(rand:bytes(10))},
+        {progress, rand:uniform(100)},
+        {changes_done, rand:uniform(1000000)},
+        {total_changes, rand:uniform(1000000)}
+    ].

--- a/src/couch/src/couch_httpd_misc_handlers.erl
+++ b/src/couch/src/couch_httpd_misc_handlers.erl
@@ -92,7 +92,7 @@ handle_all_dbs_req(Req) ->
 handle_task_status_req(#httpd{method = 'GET'} = Req) ->
     ok = couch_httpd:verify_is_server_admin(Req),
     % convert the list of prop lists to a list of json objects
-    send_json(Req, [{Props} || Props <- couch_task_status:all()]);
+    send_json(Req, [{Props} || Props <- lists:sort(couch_task_status:all())]);
 handle_task_status_req(Req) ->
     send_method_not_allowed(Req, "GET,HEAD").
 


### PR DESCRIPTION
We observed on at least one busy cluster couch_task_status gen_server would not be able to keep up with task updates and `all` task fetching calls. The singleton gen_server would start to get unbounded message backups, where the only solution was to restart couch application.

To help with that there are at least two optimizations we can do:

 1) Avoiding blocking `couch_task_status` gen_sever when fetching all task
properties. That operation now happens outside of the gen_server in the `all` function.

 2) Use a set ets instead of an ordered set ets table. Previously, in CouchDB
1.x, we relied on the ordered ets table to keep a sorted task list, however with clustering in CouchDB 2.x+ we had to call lists:sort/1 on the task result anyway, so there is no reason to waste time maintaining an ordered ets.

To fetch the tasks use the newer `erpc` Erlang module. One concern with this change is how `_active_tasks` will act during rolling upgrades. In that case there are two scenarios:

 1) Old nodes would be calling `gen_server:multi_call/2`. For those nodes we
 left the `all` gen_server callback in so they would not fail.

 2) New nodes calling `erpc:multicall(Nodes, couch_task_status, all, [])` on
 old nodes. In that case the old nodes already have the `all/0` function and
 will in-turn perform a local `gen_server:call(?MODULE, all)` and return the
 results as expected.

While at it, modernize the tests a bit by using the newer `?TDEF_FE` macros and remove optional gen_server callbacks and module attributes.
