### PR TITLE
Remove code_change and empty terminate callbacks

### DIFF
--- a/src/chttpd/src/chttpd_auth_cache.erl
+++ b/src/chttpd/src/chttpd_auth_cache.erl
@@ -19,8 +19,7 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    terminate/2,
-    code_change/3
+    terminate/2
 ]).
 -export([listen_for_changes/1, changes_callback/2]).
 
@@ -144,9 +143,6 @@ terminate(_Reason, #state{changes_pid = Pid}) when is_pid(Pid) ->
     exit(Pid, kill);
 terminate(_Reason, _State) ->
     ok.
-
-code_change(_OldVsn, #state{} = State, _Extra) ->
-    {ok, State}.
 
 %% private functions
 

--- a/src/config/src/config.erl
+++ b/src/config/src/config.erl
@@ -36,7 +36,7 @@
 -export([subscribe_for_changes/1]).
 -export([parse_ini_file/1]).
 
--export([init/1, terminate/2, code_change/3]).
+-export([init/1]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -export([is_sensitive/2]).
@@ -264,9 +264,6 @@ init(IniFiles) ->
     debug_config(),
     {ok, #config{ini_files = IniFiles, write_filename = WriteFile}}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call(all, _From, Config) ->
     Resp = lists:sort((ets:tab2list(?MODULE))),
     {reply, Resp, Config};
@@ -413,9 +410,6 @@ handle_cast(_Msg, State) ->
 handle_info(Info, State) ->
     couch_log:error("config:handle_info Info: ~p~n", [Info]),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 is_sensitive(Section, Key) ->
     Sensitive = application:get_env(config, sensitive, #{}),

--- a/src/config/src/config_listener.erl
+++ b/src/config/src/config_listener.erl
@@ -24,8 +24,7 @@
     handle_event/2,
     handle_call/2,
     handle_info/2,
-    terminate/2,
-    code_change/3
+    terminate/2
 ]).
 
 -callback handle_config_change(
@@ -69,6 +68,3 @@ handle_info(_Info, St) ->
 
 terminate(Reason, {Module, {Subscriber, State}}) ->
     Module:handle_config_terminate(Subscriber, Reason, State).
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.

--- a/src/config/src/config_listener_mon.erl
+++ b/src/config/src/config_listener_mon.erl
@@ -20,11 +20,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -record(st, {
@@ -51,9 +49,6 @@ init({Pid, Mod, InitSt}) ->
             proc_lib:init_ack(Else)
     end.
 
-terminate(_Reason, _St) ->
-    ok.
-
 handle_call(_Message, _From, St) ->
     {reply, ignored, St}.
 
@@ -74,6 +69,3 @@ handle_info({gen_event_EXIT, {config_listener, Module}, Reason}, St) ->
     {stop, shutdown, St};
 handle_info(_, St) ->
     {noreply, St}.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.

--- a/src/config/src/config_notifier.erl
+++ b/src/config/src/config_notifier.erl
@@ -23,9 +23,7 @@
     init/1,
     handle_event/2,
     handle_call/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
 subscribe(Subscription) ->
@@ -52,12 +50,6 @@ handle_call(_Request, St) ->
     {ok, ignored, St}.
 
 handle_info(_Info, St) ->
-    {ok, St}.
-
-terminate(_Reason, {_Subscriber, _Subscription}) ->
-    ok.
-
-code_change(_OldVsn, St, _Extra) ->
     {ok, St}.
 
 maybe_notify(Event, Subscriber, all) ->

--- a/src/couch/src/couch_db_updater.erl
+++ b/src/couch/src/couch_db_updater.erl
@@ -14,7 +14,7 @@
 -behaviour(gen_server).
 
 -export([add_sizes/3, upgrade_sizes/1]).
--export([init/1, terminate/2, handle_call/3, handle_cast/2, code_change/3, handle_info/2]).
+-export([init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 -include("couch_db_int.hrl").
@@ -250,9 +250,6 @@ handle_info(Msg, Db) ->
         Else ->
             Else
     end.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 sort_and_tag_grouped_docs(Client, GroupedDocs) ->
     % These groups should already be sorted but sometimes clients misbehave.

--- a/src/couch/src/couch_event_sup.erl
+++ b/src/couch/src/couch_event_sup.erl
@@ -20,7 +20,7 @@
 -include_lib("couch/include/couch_db.hrl").
 
 -export([start_link/3, start_link/4, stop/1]).
--export([init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2, code_change/3]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 %
 % Instead calling the
@@ -57,9 +57,6 @@ init({EventMgr, EventHandler, Args}) ->
             {stop, Error}
     end.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call(stop, _From, State) ->
     {stop, normal, ok, State}.
 
@@ -68,6 +65,3 @@ handle_cast(_Msg, State) ->
 
 handle_info({gen_event_EXIT, _Handler, Reason}, State) ->
     {stop, Reason, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -50,7 +50,7 @@
 -export([last_read/1]).
 
 % gen_server callbacks
--export([init/1, terminate/2, code_change/3, format_status/2]).
+-export([init/1, terminate/2, format_status/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 %% helper functions
@@ -622,9 +622,6 @@ handle_call(find_header, _From, #file{fd = Fd, eof = Pos} = File) ->
 
 handle_cast(close, Fd) ->
     {stop, normal, Fd}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 handle_info(Msg, File) when ?IS_OLD_STATE(File) ->
     handle_info(Msg, upgrade_state(File));

--- a/src/couch/src/couch_httpd_vhost.erl
+++ b/src/couch/src/couch_httpd_vhost.erl
@@ -20,7 +20,7 @@
 -export([urlsplit_netloc/2, redirect_to_vhost/2]).
 -export([host/1, split_host_port/1]).
 
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
@@ -411,12 +411,6 @@ handle_info(restart_config_listener, State) ->
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 handle_config_change("vhosts", _, _, _, _) ->
     {ok, ?MODULE:reload()};

--- a/src/couch/src/couch_multidb_changes.erl
+++ b/src/couch/src/couch_multidb_changes.erl
@@ -23,8 +23,7 @@
     terminate/2,
     handle_call/3,
     handle_info/2,
-    handle_cast/2,
-    code_change/3
+    handle_cast/2
 ]).
 
 -export([
@@ -162,9 +161,6 @@ handle_info({'EXIT', From, Reason}, #state{pids = Pids} = State) ->
     end;
 handle_info(_Msg, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 % Private functions
 
@@ -721,8 +717,7 @@ t_start_link_no_ddocs() ->
 
 t_misc_gen_server_callbacks() ->
     ?_test(begin
-        ?assertEqual(ok, terminate(reason, state)),
-        ?assertEqual({ok, state}, code_change(old, state, extra))
+        ?assertEqual(ok, terminate(reason, state))
     end).
 
 scan_dbs_test_() ->

--- a/src/couch/src/couch_native_process.erl
+++ b/src/couch/src/couch_native_process.erl
@@ -43,10 +43,8 @@
 -export([
     start_link/0,
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    code_change/3,
     handle_info/2
 ]).
 -export([set_timeout/2, prompt/2]).
@@ -128,8 +126,6 @@ handle_info({'EXIT', _, normal}, State) ->
     {noreply, State, State#evstate.idle};
 handle_info({'EXIT', _, Reason}, State) ->
     {stop, Reason, State}.
-terminate(_Reason, _State) -> ok.
-code_change(_OldVersion, State, _Extra) -> {ok, State}.
 
 run(#evstate{list_pid = Pid} = State, [<<"list_row">>, Row]) when is_pid(Pid) ->
     Pid ! {self(), list_row, Row},

--- a/src/couch/src/couch_os_process.erl
+++ b/src/couch/src/couch_os_process.erl
@@ -15,7 +15,7 @@
 
 -export([start_link/1, stop/1]).
 -export([set_timeout/2, prompt/2]).
--export([init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2, code_change/3]).
+-export([init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -217,9 +217,6 @@ handle_info({Port, {exit_status, Status}}, #os_proc{port = Port} = OsProc) ->
 handle_info(Msg, #os_proc{idle = Idle} = OsProc) ->
     couch_log:debug("OS Proc: Unknown info: ~p", [Msg]),
     {noreply, OsProc, Idle}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 killer(KillCmd) ->
     receive

--- a/src/couch/src/couch_password_hasher.erl
+++ b/src/couch/src/couch_password_hasher.erl
@@ -21,8 +21,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([maybe_upgrade_password_hash/4, hash_admin_passwords/1]).
@@ -93,9 +92,6 @@ handle_info({done, AuthModule, UserName}, State) ->
     {noreply, State};
 handle_info(Msg, State) ->
     {stop, {invalid_info, Msg}, State}.
-
-code_change(_OldVsn, #state{} = State, _Extra) ->
-    {ok, State}.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -33,8 +33,7 @@
     terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([
@@ -277,9 +276,6 @@ handle_info(restart_config_listener, State) ->
     {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, #state{} = State, _Extra) ->
-    {ok, State}.
 
 handle_config_terminate(_, stop, _) ->
     ok;

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -17,7 +17,7 @@
 -export([open/2, create/2, delete/2, get_version/0, get_version/1, get_git_sha/0, get_uuid/0]).
 -export([all_databases/0, all_databases/2]).
 -export([init/1, handle_call/3, sup_start_link/1]).
--export([handle_cast/2, code_change/3, handle_info/2, terminate/2]).
+-export([handle_cast/2, handle_info/2, terminate/2]).
 -export([dev_start/0, is_admin/2, has_admins/0, get_stats/0]).
 -export([close_db_if_idle/1]).
 -export([delete_compaction_files/1]).
@@ -718,9 +718,6 @@ handle_cast({close_db_if_idle, DbName}, Server) ->
     end;
 handle_cast(Msg, Server) ->
     {stop, {unknown_cast_message, Msg}, Server}.
-
-code_change(_OldVsn, #server{} = State, _Extra) ->
-    {ok, State}.
 
 handle_info({'EXIT', _Pid, config_change}, Server) ->
     {stop, config_change, Server};

--- a/src/couch/src/couch_stream.erl
+++ b/src/couch/src/couch_stream.erl
@@ -30,11 +30,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -197,9 +195,6 @@ init({Engine, OpenerPid, OpenerPriority, Options}) ->
         )
     }}.
 
-terminate(_Reason, _Stream) ->
-    ok.
-
 handle_call({write, Bin}, _From, Stream) ->
     BinSize = iolist_size(Bin),
     #stream{
@@ -279,9 +274,6 @@ handle_call(close, _From, Stream) ->
 
 handle_cast(_Msg, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 handle_info({'DOWN', Ref, _, _, _}, #stream{opener_monitor = Ref} = State) ->
     {stop, normal, State};

--- a/src/couch/src/couch_uuids.erl
+++ b/src/couch/src/couch_uuids.erl
@@ -18,7 +18,7 @@
 -export([start/0, stop/0]).
 -export([new/0, random/0]).
 
--export([init/1, terminate/2, code_change/3]).
+-export([init/1]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 % config_listener api
@@ -41,9 +41,6 @@ random() ->
 init([]) ->
     ok = config:listen_for_changes(?MODULE, nil),
     {ok, state()}.
-
-terminate(_Reason, _State) ->
-    ok.
 
 handle_call(create, _From, random) ->
     {reply, random(), random};
@@ -75,9 +72,6 @@ handle_info(restart_config_listener, State) ->
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 handle_config_change("uuids", _, _, _, _) ->
     {ok, gen_server:cast(?MODULE, change)};

--- a/src/couch/src/couch_work_queue.erl
+++ b/src/couch/src/couch_work_queue.erl
@@ -20,7 +20,7 @@
 
 % gen_server callbacks
 -export([init/1, terminate/2]).
--export([handle_call/3, handle_cast/2, code_change/3, handle_info/2]).
+-export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -record(q, {
     queue = queue:new(),
@@ -165,9 +165,6 @@ handle_cast(close, #q{items = 0} = Q) ->
     {stop, normal, Q};
 handle_cast(close, Q) ->
     {noreply, Q#q{close_on_dequeue = true}}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 handle_info(X, Q) ->
     {stop, X, Q}.

--- a/src/couch/test/eunit/test_web.erl
+++ b/src/couch/test/eunit/test_web.erl
@@ -16,7 +16,7 @@
 -compile(tuple_calls).
 
 -export([start_link/0, stop/0, loop/1, get_port/0, set_assert/1, check_last/0]).
--export([init/1, terminate/2, code_change/3]).
+-export([init/1]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("couch/include/couch_eunit.hrl").
@@ -67,9 +67,6 @@ check_last() ->
 init(_) ->
     {ok, nil}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 stop() ->
     mochiweb_http:stop(?SERVER).
 
@@ -109,6 +106,3 @@ handle_cast(Msg, State) ->
 handle_info(Msg, State) ->
     ?debugFmt("Ignoring info message: ~p", [Msg]),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.

--- a/src/couch_event/src/couch_event_server.erl
+++ b/src/couch_event/src/couch_event_server.erl
@@ -19,11 +19,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -include("couch_event_int.hrl").
@@ -43,9 +41,6 @@ init(_) ->
         by_pid = ByPid,
         by_dbname = ByDbName
     }}.
-
-terminate(_Reason, _St) ->
-    ok.
 
 handle_call({register, Pid, NewDbNames}, _From, St) ->
     case khash:get(St#st.by_pid, Pid) of
@@ -90,9 +85,6 @@ handle_info({'DOWN', Ref, process, Pid, _Reason}, St) ->
 handle_info(Msg, St) ->
     couch_log:notice("~s ignoring info ~w", [?MODULE, Msg]),
     {noreply, St}.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 notify_listeners(ByDbName, DbName, Event) ->
     Msg = {'$couch_event', DbName, Event},

--- a/src/couch_index/src/couch_index.erl
+++ b/src/couch_index/src/couch_index.erl
@@ -21,7 +21,7 @@
 -export([compact/1, compact/2, get_compactor_pid/1]).
 
 %% gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -363,9 +363,6 @@ handle_info({'DOWN', _, _, _Pid, _}, #st{mod = Mod, idx_state = IdxState} = Stat
     couch_log:debug("Index shutdown by monitor notice for db: ~s idx: ~s", Args),
     catch send_all(State#st.waiters, shutdown),
     {stop, normal, State#st{waiters = []}}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 maybe_restart_updater(#st{waiters = []}) ->
     ok;

--- a/src/couch_index/src/couch_index_compactor.erl
+++ b/src/couch_index/src/couch_index_compactor.erl
@@ -17,7 +17,7 @@
 -export([start_link/2, run/2, cancel/1, is_running/1, get_compacting_pid/1]).
 
 %% gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -88,9 +88,6 @@ handle_info({'EXIT', Pid, _Reason}, #st{idx = Pid} = State) ->
     {stop, normal, State};
 handle_info(_Mesg, State) ->
     {stop, unknown_info, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 compact(Parent, Mod, IdxState) ->
     DbName = Mod:get(db_name, IdxState),

--- a/src/couch_index/src/couch_index_server.erl
+++ b/src/couch_index/src/couch_index_server.erl
@@ -16,7 +16,7 @@
 
 -export([start_link/1, validate/2, get_index/4, get_index/3, get_index/2]).
 
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 % Sharding functions
@@ -241,9 +241,6 @@ handle_info(restart_config_listener, State) ->
 handle_info(Msg, State) ->
     couch_log:warning("~p did not expect ~p", [?MODULE, Msg]),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 handle_config_change("couchdb", "index_dir", RootDir, _, #st{root_dir = RootDir} = St) ->
     {ok, St};

--- a/src/couch_index/src/couch_index_updater.erl
+++ b/src/couch_index/src/couch_index_updater.erl
@@ -20,7 +20,7 @@
 -export([update/3]).
 
 %% gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -109,9 +109,6 @@ handle_info({'EXIT', _Pid, normal}, State) ->
     {noreply, State};
 handle_info(_Mesg, State) ->
     {stop, unknown_info, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 update(Idx, Mod, IdxState) ->
     DbName = Mod:get(db_name, IdxState),

--- a/src/couch_log/src/couch_log_error_logger_h.erl
+++ b/src/couch_log/src/couch_log_error_logger_h.erl
@@ -20,18 +20,13 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/2,
     handle_event/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 init(_) ->
     {ok, undefined}.
-
-terminate(_Reason, _St) ->
-    ok.
 
 handle_call(_, St) ->
     {ok, ignored, St}.
@@ -43,6 +38,3 @@ handle_event(Event, St) ->
 
 handle_info(_, St) ->
     {ok, St}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.

--- a/src/couch_log/src/couch_log_monitor.erl
+++ b/src/couch_log/src/couch_log_monitor.erl
@@ -20,11 +20,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -define(HANDLER_MOD, couch_log_error_logger_h).
@@ -38,9 +36,6 @@ init(_) ->
     ok = gen_event:add_sup_handler(error_logger, ?HANDLER_MOD, []),
     {ok, nil}.
 
-terminate(_, _) ->
-    ok.
-
 handle_call(_Msg, _From, St) ->
     {reply, ignored, St}.
 
@@ -51,6 +46,3 @@ handle_info({gen_event_EXIT, ?HANDLER_MOD, Reason}, St) ->
     {stop, Reason, St};
 handle_info(_Msg, St) ->
     {noreply, St}.
-
-code_change(_, State, _) ->
-    {ok, State}.

--- a/src/couch_log/src/couch_log_server.erl
+++ b/src/couch_log/src/couch_log_server.erl
@@ -24,8 +24,7 @@
     terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -include("couch_log.hrl").
@@ -87,6 +86,3 @@ handle_cast(Msg, St) ->
 handle_info(Msg, St) ->
     {reply, ok, NewSt} = handle_call(Msg, nil, St),
     {noreply, NewSt}.
-
-code_change(_Vsn, St, _Extra) ->
-    {ok, St}.

--- a/src/couch_log/test/eunit/couch_log_error_logger_h_test.erl
+++ b/src/couch_log/test/eunit/couch_log_error_logger_h_test.erl
@@ -18,8 +18,7 @@
 
 couch_log_error_logger_h_test_() ->
     {setup, fun couch_log_test_util:start/0, fun couch_log_test_util:stop/1, [
-        fun handler_ignores_unknown_messages/0,
-        fun coverage_test/0
+        fun handler_ignores_unknown_messages/0
     ]}.
 
 handler_ignores_unknown_messages() ->
@@ -30,7 +29,3 @@ handler_ignores_unknown_messages() ->
     error_logger ! this_is_a_message,
     Handlers2 = gen_event:which_handlers(error_logger),
     ?assert(lists:member(?HANDLER, Handlers2)).
-
-coverage_test() ->
-    Resp = couch_log_error_logger_h:code_change(foo, bazinga, baz),
-    ?assertEqual({ok, bazinga}, Resp).

--- a/src/couch_log/test/eunit/couch_log_monitor_test.erl
+++ b/src/couch_log/test/eunit/couch_log_monitor_test.erl
@@ -19,8 +19,7 @@
 couch_log_monitor_test_() ->
     {setup, fun couch_log_test_util:start/0, fun couch_log_test_util:stop/1, [
         fun monitor_ignores_unknown_messages/0,
-        fun monitor_restarts_handler/0,
-        fun coverage_test/0
+        fun monitor_restarts_handler/0
     ]}.
 
 monitor_ignores_unknown_messages() ->
@@ -45,10 +44,6 @@ monitor_restarts_handler() ->
 
     Handlers = gen_event:which_handlers(error_logger),
     ?assert(lists:member(?HANDLER, Handlers)).
-
-coverage_test() ->
-    Resp = couch_log_monitor:code_change(foo, bazinga, baz),
-    ?assertEqual({ok, bazinga}, Resp).
 
 get_monitor_pid() ->
     Children = supervisor:which_children(couch_log_sup),

--- a/src/couch_log/test/eunit/couch_log_server_test.erl
+++ b/src/couch_log/test/eunit/couch_log_server_test.erl
@@ -104,7 +104,3 @@ check_logs_ignored_messages() ->
         },
         couch_log_test_util:last_log()
     ).
-
-coverage_test() ->
-    Resp = couch_log_server:code_change(foo, bazinga, baz),
-    ?assertEqual({ok, bazinga}, Resp).

--- a/src/couch_mrview/src/couch_mrview_update_notifier.erl
+++ b/src/couch_mrview/src/couch_mrview_update_notifier.erl
@@ -15,7 +15,7 @@
 -behaviour(gen_event).
 
 -export([start_link/1, notify/1]).
--export([init/1, terminate/2, handle_event/2, handle_call/2, handle_info/2, code_change/3, stop/1]).
+-export([init/1, handle_event/2, handle_call/2, handle_info/2, stop/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -33,9 +33,6 @@ stop(Pid) ->
 init(Fun) ->
     {ok, Fun}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_event(Event, Fun) ->
     Fun(Event),
     {ok, Fun}.
@@ -46,6 +43,3 @@ handle_call(_Request, State) ->
 handle_info({'EXIT', Pid, Reason}, Pid) ->
     couch_log:error("View update notification process ~p died: ~p", [Pid, Reason]),
     remove_handler.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.

--- a/src/couch_peruser/src/couch_peruser.erl
+++ b/src/couch_peruser/src/couch_peruser.erl
@@ -23,9 +23,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([init_changes_handler/1, changes_handler/3]).
@@ -497,11 +495,3 @@ handle_info(restart_config_listener, State) ->
     {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    %% Everything should be linked or monitored, let nature
-    %% take its course.
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.

--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -59,11 +59,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3,
     format_status/2
 ]).
 
@@ -131,9 +129,6 @@ cleanup({Pid, _Epoch, Timeout}) ->
 init([#state{} = State]) ->
     {ok, State}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call({update_headers, Headers, _Epoch}, _From, State) ->
     case maybe_refresh(State) of
         {ok, State1} ->
@@ -158,9 +153,6 @@ handle_cast(Msg, State) ->
 handle_info(Msg, State) ->
     couch_log:error("~p : Received un-expected message ~p", [?MODULE, Msg]),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 format_status(_Opt, [_PDict, State]) ->
     [

--- a/src/couch_replicator/src/couch_replicator_clustering.erl
+++ b/src/couch_replicator/src/couch_replicator_clustering.erl
@@ -34,11 +34,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_info/2,
-    handle_cast/2,
-    code_change/3
+    handle_cast/2
 ]).
 
 -export([
@@ -151,9 +149,6 @@ init([]) ->
     ),
     {ok, #state{mem3_cluster_pid = Mem3Cluster, cluster_stable = false}}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call(is_stable, _From, #state{cluster_stable = IsStable} = State) ->
     {reply, IsStable, State};
 handle_call(set_stable, _From, State) ->
@@ -168,9 +163,6 @@ handle_cast({set_period, Period}, #state{mem3_cluster_pid = Pid} = State) ->
 handle_info(restart_config_listener, State) ->
     ok = config:listen_for_changes(?MODULE, nil),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 %% Internal functions
 

--- a/src/couch_replicator/src/couch_replicator_connection.erl
+++ b/src/couch_replicator/src/couch_replicator_connection.erl
@@ -21,11 +21,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_info/2,
-    handle_cast/2,
-    code_change/3
+    handle_cast/2
 ]).
 
 -export([
@@ -243,12 +241,6 @@ handle_info(close_idle_connections, State) ->
 handle_info(restart_config_listener, State) ->
     ok = config:listen_for_changes(?MODULE, nil),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-terminate(_Reason, _State) ->
-    ok.
 
 maybe_log_worker_death(_Host, _Port, normal) ->
     ok;

--- a/src/couch_replicator/src/couch_replicator_db_changes.erl
+++ b/src/couch_replicator/src/couch_replicator_db_changes.erl
@@ -20,11 +20,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_info/2,
-    handle_cast/2,
-    code_change/3
+    handle_cast/2
 ]).
 
 -export([
@@ -59,9 +57,6 @@ init([]) ->
             {ok, State}
     end.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call(_Msg, _From, State) ->
     {reply, {error, invalid_call}, State}.
 
@@ -72,9 +67,6 @@ handle_cast({cluster, stable}, State) ->
 
 handle_info(_Msg, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 -spec restart_mdb_changes(#state{}) -> #state{}.
 restart_mdb_changes(#state{mdb_changes = nil} = State) ->

--- a/src/couch_replicator/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor.erl
@@ -21,11 +21,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_info/2,
-    handle_cast/2,
-    code_change/3
+    handle_cast/2
 ]).
 
 -export([
@@ -205,9 +203,6 @@ init([]) ->
     ),
     {ok, nil}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call({updated, Id, Rep, Filter}, _From, State) ->
     ok = updated_doc(Id, Rep, Filter),
     {reply, ok, State};
@@ -243,9 +238,6 @@ handle_info(
     {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 % Doc processor gen_server private helper functions
 

--- a/src/couch_replicator/src/couch_replicator_httpc_pool.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc_pool.erl
@@ -19,7 +19,7 @@
 
 % gen_server API
 -export([init/1, handle_call/3, handle_info/2, handle_cast/2]).
--export([code_change/3, terminate/2, format_status/2]).
+-export([format_status/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -134,12 +134,6 @@ handle_info({'DOWN', Ref, process, _, _}, #state{callers = Callers} = State) ->
         false ->
             {noreply, State}
     end.
-
-code_change(_OldVsn, #state{} = State, _Extra) ->
-    {ok, State}.
-
-terminate(_Reason, _State) ->
-    ok.
 
 format_status(_Opt, [_PDict, State]) ->
     #state{

--- a/src/couch_replicator/src/couch_replicator_notifier.erl
+++ b/src/couch_replicator/src/couch_replicator_notifier.erl
@@ -18,7 +18,7 @@
 -export([start_link/1, stop/1, notify/1]).
 
 % gen_event callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1]).
 -export([handle_event/2, handle_call/2, handle_info/2]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -39,9 +39,6 @@ stop(Pid) ->
 init(FunAcc) ->
     {ok, FunAcc}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_event(Event, Fun) when is_function(Fun, 1) ->
     Fun(Event),
     {ok, Fun};
@@ -53,7 +50,4 @@ handle_call(_Msg, State) ->
     {ok, ok, State}.
 
 handle_info(_Msg, State) ->
-    {ok, State}.
-
-code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/src/couch_replicator/src/couch_replicator_rate_limiter.erl
+++ b/src/couch_replicator/src/couch_replicator_rate_limiter.erl
@@ -45,11 +45,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_info/2,
-    handle_cast/2,
-    code_change/3
+    handle_cast/2
 ]).
 
 -export([
@@ -127,9 +125,6 @@ init([]) ->
     couch_replicator_rate_limiter_tables:create(#rec.id),
     {ok, #state{timer = new_timer()}}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call(_Msg, _From, State) ->
     {reply, invalid, State}.
 
@@ -141,9 +136,6 @@ handle_info(cleanup, #state{timer = Timer}) ->
     TIds = couch_replicator_rate_limiter_tables:tids(),
     [cleanup_table(TId, now_msec() - ?MAX_INTERVAL) || TId <- TIds],
     {noreply, #state{timer = new_timer()}}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 % Private functions
 

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -25,7 +25,6 @@
     handle_call/3,
     handle_info/2,
     handle_cast/2,
-    code_change/3,
     format_status/2
 ]).
 
@@ -341,9 +340,6 @@ handle_info(restart_config_listener, State) ->
     {noreply, State};
 handle_info(_, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 terminate(_Reason, _State) ->
     couch_replicator_share:clear(),

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -24,7 +24,6 @@
     handle_call/3,
     handle_info/2,
     handle_cast/2,
-    code_change/3,
     format_status/2,
     sum_stats/2,
     report_seq_done/3
@@ -457,9 +456,6 @@ terminate_cleanup(#rep_state{rep_details = #rep{id = RepId}} = State) ->
     update_task(State),
     couch_replicator_api_wrap:db_close(State#rep_state.source),
     couch_replicator_api_wrap:db_close(State#rep_state.target).
-
-code_change(_OldVsn, #rep_state{} = State, _Extra) ->
-    {ok, State}.
 
 format_status(_Opt, [_PDict, State]) ->
     #rep_state{

--- a/src/couch_replicator/src/couch_replicator_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_worker.erl
@@ -17,7 +17,7 @@
 -export([start_link/5]).
 
 % gen_server callbacks
--export([init/1, terminate/2, code_change/3]).
+-export([init/1]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 -export([format_status/2]).
 
@@ -242,9 +242,6 @@ handle_info({'EXIT', _Pid, {doc_write_failed, _} = Err}, State) ->
 handle_info({'EXIT', Pid, Reason}, State) ->
     {stop, {process_died, Pid, Reason}, State}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 format_status(_Opt, [_PDict, State]) ->
     #state{
         cp = MainJobPid,
@@ -264,9 +261,6 @@ format_status(_Opt, [_PDict, State]) ->
         {pending_fetch, PendingFetch},
         {batch_size, BatchSize}
     ].
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 sum_stats(Pid, Stats) when is_pid(Pid) ->
     ok = gen_server:cast(Pid, {sum_stats, Stats}).

--- a/src/couch_stats/src/couch_stats_process_tracker.erl
+++ b/src/couch_stats/src/couch_stats_process_tracker.erl
@@ -23,9 +23,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3,
-    terminate/2
+    handle_info/2
 ]).
 
 -record(st, {}).
@@ -72,9 +70,3 @@ handle_info({'DOWN', Ref, _, _, _} = Msg, State) ->
 handle_info(Msg, State) ->
     error_logger:error_msg("~p received unknown message ~p", [?MODULE, Msg]),
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.

--- a/src/custodian/src/custodian_db_checker.erl
+++ b/src/custodian/src/custodian_db_checker.erl
@@ -20,8 +20,7 @@
     terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([
@@ -63,9 +62,6 @@ handle_info({'EXIT', Pid, Reason}, #st{checker = Pid} = St) ->
     {noreply, restart_checker(St#st{checker = undefined})};
 handle_info(Msg, St) ->
     {stop, {invalid_info, Msg}, St}.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 restart_checker(#st{checker = undefined} = St) ->
     Pid = spawn_link(fun ?MODULE:check_dbs/0),

--- a/src/custodian/src/custodian_server.erl
+++ b/src/custodian/src/custodian_server.erl
@@ -23,7 +23,6 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3,
     terminate/2
 ]).
 
@@ -42,8 +41,6 @@
     shard_checker,
     rescan = false
 }).
-
--define(VSN_0_2_7, 184129240591641721395874905059581858099).
 
 -ifdef(TEST).
 -define(RELISTEN_DELAY, 50).
@@ -112,12 +109,6 @@ terminate(_Reason, State) ->
     couch_event:stop_listener(State#state.event_listener),
     couch_util:shutdown_sync(State#state.shard_checker),
     ok.
-
-code_change(?VSN_0_2_7, State, _Extra) ->
-    ok = config:listen_for_changes(?MODULE, nil),
-    {ok, State};
-code_change(_OldVsn, #state{} = State, _Extra) ->
-    {ok, State}.
 
 % private functions
 

--- a/src/ddoc_cache/src/ddoc_cache_entry.erl
+++ b/src/ddoc_cache/src/ddoc_cache_entry.erl
@@ -34,8 +34,7 @@
     terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([
@@ -256,9 +255,6 @@ handle_info({'DOWN', _, _, Pid, Resp}, #st{key = Key, opener = Pid} = St) ->
     end;
 handle_info(Msg, St) ->
     {stop, {bad_info, Msg}, St}.
-
-code_change(_, St, _) ->
-    {ok, St}.
 
 spawn_opener(Key) ->
     {Pid, _} = erlang:spawn_monitor(?MODULE, do_open, [Key]),

--- a/src/ddoc_cache/src/ddoc_cache_lru.erl
+++ b/src/ddoc_cache/src/ddoc_cache_lru.erl
@@ -25,8 +25,7 @@
     terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([
@@ -217,9 +216,6 @@ handle_info({'EXIT', Pid, normal}, St) ->
     {noreply, St};
 handle_info(Msg, St) ->
     {stop, {invalid_info, Msg}, St}.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 handle_db_event(ShardDbName, created, St) ->
     gen_server:cast(?MODULE, {evict, mem3:dbname(ShardDbName)}),

--- a/src/ddoc_cache/test/eunit/ddoc_cache_coverage_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_coverage_test.erl
@@ -29,8 +29,7 @@ coverage_test_() ->
 
 restart_lru() ->
     send_bad_messages(ddoc_cache_lru),
-    ?assertEqual(ok, ddoc_cache_lru:terminate(bang, {st, a, b, c})),
-    ?assertEqual({ok, foo}, ddoc_cache_lru:code_change(1, foo, [])).
+    ?assertEqual(ok, ddoc_cache_lru:terminate(bang, {st, a, b, c})).
 
 stop_on_evictor_death() ->
     meck:new(ddoc_cache_ev, [passthrough]),

--- a/src/ddoc_cache/test/eunit/ddoc_cache_entry_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_entry_test.erl
@@ -44,8 +44,7 @@ check_entry_test_() ->
             ?TDEF(kill_opener_on_terminate),
             ?TDEF(evict_when_not_accessed),
             ?TDEF(open_dead_entry),
-            ?TDEF(handles_bad_messages),
-            ?TDEF(handles_code_change)
+            ?TDEF(handles_bad_messages)
         ])
     }.
 
@@ -131,10 +130,6 @@ handles_bad_messages(_) ->
     ?assertEqual(CallExpect, ddoc_cache_entry:handle_call(foo, bar, baz)),
     ?assertEqual(CastExpect, ddoc_cache_entry:handle_cast(foo, bar)),
     ?assertEqual(InfoExpect, ddoc_cache_entry:handle_info(foo, bar)).
-
-handles_code_change(_) ->
-    CCExpect = {ok, bar},
-    ?assertEqual(CCExpect, ddoc_cache_entry:code_change(foo, bar, baz)).
 
 handles_bad_shutdown_test_() ->
     {timeout, 10,

--- a/src/dreyfus/src/dreyfus_index.erl
+++ b/src/dreyfus/src/dreyfus_index.erl
@@ -36,9 +36,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
 % private definitions.
@@ -286,12 +284,6 @@ handle_info(
     ),
     [gen_server:reply(P, {error, Reason}) || {P, _} <- WaitList],
     {stop, normal, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 % private functions.
 

--- a/src/dreyfus/src/dreyfus_index_manager.erl
+++ b/src/dreyfus/src/dreyfus_index_manager.erl
@@ -28,9 +28,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([handle_db_event/3]).
@@ -110,12 +108,6 @@ handle_info({'EXIT', FromPid, Reason}, State) ->
             delete_from_ets(FromPid, DbName, Sig)
     end,
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, nil, _Extra) ->
-    {ok, nil}.
 
 % private functions
 

--- a/src/ets_lru/src/ets_lru.erl
+++ b/src/ets_lru/src/ets_lru.erl
@@ -36,9 +36,7 @@
 
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-
-    code_change/3
+    handle_info/2
 ]).
 
 -define(DEFAULT_TIME_UNIT, millisecond).
@@ -215,9 +213,6 @@ handle_info(timeout, St) ->
     {noreply, St, next_timeout(St)};
 handle_info(Msg, St) ->
     {stop, {invalid_info, Msg}, St}.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 accessed(Key, St) ->
     Pattern = #entry{key = Key, atime = '$1', _ = '_'},

--- a/src/global_changes/src/global_changes_server.erl
+++ b/src/global_changes/src/global_changes_server.erl
@@ -19,11 +19,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([
@@ -74,9 +72,6 @@ init([]) ->
         handler_ref = erlang:monitor(process, Handler)
     },
     {ok, State}.
-
-terminate(_Reason, _Srv) ->
-    ok.
 
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
@@ -136,9 +131,6 @@ handle_info({'DOWN', Ref, _, _, Reason}, #state{handler_ref = Ref} = State) ->
     {noreply, State};
 handle_info(_, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 flush_updates(State) ->
     DocIds = sets:to_list(State#state.pending_updates),

--- a/src/ioq/src/ioq.erl
+++ b/src/ioq/src/ioq.erl
@@ -17,7 +17,7 @@
 -export([start_link/0, call/3, call_search/3]).
 -export([get_queue_lengths/0]).
 -export([get_io_priority/0, set_io_priority/1, maybe_set_io_priority/1]).
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, code_change/3, terminate/2]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 % config_listener api
 -export([handle_config_change/5, handle_config_terminate/3]).
@@ -174,12 +174,6 @@ handle_config_terminate(_Server, stop, _State) ->
     ok;
 handle_config_terminate(_Server, _Reason, _State) ->
     erlang:send_after(?RELISTEN_DELAY, whereis(?MODULE), restart_config_listener).
-
-code_change(_Vsn, State, _Extra) ->
-    {ok, State}.
-
-terminate(_Reason, _State) ->
-    ok.
 
 enqueue_request(#request{priority = compaction} = Request, #state{} = State) ->
     State#state{background = queue:in(Request, State#state.background)};

--- a/src/jwtf/src/jwtf_keystore.erl
+++ b/src/jwtf/src/jwtf_keystore.erl
@@ -27,9 +27,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3,
-    terminate/2
+    handle_info/2
 ]).
 
 % config_listener api
@@ -76,12 +74,6 @@ handle_info(restart_config_listener, State) ->
     {noreply, State};
 handle_info(_Msg, State) ->
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 % config listener callback
 

--- a/src/ken/src/ken_server.erl
+++ b/src/ken/src/ken_server.erl
@@ -14,8 +14,8 @@
 
 % gen_server boilerplate
 -behaviour(gen_server).
--export([init/1, terminate/2]).
--export([handle_call/3, handle_cast/2, handle_info/2, code_change/3]).
+-export([init/1]).
+-export([handle_call/3, handle_cast/2, handle_info/2]).
 
 % Public interface
 -export([start_link/0]).
@@ -114,9 +114,6 @@ init(_) ->
     ets:new(ken_resubmit, [named_table]),
     ets:new(ken_workers, [named_table, public, {keypos, #job.name}]),
     {ok, #state{pruned_last = erlang:monotonic_time()}}.
-
-terminate(_Reason, _State) ->
-    ok.
 
 handle_call({set_batch_size, BS}, _From, #state{batch_size = Old} = State) ->
     {reply, Old, State#state{batch_size = BS}, 0};
@@ -222,9 +219,6 @@ handle_info({'DOWN', _, _, Pid, Reason}, State) ->
     {noreply, State, 0};
 handle_info(Msg, State) ->
     {stop, {unknown_info, Msg}, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 %% private functions
 

--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -24,8 +24,7 @@
     terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -record(st, {
@@ -108,9 +107,6 @@ handle_cast(Msg, St) ->
 
 handle_info(Msg, St) ->
     {stop, {invalid_info, Msg}, St}.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 map_doc(#st{indexes = Indexes}, Doc) ->
     lists:map(fun(Idx) -> get_index_entries(Idx, Doc) end, Indexes).

--- a/src/mem3/src/mem3_cluster.erl
+++ b/src/mem3/src/mem3_cluster.erl
@@ -36,11 +36,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -callback cluster_stable(Context :: term()) -> NewContext :: term().
@@ -81,9 +79,6 @@ init([Module, Context, StartPeriod, Period]) ->
         timer = new_timer(StartPeriod)
     }}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call(_Msg, _From, State) ->
     {reply, ignored, State}.
 
@@ -103,9 +98,6 @@ handle_info(stability_check, #state{mod = Mod, ctx = Ctx} = State) ->
             Timer = new_timer(interval(State)),
             {noreply, State#state{timer = Timer}}
     end.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 %% Internal functions
 

--- a/src/mem3/src/mem3_distribution.erl
+++ b/src/mem3/src/mem3_distribution.erl
@@ -26,8 +26,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -define(JITTER_PERCENT, 0.25).
@@ -58,9 +57,6 @@ handle_info(connect, #st{} = St) ->
     {noreply, St#st{tref = erlang:send_after(wait_msec(), self(), connect)}};
 handle_info(Msg, St) ->
     {stop, {bad_info, Msg}, St}.
-
-code_change(_OldVsn, #st{} = St, _Extra) ->
-    {ok, St}.
 
 connect(Log) ->
     Expected = ordsets:from_list([N || N <- mem3:nodes(), N =/= node()]),

--- a/src/mem3/src/mem3_nodes.erl
+++ b/src/mem3/src/mem3_nodes.erl
@@ -16,9 +16,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([start_link/0, get_nodelist/0, get_node_info/2]).
@@ -95,12 +93,6 @@ handle_info(start_listener, #state{update_seq = Seq} = State) ->
     {noreply, State#state{changes_pid = NewPid}};
 handle_info(_Info, State) ->
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, #state{} = State, _Extra) ->
-    {ok, State}.
 
 %% internal functions
 

--- a/src/mem3/src/mem3_reshard.erl
+++ b/src/mem3/src/mem3_reshard.erl
@@ -44,8 +44,7 @@
     terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -include("mem3_reshard.hrl").
@@ -355,9 +354,6 @@ handle_info({'DOWN', _Ref, process, Pid, Info}, State) ->
 handle_info(Info, State) ->
     couch_log:error("~p unexpected info ~p", [?MODULE, Info]),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 %% Private API
 

--- a/src/mem3/src/mem3_reshard_dbdoc.erl
+++ b/src/mem3/src/mem3_reshard_dbdoc.erl
@@ -20,11 +20,9 @@
     start_link/0,
 
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -include_lib("couch/include/couch_db.hrl").
@@ -64,9 +62,6 @@ init(_) ->
     couch_log:notice("~p start init()", [?MODULE]),
     {ok, nil}.
 
-terminate(_Reason, _State) ->
-    ok.
-
 handle_call({update_shard_map, Source, Target}, _From, State) ->
     Res =
         try
@@ -87,9 +82,6 @@ handle_cast(Cast, State) ->
 handle_info(Info, State) ->
     couch_log:error("~p unexpected info ~p", [?MODULE, Info]),
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 % Private
 

--- a/src/mem3/src/mem3_seeds.erl
+++ b/src/mem3/src/mem3_seeds.erl
@@ -17,9 +17,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3,
-    terminate/2
+    handle_info/2
 ]).
 
 -export([
@@ -91,12 +89,6 @@ handle_info({'DOWN', Ref, _, Pid, Output}, #st{jobref = {Pid, Ref}} = St) ->
     {noreply, update_state(St, Output)};
 handle_info(_Msg, St) ->
     {noreply, St}.
-
-terminate(_Reason, _St) ->
-    ok.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 % internal functions
 

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -14,7 +14,7 @@
 -behaviour(gen_server).
 -behaviour(config_listener).
 
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 -export([handle_config_change/5, handle_config_terminate/3]).
 
@@ -300,9 +300,6 @@ handle_info(_Msg, St) ->
 terminate(_Reason, #st{changes_pid = Pid}) ->
     exit(Pid, kill),
     ok.
-
-code_change(_OldVsn, #st{} = St, _Extra) ->
-    {ok, St}.
 
 %% internal functions
 

--- a/src/mem3/src/mem3_sync.erl
+++ b/src/mem3/src/mem3_sync.erl
@@ -17,8 +17,7 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    terminate/2,
-    code_change/3
+    terminate/2
 ]).
 
 -export([
@@ -183,11 +182,6 @@ handle_info(Msg, State) ->
 terminate(_Reason, State) ->
     [exit(Pid, shutdown) || #job{pid = Pid} <- State#state.active],
     ok.
-
-code_change(_, #state{waiting = WaitingList} = State, _) when is_list(WaitingList) ->
-    {ok, State#state{waiting = from_list(WaitingList)}};
-code_change(_, State, _) ->
-    {ok, State}.
 
 maybe_resubmit(State, #job{name = DbName, node = Node} = Job) ->
     case lists:member(DbName, local_dbs()) of

--- a/src/mem3/src/mem3_sync_event.erl
+++ b/src/mem3/src/mem3_sync_event.erl
@@ -17,9 +17,7 @@
     init/1,
     handle_event/2,
     handle_call/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
 init(_) ->
@@ -48,12 +46,6 @@ handle_info({nodedown, Node}, State) ->
     mem3_sync:remove_node(Node),
     {ok, State};
 handle_info(_Info, State) ->
-    {ok, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 drain_nodeups(Acc) ->

--- a/src/mem3/src/mem3_sync_nodes.erl
+++ b/src/mem3/src/mem3_sync_nodes.erl
@@ -16,7 +16,7 @@
 -export([start_link/0]).
 -export([add/1]).
 
--export([init/1, terminate/2, code_change/3]).
+-export([init/1, terminate/2]).
 -export([handle_call/3, handle_cast/2, handle_info/2]).
 
 -export([monitor_sync/1]).
@@ -78,9 +78,6 @@ handle_info({'DOWN', _, _, _, {sync_error, Nodes}}, #st{tid = Tid} = St) ->
     {noreply, St};
 handle_info(Msg, St) ->
     {stop, {invalid_info, Msg}, St}.
-
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 start_sync(Nodes) ->
     {Pid, _} = spawn_monitor(?MODULE, monitor_sync, [Nodes]),

--- a/src/rexi/src/rexi_buffer.erl
+++ b/src/rexi/src/rexi_buffer.erl
@@ -18,9 +18,7 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([
@@ -87,15 +85,6 @@ handle_info(timeout, State) ->
     {noreply, State};
 handle_info({'DOWN', Ref, _, Pid, _}, #state{sender = {Pid, Ref}} = State) ->
     {noreply, State#state{sender = nil}, 0}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-code_change(_OldVsn, {state, Buffer, Sender, Count}, _Extra) ->
-    Max = list_to_integer(config:get("rexi", "buffer_count", "2000")),
-    {ok, #state{buffer = Buffer, sender = Sender, count = Count, max_count = Max}};
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 should_drop(#state{count = Count, max_count = Max}) ->
     Count >= Max.

--- a/src/rexi/src/rexi_server.erl
+++ b/src/rexi/src/rexi_server.erl
@@ -17,8 +17,7 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    terminate/2,
-    code_change/3
+    terminate/2
 ]).
 
 -export([start_link/1, init_p/2, init_p/3]).
@@ -121,9 +120,6 @@ terminate(_Reason, St) ->
         St#st.workers
     ),
     ok.
-
-code_change(_OldVsn, #st{} = State, _Extra) ->
-    {ok, State}.
 
 init_p(From, MFA) ->
     init_p(From, MFA, undefined).

--- a/src/rexi/src/rexi_server_mon.erl
+++ b/src/rexi/src/rexi_server_mon.erl
@@ -23,11 +23,9 @@
 
 -export([
     init/1,
-    terminate/2,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    code_change/3
+    handle_info/2
 ]).
 
 -export([
@@ -68,9 +66,6 @@ init(ChildMod) ->
     couch_log:notice("~s : started servers", [ChildMod]),
     {ok, ChildMod}.
 
-terminate(_Reason, _St) ->
-    ok.
-
 handle_call(status, _From, ChildMod) ->
     case missing_servers(ChildMod) of
         [] ->
@@ -103,11 +98,6 @@ handle_cast(Msg, St) ->
 handle_info(Msg, St) ->
     couch_log:notice("~s ignored_info ~w", [?MODULE, Msg]),
     {noreply, St}.
-
-code_change(_OldVsn, nil, _Extra) ->
-    {ok, rexi_server};
-code_change(_OldVsn, St, _Extra) ->
-    {ok, St}.
 
 start_servers(ChildMod) ->
     lists:foreach(

--- a/src/smoosh/src/smoosh_server.erl
+++ b/src/smoosh/src/smoosh_server.erl
@@ -33,7 +33,6 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3,
     terminate/2
 ]).
 
@@ -263,9 +262,6 @@ terminate(_Reason, #state{access_cleaner = CPid}) ->
         smoosh_channel:close(P)
     end,
     ets:foldl(Fun, ok, ?MODULE).
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 update_access(Object) ->
     Now = erlang:monotonic_time(second),


### PR DESCRIPTION
We don't support hot-code release upgrades and these are now optional gen_server callbacks.

For references:
 https://www.erlang.org/doc/man/gen_server#Module:code_change-3
 https://www.erlang.org/doc/man/gen_server#Module:terminate-2
