### PR TITLE
Avoid read docs twice when filtered `_changes` is triggered

### DIFF
--- a/src/chttpd/test/eunit/chttpd_changes_test.erl
+++ b/src/chttpd/test/eunit/chttpd_changes_test.erl
@@ -873,7 +873,7 @@ t_selector_open_doc_times({_, DbUrl}) ->
     Filter = called_times(fun() -> changes_post(DbUrl, Body, F) end, DbUrl),
     FilterDocs = called_times(fun() -> changes_post(DbUrl, Body, F ++ I) end, DbUrl),
     FilterAllDocs = called_times(fun() -> changes_post(DbUrl, Body, F ++ I ++ S) end, DbUrl),
-    ?assertEqual({3, 4, 6}, {Filter, FilterDocs, FilterAllDocs}).
+    ?assertEqual({3, 3, 5}, {Filter, FilterDocs, FilterAllDocs}).
 
 t_js_filter_open_doc_times({_, DbUrl}) ->
     {DDocUrl, Rev} = create_ddocs(DbUrl, ?DOC1, custom),
@@ -883,7 +883,7 @@ t_js_filter_open_doc_times({_, DbUrl}) ->
     Filter = called_times(fun() -> changes(DbUrl, F) end, DbUrl),
     FilterDocs = called_times(fun() -> changes(DbUrl, F ++ I) end, DbUrl),
     FilterAllDocs = called_times(fun() -> changes(DbUrl, F ++ I ++ S) end, DbUrl),
-    ?assertEqual({4, 5, 7}, {Filter, FilterDocs, FilterAllDocs}),
+    ?assertEqual({4, 4, 6}, {Filter, FilterDocs, FilterAllDocs}),
     delete_ddocs(DDocUrl, Rev).
 
 t_view_open_doc_times({_, DbUrl}) ->
@@ -894,7 +894,7 @@ t_view_open_doc_times({_, DbUrl}) ->
     Filter = called_times(fun() -> changes(DbUrl, F) end, DbUrl),
     FilterDocs = called_times(fun() -> changes(DbUrl, F ++ I) end, DbUrl),
     FilterAllDocs = called_times(fun() -> changes(DbUrl, F ++ S ++ I) end, DbUrl),
-    ?assertEqual({4, 5, 7}, {Filter, FilterDocs, FilterAllDocs}),
+    ?assertEqual({4, 4, 6}, {Filter, FilterDocs, FilterAllDocs}),
     delete_ddocs(DDocUrl, Rev).
 
 % Utility functions

--- a/src/chttpd/test/eunit/chttpd_changes_test.erl
+++ b/src/chttpd/test/eunit/chttpd_changes_test.erl
@@ -891,20 +891,11 @@ teardown_basic({Ctx, DbUrl}) ->
     teardown_ctx({Ctx, DbUrl}).
 
 create_db(Top, Db, Params) ->
-    case req(put, Top ++ Db ++ Params) of
-        {201, #{}} ->
-            ok;
-        Error ->
-            error({failed_to_create_test_db, Db, Error})
-    end.
+    {201, #{}} = req(put, Top ++ Db ++ Params),
+    ok.
 
 delete_db(DbUrl) ->
-    case req(delete, DbUrl) of
-        {200, #{}} ->
-            ok;
-        Error ->
-            error({failed_to_delete_test_db, DbUrl, Error})
-    end.
+    {200, #{}} = req(delete, DbUrl).
 
 doc_fun({Id, Revs, Deleted}) ->
     Doc = #{

--- a/src/chttpd/test/eunit/chttpd_changes_test.erl
+++ b/src/chttpd/test/eunit/chttpd_changes_test.erl
@@ -153,6 +153,18 @@ changes_include_docs_test_() ->
         ]
     }.
 
+changes_open_doc_times_test_() ->
+    {
+        foreach,
+        fun setup_basic/0,
+        fun teardown_basic/1,
+        [
+            ?TDEF_FE(t_selector_open_doc_times),
+            ?TDEF_FE(t_js_filter_open_doc_times),
+            ?TDEF_FE(t_view_open_doc_times)
+        ]
+    }.
+
 t_basic({_, DbUrl}) ->
     Res = {Seq, Pending, Rows} = changes(DbUrl),
     ?assertEqual(8, Seq),
@@ -853,8 +865,39 @@ t_view_all_docs_conflicts_include_docs({_, DbUrl}) ->
     ?assertEqual(Res1, Res2),
     delete_ddocs(DDocUrl, Rev).
 
-% Utility functions
+t_selector_open_doc_times({_, DbUrl}) ->
+    Body = #{<<"selector">> => #{<<"_id">> => ?DOC1}},
+    F = "?filter=_selector",
+    I = "&include_docs=true",
+    S = "&style=all_docs",
+    Filter = called_times(fun() -> changes_post(DbUrl, Body, F) end, DbUrl),
+    FilterDocs = called_times(fun() -> changes_post(DbUrl, Body, F ++ I) end, DbUrl),
+    FilterAllDocs = called_times(fun() -> changes_post(DbUrl, Body, F ++ I ++ S) end, DbUrl),
+    ?assertEqual({3, 4, 6}, {Filter, FilterDocs, FilterAllDocs}).
 
+t_js_filter_open_doc_times({_, DbUrl}) ->
+    {DDocUrl, Rev} = create_ddocs(DbUrl, ?DOC1, custom),
+    F = "?filter=filters/f",
+    I = "&include_docs=true",
+    S = "&style=all_docs",
+    Filter = called_times(fun() -> changes(DbUrl, F) end, DbUrl),
+    FilterDocs = called_times(fun() -> changes(DbUrl, F ++ I) end, DbUrl),
+    FilterAllDocs = called_times(fun() -> changes(DbUrl, F ++ I ++ S) end, DbUrl),
+    ?assertEqual({4, 5, 7}, {Filter, FilterDocs, FilterAllDocs}),
+    delete_ddocs(DDocUrl, Rev).
+
+t_view_open_doc_times({_, DbUrl}) ->
+    {DDocUrl, Rev} = create_ddocs(DbUrl, ?DOC1, view),
+    F = "?filter=_view&view=views/v",
+    I = "&include_docs=true",
+    S = "&style=all_docs",
+    Filter = called_times(fun() -> changes(DbUrl, F) end, DbUrl),
+    FilterDocs = called_times(fun() -> changes(DbUrl, F ++ I) end, DbUrl),
+    FilterAllDocs = called_times(fun() -> changes(DbUrl, F ++ S ++ I) end, DbUrl),
+    ?assertEqual({4, 5, 7}, {Filter, FilterDocs, FilterAllDocs}),
+    delete_ddocs(DDocUrl, Rev).
+
+% Utility functions
 setup_ctx(DbCreateParams) ->
     Ctx = test_util:start_couch([chttpd]),
     Hashed = couch_passwords:hash_admin_password(?PASS),
@@ -883,6 +926,7 @@ setup_basic() ->
     CfgKey = "changes_doc_ids_optimization_threshold",
     ok = config:set("couchdb", CfgKey, "2", _Persist = false),
     meck:new(couch_changes, [passthrough]),
+    meck:new(couch_db, [passthrough]),
     {Ctx, DbUrl}.
 
 teardown_basic({Ctx, DbUrl}) ->
@@ -1024,3 +1068,23 @@ seq(<<_/binary>> = Seq) ->
     binary_to_integer(NumStr);
 seq(null) ->
     null.
+
+called_times(ReqFun, DbUrl) ->
+    meck:reset(couch_db),
+    ReqFun(),
+    open_doc_calls(DbUrl).
+
+open_doc_calls(DbUrl) ->
+    #{path := "/" ++ DbName0} = uri_string:parse(DbUrl),
+    DbName = ?l2b(DbName0),
+    FoldFun =
+        fun([Db, IdOrDocInfo, _Opts], Acc) ->
+            case {mem3:dbname(couch_db:name(Db)), IdOrDocInfo} of
+                {DbName, #doc_info{}} -> Acc + 1;
+                _ -> Acc
+            end
+        end,
+    lists:foldl(FoldFun, 0, meck_history(couch_db, open_doc, 3)).
+
+meck_history(Mod, Fun, Arity) ->
+    [A || {_Pid, {_M, F, A}, _R} <- meck:history(Mod), F =:= Fun, length(A) =:= Arity].

--- a/src/fabric/test/eunit/fabric_changes_test.erl
+++ b/src/fabric/test/eunit/fabric_changes_test.erl
@@ -1,0 +1,558 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric_changes_test).
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch/include/couch_eunit.hrl").
+
+-define(View,
+    {<<"views">>,
+        {[{<<"v">>, {[{<<"map">>, <<"function(doc) { if (doc._id == 'a') { emit(doc); } }">>}]}}]}}
+).
+-define(Custom, {<<"filters">>, {[{<<"f">>, <<"function(doc) { return (doc._id == 'a'); }">>}]}}).
+
+fabric_changes_test_() ->
+    {
+        setup,
+        fun setup/0,
+        fun teardown/1,
+        with([
+            ?TDEF(t_main_only),
+            ?TDEF(t_all_docs),
+            ?TDEF(t_main_only_include_docs),
+            ?TDEF(t_all_docs_include_docs),
+            ?TDEF(t_main_only_include_docs_conflicts),
+            ?TDEF(t_all_docs_include_docs_conflicts)
+        ])
+    }.
+
+changes_selector_test_() ->
+    {
+        setup,
+        fun setup/0,
+        fun teardown/1,
+        with([
+            ?TDEF(t_selector_main_only),
+            ?TDEF(t_selector_all_docs),
+            ?TDEF(t_selector_main_only_include_docs),
+            ?TDEF(t_selector_all_docs_include_docs),
+            ?TDEF(t_selector_main_only_include_docs_conflicts),
+            ?TDEF(t_selector_all_docs_include_docs_conflicts)
+        ])
+    }.
+
+changes_view_test_() ->
+    {
+        setup,
+        fun() -> setup_ddoc(?View) end,
+        fun teardown/1,
+        with([
+            ?TDEF(t_view_main_only),
+            ?TDEF(t_view_all_docs),
+            ?TDEF(t_view_main_only_include_docs),
+            ?TDEF(t_view_all_docs_include_docs),
+            ?TDEF(t_view_main_only_include_docs_conflicts),
+            ?TDEF(t_view_all_docs_include_docs_conflicts)
+        ])
+    }.
+
+changes_custom_test_() ->
+    {
+        setup,
+        fun() -> setup_ddoc(?Custom) end,
+        fun teardown/1,
+        with([
+            ?TDEF(t_custom_main_only),
+            ?TDEF(t_custom_all_docs),
+            ?TDEF(t_custom_main_only_include_docs),
+            ?TDEF(t_custom_all_docs_include_docs),
+            ?TDEF(t_custom_main_only_include_docs_conflicts),
+            ?TDEF(t_custom_all_docs_include_docs_conflicts)
+        ])
+    }.
+
+t_main_only({_, DbName}) ->
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{style = main_only}),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes).
+
+t_all_docs({_, DbName}) ->
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{style = all_docs}),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ).
+
+t_main_only_include_docs({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            include_docs = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_all_docs_include_docs({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            include_docs = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_main_only_include_docs_conflicts({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+t_all_docs_include_docs_conflicts({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+t_selector_main_only({_, DbName}) ->
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "_selector",
+            filter_fun = {selector, main_only, {{[{<<"_id">>, {[{<<"$eq">>, <<"a">>}]}}]}, nil}}
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes).
+
+t_selector_all_docs({_, DbName}) ->
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "_selector",
+            filter_fun = {selector, all_docs, {{[{<<"_id">>, {[{<<"$eq">>, <<"a">>}]}}]}, nil}}
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ).
+
+t_selector_main_only_include_docs({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "_selector",
+            filter_fun = {selector, main_only, {{[{<<"_id">>, {[{<<"$eq">>, <<"a">>}]}}]}, nil}},
+            include_docs = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_selector_all_docs_include_docs({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "_selector",
+            filter_fun = {selector, all_docs, {{[{<<"_id">>, {[{<<"$eq">>, <<"a">>}]}}]}, nil}},
+            include_docs = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_selector_main_only_include_docs_conflicts({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "_selector",
+            filter_fun = {selector, main_only, {{[{<<"_id">>, {[{<<"$eq">>, <<"a">>}]}}]}, nil}},
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+t_selector_all_docs_include_docs_conflicts({_, DbName}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "_selector",
+            filter_fun = {selector, all_docs, {{[{<<"_id">>, {[{<<"$eq">>, <<"a">>}]}}]}, nil}},
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+t_view_main_only({_, DbName, Rev}) ->
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "_view",
+            filter_fun = {fetch, view, main_only, {<<"_design/ddoc">>, Rev}, <<"v">>}
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes).
+
+t_view_all_docs({_, DbName, Rev}) ->
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "_view",
+            filter_fun = {fetch, view, all_docs, {<<"_design/ddoc">>, Rev}, <<"v">>}
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ).
+
+t_view_main_only_include_docs({_, DbName, Rev}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "_view",
+            filter_fun = {fetch, view, main_only, {<<"_design/ddoc">>, Rev}, <<"v">>},
+            include_docs = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_view_all_docs_include_docs({_, DbName, Rev}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "_view",
+            filter_fun = {fetch, view, all_docs, {<<"_design/ddoc">>, Rev}, <<"v">>},
+            include_docs = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_view_main_only_include_docs_conflicts({_, DbName, Rev}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "_view",
+            filter_fun = {fetch, view, main_only, {<<"_design/ddoc">>, Rev}, <<"v">>},
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+t_view_all_docs_include_docs_conflicts({_, DbName, Rev}) ->
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "_view",
+            filter_fun = {fetch, view, all_docs, {<<"_design/ddoc">>, Rev}, <<"v">>},
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+t_custom_main_only({_, DbName, Rev}) ->
+    Req = {json_req, null},
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "ddoc/f",
+            filter_fun = {fetch, custom, main_only, Req, {<<"_design/ddoc">>, Rev}, <<"f">>}
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes).
+
+t_custom_all_docs({_, DbName, Rev}) ->
+    Req = {json_req, null},
+    {ok, [#{changes := Changes}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "ddoc/f",
+            filter_fun = {fetch, custom, all_docs, Req, {<<"_design/ddoc">>, Rev}, <<"f">>}
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ).
+
+t_custom_main_only_include_docs({_, DbName, Rev}) ->
+    Req = {json_req, null},
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "ddoc/f",
+            filter_fun = {fetch, custom, main_only, Req, {<<"_design/ddoc">>, Rev}, <<"f">>},
+            include_docs = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_custom_all_docs_include_docs({_, DbName, Rev}) ->
+    Req = {json_req, null},
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "ddoc/f",
+            filter_fun = {fetch, custom, all_docs, Req, {<<"_design/ddoc">>, Rev}, <<"f">>},
+            include_docs = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>}
+        ]},
+        Doc
+    ).
+
+t_custom_main_only_include_docs_conflicts({_, DbName, Rev}) ->
+    Req = {json_req, null},
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = main_only,
+            filter = "ddoc/f",
+            filter_fun = {fetch, custom, main_only, Req, {<<"_design/ddoc">>, Rev}, <<"f">>},
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual([{[{<<"rev">>, <<"2-y">>}]}], Changes),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+t_custom_all_docs_include_docs_conflicts({_, DbName, Rev}) ->
+    Req = {json_req, null},
+    {ok, [#{changes := Changes, doc := Doc}], _, _} =
+        changes(DbName, #changes_args{
+            style = all_docs,
+            filter = "ddoc/f",
+            filter_fun = {fetch, custom, all_docs, Req, {<<"_design/ddoc">>, Rev}, <<"f">>},
+            include_docs = true,
+            conflicts = true
+        }),
+    ?assertEqual(
+        [
+            {[{<<"rev">>, <<"2-y">>}]},
+            {[{<<"rev">>, <<"2-x">>}]},
+            {[{<<"rev">>, <<"2-d">>}]}
+        ],
+        Changes
+    ),
+    ?assertEqual(
+        {[
+            {<<"_id">>, <<"a">>},
+            {<<"_rev">>, <<"2-y">>},
+            {<<"_conflicts">>, [<<"2-x">>]}
+        ]},
+        Doc
+    ).
+
+%%%%%%%%%%%%%%%%%%%% Utility Functions %%%%%%%%%%%%%%%%%%%%
+setup() ->
+    Ctx = test_util:start_couch([fabric]),
+    DbName = ?tempdb(),
+    ok = fabric:create_db(DbName, [{q, 1}, {n, 1}]),
+    Docs = [
+        #doc{id = <<"a">>, revs = {1, [<<"z">>]}},
+        #doc{id = <<"a">>, revs = {2, [<<"x">>, <<"z">>]}},
+        #doc{id = <<"a">>, revs = {2, [<<"y">>, <<"z">>]}},
+        #doc{id = <<"a">>, revs = {2, [<<"d">>, <<"z">>]}, deleted = true}
+    ],
+    Opts = [?REPLICATED_CHANGES],
+    {ok, []} = fabric:update_docs(DbName, Docs, Opts),
+    {Ctx, DbName}.
+
+setup_ddoc(Ddoc) ->
+    {Ctx, DbName} = setup(),
+    Doc = #doc{
+        id = <<"_design/ddoc">>,
+        revs = {0, []},
+        body = {[{<<"language">>, <<"javascript">>}, Ddoc]}
+    },
+    {ok, Rev} = fabric:update_doc(DbName, Doc, [?ADMIN_CTX]),
+    {Ctx, DbName, Rev}.
+
+teardown({Ctx, DbName, _}) ->
+    teardown({Ctx, DbName});
+teardown({Ctx, DbName}) ->
+    ok = fabric:delete_db(DbName, [?ADMIN_CTX]),
+    test_util:stop_couch(Ctx).
+
+changes_callback(start, Acc) ->
+    {ok, Acc};
+changes_callback({change, {Change}}, Acc) ->
+    CM = maps:from_list(Change),
+    {ok, [CM | Acc]};
+changes_callback({stop, EndSeq, Pending}, Acc) ->
+    {ok, Acc, EndSeq, Pending}.
+
+changes(DbName, #changes_args{} = Args) ->
+    fabric_util:isolate(fun() -> fabric:changes(DbName, fun changes_callback/2, [], Args) end).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
   
- When filered `_changes` is triggered, `open_revs()` will
read docs. If request parameter has `include_docs=true`,
then `doc_member()` will also read docs.

Change `filter/3` to `filter/5` to avoid the above behavior.

- When using filtered `_changes` with `style=all_docs`,
`conflicts=true` and `include_docs=true`, the response should
contain the `_conflicts` field.

Add `open_all_revs_include_doc/2` to include this field.

- Add tests to verify the number of calls to `open_doc/3`.


## Testing recommendations
```bash
make eunit apps=chttpd suites=chttpd_changes_test
make eunit apps=couch suites=couch_changes_tests
```


<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
