### PR TITLE
Attempt to fix flaky users db security test

### DIFF
--- a/test/elixir/test/cookie_auth_test.exs
+++ b/test/elixir/test/cookie_auth_test.exs
@@ -31,32 +31,13 @@ defmodule CookieAuthTest do
   @password "3.141592653589"
 
   setup do
-    # Create db if not exists
-    Couch.put("/#{@users_db}")
-
-    retry_until(fn ->
-      resp =
-        Couch.get(
-          "/#{@users_db}/_changes",
-          query: [feed: "longpoll", timeout: 5000, filter: "_design"]
-        )
-        length(resp.body["results"]) > 0
-    end)
-
+    reset_db(@users_db)
+    wait_for_design_auth(@users_db)
     on_exit(&tear_down/0)
-
-    :ok
   end
 
   defp tear_down do
-    # delete users
-    user = URI.encode("org.couchdb.user:jchris")
-    user_doc = Couch.get("/#{@users_db}/#{URI.encode(user)}").body
-    Couch.delete("/#{@users_db}/#{user}", query: [rev: user_doc["_rev"]])
-
-    user = URI.encode("org.couchdb.user:Jason Davies")
-    user_doc = Couch.get("/#{@users_db}/#{user}").body
-    Couch.delete("/#{@users_db}/#{user}", query: [rev: user_doc["_rev"]])
+    reset_db(@users_db)
   end
 
   defp login(user, password) do

--- a/test/elixir/test/reader_acl_test.exs
+++ b/test/elixir/test/reader_acl_test.exs
@@ -19,8 +19,7 @@ defmodule ReaderACLTest do
                }
              ]
   setup do
-    # Create db if not exists
-    Couch.put("/#{@users_db_name}")
+    reset_db(@users_db_name)
 
     # create a user with top-secret-clearance
     user_doc =

--- a/test/elixir/test/users_db_test.exs
+++ b/test/elixir/test/users_db_test.exs
@@ -29,25 +29,13 @@ defmodule UsersDbTest do
              ]
 
   setup do
-    # Create db if not exists
-    Couch.put("/#{@users_db_name}")
-
-    resp =
-      Couch.get(
-        "/#{@users_db_name}/_changes",
-        query: [feed: "longpoll", timeout: 5000, filter: "_design"]
-      )
-
-    assert resp.body
-
+    reset_db(@users_db_name)
+    wait_for_design_auth(@users_db_name)
     on_exit(&tear_down/0)
-
-    :ok
   end
 
   defp tear_down do
-    delete_db(@users_db_name)
-    create_db(@users_db_name)
+    reset_db(@users_db_name)
   end
 
   defp save_as(db_name, doc, options) do


### PR DESCRIPTION
 * Reset _users db before and after use to avoid polluting other tests.

 * Use a common reset db and "wait for auth cache" helper function

 * Since we're testing chttpd auth don't bother also setting httpd authentication_db, that just stops and resets the local port httpd listener, but we're not testing backend auth.

 * Use a retry in login for security db to avoid flakiness
