### PR TITLE
fix(`mango`): test `text` index creation

### DIFF
--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -281,7 +281,7 @@ class IndexSelectorText(mango.DbPerClass):
         partial_selector = {"location": {"$gte": "FRA"}}
         selector = {"location": {"$exists": True}}
         self.db.create_text_index(
-            ["location"],
+            fields=[{"name": "location", "type": "string"}],
             partial_filter_selector=partial_selector,
             ddoc="Selected",
             name="Selected",


### PR DESCRIPTION
In `16-index-selectors-test.IndexSelectorText.test_uses_partial_index_with_non_indexable_selector`, the parametrization of the `create_text_index()` is incorrect.  It passes `["location"]` as a set of fields to index, but that is actually taken as an analyzer.  It is probably a result of copy-and-pasting over from the `json` index creation above where the first parameter to the corresponding function is the list of fields.