### PR TITLE
Convert some regex strings to raw format

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -531,7 +531,7 @@ def boot_nouveau(ctx):
 
 
 CLOUSEAU_DIR = "clouseau"
-JAVA_VERSION_RE = re.compile('"(\d+\.\d+).*"')
+JAVA_VERSION_RE = re.compile(r'"(\d+\.\d+).*"')
 
 
 def get_java_version(java):
@@ -683,7 +683,7 @@ def maybe_check_clouseau_node_alive(ctx, idx):
 
 def hack_default_ini(ctx, node, contents):
     contents = re.sub(
-        "^\[httpd\]$",
+        r"^\[httpd\]$",
         "[httpd]\nenable = true",
         contents,
         flags=re.MULTILINE,
@@ -691,7 +691,7 @@ def hack_default_ini(ctx, node, contents):
 
     if ctx["enable_erlang_views"]:
         contents = re.sub(
-            "^\[native_query_servers\]$",
+            r"^\[native_query_servers\]$",
             "[native_query_servers]\nerlang = {couch_native_process, start_link, []}",
             contents,
             flags=re.MULTILINE,


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Using Python 3.12.0 for `dev/run` gives these warnings:
```
❯ dev/run -a adm:pass --with-haproxy --no-eval REMSHID=1 dev/remsh
/Users/jay/repos/couchdb/dev/run:534: SyntaxWarning: invalid escape sequence '\d'
  JAVA_VERSION_RE = re.compile('"(\d+\.\d+).*"')
/Users/jay/repos/couchdb/dev/run:686: SyntaxWarning: invalid escape sequence '\['
  "^\[httpd\]$",
/Users/jay/repos/couchdb/dev/run:694: SyntaxWarning: invalid escape sequence '\['
  "^\[native_query_servers\]$",
```
This changes the strings in question to "raw" format, and eliminates the warnings.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Installing Python `3.12.0` and running e.g.
```
dev/run -a adm:pass --with-haproxy --no-eval REMSHID=1 dev/remsh
```
should not display any `SyntaxWarning`s.

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
