### PR TITLE
Add an option to scrub some sensitive headers from external json requests

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -214,6 +214,10 @@ bind_address = 127.0.0.1
 ; stampede in case when there are lot of concurrent clients connecting.
 ;disconnect_check_jitter_msec = 15000
 
+; Scrub auth and cookie headers from external json request objects.
+; Set to false to avoid scrubbing and revert to the previous behavior.
+;scrub_json_request = true
+
 ;[jwt_auth]
 ; List of claims to validate
 ; can be the name of a claim like "exp" or a tuple if the claim requires


### PR DESCRIPTION
We're already doing it for the cached request object in the process dictionary so it makes sense to do it for the external json requests as well.

For compatibility, allow reverting to previous behavior using the `[chttpd] scrub_json_request` config setting.
