### PR TITLE
Add an option to scrub some sensitive headers from external json requests

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -202,6 +202,10 @@ bind_address = 127.0.0.1
 ; stampede in case when there are lot of concurrent clients connecting.
 ;disconnect_check_jitter_msec = 15000
 
+; Scrub auth and cookie headers from external json request objects.
+; Set to false to avoid scrubbing and revert to the previous behavior.
+;scrub_json_request = true
+
 ;[jwt_auth]
 ; List of claims to validate
 ; can be the name of a claim like "exp" or a tuple if the claim requires

--- a/src/chttpd/src/chttpd_util.erl
+++ b/src/chttpd/src/chttpd_util.erl
@@ -23,6 +23,7 @@
     get_chttpd_auth_config_boolean/2,
     maybe_add_csp_header/3,
     get_db_info/1,
+    scrub_mochiweb_client_req/1,
     mochiweb_client_req_set/1,
     mochiweb_client_req_clean/0,
     mochiweb_client_req_get/0,
@@ -120,20 +121,22 @@ get_db_info(DbName) ->
         _Tag:Error -> {error, Error}
     end.
 
-mochiweb_client_req_set(ClientReq) ->
+scrub_mochiweb_client_req(ClientReq) ->
     Method = mochiweb_request:get(method, ClientReq),
     Socket = mochiweb_request:get(socket, ClientReq),
     Path = mochiweb_request:get(raw_path, ClientReq),
     Version = mochiweb_request:get(version, ClientReq),
     Opts = mochiweb_request:get(opts, ClientReq),
     Headers = mochiweb_request:get(headers, ClientReq),
-    % Remove any senstive info in case process dict gets dumped
-    % to the logs at some point
     Headers1 = mochiweb_headers:delete_any("Authorization", Headers),
     Headers2 = mochiweb_headers:delete_any("Cookie", Headers1),
     Headers3 = mochiweb_headers:delete_any("X-Auth-CouchDB-Token", Headers2),
-    ClientReq1 = mochiweb_request:new(Socket, Opts, Method, Path, Version, Headers3),
-    put(?MOCHIWEB_CLIENT_REQ, ClientReq1).
+    mochiweb_request:new(Socket, Opts, Method, Path, Version, Headers3).
+
+mochiweb_client_req_set(ClientReq) ->
+    % Remove any sensitive info in case process dict gets dumped
+    % to the logs at some point
+    put(?MOCHIWEB_CLIENT_REQ, scrub_mochiweb_client_req(ClientReq)).
 
 mochiweb_client_req_clean() ->
     erase(?MOCHIWEB_CLIENT_REQ).


### PR DESCRIPTION
We're already doing it for the cached request object in the process dictionary so it makes sense to do it for the external json requests as well.

For compatibility, allow reverting to previous behavior using the `[chttpd] scrub_json_request` config setting.

This is a backport from main to 3.3.x
