### PR TITLE
Look up search node name in config for weatherreport

### DIFF
--- a/src/weatherreport/src/weatherreport_check_search.erl
+++ b/src/weatherreport/src/weatherreport_check_search.erl
@@ -44,16 +44,24 @@ valid() ->
 
 -spec check(list()) -> [{atom(), term()}].
 check(_Opts) ->
-    SearchNode = 'clouseau@127.0.0.1',
-    case net_adm:ping(SearchNode) of
-        pong ->
-            [{info, {clouseau_ok, SearchNode}}];
-        Error ->
-            % only warning since search is not enabled by default
-            [{warning, {clouseau_error, SearchNode, Error}}]
+    SearchNodeStr = config:get("dreyfus", "name"),
+    case SearchNodeStr of
+        undefined ->
+            [{info, clouseau_not_configured}];
+        _ ->
+            SearchNode = list_to_atom(SearchNodeStr),
+            case net_adm:ping(SearchNode) of
+                pong ->
+                    [{info, {clouseau_ok, SearchNode}}];
+                Error ->
+                    % only warning since search is not enabled by default
+                    [{warning, {clouseau_error, SearchNode, Error}}]
+            end
     end.
 
 -spec format(term()) -> {io:format(), [term()]}.
+format(clouseau_not_configured) ->
+    {"Clouseau service is not configured", []};
 format({clouseau_ok, SearchNode}) ->
     {"Local search node at ~w responding ok", [SearchNode]};
 format({clouseau_error, SearchNode, Error}) ->


### PR DESCRIPTION
## Overview

Weatherreport is hard-coded to assume the search node is at 'clouseau@127.0.0.1' and that it is running. This results in a useless warning for users that do not have search enabled, and also means that it will fail to connect if Clouseau is running somewhere other than 127.0.0.1.

This replaces the hard-coded node name with a config lookup to `[dreyfus] name` and handles the case of it not being set.

## Testing recommendations

On `main`, running `weatherreport` against my dev cluster prints this warning about Clouseau not responding, regardless of what `[dreyfus] name` is set to:

```
$ ./weatherreport -c ../../dev/lib/node1/etc
['node1@127.0.0.1'] [warning] Local search node at 'clouseau@127.0.0.1' not responding: pang
```

With this change, the above warning is not printed unless `[dreyfus] name` has been set:

```
$ cdb '/_node/_local/_config/dreyfus/name' -X DELETE
"clouseau1@127.0.0.1"

$ ./weatherreport -c ../../dev/lib/node1/etc
(no warning)

$ cdb '/_node/_local/_config/dreyfus/name' -X PUT -d '"clouseau@example.com"'
""

$ ./weatherreport -c ../../dev/lib/node1/etc
['node1@127.0.0.1'] [warning] Local search node at 'clouseau@example.com' not responding: pang
```

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
