### PR TITLE
Ensure all config get's throw on no ets table

### DIFF
--- a/src/config/src/config.erl
+++ b/src/config/src/config.erl
@@ -68,8 +68,9 @@ all() ->
     lists:sort(gen_server:call(?MODULE, all, infinity)).
 
 get_integer(Section, Key, Default) when is_integer(Default) ->
+    Val = get(Section, Key, Default),
     try
-        to_integer(get(Section, Key, Default))
+        to_integer(Val)
     catch
         error:badarg ->
             Default
@@ -91,8 +92,9 @@ to_integer(Bin) when is_binary(Bin) ->
     list_to_integer(binary_to_list(Bin)).
 
 get_float(Section, Key, Default) when is_float(Default) ->
+    Val = get(Section, Key, Default),
     try
-        to_float(get(Section, Key, Default))
+        to_float(Val)
     catch
         error:badarg ->
             Default
@@ -116,8 +118,9 @@ to_float(Bin) when is_binary(Bin) ->
     list_to_float(binary_to_list(Bin)).
 
 get_boolean(Section, Key, Default) when is_boolean(Default) ->
+    Val = get(Section, Key, Default),
     try
-        to_boolean(get(Section, Key, Default))
+        to_boolean(Val)
     catch
         error:badarg ->
             Default


### PR DESCRIPTION
This fixes https://github.com/apache/couchdb/issues/4890 by ensuring that the type coercion get wrappers in `config:get_*` perform the call to `config:get/3` outside of the `try-catch` block intended to catch type coercion exceptions.