### PR TITLE
Reduce EUnit log noise

### DIFF
--- a/rel/files/eunit.config
+++ b/rel/files/eunit.config
@@ -11,6 +11,6 @@
 % the License.
 
 [
-    {kernel, [{error_logger, silent}]},
+    {kernel, [{logger_level, error}, {error_logger, silent}]},
     {sasl, [{sasl_error_logger, false}]}
 ].

--- a/rel/files/eunit.ini
+++ b/rel/files/eunit.ini
@@ -31,7 +31,7 @@ port = 0
 ; log to a file to save our terminals from log spam
 writer = file
 file = {{log_dir}}/couch.log
-level = info
+level = notice
 
 [replicator]
 ; disable jitter to reduce test run times


### PR DESCRIPTION
We dump the logs to Jenkins console on failure, but when the volume of the logs is too large, it locks the browser and make it impossible to inspect. This should reduce the logging volume about 10MB instead of 40MB and hopefully make it more manageably to inspect in the browser.