### PR TITLE
Fix flaky tests by increasing timeout

### DIFF
--- a/src/couch/test/eunit/couch_js_tests.erl
+++ b/src/couch/test/eunit/couch_js_tests.erl
@@ -18,7 +18,7 @@ couch_js_test_() ->
         "Test couchjs",
         {
             setup,
-            fun test_util:start_couch/0,
+            fun() -> test_util:start_couch([config]) end,
             fun test_util:stop_couch/1,
             with([
                 ?TDEF(should_create_sandbox),
@@ -29,8 +29,8 @@ couch_js_test_() ->
                 ?TDEF(should_replace_broken_utf16),
                 ?TDEF(should_allow_js_string_mutations),
                 ?TDEF(should_bump_timing_and_call_stats),
-                ?TDEF(should_exit_on_oom, 60000),
-                ?TDEF(should_exit_on_internal_error, 60000)
+                ?TDEF(should_exit_on_oom, 60),
+                ?TDEF(should_exit_on_internal_error, 60)
             ])
         }
     }.
@@ -344,6 +344,7 @@ should_bump_timing_and_call_stats(_) ->
 
 %% erlfmt-ignore
 should_exit_on_oom(_) ->
+    config:set("couchdb", "os_process_timeout", "15000", _Persist = false),
     Src = <<"
         var state = [];
         function(doc) {
@@ -363,6 +364,7 @@ should_exit_on_internal_error(_) ->
     % A different way to trigger OOM which previously used to
     % throw an InternalError on SM. Check that we still exit on that
     % type of error
+    config:set("couchdb", "os_process_timeout", "15000", _Persist = false),
     Src = <<"
         function(doc) {
             function mkstr(l) {


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Fix the following error by increasing the timeout.

Error logs:
```
::in function gen_server:call/3 (gen_server.erl, line 385)
in call from couch_proc_manager:get_proc/1 (src/couch_proc_manager.erl, line 90)
in call from couch_query_servers:get_os_process/1 (src/couch_query_servers.erl, line 713)
in call from couch_js_tests:should_exit_on_internal_error/1 (test/eunit/couch_js_tests.erl, line 378)
in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356)
in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514)
**exit:{timeout,
    {gen_server,call,
        [couch_proc_manager,
         {get_proc,
             {client,undefined,undefined,<<"javascript">>,undefined,
                 undefined,undefined}},
         5000]}}
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

`make eunit apps=couch suites=couch_js_tests`

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
