### PR TITLE
fix(`mango`): communicate rows read for global stats collection

### DIFF
--- a/src/mango/src/mango_execution_stats.erl
+++ b/src/mango/src/mango_execution_stats.erl
@@ -15,6 +15,7 @@
 -export([
     to_json/1,
     to_map/1,
+    incr_keys_examined/1,
     incr_keys_examined/2,
     incr_docs_examined/1,
     incr_docs_examined/2,
@@ -52,6 +53,9 @@ to_map(Stats) ->
         results_returned => Stats#execution_stats.resultsReturned,
         execution_time_ms => Stats#execution_stats.executionTimeMs
     }.
+
+incr_keys_examined(Stats) ->
+    incr_keys_examined(Stats, 1).
 
 incr_keys_examined(Stats, N) ->
     Stats#execution_stats{
@@ -92,8 +96,8 @@ log_end(Stats) ->
 maybe_add_stats(Opts, UserFun, Stats0, UserAcc) ->
     Stats1 = log_end(Stats0),
     couch_stats:update_histogram([mango, query_time], Stats1#execution_stats.executionTimeMs),
-    %% TODO: add rows read when we collect the stats
     %% TODO: add docs vs quorum docs
+    chttpd_stats:incr_rows(Stats1#execution_stats.totalKeysExamined),
     chttpd_stats:incr_reads(Stats1#execution_stats.totalDocsExamined),
 
     FinalAcc =

--- a/src/mango/test/15-execution-stats-test.py
+++ b/src/mango/test/15-execution-stats-test.py
@@ -81,7 +81,7 @@ class ExecutionStatsTests_Text(mango.UserDocsTextTests):
             {"$text": "Stephanie"}, return_raw=True, executionStats=True
         )
         self.assertEqual(len(resp["docs"]), 1)
-        self.assertEqual(resp["execution_stats"]["total_keys_examined"], 0)
+        self.assertEqual(resp["execution_stats"]["total_keys_examined"], 1)
         self.assertEqual(resp["execution_stats"]["total_docs_examined"], 1)
         self.assertEqual(resp["execution_stats"]["total_quorum_docs_examined"], 0)
         self.assertEqual(resp["execution_stats"]["results_returned"], 1)


### PR DESCRIPTION
Besides the execution statistics that could be shown for the user, the number of rows and documents read are tracked separately on the global level.  (Which is more like a bug than a feature, but that is out of the scope of this change.)

With the introduction of covering indexes, these two have been become different, therefore global counting has to be taught about the number of times when no documents were read but rows only.  For `text` indexes, the number of rows and documents should be the same, the distinction makes sense only for `json` indexes.

## Testing recommendations

The changes are covered by the respective portion of the tests:

```shell
make eunit apps=mango
make mango-test
```

The global stats should always report the same values as it is added for the (Mango) execution stats.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
