### PR TITLE
couch_passwords:verify should always return false for bad inputs

### DIFF
--- a/src/couch/src/couch_passwords.erl
+++ b/src/couch/src/couch_passwords.erl
@@ -137,6 +137,8 @@ verify(ListA, ListB) when is_list(ListA), is_list(ListB) ->
 verify(BinA, BinB) when is_binary(BinA), is_binary(BinB), byte_size(BinA) == byte_size(BinB) ->
     crypto:hash_equals(BinA, BinB);
 verify(BinA, BinB) when is_binary(BinA), is_binary(BinB) ->
+    false;
+verify(_A, _B) ->
     false.
 -else.
 -spec verify(string(), string(), integer()) -> boolean().


### PR DESCRIPTION
Parts of the codebase depend on being able to pass in `nil` as the expected hash (e.g, if the user doesn't exist).

In commit 21c2dec1d4 I enhanced couch_passwords:verify/2 to use OTP 25's new `crypto:hash_equals/2` function, but foolishly omitted the final fallback clause of our original `verify/2` function. This PR restores it.
