### PR TITLE
Optimize and clean up couch_multidb_changes

### DIFF
--- a/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
@@ -101,8 +101,8 @@ t_replicator_doc_state_fields_test_() ->
         fun setup_prefixed_replicator_db/0,
         fun teardown/1,
         with([
-            ?TDEF(t_doc_fields_are_updated, 10),
-            ?TDEF(t_doc_fields_are_ignored, 10)
+            ?TDEF(t_doc_fields_are_updated, 15),
+            ?TDEF(t_doc_fields_are_ignored, 15)
         ])
     }.
 
@@ -112,8 +112,8 @@ t_replicator_doc_state_fields_update_docs_true_test_() ->
         fun setup_prefixed_replicator_db_with_update_docs_true/0,
         fun teardown/1,
         with([
-            ?TDEF(t_doc_fields_are_updated, 10),
-            ?TDEF(t_doc_fields_are_ignored, 10)
+            ?TDEF(t_doc_fields_are_updated, 15),
+            ?TDEF(t_doc_fields_are_ignored, 15)
         ])
     }.
 
@@ -135,7 +135,7 @@ t_scheduler_docs_total_rows({_Ctx, {RepDb, Source, Target}}) ->
                 {_, #{}} -> wait
             end
         end,
-        10000,
+        14000,
         1000
     ),
     Docs = maps:get(<<"docs">>, Body),
@@ -183,7 +183,7 @@ t_doc_fields_are_updated({_Ctx, {RepDb, Source, Target}}) ->
                 {_, #{}} -> wait
             end
         end,
-        10000,
+        14000,
         1000
     ),
     ?assertMatch(
@@ -225,7 +225,7 @@ t_doc_fields_are_ignored({_Ctx, {RepDb, Source, Target}}) ->
                 {_, #{}} -> wait
             end
         end,
-        10000,
+        14000,
         1000
     ),
     ?assertMatch(


### PR DESCRIPTION
couch_multidb_changes is in charge of monitoring changes to multiple databases. It is what drives the couch_replicator application when users update replication docs. It starts off by scanning all the local db shards and launches changes feeds for each of them. After it processes each changes feed, it checkpoints where it stops. As the shards are updated, it starts change feeds for those updated shards and checkpoints again. The checkpoints are kept in an ets table and the main logic which decides when to start a changes feed for a particular shard is in the resume_scan/2 function.

This change makes a few small optimizations:

 * Use a map to track Pid -> DbName mappings. This avoids using a O(N) operation for looking up exiting change feed processes. So `pids` is switched to be a map of `#{Pid => DbName}` and the ets table has a 4th tuple member to keep track of `dbname -> pid` mappings.

 * Previously, when the plain "suffix" dbname (just <<"_replicator">>) was found, we tried to open and close it to see if it exists. Change to use `couch_server:exists/1` instead.

The are also a few clean-ups:

 * Update tests to use ?TDEF_FE/?TDEF macros. This shortens them a bit and saves one indentation level.

 * Increase test coverage from 86% to 96%. To help create a few more test scenarios switched to using a public ets table instead of a private one.
