### PR TITLE
Wait for 200 response in design doc tests

### DIFF
--- a/src/couch/test/eunit/couchdb_design_doc_tests.erl
+++ b/src/couch/test/eunit/couchdb_design_doc_tests.erl
@@ -92,8 +92,14 @@ create_design_doc(DbName, DDName) ->
     Rev.
 
 query_text(BaseUrl, DbName, DDoc, Path) ->
-    {ok, Code, _Headers, Body} = test_request:get(
-        BaseUrl ++ "/" ++ DbName ++ "/_design/" ++ DDoc ++ "/" ++ Path
-    ),
-    ?assertEqual(200, Code),
-    Body.
+    test_util:wait(
+        fun() ->
+            {ok, Code, _Headers, Body} = test_request:get(
+                BaseUrl ++ "/" ++ DbName ++ "/_design/" ++ DDoc ++ "/" ++ Path
+            ),
+            case Code of
+                200 -> Body;
+                _ -> wait
+            end
+        end
+    ).


### PR DESCRIPTION
Maybe this will help flaky tests like:
```
023-12-12T23:06:33.893Z] in function couch_os_process:prompt/2 (src/couch_os_process.erl, line 47)
[2023-12-12T23:06:33.893Z] in call from couch_query_servers:proc_prompt/2 (src/couch_query_servers.erl, line 601)
[2023-12-12T23:06:33.893Z] in call from couch_js_tests:trigger_oom/1 (test/eunit/couch_js_tests.erl, line 406)
[2023-12-12T23:06:33.893Z] in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
[2023-12-12T23:06:33.893Z] in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531)
[2023-12-12T23:06:33.893Z] in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356)
[2023-12-12T23:06:33.893Z] in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514)
[2023-12-12T23:06:33.893Z] in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456)
[2023-12-12T23:06:33.893Z] **throw:{os_process_error,{exit_status,139}}
[2023-12-12T23:06:33.893Z]   output:<<"">>
[2023-12-12T23:06:33.893Z]
[2023-12-12T23:06:37.546Z]     couch_js_tests:99: -with/1-fun-1- (should_exit_on_internal_error)...[3.625 s] ok
[2023-12-12T23:06:37.546Z]     [done in 3.771 s]
[2023-12-12T23:06:37.546Z]   [done in 3.887 s]
[2023-12-12T23:06:37.546Z] module 'couchdb_design_doc_tests'
[2023-12-12T23:06:37.546Z]   Check _list functionality
[2023-12-12T23:06:38.092Z]     couchdb_design_doc_tests:52: -should_return_empty_when_plain_return/1-fun-1-...*failed*
[2023-12-12T23:06:38.093Z] in function couchdb_design_doc_tests:query_text/4 (test/eunit/couchdb_design_doc_tests.erl, line 98)
[2023-12-12T23:06:38.093Z] in call from couchdb_design_doc_tests:'-should_return_empty_when_plain_return/1-fun-1-'/2 (test/eunit/couchdb_design_doc_tests.erl, line 55)
[2023-12-12T23:06:38.093Z] in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
[2023-12-12T23:06:38.093Z] in call from eunit_proc:run_test/1 (eunit_proc.erl, line 531)
[2023-12-12T23:06:38.093Z] in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 356)
[2023-12-12T23:06:38.093Z] in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 514)
[2023-12-12T23:06:38.093Z] in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 456)
[2023-12-12T23:06:38.093Z] in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 346)
[2023-12-12T23:06:38.093Z] **error:{assertEqual,[{module,couchdb_design_doc_tests},
[2023-12-12T23:06:38.093Z]               {line,98},
[2023-12-12T23:06:38.093Z]               {expression,"Code"},
[2023-12-12T23:06:38.093Z]               {expected,200},
[2023-12-12T23:06:38.093Z]               {value,500}]}
[2023-12-12T23:06:38.093Z]   output:<<"">>
```

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
