### PR TITLE
Use the latest Erlang versions in CI

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -14,11 +14,11 @@
 // the License.
 
 // Erlang version embedded in binary packages
-ERLANG_VERSION = '24.3.4.14'
+ERLANG_VERSION = '24.3.4.15'
 
 // Erlang version used for rebar in release process. CouchDB will not build from
 // the release tarball on Erlang versions older than this
-MINIMUM_ERLANG_VERSION = '24.3.4.14'
+MINIMUM_ERLANG_VERSION = '24.3.4.15'
 
 // We create parallel build / test / package stages for each OS using the metadata
 // in this map. Adding a new OS should ideally only involve adding a new entry here.

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -50,7 +50,7 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    LOW_ERLANG_VER = '24.3.4.14'
+    LOW_ERLANG_VER = '24.3.4.15'
   }
 
   options {
@@ -247,7 +247,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '24.3.4.14', '25.3.2.7', '26.1.2'
+            values '24.3.4.15', '25.3.2.8', '26.2.1'
           }
           axis {
             name 'SM_VSN'


### PR DESCRIPTION
The versions are:
 * 24.3.4.15
 * 25.3.2.8
 * 26.2.1

Related: https://github.com/apache/couchdb-ci/pull/65

https://hub.docker.com/repository/docker/apache/couchdbci-debian/general https://hub.docker.com/repository/docker/apache/couchdbci-ubuntu/general https://hub.docker.com/repository/docker/apache/couchdbci-centos/general
