### PR TITLE
Add extension for copying code blocks with just one click

### DIFF
--- a/src/docs/requirements.txt
+++ b/src/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
 sphinxcontrib-httpdomain==1.8.1
 sphinxcontrib-jquery==4.1
+sphinx-copybutton==0.5.2

--- a/src/docs/src/conf.py
+++ b/src/docs/src/conf.py
@@ -24,6 +24,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinxcontrib.httpdomain",
     "sphinxcontrib.jquery",
+    "sphinx_copybutton",
     "configdomain",
 ]
 


### PR DESCRIPTION
Add the sphinx-copybutton extension to get this functionality for code blocks.

Before:
![grafik](https://github.com/apache/couchdb/assets/9985963/9f281386-6747-46e4-ab19-a9b9252f43ff)


After:
![grafik](https://github.com/apache/couchdb/assets/9985963/ecdd7265-ef94-4aac-a9cf-61df32498b27)
