### PR TITLE
Control nouveau.yaml in configure and dev/run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ python-black-update: .venv/bin/black
 		build-aux/*.py dev/run src/mango/test/*.py src/docs/src/conf.py src/docs/ext/*.py .
 
 -include install.mk
-ifeq ($(with_nouveau), 0)
+ifeq ($(with_nouveau), false)
   exclude_nouveau=--exclude nouveau
 endif
 
@@ -429,7 +429,7 @@ else
 endif
 endif
 
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@mkdir rel/couchdb/nouveau
 	@cd nouveau && ./gradlew installDist
 	@cp -R nouveau/build/install/nouveau rel/couchdb
@@ -475,7 +475,7 @@ clean:
 	@rm -f src/couch/priv/couch_js/config.h
 	@rm -f dev/*.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
 	@rm -f src/couch_dist/certs/out
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@cd nouveau && ./gradlew clean
 endif
 
@@ -546,7 +546,7 @@ derived:
 .PHONY: nouveau
 # Build nouveau
 nouveau:
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@cd nouveau && ./gradlew spotlessApply
 	@cd nouveau && ./gradlew build -x test
 endif
@@ -556,7 +556,7 @@ nouveau-test: nouveau-test-gradle nouveau-test-elixir
 
 .PHONY: nouveau-test-gradle
 nouveau-test-gradle: couch nouveau
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@cd nouveau && ./gradlew test
 endif
 
@@ -564,7 +564,7 @@ endif
 nouveau-test-elixir: export MIX_ENV=integration
 nouveau-test-elixir: elixir-init devclean
 nouveau-test-elixir: couch nouveau
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@dev/run "$(TEST_OPTS)" -n 1 -q -a adm:pass --with-nouveau \
 		--locald-config test/config/test-config.ini \
 		--no-eval 'mix test --trace --include test/elixir/test/config/nouveau.elixir'

--- a/Makefile.win
+++ b/Makefile.win
@@ -206,7 +206,7 @@ python-black-update: .venv/bin/black
 
 -include install.mk
 
-ifeq ($(with_nouveau), 0)
+ifeq ($(with_nouveau), false)
   exclude_nouveau=--exclude nouveau
 endif
 
@@ -389,7 +389,7 @@ else
 endif
 endif
 
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	-@mkdir rel\couchdb\nouveau
 	@cd nouveau && .\gradlew installDist
 	@xcopy nouveau\build\install\nouveau rel\couchdb /E /I
@@ -435,7 +435,7 @@ clean:
 	-@rmdir /s/q src\mango\.venv >NUL 2>&1 || true
 	-@del /f/q src\couch\priv\couch_js\config.h >NUL 2>&1 || true
 	-@del /f/q dev\boot_node.beam dev\pbkdf2.pyc log\crash.log >NUL 2>&1 || true
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@cd nouveau && .\gradlew clean
 endif
 
@@ -512,7 +512,7 @@ derived:
 .PHONY: nouveau
 # target: nouveau - Build nouveau
 nouveau:
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@cd nouveau && .\gradlew build -x test
 endif
 
@@ -522,7 +522,7 @@ nouveau-test: nouveau-test-gradle nouveau-test-elixir
 
 .PHONY: nouveau-test-gradle
 nouveau-test-gradle: couch nouveau
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@cd nouveau && .\gradlew test
 endif
 
@@ -530,7 +530,7 @@ endif
 nouveau-test-elixir: export MIX_ENV=integration
 nouveau-test-elixir: elixir-init devclean
 nouveau-test-elixir: couch nouveau
-ifeq ($(with_nouveau), 1)
+ifeq ($(with_nouveau), true)
 	@dev\run "$(TEST_OPTS)" -n 1 -q -a adm:pass --with-nouveau \
 		--locald-config test/elixir/test/config/test-config.ini \
 		--no-eval 'mix test --trace --include test/elixir/test/config/nouveau.elixir'

--- a/configure
+++ b/configure
@@ -28,7 +28,7 @@ ERLFMT_VERSION="v1.3.0"
 WITH_PROPER="true"
 WITH_FAUXTON=1
 WITH_DOCS=1
-WITH_NOUVEAU=0
+WITH_NOUVEAU="false"
 WITH_CLOUSEAU=0
 ERLANG_MD5="false"
 SKIP_DEPS=0
@@ -105,7 +105,7 @@ parse_opts() {
                 ;;
 
             --enable-nouveau)
-                WITH_NOUVEAU=1
+                WITH_NOUVEAU="true"
                 shift
                 continue
                 ;;
@@ -137,7 +137,7 @@ parse_opts() {
             --dev-with-nouveau)
                 WITH_DOCS=0
                 WITH_FAUXTON=0
-                WITH_NOUVEAU=1
+                WITH_NOUVEAU="true"
                 shift
                 continue
                 ;;
@@ -341,6 +341,11 @@ cat > rel/couchdb.config << EOF
 {prefix, "."}.
 {data_dir, "./data"}.
 {view_index_dir, "./data"}.
+{nouveau_enable, "$WITH_NOUVEAU"}.
+{nouveau_index_dir, "./data/nouveau"}.
+{nouveau_url, "http://127.0.0.1:5987"}.
+{nouveau_port, 5987}.
+{nouveau_admin_port, 5988}.
 {state_dir, "./data"}.
 {log_file, "$LOG_FILE"}.
 {fauxton_root, "./share/www"}.

--- a/configure.ps1
+++ b/configure.ps1
@@ -140,7 +140,7 @@ $InstallDir="$LibDir\couchdb"
 $LogFile="$LogDir\couch.log"
 $BuildFauxton = [int](-not $DisableFauxton)
 $BuildDocs = [int](-not $DisableDocs)
-$BuildNouveau = $(If ($EnableNouveau) {1} else {0})
+$WithNouveau = ($EnableNouveau).ToString().ToLower()
 $WithClouseau = $(If ($EnableClouseau) {1} else {0})
 $Hostname = [System.Net.Dns]::GetHostEntry([string]"localhost").HostName
 $WithProper = (-not $DisableProper).ToString().ToLower()
@@ -166,6 +166,11 @@ $CouchDBConfig = @"
 {prefix, "."}.
 {data_dir, "./data"}.
 {view_index_dir, "./data"}.
+{nouveau_enable, "$WithNouveau"}.
+{nouveau_index_dir, "./data/nouveau"}.
+{nouveau_url, "http://127.0.0.1:5987"}.
+{nouveau_port, 5987}.
+{nouveau_admin_port, 5988}.
 {state_dir, "./data"}.
 {log_file, ""}.
 {fauxton_root, "./share/www"}.
@@ -212,7 +217,7 @@ man_dir = $ManDir
 
 with_fauxton = $BuildFauxton
 with_docs = $BuildDocs
-with_nouveau = $BuildNouveau
+with_nouveau = $WithNouveau
 with_clouseau = $WithClouseau
 
 user = $CouchDBUser

--- a/dev/run
+++ b/dev/run
@@ -362,12 +362,14 @@ def setup_configs(ctx):
             "backend_port": backend_port,
             "prometheus_port": prometheus_port,
             "uuid": "fake_uuid_for_dev",
-            "with_nouveau": str(ctx["with_nouveau"]).lower(),
+            "nouveau_enable": str(ctx["with_nouveau"]).lower(),
+            "nouveau_url": "http://127.0.0.1:5987",
             "_default": "",
         }
         write_config(ctx, node, env)
         write_locald_configs(ctx, node, env)
     generate_haproxy_config(ctx)
+    generate_nouveau_config(ctx)
 
 
 def write_locald_configs(ctx, node, env):
@@ -408,6 +410,26 @@ def generate_haproxy_config(ctx):
     with open(haproxy_config, "w") as handle:
         handle.write("\n".join(out))
         handle.write("\n")
+
+
+def generate_nouveau_config(ctx):
+    src = os.path.join(ctx["rootdir"], "rel", "nouveau.yaml")
+    tgt = os.path.join(ctx["devdir"], "lib", "nouveau.yaml")
+
+    config = {
+        "nouveau_index_dir": os.path.join(ctx["devdir"], "lib", "nouveau"),
+        "nouveau_port": 5987,
+        "nouveau_admin_port": 5988,
+    }
+
+    with open(src) as handle:
+        content = handle.read()
+
+    for key in config:
+        content = re.sub("{{%s}}" % key, str(config[key]), content)
+
+    with open(tgt, "w") as handle:
+        handle.write(content)
 
 
 def apply_config_overrides(ctx, content):
@@ -512,11 +534,12 @@ def boot_haproxy(ctx):
 def boot_nouveau(ctx):
     if not ctx["with_nouveau"]:
         return
+    config = os.path.join(ctx["devdir"], "lib", "nouveau.yaml")
     cmd = [
         "./gradlew",
         "run",
         "--args",
-        "server src/test/resources/nouveau.yaml",
+        "server {}".format(config),
     ]
     logfname = os.path.join(ctx["devdir"], "logs", "nouveau.log")
     log = open(logfname, "w")

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/core/IndexManager.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/core/IndexManager.java
@@ -265,7 +265,7 @@ public final class IndexManager implements Managed {
     }
 
     private Path indexRootPath(final String name) {
-        final Path result = rootDir.resolve(name).normalize();
+        final Path result = rootDir.resolve(name);
         if (result.startsWith(rootDir)) {
             return result;
         }

--- a/rel/nouveau.yaml
+++ b/rel/nouveau.yaml
@@ -1,7 +1,7 @@
-maxIndexesOpen: 100
+maxIndexesOpen: 3000
 commitIntervalSeconds: 30
 idleSeconds: 60
-rootDir: target/indexes
+rootDir: {{nouveau_index_dir}}
 
 logging:
   level: INFO
@@ -10,12 +10,12 @@ server:
   applicationConnectors:
     - type: http
       bindHost: 127.0.0.1
-      port: 5987
+      port: {{nouveau_port}}
       useDateHeader: false
   adminConnectors:
     - type: http
       bindHost: 127.0.0.1
-      port: 5988
+      port: {{nouveau_admin_port}}
       useDateHeader: false
   gzip:
     includedMethods:

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -911,7 +911,8 @@ port = {{prometheus_port}}
 ;use_cluster_n_as_expected_n = false
 
 [nouveau]
-enable = {{with_nouveau}}
+enable = {{nouveau_enable}}
+url = {{nouveau_url}}
 
 [disk_monitor]
 ;enable = false

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -150,5 +150,6 @@
     {template, "overlay/etc/default.ini", "etc/default.ini"},
     {template, "overlay/etc/vm.args", "etc/vm.args"},
     {template, "files/couchdb.in", "bin/couchdb"},
-    {template, "files/couchdb.cmd.in", "bin/couchdb.cmd"}
+    {template, "files/couchdb.cmd.in", "bin/couchdb.cmd"},
+    {template, "nouveau.yaml", "etc/nouveau.yaml"}
 ]}.


### PR DESCRIPTION
Move the generation/templating of nouveau.yaml to couchdb side to make packaging of nouveau simpler and more consistent with the rest.