### PR TITLE
Make multidb changes shard map aware

### DIFF
--- a/src/couch_replicator/priv/stats_descriptions.cfg
+++ b/src/couch_replicator/priv/stats_descriptions.cfg
@@ -62,10 +62,6 @@
     {type, counter},
     {desc, <<"number of times replicator db scans have been started">>}
 ]}.
-{[couch_replicator, docs, dbs_created], [
-    {type, counter},
-    {desc, <<"number of db shard creations seen by replicator doc processor">>}
-]}.
 {[couch_replicator, docs, dbs_deleted], [
     {type, counter},
     {desc, <<"number of db shard deletions seen by replicator doc processor">>}

--- a/src/couch_replicator/src/couch_replicator_db_changes.erl
+++ b/src/couch_replicator/src/couch_replicator_db_changes.erl
@@ -72,7 +72,9 @@ handle_info(_Msg, State) ->
 restart_mdb_changes(#state{mdb_changes = nil} = State) ->
     Suffix = <<"_replicator">>,
     CallbackMod = couch_replicator_doc_processor,
-    Options = [skip_ddocs],
+    Interval = couch_replicator_scheduler:get_interval_msec(),
+    Options = [skip_ddocs, {shards_db_check_msec, Interval div 2}],
+
     {ok, Pid} = couch_multidb_changes:start_link(
         Suffix,
         CallbackMod,

--- a/src/couch_replicator/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor.erl
@@ -27,7 +27,6 @@
 ]).
 
 -export([
-    db_created/2,
     db_deleted/2,
     db_found/2,
     db_change/3
@@ -72,10 +71,6 @@
 }).
 
 % couch_multidb_changes API callbacks
-
-db_created(_DbName, Server) ->
-    couch_stats:increment_counter([couch_replicator, docs, dbs_created]),
-    Server.
 
 db_deleted(DbName, Server) ->
     couch_stats:increment_counter([couch_replicator, docs, dbs_deleted]),

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -40,7 +40,8 @@
     jobs/0,
     job/1,
     restart_job/1,
-    update_job_stats/2
+    update_job_stats/2,
+    get_interval_msec/0
 ]).
 
 %% config_listener callbacks
@@ -205,6 +206,9 @@ restart_job(JobId) ->
 update_job_stats(JobId, Stats) ->
     gen_server:cast(?MODULE, {update_job_stats, JobId, Stats}).
 
+get_interval_msec() ->
+    config:get_integer("replicator", "interval", ?DEFAULT_SCHEDULER_INTERVAL).
+
 %% gen_server functions
 
 init(_) ->
@@ -218,11 +222,7 @@ init(_) ->
     ?MODULE = ets:new(?MODULE, EtsOpts),
     ok = couch_replicator_share:init(),
     ok = config:listen_for_changes(?MODULE, nil),
-    Interval = config:get_integer(
-        "replicator",
-        "interval",
-        ?DEFAULT_SCHEDULER_INTERVAL
-    ),
+    Interval = get_interval_msec(),
     MaxJobs = config:get_integer("replicator", "max_jobs", ?DEFAULT_MAX_JOBS),
     MaxChurn = config:get_integer(
         "replicator",

--- a/src/docs/src/api/server/common.rst
+++ b/src/docs/src/api/server/common.rst
@@ -1782,8 +1782,6 @@ containing only the requested individual statistic.
         couchdb_couch_replicator_docs_completed_state_updates_total 0
         # TYPE couchdb_couch_replicator_docs_db_changes_total counter
         couchdb_couch_replicator_docs_db_changes_total 0
-        # TYPE couchdb_couch_replicator_docs_dbs_created_total counter
-        couchdb_couch_replicator_docs_dbs_created_total 0
         # TYPE couchdb_couch_replicator_docs_dbs_deleted_total counter
         couchdb_couch_replicator_docs_dbs_deleted_total 0
         # TYPE couchdb_couch_replicator_docs_dbs_found_total counter


### PR DESCRIPTION
couch_multidb_changes module is monitoring shards whose names match a particular suffix, and notifies users with found, updated and deleted events. This is the module which drives replicator jobs when `*/_replicator` databases are updated.

Previously, couch_multidb_changes reacted only to node-local shard file events and was not aware of the shard map membership of those files. This was mostly evident during shard moves: the target shard could be created long before the
shard file becomes a part of the shard map. The replicator could notice the new target shard file and spawn a replication job on the new node, but keep the same replication job running on the source node. The two replication jobs will eventually conflict in the PG system (https://www.erlang.org/doc/man/pg.html) and one of them would start crashing with a "duplicate job" error. This could last days depending on how long it would take to populate the data on the target. Even after recovery, the target shard could be backed-off up to another extra 8 hours until it may run again.

To avoid issues like that, make couch_multidb_changes aware of shard map membership updates. When a shard file is discovered, and it is not in the shard map, mark it with a `wait_shard_map = true` flag. Then, re-use the existing db event monitoring mechanism to notice when shards db is updated, and schedule a delayed membership check for the shards tracked in our ETS table.

Other changes to the module are mostly cosmetic:

 * Remove the unused `created` callback. `db_found` is used instead, both when dbs are created, and during startup when they are discovered.

 * In the ETS table use a proper `#row{}` record since we now have 5 items in the tuple. This simplifies some of the existing code as well.

 * During deletion and creation, actually delete the entries from the ETS table. Previously we didn't do it so the would hang around forever until the node was restarted.

 * Add comments to a few tricky sections explaining what should be happening there.

 * Add more tests, both the old and new functionality. Increase coverage from 96% to 98%.
