### PR TITLE
Exclude PPC64LE CI worker temporarily

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -83,14 +83,15 @@ meta = [
   //   node_label: 'arm64v8'
   // ],
 
-  'bullseye-ppc64': [
-    name: 'Debian 11 POWER',
-    spidermonkey_vsn: '78',
-    enable_nouveau: true,
-    enable_clouseau: true,
-    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
-    node_label: 'ppc64le'
-  ],
+  // Exclude while OSU rebuilds the image
+  // 'bullseye-ppc64': [
+  //   name: 'Debian 11 POWER',
+  //   spidermonkey_vsn: '78',
+  //   enable_nouveau: true,
+  //   enable_clouseau: true,
+  //   image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+  //   node_label: 'ppc64le'
+  // ],
 
   // Exclude until hex.pm downloads are resolved
   //   https://github.com/linuxone-community-cloud/tickets/issues/58


### PR DESCRIPTION
I was notified it has be rebuilt. In the meantime it would be nice to keep our green passing streak going in the full CI.

