### PR TITLE
Try to fix password test timeout

### DIFF
--- a/test/elixir/test/password_cache_test.exs
+++ b/test/elixir/test/password_cache_test.exs
@@ -129,7 +129,7 @@ defmodule PasswordCacheTest do
     save_doc(db_name, user1)
 
     # Wait for auth cache to notice password change
-    :timer.sleep(5000)
+    :timer.sleep(5500)
 
     # Slow rejection for wrong password
     assert_cache(:expect_slow, "user1", "wrong_password", :expect_login_fail)


### PR DESCRIPTION
In this test we have to wait for 5 seconds as that's the hardcoded timeout in the hash worker. However let's try to wait just a bit longer (+500msec) in case there a race condition or some schedulers are blocked.
