### PR TITLE
feat(`fabric`): switch to maps for view rows

### DIFF
--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -273,7 +273,8 @@ query_all_docs(Db, Args0, Callback, Acc) ->
     all_docs_fold(Db, Args2, Callback, Acc1).
 
 query_view(Db, DDoc, VName) ->
-    query_view(Db, DDoc, VName, #mrargs{}).
+    Args = #mrargs{extra = [{view_row_map, true}]},
+    query_view(Db, DDoc, VName, Args).
 
 query_view(Db, DDoc, VName, Args) when is_list(Args) ->
     query_view(Db, DDoc, VName, to_mrargs(Args), fun default_cb/2, []);
@@ -325,7 +326,7 @@ get_view_info(Db, DDoc, VName) ->
         Db,
         DDoc,
         VName,
-        #mrargs{}
+        #mrargs{extra = [{view_row_map, true}]}
     ),
 
     %% get the total number of rows
@@ -763,7 +764,7 @@ to_mrargs(KeyList) ->
             Index = lookup_index(couch_util:to_existing_atom(Key)),
             setelement(Index, Acc, Value)
         end,
-        #mrargs{},
+        #mrargs{extra = [{view_row_map, true}]},
         KeyList
     ).
 

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -472,7 +472,7 @@ row_to_json(Id0, Row) ->
 parse_params(#httpd{} = Req, Keys) ->
     parse_params(chttpd:qs(Req), Keys);
 parse_params(Props, Keys) ->
-    Args = #mrargs{},
+    Args = #mrargs{extra = [{view_row_map, true}]},
     parse_params(Props, Keys, Args).
 
 parse_params(Props, Keys, Args) ->
@@ -511,13 +511,16 @@ parse_body_and_query(Req, Keys) ->
         #mrargs{
             keys = Keys,
             group = undefined,
-            group_level = undefined
+            group_level = undefined,
+            extra = [{view_row_map, true}]
         },
         [keep_group_level]
     ).
 
 parse_body_and_query(Req, {Props}, Keys) ->
-    Args = #mrargs{keys = Keys, group = undefined, group_level = undefined},
+    Args = #mrargs{
+        keys = Keys, group = undefined, group_level = undefined, extra = [{view_row_map, true}]
+    },
     BodyArgs0 = parse_params(Props, Keys, Args, [decoded]),
     BodyArgs1 =
         case is_view(Req) of

--- a/src/couch_replicator/src/couch_replicator_fabric.erl
+++ b/src/couch_replicator/src/couch_replicator_fabric.erl
@@ -81,6 +81,24 @@ docs_int(DbName, Workers, QueryArgs, Callback, Acc0) ->
             {ok, Resp}
     end.
 
+handle_row(Row0, {Worker, From} = Source, State) ->
+    #collector{query_args = Args, counters = Counters0, rows = Rows0} = State,
+    Id = fabric_view_row:get_id(Row0),
+    Doc = fabric_view_row:get_doc(Row0),
+    case maybe_fetch_and_filter_doc(Id, Doc, State) of
+        {[_ | _]} = NewDoc ->
+            Row1 = fabric_view_row:set_doc(Row0, NewDoc),
+            Row = fabric_view_row:set_worker(Row1, Source),
+            Dir = Args#mrargs.direction,
+            Rows = merge_row(Dir, Row, Rows0),
+            Counters1 = fabric_dict:update_counter(Worker, 1, Counters0),
+            State1 = State#collector{rows = Rows, counters = Counters1},
+            fabric_view:maybe_send_row(State1);
+        skip ->
+            rexi:stream_ack(From),
+            {ok, State}
+    end.
+
 handle_message({rexi_DOWN, _, {_, NodeRef}, _}, _, State) ->
     fabric_view:check_down_shards(State, NodeRef);
 handle_message({rexi_EXIT, Reason}, Worker, State) ->
@@ -120,32 +138,31 @@ handle_message({meta, Meta0}, {Worker, From}, State) ->
                 user_acc = Acc
             }}
     end;
-handle_message(#view_row{id = Id, doc = Doc} = Row0, {Worker, From}, State) ->
-    #collector{query_args = Args, counters = Counters0, rows = Rows0} = State,
-    case maybe_fetch_and_filter_doc(Id, Doc, State) of
-        {[_ | _]} = NewDoc ->
-            Row = Row0#view_row{doc = NewDoc},
-            Dir = Args#mrargs.direction,
-            Rows = merge_row(Dir, Row#view_row{worker = {Worker, From}}, Rows0),
-            Counters1 = fabric_dict:update_counter(Worker, 1, Counters0),
-            State1 = State#collector{rows = Rows, counters = Counters1},
-            fabric_view:maybe_send_row(State1);
-        skip ->
-            rexi:stream_ack(From),
-            {ok, State}
-    end;
+handle_message(#view_row{} = Row, {_, _} = Source, State) ->
+    handle_row(Row, Source, State);
+handle_message({view_row, #{}} = Row, {_, _} = Source, State) ->
+    handle_row(Row, Source, State);
 handle_message(complete, Worker, State) ->
     Counters = fabric_dict:update_counter(Worker, 1, State#collector.counters),
     fabric_view:maybe_send_row(State#collector{counters = Counters}).
 
-merge_row(fwd, Row, Rows) ->
-    lists:keymerge(#view_row.id, [Row], Rows);
-merge_row(rev, Row, Rows) ->
-    lists:rkeymerge(#view_row.id, [Row], Rows).
+merge_row(Dir, Row, Rows) ->
+    lists:merge(
+        fun(RowA, RowB) ->
+            IdA = fabric_view_row:get_id(RowA),
+            IdB = fabric_view_row:get_id(RowB),
+            case Dir of
+                fwd -> IdA < IdB;
+                rev -> IdA > IdB
+            end
+        end,
+        [Row],
+        Rows
+    ).
 
 maybe_fetch_and_filter_doc(Id, undecided, State) ->
-    #collector{db_name = DbName, query_args = #mrargs{extra = Extra}} = State,
-    FilterStates = proplists:get_value(filter_states, Extra),
+    #collector{db_name = DbName, query_args = #mrargs{extra = Options}} = State,
+    FilterStates = couch_util:get_value(filter_states, Options),
     case couch_replicator:active_doc(DbName, Id) of
         {ok, {Props} = DocInfo} ->
             DocState = couch_util:get_value(state, Props),
@@ -156,3 +173,278 @@ maybe_fetch_and_filter_doc(Id, undecided, State) ->
     end;
 maybe_fetch_and_filter_doc(_Id, Doc, _State) ->
     Doc.
+
+-ifdef(TEST).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+handle_message_test_() ->
+    {
+        foreach,
+        fun() ->
+            meck:new(foo, [non_strict]),
+            meck:new(fabric_view)
+        end,
+        fun(_) -> meck:unload() end,
+        [
+            ?TDEF_FE(t_handle_message_rexi_down),
+            ?TDEF_FE(t_handle_message_rexi_exit),
+            ?TDEF_FE(t_handle_message_meta_zero),
+            ?TDEF_FE(t_handle_message_meta),
+            ?TDEF_FE(t_handle_message_row_skip),
+            ?TDEF_FE(t_handle_message_row),
+            ?TDEF_FE(t_handle_message_complete)
+        ]
+    }.
+
+t_handle_message_rexi_down(_) ->
+    Message = {rexi_DOWN, undefined, {undefined, node}, undefined},
+    meck:expect(fabric_view, check_down_shards, [state, node], meck:val(fabric_view_result)),
+    ?assertEqual(fabric_view_result, handle_message(Message, source, state)).
+
+t_handle_message_rexi_exit(_) ->
+    Message = {rexi_EXIT, reason},
+    meck:expect(
+        fabric_view, handle_worker_exit, [state, source, reason], meck:val(fabric_view_result)
+    ),
+    ?assertEqual(fabric_view_result, handle_message(Message, source, state)).
+
+t_handle_message_meta_zero(_) ->
+    Meta = [{total, 3}, {offset, 2}, {update_seq, 1}],
+    Worker = {worker1, from},
+    Counters1 = [{worker1, 0}, {worker2, 0}],
+    Counters2 = [{worker1, 1}, {worker2, 0}],
+    State1 = #collector{counters = Counters1, total_rows = 0, update_seq = nil, offset = 0},
+    State2 = #collector{counters = Counters2, total_rows = 3, update_seq = nil, offset = 2},
+    meck:expect(rexi, stream_ack, [from], meck:val(ok)),
+    ?assertEqual({ok, State2}, handle_message({meta, Meta}, Worker, State1)).
+
+t_handle_message_meta(_) ->
+    Meta1 = [{total, 10}, {offset, 2}],
+    Meta2 = [{total, 10}, {offset, 5}],
+    Meta3 = [{total, 10}, {offset, 5}],
+    Worker = {worker1, from},
+    Counters1 = [{worker1, 0}, {worker2, 3}, {worker3, 5}],
+    Counters2 = [{worker1, 0}, {worker2, 2}, {worker3, 4}],
+    State1 = #collector{
+        counters = Counters1,
+        total_rows = 0,
+        update_seq = [],
+        offset = 0,
+        skip = 3,
+        callback = fun foo:bar/2,
+        user_acc = accumulator1
+    },
+    State2 = #collector{
+        counters = Counters1,
+        total_rows = 0,
+        update_seq = nil,
+        offset = 0,
+        skip = 3,
+        callback = fun foo:bar/2,
+        user_acc = accumulator2
+    },
+    State3 = #collector{
+        counters = Counters2,
+        total_rows = 10,
+        update_seq = [],
+        offset = 5,
+        skip = 3,
+        callback = fun foo:bar/2,
+        user_acc = updated_accumulator1
+    },
+    State4 = #collector{
+        counters = Counters2,
+        total_rows = 10,
+        update_seq = nil,
+        offset = 5,
+        skip = 3,
+        callback = fun foo:bar/2,
+        user_acc = updated_accumulator2
+    },
+    meck:expect(
+        foo,
+        bar,
+        [
+            {[{meta, Meta2}, accumulator1], meck:val({go1, updated_accumulator1})},
+            {[{meta, Meta3}, accumulator2], meck:val({go2, updated_accumulator2})}
+        ]
+    ),
+    meck:expect(rexi, stream_ack, [from], meck:val(ok)),
+    ?assertEqual({go1, State3}, handle_message({meta, Meta1}, Worker, State1)),
+    ?assertEqual({go2, State4}, handle_message({meta, Meta1}, Worker, State2)).
+
+t_handle_message_row_skip(_) ->
+    State = #collector{db_name = db, query_args = #mrargs{}},
+    Worker = {worker, from},
+    Row1 = #view_row{id = id, doc = undecided},
+    Row2 = {view_row, #{id => id, doc => undecided}},
+    meck:expect(couch_replicator, active_doc, [db, id], meck:val({error, not_found})),
+    meck:expect(rexi, stream_ack, [from], meck:val(ok)),
+    ?assertEqual({ok, State}, handle_message(Row1, Worker, State)),
+    ?assertEqual({ok, State}, handle_message(Row2, Worker, State)).
+
+t_handle_message_row(_) ->
+    QueryArgs = #mrargs{direction = fwd, extra = [{filter_states, []}]},
+    Counters1 = [{worker, 4}],
+    Counters2 = [{worker, 5}],
+    Worker = {worker, from},
+    Doc = {[{<<"_id">>, doc_id}, {<<"_rev">>, doc_rev}]},
+    Row1 = #view_row{id = id, doc = Doc},
+    Row11 = #view_row{id = id, doc = Doc, worker = Worker},
+    Row2 = {view_row, #{id => id, doc => undecided}},
+    Row21 = {view_row, #{id => id, doc => Doc, worker => Worker}},
+    Rows1 = [],
+    Rows2 = [],
+    Rows3 = [Row11],
+    Rows4 = [Row21],
+    State1 = #collector{db_name = db, query_args = QueryArgs, counters = Counters1, rows = Rows1},
+    State2 = #collector{db_name = db, query_args = QueryArgs, counters = Counters1, rows = Rows2},
+    State3 = #collector{db_name = db, query_args = QueryArgs, counters = Counters2, rows = Rows3},
+    State4 = #collector{db_name = db, query_args = QueryArgs, counters = Counters2, rows = Rows4},
+    meck:expect(couch_replicator, active_doc, [db, id], meck:val({ok, Doc})),
+    meck:expect(fabric_view, maybe_send_row, [
+        {[State3], meck:val(next_row1)}, {[State4], meck:val(next_row2)}
+    ]),
+    ?assertEqual(next_row1, handle_message(Row1, Worker, State1)),
+    ?assertEqual(next_row2, handle_message(Row2, Worker, State2)).
+
+t_handle_message_complete(_) ->
+    Worker = worker,
+    Counters1 = [{Worker, 6}],
+    Counters2 = [{Worker, 7}],
+    State1 = #collector{counters = Counters1},
+    State2 = #collector{counters = Counters2},
+    meck:expect(fabric_view, maybe_send_row, [State2], meck:val(maybe_row)),
+    ?assertEqual(maybe_row, handle_message(complete, Worker, State1)).
+
+merge_row_test_() ->
+    {
+        foreach,
+        fun() -> ok end,
+        fun(_) -> ok end,
+        [
+            ?TDEF_FE(t_merge_row_record_fwd),
+            ?TDEF_FE(t_merge_row_record_rev),
+            ?TDEF_FE(t_merge_row_map_fwd),
+            ?TDEF_FE(t_merge_row_map_rev),
+            ?TDEF_FE(t_merge_row_mixed_fwd),
+            ?TDEF_FE(t_merge_row_mixed_rev)
+        ]
+    }.
+
+t_merge_row_record_fwd(_) ->
+    RowX1 = #view_row{id = 4},
+    Row1 = #view_row{id = 1},
+    Row2 = #view_row{id = 3},
+    Row3 = #view_row{id = 5},
+    Row4 = #view_row{id = 7},
+    Rows = [Row1, Row2, Row3, Row4],
+    Expected1 = [Row1, Row2, RowX1, Row3, Row4],
+    ?assertEqual(Expected1, merge_row(fwd, RowX1, Rows)),
+    RowX2 = #view_row{id = 0},
+    Expected2 = [RowX2, Row1, Row2, Row3, Row4],
+    ?assertEqual(Expected2, merge_row(fwd, RowX2, Rows)),
+    RowX3 = #view_row{id = 8},
+    Expected3 = [Row1, Row2, Row3, Row4, RowX3],
+    ?assertEqual(Expected3, merge_row(fwd, RowX3, Rows)),
+    RowX4 = #view_row{id = 5},
+    Expected4 = [Row1, Row2, RowX4, Row3, Row4],
+    ?assertEqual(Expected4, merge_row(fwd, RowX4, Rows)).
+
+t_merge_row_record_rev(_) ->
+    RowX1 = #view_row{id = 5},
+    Row1 = #view_row{id = 2},
+    Row2 = #view_row{id = 4},
+    Row3 = #view_row{id = 6},
+    Row4 = #view_row{id = 8},
+    Rows = [Row4, Row3, Row2, Row1],
+    Expected1 = [Row4, Row3, RowX1, Row2, Row1],
+    ?assertEqual(Expected1, merge_row(rev, RowX1, Rows)),
+    RowX2 = #view_row{id = 1},
+    Expected2 = [Row4, Row3, Row2, Row1, RowX2],
+    ?assertEqual(Expected2, merge_row(rev, RowX2, Rows)),
+    RowX3 = #view_row{id = 9},
+    Expected3 = [RowX3, Row4, Row3, Row2, Row1],
+    ?assertEqual(Expected3, merge_row(rev, RowX3, Rows)),
+    RowX4 = #view_row{id = 6},
+    Expected4 = [Row4, Row3, RowX4, Row2, Row1],
+    ?assertEqual(Expected4, merge_row(rev, RowX4, Rows)).
+
+t_merge_row_map_fwd(_) ->
+    RowX1 = {view_row, #{id => 4}},
+    Row1 = {view_row, #{id => 1}},
+    Row2 = {view_row, #{id => 3}},
+    Row3 = {view_row, #{id => 5}},
+    Row4 = {view_row, #{id => 7}},
+    Rows = [Row1, Row2, Row3, Row4],
+    Expected1 = [Row1, Row2, RowX1, Row3, Row4],
+    ?assertEqual(Expected1, merge_row(fwd, RowX1, Rows)),
+    RowX2 = {view_row, #{id => 0}},
+    Expected2 = [RowX2, Row1, Row2, Row3, Row4],
+    ?assertEqual(Expected2, merge_row(fwd, RowX2, Rows)),
+    RowX3 = {view_row, #{id => 8}},
+    Expected3 = [Row1, Row2, Row3, Row4, RowX3],
+    ?assertEqual(Expected3, merge_row(fwd, RowX3, Rows)),
+    RowX4 = {view_row, #{id => 5}},
+    Expected4 = [Row1, Row2, RowX4, Row3, Row4],
+    ?assertEqual(Expected4, merge_row(fwd, RowX4, Rows)).
+
+t_merge_row_map_rev(_) ->
+    RowX1 = {view_row, #{id => 5}},
+    Row1 = {view_row, #{id => 2}},
+    Row2 = {view_row, #{id => 4}},
+    Row3 = {view_row, #{id => 6}},
+    Row4 = {view_row, #{id => 8}},
+    Rows = [Row4, Row3, Row2, Row1],
+    Expected1 = [Row4, Row3, RowX1, Row2, Row1],
+    ?assertEqual(Expected1, merge_row(rev, RowX1, Rows)),
+    RowX2 = {view_row, #{id => 1}},
+    Expected2 = [Row4, Row3, Row2, Row1, RowX2],
+    ?assertEqual(Expected2, merge_row(rev, RowX2, Rows)),
+    RowX3 = {view_row, #{id => 9}},
+    Expected3 = [RowX3, Row4, Row3, Row2, Row1],
+    ?assertEqual(Expected3, merge_row(rev, RowX3, Rows)),
+    RowX4 = {view_row, #{id => 6}},
+    Expected4 = [Row4, Row3, RowX4, Row2, Row1],
+    ?assertEqual(Expected4, merge_row(rev, RowX4, Rows)).
+
+t_merge_row_mixed_fwd(_) ->
+    RowX1 = #view_row{id = 4},
+    Row1 = {view_row, #{id => 1}},
+    Row2 = {view_row, #{id => 3}},
+    Row3 = #view_row{id = 5},
+    Row4 = {view_row, #{id => 7}},
+    Rows = [Row1, Row2, Row3, Row4],
+    Expected1 = [Row1, Row2, RowX1, Row3, Row4],
+    ?assertEqual(Expected1, merge_row(fwd, RowX1, Rows)),
+    RowX2 = {view_row, #{id => 0}},
+    Expected2 = [RowX2, Row1, Row2, Row3, Row4],
+    ?assertEqual(Expected2, merge_row(fwd, RowX2, Rows)),
+    RowX3 = {view_row, #{id => 8}},
+    Expected3 = [Row1, Row2, Row3, Row4, RowX3],
+    ?assertEqual(Expected3, merge_row(fwd, RowX3, Rows)),
+    RowX4 = {view_row, #{id => 5}},
+    Expected4 = [Row1, Row2, Row3, RowX4, Row4],
+    ?assertEqual(Expected4, merge_row(fwd, RowX4, Rows)).
+
+t_merge_row_mixed_rev(_) ->
+    RowX1 = {view_row, #{id => 5}},
+    Row1 = #view_row{id = 2},
+    Row2 = #view_row{id = 4},
+    Row3 = {view_row, #{id => 6}},
+    Row4 = #view_row{id = 8},
+    Rows = [Row4, Row3, Row2, Row1],
+    Expected1 = [Row4, Row3, RowX1, Row2, Row1],
+    ?assertEqual(Expected1, merge_row(rev, RowX1, Rows)),
+    RowX2 = #view_row{id = 1},
+    Expected2 = [Row4, Row3, Row2, Row1, RowX2],
+    ?assertEqual(Expected2, merge_row(rev, RowX2, Rows)),
+    RowX3 = #view_row{id = 9},
+    Expected3 = [RowX3, Row4, Row3, Row2, Row1],
+    ?assertEqual(Expected3, merge_row(rev, RowX3, Rows)),
+    RowX4 = #view_row{id = 6},
+    Expected4 = [Row4, Row3, RowX4, Row2, Row1],
+    ?assertEqual(Expected4, merge_row(rev, RowX4, Rows)).
+
+-endif.

--- a/src/couch_replicator/src/couch_replicator_httpd.erl
+++ b/src/couch_replicator/src/couch_replicator_httpd.erl
@@ -135,11 +135,12 @@ handle_scheduler_docs(Db, Req) when is_binary(Db) ->
     VArgs0 = couch_mrview_http:parse_params(Req, undefined),
     StatesQs = chttpd:qs_value(Req, "states"),
     States = couch_replicator_httpd_util:parse_replication_state_filter(StatesQs),
+    Extra = VArgs0#mrargs.extra,
     VArgs1 = VArgs0#mrargs{
         view_type = map,
         include_docs = true,
         reduce = false,
-        extra = [{filter_states, States}]
+        extra = [{filter_states, States} | Extra]
     },
     VArgs2 = couch_mrview_util:validate_args(VArgs1),
     Opts = [{user_ctx, Req#httpd.user_ctx}],

--- a/src/fabric/include/fabric.hrl
+++ b/src/fabric/include/fabric.hrl
@@ -42,3 +42,17 @@
 
 -record(view_row, {key, id, value, doc, worker}).
 -record(change, {key, id, value, deleted=false, doc, worker}).
+
+-type row_property_key() :: id | key | value | doc | worker.
+-type row_properties() :: [{row_property_key(), any()}].
+
+-type view_row_map() ::
+	#{
+	  id => term(),
+	  key => term(),
+	  value => term(),
+	  doc => term(),
+	  worker => term()
+	 }.
+
+-type view_row() :: #view_row{} | {view_row, view_row_map()}.

--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -442,7 +442,8 @@ changes(DbName, Callback, Acc0, Options) ->
 
 %% @equiv query_view(DbName, DesignName, ViewName, #mrargs{})
 query_view(DbName, DesignName, ViewName) ->
-    query_view(DbName, DesignName, ViewName, #mrargs{}).
+    QueryArgs = #mrargs{extra = [{view_row_map, true}]},
+    query_view(DbName, DesignName, ViewName, QueryArgs).
 
 %% @equiv query_view(DbName, DesignName,
 %%                     ViewName, fun default_callback/2, [], QueryArgs)
@@ -545,10 +546,11 @@ end_changes() ->
 %% @doc retrieve all the design docs from a database
 -spec design_docs(dbname()) -> {ok, [json_obj()]} | {error, Reason :: term()}.
 design_docs(DbName) ->
+    Extra0 = [{view_row_map, true}],
     Extra =
         case get(io_priority) of
-            undefined -> [];
-            Else -> [{io_priority, Else}]
+            undefined -> Extra0;
+            Else -> [{io_priority, Else} | Extra0]
         end,
     QueryArgs0 = #mrargs{
         include_docs = true,

--- a/src/fabric/src/fabric_view_row.erl
+++ b/src/fabric/src/fabric_view_row.erl
@@ -1,0 +1,355 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric_view_row).
+-export([
+    from_props/2,
+    get_id/1,
+    get_key/1,
+    get_value/1,
+    get_doc/1,
+    get_worker/1,
+    set_key/2,
+    set_doc/2,
+    set_worker/2,
+    transform/1
+]).
+
+-include_lib("fabric/include/fabric.hrl").
+
+from_props(Props, Options) ->
+    case couch_util:get_value(view_row_map, Options, false) of
+        true ->
+            Row = maps:from_list(Props),
+            {view_row, Row};
+        false ->
+            #view_row{
+                key = couch_util:get_value(key, Props),
+                id = couch_util:get_value(id, Props),
+                value = couch_util:get_value(value, Props),
+                doc = couch_util:get_value(doc, Props),
+                worker = couch_util:get_value(worker, Props)
+            }
+    end.
+
+get_id(#view_row{id = Id}) ->
+    Id;
+get_id({view_row, #{id := Id}}) ->
+    Id;
+get_id({view_row, #{}}) ->
+    undefined.
+
+get_key(#view_row{key = Key}) ->
+    Key;
+get_key({view_row, #{key := Key}}) ->
+    Key;
+get_key({view_row, #{}}) ->
+    undefined.
+
+set_key(#view_row{} = Row, Key) ->
+    Row#view_row{key = Key};
+set_key({view_row, #{} = Row}, Key) ->
+    {view_row, Row#{key => Key}}.
+
+get_value(#view_row{value = Value}) ->
+    Value;
+get_value({view_row, #{value := Value}}) ->
+    Value;
+get_value({view_row, #{}}) ->
+    undefined.
+
+get_doc(#view_row{doc = Doc}) ->
+    Doc;
+get_doc({view_row, #{doc := Doc}}) ->
+    Doc;
+get_doc({view_row, #{}}) ->
+    undefined.
+
+set_doc(#view_row{} = Row, Doc) ->
+    Row#view_row{doc = Doc};
+set_doc({view_row, #{} = Row}, Doc) ->
+    {view_row, Row#{doc => Doc}}.
+
+get_worker(#view_row{worker = Worker}) ->
+    Worker;
+get_worker({view_row, #{worker := Worker}}) ->
+    Worker;
+get_worker({view_row, #{}}) ->
+    undefined.
+
+set_worker(#view_row{} = Row, Worker) ->
+    Row#view_row{worker = Worker};
+set_worker({view_row, #{} = Row}, Worker) ->
+    {view_row, Row#{worker => Worker}}.
+
+transform(#view_row{value = {[{reduce_overflow_error, Msg}]}}) ->
+    {row, [{key, null}, {id, error}, {value, reduce_overflow_error}, {reason, Msg}]};
+transform(#view_row{key = Key, id = reduced, value = Value}) ->
+    {row, [{key, Key}, {value, Value}]};
+transform(#view_row{key = Key, id = undefined}) ->
+    {row, [{key, Key}, {id, error}, {value, not_found}]};
+transform(#view_row{key = Key, id = Id, value = Value, doc = undefined}) ->
+    {row, [{id, Id}, {key, Key}, {value, Value}]};
+transform(#view_row{key = Key, doc = {error, Reason}}) ->
+    {row, [{id, error}, {key, Key}, {value, Reason}]};
+transform(#view_row{key = Key, id = Id, value = Value, doc = Doc}) ->
+    {row, [{id, Id}, {key, Key}, {value, Value}, {doc, Doc}]};
+transform({view_row, #{} = Row0}) ->
+    Id = maps:get(id, Row0, undefined),
+    Key = maps:get(key, Row0, undefined),
+    Value = maps:get(value, Row0, undefined),
+    Doc = maps:get(doc, Row0, undefined),
+    Worker = maps:get(worker, Row0, undefined),
+    Row = #view_row{id = Id, key = Key, value = Value, doc = Doc, worker = Worker},
+    transform(Row).
+
+-ifdef(TEST).
+-include_lib("couch/include/couch_eunit.hrl").
+
+from_props_test_() ->
+    {
+        foreach,
+        fun() -> ok end,
+        fun(_) -> ok end,
+        [
+            ?TDEF_FE(t_from_props_record),
+            ?TDEF_FE(t_from_props_map_empty),
+            ?TDEF_FE(t_from_props_map)
+        ]
+    }.
+
+t_from_props_record(_) ->
+    Options1 = [],
+    Options2 = [{view_row_map, false}],
+    Props = [{id, id}, {key, key}, {value, value}],
+    ViewRow = #view_row{id = id, key = key, value = value, doc = undefined, worker = undefined},
+    ?assertEqual(ViewRow, from_props(Props, Options1)),
+    ?assertEqual(ViewRow, from_props(Props, Options2)).
+
+t_from_props_map_empty(_) ->
+    Options = [{view_row_map, true}],
+    Props = [],
+    ViewRow = {view_row, #{}},
+    ?assertEqual(ViewRow, from_props(Props, Options)).
+
+t_from_props_map(_) ->
+    Options = [{view_row_map, true}],
+    Props = [{id, id}, {key, key}, {doc, doc}],
+    ViewRow = {view_row, #{id => id, key => key, doc => doc}},
+    ?assertEqual(ViewRow, from_props(Props, Options)).
+
+getter_test_() ->
+    {
+        foreach,
+        fun() -> ok end,
+        fun(_) -> ok end,
+        [
+            ?TDEF_FE(t_get_id_record),
+            ?TDEF_FE(t_get_key_record),
+            ?TDEF_FE(t_get_value_record),
+            ?TDEF_FE(t_get_doc_record),
+            ?TDEF_FE(t_get_worker_record),
+            ?TDEF_FE(t_get_id_map),
+            ?TDEF_FE(t_get_key_map),
+            ?TDEF_FE(t_get_value_map),
+            ?TDEF_FE(t_get_doc_map),
+            ?TDEF_FE(t_get_worker_map)
+        ]
+    }.
+
+t_get_id_record(_) ->
+    ViewRow1 = #view_row{},
+    ?assertEqual(undefined, get_id(ViewRow1)),
+    ViewRow2 = #view_row{id = id},
+    ?assertEqual(id, get_id(ViewRow2)).
+
+t_get_id_map(_) ->
+    ViewRow1 = {view_row, #{}},
+    ?assertEqual(undefined, get_id(ViewRow1)),
+    ViewRow2 = {view_row, #{id => id}},
+    ?assertEqual(id, get_id(ViewRow2)).
+
+t_get_key_record(_) ->
+    ViewRow1 = #view_row{},
+    ?assertEqual(undefined, get_key(ViewRow1)),
+    ViewRow2 = #view_row{key = key},
+    ?assertEqual(key, get_key(ViewRow2)).
+
+t_get_key_map(_) ->
+    ViewRow1 = {view_row, #{}},
+    ?assertEqual(undefined, get_key(ViewRow1)),
+    ViewRow2 = {view_row, #{key => key}},
+    ?assertEqual(key, get_key(ViewRow2)).
+
+t_get_value_record(_) ->
+    ViewRow1 = #view_row{},
+    ?assertEqual(undefined, get_value(ViewRow1)),
+    ViewRow2 = #view_row{value = value},
+    ?assertEqual(value, get_value(ViewRow2)).
+
+t_get_value_map(_) ->
+    ViewRow1 = {view_row, #{}},
+    ?assertEqual(undefined, get_value(ViewRow1)),
+    ViewRow2 = {view_row, #{value => value}},
+    ?assertEqual(value, get_value(ViewRow2)).
+
+t_get_doc_record(_) ->
+    ViewRow1 = #view_row{},
+    ?assertEqual(undefined, get_doc(ViewRow1)),
+    ViewRow2 = #view_row{doc = doc},
+    ?assertEqual(doc, get_doc(ViewRow2)).
+
+t_get_doc_map(_) ->
+    ViewRow1 = {view_row, #{}},
+    ?assertEqual(undefined, get_doc(ViewRow1)),
+    ViewRow2 = {view_row, #{doc => doc}},
+    ?assertEqual(doc, get_doc(ViewRow2)).
+
+t_get_worker_record(_) ->
+    ViewRow1 = #view_row{},
+    ?assertEqual(undefined, get_worker(ViewRow1)),
+    ViewRow2 = #view_row{worker = worker},
+    ?assertEqual(worker, get_worker(ViewRow2)).
+
+t_get_worker_map(_) ->
+    ViewRow1 = {view_row, #{}},
+    ?assertEqual(undefined, get_worker(ViewRow1)),
+    ViewRow2 = {view_row, #{worker => worker}},
+    ?assertEqual(worker, get_worker(ViewRow2)).
+
+setter_test_() ->
+    {
+        foreach,
+        fun() -> ok end,
+        fun(_) -> ok end,
+        [
+            ?TDEF_FE(t_set_key_record),
+            ?TDEF_FE(t_set_doc_record),
+            ?TDEF_FE(t_set_worker_record),
+            ?TDEF_FE(t_set_key_map),
+            ?TDEF_FE(t_set_doc_map),
+            ?TDEF_FE(t_set_worker_map)
+        ]
+    }.
+
+t_set_key_record(_) ->
+    ViewRow1 = #view_row{key = key},
+    ViewRow2 = #view_row{key = updated_key},
+    ?assertEqual(ViewRow2, set_key(ViewRow1, updated_key)).
+
+t_set_key_map(_) ->
+    ViewRow1 = {view_row, #{key => key}},
+    ViewRow2 = {view_row, #{key => updated_key}},
+    ?assertEqual(ViewRow2, set_key(ViewRow1, updated_key)).
+
+t_set_doc_record(_) ->
+    ViewRow1 = #view_row{doc = doc},
+    ViewRow2 = #view_row{doc = updated_doc},
+    ?assertEqual(ViewRow2, set_doc(ViewRow1, updated_doc)).
+
+t_set_doc_map(_) ->
+    ViewRow1 = {view_row, #{doc => doc}},
+    ViewRow2 = {view_row, #{doc => updated_doc}},
+    ?assertEqual(ViewRow2, set_doc(ViewRow1, updated_doc)).
+
+t_set_worker_record(_) ->
+    ViewRow1 = #view_row{worker = worker},
+    ViewRow2 = #view_row{worker = updated_worker},
+    ?assertEqual(ViewRow2, set_worker(ViewRow1, updated_worker)).
+
+t_set_worker_map(_) ->
+    ViewRow1 = {view_row, #{worker => worker}},
+    ViewRow2 = {view_row, #{worker => updated_worker}},
+    ?assertEqual(ViewRow2, set_worker(ViewRow1, updated_worker)).
+
+transform_test_() ->
+    {
+        foreach,
+        fun() -> ok end,
+        fun(_) -> ok end,
+        [
+            ?TDEF_FE(t_transform_record_reduce_overflow_error),
+            ?TDEF_FE(t_transform_record_reduced),
+            ?TDEF_FE(t_transform_record_id_undefined),
+            ?TDEF_FE(t_transform_record_doc_undefined),
+            ?TDEF_FE(t_transform_record_doc_error),
+            ?TDEF_FE(t_transform_record),
+            ?TDEF_FE(t_transform_map_reduce_overflow_error),
+            ?TDEF_FE(t_transform_map_reduced),
+            ?TDEF_FE(t_transform_map_id_undefined),
+            ?TDEF_FE(t_transform_map_doc_undefined),
+            ?TDEF_FE(t_transform_map_doc_error),
+            ?TDEF_FE(t_transform_map)
+        ]
+    }.
+
+t_transform_record_reduce_overflow_error(_) ->
+    ViewRow = #view_row{value = {[{reduce_overflow_error, reason}]}},
+    Props = {row, [{key, null}, {id, error}, {value, reduce_overflow_error}, {reason, reason}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_map_reduce_overflow_error(_) ->
+    ViewRow = {view_row, #{value => {[{reduce_overflow_error, reason}]}}},
+    Props = {row, [{key, null}, {id, error}, {value, reduce_overflow_error}, {reason, reason}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_record_reduced(_) ->
+    ViewRow = #view_row{key = key, id = reduced, value = value},
+    Props = {row, [{key, key}, {value, value}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_map_reduced(_) ->
+    ViewRow = {view_row, #{key => key, id => reduced, value => value}},
+    Props = {row, [{key, key}, {value, value}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_record_id_undefined(_) ->
+    ViewRow = #view_row{key = key, id = undefined},
+    Props = {row, [{key, key}, {id, error}, {value, not_found}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_map_id_undefined(_) ->
+    ViewRow = {view_row, #{key => key, id => undefined}},
+    Props = {row, [{key, key}, {id, error}, {value, not_found}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_record_doc_undefined(_) ->
+    ViewRow = #view_row{key = key, id = id, value = value, doc = undefined},
+    Props = {row, [{id, id}, {key, key}, {value, value}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_map_doc_undefined(_) ->
+    ViewRow = {view_row, #{key => key, id => id, value => value, doc => undefined}},
+    Props = {row, [{id, id}, {key, key}, {value, value}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_record_doc_error(_) ->
+    ViewRow = #view_row{key = key, id = id, doc = {error, reason}},
+    Props = {row, [{id, error}, {key, key}, {value, reason}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_map_doc_error(_) ->
+    ViewRow = {view_row, #{key => key, id => id, doc => {error, reason}}},
+    Props = {row, [{id, error}, {key, key}, {value, reason}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_record(_) ->
+    ViewRow = #view_row{key = key, id = id, value = value, doc = doc},
+    Props = {row, [{id, id}, {key, key}, {value, value}, {doc, doc}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+t_transform_map(_) ->
+    ViewRow = {view_row, #{key => key, id => id, value => value, doc => doc}},
+    Props = {row, [{id, id}, {key, key}, {value, value}, {doc, doc}]},
+    ?assertEqual(Props, transform(ViewRow)).
+
+-endif.

--- a/src/mango/src/mango.hrl
+++ b/src/mango/src/mango.hrl
@@ -53,9 +53,6 @@
          keys_examined => non_neg_integer()
     }.
 
--type row_property_key() :: id | key | value | doc.
--type row_properties() :: [{row_property_key(), any()}].
-
 -type reason() :: needs_text_search
 		| field_mismatch
 		| sort_order_mismatch


### PR DESCRIPTION
The `#view_row{}` record that is used for capturing messages with row data is not flexible enough to have it extended easily.  If one wanted to introduce a fresh field, the change would have to be propagated through many functions and modules.  Especially, if support for mixed-version clusters is a concern, this would come with some degree of duplication.

Leverage Erlang/OTP's built-in maps for mitigating this issue and offer the view callbacks the `view_row_map` Boolean key in `#mrargs.extra` to request this communication format.  This way the old record-based format would be still in use unless requested otherwise.  This facilitates the smooth interoperability of old coordinators and new workers.  In parallel to that, the new coordinator could still receive view rows from old workers.

## Testing recommendations

The unit and integration tests should cover all the changes.  There are no user-facing changes, it is internal to the communication of the coordinator and the workers over fabric.  Backwards compatibility is maintained.

```console
make eunit apps=fabric,couch_replicator,mango
make elixir
make elixir-search
make mango-test
```

Unit test coverage improvements:
- `couch_replicator`: 85% ⟶ 86%
- `fabric`: 72% ⟶ 79%

## Related Issues or Pull Requests

This is to set the stage for #4958.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
