### PR TITLE
Change server instance to cluster for UUID docs

### DIFF
--- a/src/docs/src/config/couchdb.rst
+++ b/src/docs/src/config/couchdb.rst
@@ -213,11 +213,11 @@ Base CouchDB Options
             [couchdb]
             util_driver_dir = /usr/lib/couchdb/erlang/lib/couch-1.5.0/priv/lib
 
-    .. config:option:: uuid :: CouchDB server UUID
+    .. config:option:: uuid :: CouchDB cluster UUID
 
         .. versionadded:: 1.3
 
-        Unique identifier for this CouchDB server instance. ::
+        Unique identifier for this CouchDB cluster. ::
 
             [couchdb]
             uuid = 0a959b9b8227188afc2ac26ccdf345a6


### PR DESCRIPTION
## Overview

Server instance is easily misunderstood. It can be interpreted as if there should be a unique UUID per node.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
