### PR TITLE
fix(`couch_replicator`): reporting for unexpected test responses

### DIFF
--- a/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_scheduler_docs_tests.erl
@@ -133,6 +133,9 @@ t_scheduler_docs_total_rows({_Ctx, {RepDb, Source, Target}}) ->
             case req(get, SchedulerDocsUrl) of
                 {200, #{<<"docs">> := [_ | _]} = Decoded} ->
                     Decoded;
+                {_, #{<<"error">> := (<<"unknown_error">> = Error), <<"reason">> := StackTrace}} ->
+                    ?debugVal(Error),
+                    ?debugVal(StackTrace, 100);
                 {_, #{<<"error">> := Error, <<"reason">> := Reason}} ->
                     ?debugVal(Error, 100),
                     ?debugVal(binary_to_list(Reason), 100);
@@ -143,7 +146,7 @@ t_scheduler_docs_total_rows({_Ctx, {RepDb, Source, Target}}) ->
         14000,
         1000
     ),
-    ?assertNotEqual(Body, timeout),
+    ?assertMatch(#{<<"docs">> := _, <<"total_rows">> := _}, Body),
     Docs = maps:get(<<"docs">>, Body),
     TotalRows = maps:get(<<"total_rows">>, Body),
     ?assertEqual(TotalRows, length(Docs)).


### PR DESCRIPTION
The freshly introduced debugging statements for tracing the run of the `couch_replicator` scheduler docs tests fail to provide information on unknown errors (possibly crashes) which are coming with a stack trace.  Enhance the related case distinction to handle these cases.  At the same time, rewrite the assertion on the expected result to make it more specific with regard to the contents of the document.
