### PR TITLE
Improve dist diagnostics

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -314,7 +314,8 @@ get_stats() ->
         {process_limit, erlang:system_info(process_limit)},
         {message_queues, {MessageQueuesHist ++ MessageQueues}},
         {internal_replication_jobs, mem3_sync:get_backlog()},
-        {distribution, {get_distribution_stats()}}
+        {distribution, {get_distribution_stats()}},
+        {distribution_events, mem3_distribution:events()}
     ].
 
 db_pid_stats_formatted() ->

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -43,7 +43,15 @@
     restart/1,
     restart_busy/2,
     restart_busy/3,
-    restart_busy/4
+    restart_busy/4,
+    dead_nodes/0,
+    dead_nodes/1,
+    ping/1,
+    ping/2,
+    ping_nodes/0,
+    ping_nodes/1,
+    ping_nodes/2,
+    node_events/0
 ]).
 
 -export([
@@ -85,7 +93,10 @@ help() ->
         print_report,
         print_report_with_info_width,
         restart,
-        restart_busy
+        restart_busy,
+        dead_nodes,
+        ping_nodes,
+        node_events
     ].
 
 -spec help(Function :: function_name()) -> ok.
@@ -434,6 +445,49 @@ help(analyze_resource_hoggers) ->
         An example workflow is to call `resource_hoggers_snapshot(memory_info(Pids))` and pass this to `analyze_resource_hoggers/2`
         along with the number of top processes to include in result, TopN. See `couch_debug:help(resource_hoggers_snapshot)` for an 
         example and more info.
+
+        ---
+    ", []);
+help(dead_nodes) ->
+    io:format("
+        dead_nodes()
+        dead_nodes(Timeout)
+        --------------------------------
+
+        Get the list of 'dead' nodes, that is node which appears in the
+        mem3:nodes() list but are not connected to some nodes of the cluster.
+
+        ---
+    ", []);
+help(ping) ->
+    io:format("
+        ping(Node)
+        ping(Node, Timeout)
+        --------------------------------
+
+        Ping a node and return either a time in microseconds or an error term.
+
+        ---
+    ", []);
+help(ping_nodes) ->
+    io:format("
+        ping_nodes()
+        ping_nodes(Timeout)
+        ping_nodes(Nodes, Timeout)
+        --------------------------------
+
+        Ping the list of currently connected nodes. Return a list of {Node,
+        Result} tuples where Result is either a time in microseconds or an
+        error term.
+
+        ---
+    ", []);
+help(node_events) ->
+    io:format("
+        node_events()
+        --------------------------------
+
+        Return the list of nodeup/nodedown events for each node in the cluster.
 
         ---
     ", []);
@@ -909,6 +963,30 @@ restart_busy(ProcessList, Threshold, DelayInMsec, Property) when
         end,
         busy(ProcessList, Threshold, Property)
     ).
+
+dead_nodes() ->
+    mem3:dead_nodes().
+
+dead_nodes(Timeout) ->
+    mem3:dead_nodes(Timeout).
+
+ping(Node) ->
+    mem3:ping(Node).
+
+ping(Node, Timeout) ->
+    mem3:ping(Node, Timeout).
+
+ping_nodes() ->
+    mem3:ping_nodes().
+
+ping_nodes(Timeout) ->
+    mem3:ping_nodes(Timeout).
+
+ping_nodes(Nodes, Timeout) ->
+    mem3:ping_nodes(Nodes, Timeout).
+
+node_events() ->
+    mem3_distribution:events().
 
 %% Pretty print functions
 

--- a/src/mem3/src/mem3_distribution.erl
+++ b/src/mem3/src/mem3_distribution.erl
@@ -19,7 +19,8 @@
 
 -export([
     start_link/0,
-    connect_node/1
+    connect_node/1,
+    events/0
 ]).
 
 -export([
@@ -30,9 +31,13 @@
 ]).
 
 -define(JITTER_PERCENT, 0.25).
+% init + 3 up/down pairs
+-define(EVENT_MAX_HISTORY, 7).
 
 -record(st, {
-    tref
+    tref,
+    % #{Node => [Evt, ...]}
+    events = #{}
 }).
 
 start_link() ->
@@ -41,20 +46,38 @@ start_link() ->
 connect_node(Node) when is_atom(Node) ->
     net_kernel:connect_node(Node).
 
+events() ->
+    gen_server:call(?MODULE, events, infinity).
+
 init(_) ->
     connect(false),
-    {ok, #st{tref = erlang:send_after(wait_msec(), self(), connect)}}.
+    net_kernel:monitor_nodes(true, [nodedown_reason]),
+    St = #st{
+        tref = schedule_connect(),
+        events = init_events(nodes())
+    },
+    {ok, St}.
 
+handle_call(events, _From, #st{} = St) ->
+    {reply, St#st.events, St};
 handle_call(Msg, _From, #st{} = St) ->
     {stop, {bad_call, Msg}, {bad_call, Msg}, St}.
 
 handle_cast(Msg, #st{} = St) ->
     {stop, {bad_cast, Msg}, St}.
 
+handle_info({nodeup, Node, _Info}, #st{events = Events} = St) ->
+    Events1 = update_event(Node, nodeup, null, Events),
+    {noreply, St#st{events = Events1}};
+handle_info({nodedown, Node, Info}, #st{events = Events} = St) ->
+    Reason = couch_util:get_value(nodedown_reason, Info),
+    log_node_down(Node, Reason),
+    Events1 = update_event(Node, nodedown, Reason, Events),
+    {noreply, St#st{events = Events1}};
 handle_info(connect, #st{} = St) ->
     erlang:cancel_timer(St#st.tref),
     ok = connect(true),
-    {noreply, St#st{tref = erlang:send_after(wait_msec(), self(), connect)}};
+    {noreply, St#st{tref = schedule_connect()}};
 handle_info(Msg, St) ->
     {stop, {bad_info, Msg}, St}.
 
@@ -78,6 +101,18 @@ log(_, _, _) ->
     % Failed to connect or we don't want to log it
     ok.
 
+log_node_down(_Node, connection_closed) ->
+    % Received on a regular node shutdown
+    ok;
+log_node_down(_Node, disconnect) ->
+    % This node requested a disconnect
+    ok;
+log_node_down(Node, Reason) ->
+    couch_log:warning("~s : node ~s down, reason: ~p", [?MODULE, Node, Reason]).
+
+schedule_connect() ->
+    erlang:send_after(wait_msec(), self(), connect).
+
 wait_msec() ->
     IntervalSec = config:get_integer("cluster", "reconnect_interval_sec", 37),
     IntervalMSec = IntervalSec * 1000,
@@ -87,3 +122,27 @@ jitter(Interval) ->
     Jitter = round(Interval * ?JITTER_PERCENT),
     % rand:uniform(0) crashes!
     rand:uniform(max(1, Jitter)).
+
+init_events(Nodes) ->
+    NowSec = erlang:system_time(second),
+    maps:from_keys(Nodes, [make_event(NowSec, init, null)]).
+
+update_event(Node, Event, Reason, EventMap) ->
+    NowSec = erlang:system_time(second),
+    Fun = fun(Events) ->
+        History = Events ++ [make_event(NowSec, Event, Reason)],
+        Rev = lists:reverse(History),
+        RevTrim = lists:sublist(Rev, ?EVENT_MAX_HISTORY),
+        lists:reverse(RevTrim)
+    end,
+    maps:update_with(Node, Fun, [make_event(NowSec, Event, Reason)], EventMap).
+
+make_event(TSec, Event, Reason) when is_integer(TSec), TSec > 0, is_atom(Event) ->
+    TStr = calendar:system_time_to_rfc3339(TSec, [{offset, "Z"}]),
+    Res = [list_to_binary(TStr), Event],
+    % For non-TCP (custom) dist protocol reason maybe a non-atom
+    case Reason of
+        null -> Res;
+        Atom when is_atom(Atom) -> Res ++ [Atom];
+        Val -> Res ++ [couch_util:to_binary(Val)]
+    end.

--- a/src/mem3/test/eunit/mem3_distribution_test.erl
+++ b/src/mem3/test/eunit/mem3_distribution_test.erl
@@ -19,6 +19,7 @@
 setup() ->
     Ctx = test_util:start_couch([mem3]),
     meck:new(mem3, [passthrough]),
+    meck:new(mem3_util, [passthrough]),
     meck:new(mem3_distribution, [passthrough]),
     meck:new(couch_log, [passthrough]),
     Ctx.
@@ -34,19 +35,25 @@ mem3_distribution_test_() ->
         fun teardown/1,
         [
             ?TDEF_FE(periodic_scheduler_works),
-            ?TDEF_FE(connect_to_unconnected_nodes)
+            ?TDEF_FE(connect_to_unconnected_nodes),
+            ?TDEF_FE(log_non_standard_nodedown),
+            ?TDEF_FE(append_nodeup_event),
+            ?TDEF_FE(append_nodedown_event),
+            ?TDEF_FE(events_are_trimmed),
+            ?TDEF_FE(ping_nodes_test),
+            ?TDEF_FE(dead_nodes_test)
         ]
     }.
 
 periodic_scheduler_works(_) ->
     St = sys:get_state(?MOD),
-    {st, TRef} = St,
+    {st, TRef, #{}} = St,
     TVal = erlang:read_timer(TRef),
     ?assert(is_integer(TVal)),
     ?assert(TVal > 0),
     ?assert(TVal =< 70000),
     {noreply, St1} = ?MOD:handle_info(connect, St),
-    {st, TRef1} = St1,
+    {st, TRef1, #{}} = St1,
     ?assertNotEqual(TRef, TRef1),
     TVal1 = erlang:read_timer(TRef1),
     ?assert(is_integer(TVal1)).
@@ -71,3 +78,69 @@ connect_to_unconnected_nodes(_) ->
     meck:wait(?MOD, connect_node, [bar], 5000),
     % connect_node returns true => emit reconnection log
     meck:wait(2, couch_log, warning, 2, 5000).
+
+log_non_standard_nodedown(_) ->
+    meck:reset(couch_log),
+    ?MOD ! {nodedown, 'baz@foo.net', [{nodedown_reason, potato}]},
+    meck:wait(1, couch_log, warning, 2, 5000).
+
+append_nodeup_event(_) ->
+    ?assertEqual(#{}, mem3_distribution:events()),
+    ?MOD ! {nodeup, 'foo@bar.org', []},
+    test_util:wait(fun() ->
+        case map_size(mem3_distribution:events()) == 0 of
+            true -> wait;
+            false -> ok
+        end
+    end),
+    Events = mem3_distribution:events(),
+    ?assert(is_map_key('foo@bar.org', Events)),
+    #{'foo@bar.org' := NodeEvents} = Events,
+    ?assertMatch([[<<"2", _/binary>>, nodeup]], NodeEvents).
+
+append_nodedown_event(_) ->
+    ?assertEqual(#{}, mem3_distribution:events()),
+    ?MOD ! {nodedown, 'foo@bar.org', [{nodedown_reason, badness}]},
+    test_util:wait(fun() ->
+        case map_size(mem3_distribution:events()) == 0 of
+            true -> wait;
+            false -> ok
+        end
+    end),
+    Events = mem3_distribution:events(),
+    ?assert(is_map_key('foo@bar.org', Events)),
+    #{'foo@bar.org' := NodeEvents} = Events,
+    ?assertMatch([[<<_/binary>>, nodedown, badness]], NodeEvents).
+
+events_are_trimmed(_) ->
+    ?assertEqual(#{}, mem3_distribution:events()),
+    [?MOD ! {nodedown, 'x', [{nodedown_reason, I}]} || I <- lists:seq(1, 10)],
+    test_util:wait(fun() ->
+        case mem3_distribution:events() of
+            #{x := [[_, nodedown, <<"4">>] | _]} ->
+                ok;
+            #{} ->
+                wait
+        end
+    end),
+    Events = mem3_distribution:events(),
+    #{x := NodeEvents} = Events,
+    ?assertEqual(7, length(NodeEvents)),
+    ?assertMatch([<<_/binary>>, nodedown, <<"4">>], hd(NodeEvents)),
+    ?assertMatch([<<_/binary>>, nodedown, <<"10">>], lists:last(NodeEvents)).
+
+ping_nodes_test(_) ->
+    meck:expect(mem3_util, live_nodes, 0, [n1, n2]),
+    ?assertEqual(
+        [
+            {n1, {nodedown, n1}},
+            {n2, {nodedown, n2}}
+        ],
+        couch_debug:ping_nodes()
+    ),
+    ?assertEqual({nodedown, n3}, couch_debug:ping(n3, 100)).
+
+dead_nodes_test(_) ->
+    meck:expect(mem3, nodes, 0, [n1, n2, n3]),
+    meck:expect(mem3_util, live_nodes, 0, [n1, n2]),
+    ?assertEqual([n3], couch_debug:dead_nodes()).


### PR DESCRIPTION
 * Monitor nodes membership in mem3_distribution and log unexpected `nodedown` reasons.

 * Enhance mem3_distribution gen_sever to keep track of the last few events for each node. This can help detect nodes flapping or disconnecting often.

 * Expose the last few events from mem3_distribution in the .../_system endpoint, besides the already existing dist packet stats metrics.

 * Add `ping_nodes(...)` debug function. Use it to ping all connected nodes. This can help detect a still connected but slow network connection.

 * Add `dead_nodes(...)` debug function. Use it to detect a partitioned cluster, where some nodes may not be connected to each other.
