### PR TITLE
Couch Scanner

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -141,6 +141,7 @@ SubDirs = [
     "src/smoosh",
     "src/weatherreport",
     "src/couch_prometheus",
+    "src/couch_scanner",
     "rel"
 ].
 

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -930,3 +930,99 @@ url = {{nouveau_url}}
 ;max_objects = 10000
 ;max_idle = 600000
 ;enable = true
+
+[couch_scanner]
+; How often to check for configuration changes and start/stop plugins
+;interval_sec = 5
+
+; Minimum time to force a plugin to wait before running again after a crash
+;min_penalty_sec = 30
+
+; Maximum time to force a plugin to wait after repeated crashes (8 hours default)
+;max_penalty_sec = 28800
+
+; If plugin runs successfully without crashing for this long, reset its
+; repeated error count
+;heal_threshold_sec = 300
+
+; Database processing rate limit per second. This will also be the
+; rate at which design documents are fetched. The rate is shared
+; across all running plugins.
+;db_rate_limit = 25
+
+; Limits the rate per second at which plugins may open db shard files
+; on a node. The rate is shared across all running plugins.
+;shard_rate_limit = 50
+
+; Limit the rate per second at which plugins open documents. The rate
+; is shared across all running plugins.
+;doc_rate_limit = 1000
+
+[couch_scanner_plugins]
+;couch_scanner_plugin_ddoc_features = false
+;couch_scanner_plugin_find = false
+
+; The following [$plugin*] settings apply to all plugins
+
+;[$plugin]
+; Run plugin on or after this time. The default is to run once after the
+; node starts. Times are in UTC. Possible time formats are:
+;  * Unix seconds: 1712338014
+;  * Date/Time: YYYY-MM-DDTHH, YYYY-MM-DDTHH:MM, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SSZ
+;after = restart
+; Run the plugin periodically. By default it will run once after node the node starts.
+; Possible period formats are:
+;  * $num_$timeunit: 1000_sec, 30_min, 8_hours, 24_hour, 2_days, 3_weeks, 1_month
+;  * $weekday: mon, monday, Thu, thursdays
+;repeat = restart
+
+;[$plugin.skips_dbs]
+; Skip over databases if their names contain any of the strings in this section.
+;string1 = regex1
+;string2 = regex2
+
+;[$plugin.skip_ddocs]
+; For $plugin skip design docs containing string1 or string2 in their ids
+;string1 = regex1
+;string2 = regex2
+
+;[$plugin.skip_docs]
+; For $plugin skip docs containing string1 or string2 in their ids
+;string1 = regex1
+;string2 = regex2
+
+[couch_scanner_plugin_find]
+; Emit verbose logs when executing the "find" plugin. May be useful when
+; debugging or testing.
+;debug = false
+
+[couch_scanner_plugin_find.regexes]
+; Configure regular expressions to find. The format is $tag = $regex Reports
+; will be emitted to the log as warnings mentioning only their tag. By default,
+; no regular expressions are defined and the plugin will run but won't report
+; anything
+;secret1 = regex1
+;secret2 = regex2
+
+[couch_scanner_plugin_ddoc_features]
+; Which ddoc features to scan for. By default it will scan for features slated
+; to be deprecated in CouchDB 4.x:
+;updates = true
+;shows = true
+;lists = true
+;rewrites = true
+;filters = false
+;reduce = false
+;validate_doc_update = false
+
+; Run plugin on the first node or all the nodes. The default
+; is to run only on the first node of the cluster. If the value is "false" each
+; node of the cluster will process a consistent subset of the databases so
+; scanning will go faster but might consume more resources.
+;run_on_first_node = true
+
+; Emit reports for each design doc or aggregate them per database. Emitting
+; them per design doc will indicate the design document name. However, if there
+; are too many design documents, that may generate a lot of logs. The default
+; is to aggregate reports per database.
+;ddoc_report = false

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -62,6 +62,7 @@
         snappy,
         weatherreport,
         couch_prometheus,
+        couch_scanner,
 
         %% extra
         nouveau,
@@ -125,6 +126,7 @@
     {app, snappy, [{incl_cond, include}]},
     {app, weatherreport, [{incl_cond, include}]},
     {app, couch_prometheus, [{incl_cond, include}]},
+    {app, couch_scanner, [{incl_cond, include}]},
 
     %% extra
     {app, nouveau, [{incl_cond, include}]},

--- a/src/couch_scanner/README.md
+++ b/src/couch_scanner/README.md
@@ -1,0 +1,110 @@
+Couch Scanner
+=============
+
+Couch Scanner is an application which traverses all the dbs and docs in the
+background and emits various reports. There is a common traversal mechanism
+which finds all the dbs, design docs, docs and calls various reporting plugins.
+Reporting plugins implement a common API and may search for various strings in
+the doc bodies, examine design docs for certain features, check index sizes, or
+issue any other reports.
+
+Two plugins are initially included with the application are:
+  * [couch_scanner_plugin_find](src/couch_scanner_plugin_find.erl) : Find
+    occurrences of any regular expressions in the cluster. It scans through
+    document bodies, db name and doc ids. This can be used, for instance, to
+    search accidentally leaked secrets (API keys, passwords).
+  * [couch_scanner_ddoc_features](src/couch_scanner_ddoc_features.erl) : Report
+    on various features used by design docs. By default it will report features
+    which will be deprecated in CouchDB 4.x such as shows, lists, rewrites,
+    etc. But also can be configured to search for javascript filter definition,
+    custom javascript reduce functions and a few other things.
+
+By default no plugins are enabled so the scanner application won't do anything.
+Plugins can be enabled in the configuration system by setting:
+
+For instance, to enable `couch_scanner_ddoc_features` plugin use:
+
+```
+[couch_scanner_plugins]
+couch_scanner_plugin_ddoc_features = true
+```
+
+If a node is put in maintenance mode all the plugins will be automatically
+stopped on that node. When node is put back in production plugins will
+automatically resume executing. It's also possible to pause plugin execution in
+a remsh using the `couch_scanner:stop()` and then resume it later with
+`couch_scanner:resume()`.
+
+#### Application Structure
+
+Top level application API is in the [couch_scanner](src/couch_scanner.erl) module.
+
+ * status() -> return running status of plugins
+ * stop() -> stop running plugins on this node
+ * resume() -> resume running plugins on this node
+ * checkpoints() -> inspect the value of all the node local checkpoints
+ * reset_checkpoints() -> delete all the node local checkpoints
+
+#####  couch_scanner_server
+
+Plugins are run as individual processes. These processes are managed by
+[couch_scanner_server](src/couch_scanner_server.erl) gen_server. The gen_server
+inspects `couch_scanner_plugins` config section and then starts a new plugin
+process for each configured plugin. Then it waits for the process to exit. When
+the process exits it may exit normally, crash with an error, or indicate that
+it should be rescheduled to run later. Later rescheduling is indicated by
+exiting with a `{shutdown, {reschedule, UnixTimeSec}}` exit value. If the
+plugin crashes repeatedly it will be penalized with an exponential back-off
+starting at 30 seconds and up to 8 hours.
+
+##### couch_scanner_plugin
+
+Plugin processes are proc_lib processes spawned by the
+[couch_scanner_plugin](src/couch_scanner_plugin.erl) module. After spawning the
+processes will read the previously saved checkpoint from a `_local` checkpoint
+doc in the shards db (`_dbs`) and start traversing databases from the last
+checkpoint.
+
+There is a plugin processes running for each configured plugin. On startup,
+during traversal, checkpointing and before exiting it will call into the
+corresponding API function. This works very much like the gen_server pattern.
+The plugin API behavior is defined in the
+[couch_scanner_plugin](src/couch_scanner_plugin.erl) module as `-callback`
+directives. Plugin modules then refer to it as
+`-behavior(couch_scanner_plugin)`.
+
+Periodically it will checkpoint the last database it processed so if the node
+crashes or is stopped it will continue processing where it left off.
+
+During startup or when finished the plugin may exit with a
+`{shutdown,{reschedule, UnixTimeSec}}` exit message to indicate that it wants
+to be scheduled to run at a later time.
+
+##### couch_scanner_checkpoint
+
+Plugins periodically will checkpoint their database traversal progress to a
+`_local` checkpoint doc in the `_dbs` database. Each plugin has their separate
+checkpoint document. Plugin modules may implement the optional `checkpoint/1`
+API and save some plugin specific data alongside the database traversal
+checkpoint which gets saved automatically. For instance, it maybe useful for
+plugins to save their start up configuration to detect when it changes so they
+could restart their scanning. Or, it they want to accumulate some statistics
+and only emit them at the end of the scan.
+
+Reading and writing to checkpoints is done in the
+[couch_scanner_checkpoint](src/couch_scanner_checkpoint.erl) module. For
+debugging or operational intervention there is a `reset/0` call to delete all
+the checkpoints on the local node.
+
+##### couch_scanner_rate_limiter
+
+[couch_scanner_rate_limiter](src/couch_scanner_rate_limiter.erl). To limit
+plugin resource (CPU / IO) usage there is a rate limiting mechanism to ensure
+all plugins can only open so many dbs and docs per second.
+[couch_scanner_server](src/couch_scanner_server.erl) creates a shared token
+bucket as an Erlang atomics array and periodically fills it with "tokens".
+Plugins consume tokens every time they process a db or document. If they use up
+all the tokens, they start to back-off exponentially. It's a simple AIMD [1]
+algorithm. Parameters to configure it can be found in the `default.ini` file.
+
+[1] https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease

--- a/src/couch_scanner/include/couch_scanner_plugin.hrl
+++ b/src/couch_scanner/include/couch_scanner_plugin.hrl
@@ -1,0 +1,24 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/include/mem3.hrl").
+
+-define(LOG(LVL, FMT, ARGS, META), couch_scanner_util:log(LVL, ?MODULE, FMT, ARGS, META)).
+-define(INFO(FMT, ARGS, META), ?LOG(info, FMT, ARGS, META)).
+-define(INFO(FMT, ARGS), ?LOG(info, FMT, ARGS, #{})).
+-define(INFO(META), ?LOG(info, "", [], META)).
+-define(INFO(), ?LOG(info, "", [], #{})).
+-define(WARN(FMT, ARGS), ?LOG(warning, FMT, ARGS, #{})).
+-define(WARN(FMT, ARGS, META), ?LOG(warning, FMT, ARGS, META)).
+-define(DEBUG(FMT, ARGS), ?LOG(debug, FMT, ARGS, #{fn => ?FUNCTION_NAME})).
+-define(DEBUG(FMT, ARGS, META), ?LOG(debug, FMT, ARGS, META#{fn => ?FUNCTION_NAME})).

--- a/src/couch_scanner/src/couch_scanner.app.src
+++ b/src/couch_scanner/src/couch_scanner.app.src
@@ -1,0 +1,29 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+{application, couch_scanner, [
+    {description, "CouchDB Scanner"},
+    {vsn, git},
+    {registered, [
+        couch_scanner_server
+    ]},
+    {applications, [
+        kernel,
+        stdlib,
+        crypto,
+        config,
+        couch_log,
+        couch_stats,
+        fabric
+    ]},
+    {mod, {couch_scanner_app, []}}
+]}.

--- a/src/couch_scanner/src/couch_scanner.erl
+++ b/src/couch_scanner/src/couch_scanner.erl
@@ -1,0 +1,37 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_scanner).
+
+-export([
+    status/0,
+    stop/0,
+    resume/0,
+    checkpoints/0,
+    reset_checkpoints/0
+]).
+
+status() ->
+    couch_scanner_server:status().
+
+stop() ->
+    couch_scanner_server:stop().
+
+resume() ->
+    couch_scanner_server:resume().
+
+checkpoints() ->
+    couch_scanner_checkpoint:list_all().
+
+reset_checkpoints() ->
+    Fun = fun(Id, #{}) -> couch_scanner_checkpoint:reset(Id) end,
+    maps:map(Fun, checkpoints()).

--- a/src/couch_scanner/src/couch_scanner_app.erl
+++ b/src/couch_scanner/src/couch_scanner_app.erl
@@ -1,0 +1,23 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_scanner_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    couch_scanner_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/src/couch_scanner/src/couch_scanner_checkpoint.erl
+++ b/src/couch_scanner/src/couch_scanner_checkpoint.erl
@@ -1,0 +1,134 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_scanner_checkpoint).
+
+-export([
+    write/2,
+    read/1,
+    reset/1,
+    list_all/0
+]).
+
+-include_lib("couch/include/couch_db.hrl").
+
+-define(PREFIX, "scanner-checkpoint-").
+
+write(<<Plugin/binary>>, #{} = State) ->
+    with_db(fun(Db) -> update_doc(Db, doc_id(Plugin), State) end).
+
+read(<<Plugin/binary>>) ->
+    with_db(fun(Db) -> load_doc(Db, doc_id(Plugin)) end).
+
+reset(<<Plugin/binary>>) ->
+    with_db(fun(Db) -> delete_doc(Db, doc_id(Plugin)) end).
+
+list_all() ->
+    with_db(fun(Db) -> list_all(Db) end).
+
+% Private functions
+
+doc_id(Plugin) ->
+    % Dashes are more conventional for doc ids
+    Plugin1 = binary:replace(Plugin, <<"_">>, <<"-">>, [global]),
+    <<?LOCAL_DOC_PREFIX, ?PREFIX, Plugin1/binary>>.
+
+plugin_id(<<?LOCAL_DOC_PREFIX, ?PREFIX, DocId/binary>>) ->
+    binary:replace(DocId, <<"-">>, <<"_">>, [global]).
+
+delete_doc(Db, DocId) ->
+    case couch_db:open_doc(Db, DocId, []) of
+        {ok, #doc{revs = {_, RevList}}} ->
+            {ok, _} = couch_db:delete_doc(Db, DocId, RevList),
+            ok;
+        {not_found, _} ->
+            ok
+    end.
+
+update_doc(Db, DocId, #{} = Body) ->
+    EJsonBody = ejson_props(Body#{<<"_id">> => DocId}),
+    Doc = couch_doc:from_json_obj(EJsonBody),
+    case couch_db:open_doc(Db, DocId, []) of
+        {ok, #doc{revs = Revs}} ->
+            {ok, _} = couch_db:update_doc(Db, Doc#doc{revs = Revs}, []);
+        {not_found, _} ->
+            {ok, _} = couch_db:update_doc(Db, Doc, [])
+    end,
+    ok.
+
+load_doc(Db, DocId) ->
+    case couch_db:open_doc(Db, DocId, [ejson_body]) of
+        {ok, #doc{body = EJsonBody}} -> ejson_map(EJsonBody);
+        {not_found, _} -> not_found
+    end.
+
+list_all(Db) ->
+    IdPref = <<?LOCAL_DOC_PREFIX, ?PREFIX>>,
+    Len = byte_size(IdPref),
+    FoldFun = fun(#doc{id = Id, body = Body}, #{} = Acc) ->
+        case Id of
+            <<IdPref:Len/binary, _/binary>> ->
+                {ok, Acc#{plugin_id(Id) => ejson_map(Body)}};
+            <<_/binary>> ->
+                {stop, Acc}
+        end
+    end,
+    Opts = [{start_key, IdPref}],
+    {ok, #{} = Docs} = couch_db:fold_local_docs(Db, FoldFun, #{}, Opts),
+    Docs.
+
+with_db(Fun) when is_function(Fun, 1) ->
+    DbName = config:get("mem3", "shards_db", "_dbs"),
+    case mem3_util:ensure_exists(DbName) of
+        {ok, Db} ->
+            try
+                Fun(Db)
+            after
+                catch couch_db:close(Db)
+            end;
+        Else ->
+            throw(Else)
+    end.
+
+ejson_map(Obj) ->
+    couch_scanner_util:ejson_map(Obj).
+
+ejson_props(Obj) ->
+    ?JSON_DECODE(?JSON_ENCODE(Obj)).
+
+-ifdef(TEST).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+couch_scanner_checkpoint_test_() ->
+    {
+        foreach,
+        fun test_util:start_couch/0,
+        fun test_util:stop_couch/1,
+        [
+            ?TDEF_FE(t_read_write_reset)
+        ]
+    }.
+
+t_read_write_reset(_) ->
+    couch_scanner:reset_checkpoints(),
+    Plugin = <<"scanner_plugin_abc">>,
+    ?assertEqual(ok, write(Plugin, #{<<"foo">> => 1})),
+    ?assertEqual(#{<<"foo">> => 1}, read(Plugin)),
+    ?assertEqual(ok, write(Plugin, #{<<"bar">> => 2})),
+    ?assertEqual(#{<<"bar">> => 2}, read(Plugin)),
+    ?assertEqual(#{<<"scanner_plugin_abc">> => #{<<"bar">> => 2}}, list_all()),
+    ?assertEqual(not_found, read(<<"scanner_plugin_other">>)),
+    ?assertEqual(ok, reset(Plugin)),
+    ?assertEqual(not_found, read(Plugin)).
+
+-endif.

--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -1,0 +1,660 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+% Scanner plugin runner process
+%
+% This is the process which is spawned and run for each enabled plugin.
+%
+% A number of these processes are managed by the couch_scanner_server via
+% start_link/1 and complete/1 functions. After a plugin runner is spawned, the only
+% thing couch_scanner_server does is wait for it to exit.
+%
+% The plugin runner process may exit normally, crash, or exit with {shutdown,
+% {reschedule, TSec}} if they want to reschedule to run again at some point the
+% future (next day, a week later, etc).
+%
+% After the process starts, it will load and validate the plugin module. Then,
+% it will start scanning all the dbs and docs on the local node. Shard ranges
+% will be scanned only on one of the cluster nodes to avoid duplicating work.
+% For instance, if there are 2 shard ranges, 0-7, 8-f, with copies on nodes n1,
+% n2, n3. Then, 0-7 might be scanned on n1 only, and 8-f on n3.
+%
+% The plugin API defined in the behavior definition section.
+%
+% The start/2 function is called when the plugin starts running. It returns
+% some context (St), which can be any Erlang term. All subsequent function
+% calls will be called with the same St object, and may return an updated
+% version of it.
+%
+% If the plugin hasn't completed runing and has resumed running after the node
+% was restarted or an error happened, the resume/2 function will be called.
+% That's the difference between start and resume: start/2 is called when the
+% scan starts from the beginning (first db, first shard, ...), and resume/2 is
+% called when the scanning hasn't finished and has to continue.
+%
+% If start/2 or resume/2 returns `reset` then the checkpoint will be reset and
+% the plugin will be restarted. This may be useful in cases when the plugin
+% detects configuration changes since last scanning session had already
+% started, or when the plugin module was updated and the checkpoint version is
+% stale.
+%
+% The checkpoint/1 callback is periodically called to checkpoint the scanning
+% progress. start/2 and resume/2 function will be called with the last saved
+% checkpoint map value.
+%
+% The complete/1 callback is called when the scan has finished. The complete
+% callback should return final checkpoint map object. The last checkoint will
+% be written and then it will be passed to the start/2 callback if the plugin
+% runs again.
+%
+% As the cluster dbs, shards, ddocs and individual docs are discovered during
+% scanning, the appropriate callbacks will be called. Most callbacks, besides
+% the updated St object, can reply with ok, skip or complete tags. The meaning of
+% those are:
+%
+%   * ok  - continue to the next object
+%
+%   * skip - skip the current object and don't scan its internal (ex: skip a db
+%     and don't scan its ddocs, but continue with the next db)
+%
+%   * stop - stop scanning any remaining objects of that type (ex: don't scan
+%     any more dbs)
+%
+%   * reset - stop, reset the checkpoint data and restart, this may be useful
+%     if the configuration changes and it's best to just restart with the new
+%     settings
+
+-module(couch_scanner_plugin).
+
+-export([
+    % Main plugin process API
+    spawn_link/1,
+    stop/1,
+    % Internal export
+    run/1
+]).
+
+-include_lib("couch_scanner/include/couch_scanner_plugin.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl").
+
+% Behaviour callback definitions
+
+-callback start(ScanId :: binary(), EJson :: #{}) ->
+    {ok, St :: term()} | skip | reset.
+
+-callback resume(ScanId :: binary(), EJson :: #{}) ->
+    {ok, St :: term()} | skip | reset.
+
+% Optional
+-callback complete(St :: term()) ->
+    {ok, EJson :: #{}}.
+
+% Optional
+-callback checkpoint(St :: term()) ->
+    {ok, EJson :: #{}}.
+
+-callback db(St :: term(), DbName :: binary()) ->
+    {ok | skip | stop, St1 :: term()}.
+
+% Optional
+-callback ddoc(St :: term(), DbName :: binary(), #doc{}) ->
+    {ok | stop, St1 :: term()}.
+
+% Optional. If no subsequent callbacks are defined, then the default function
+% returns [] (don't open any shards). If any subsequent callbacks are defined,
+% the default action is to return all the shards in the list.
+-callback shards(St :: term(), [#shard{}]) ->
+    {[#shard{}], St1 :: term()}.
+
+% Optional
+-callback db_opened(St :: term(), Db :: term()) ->
+    {ok, St :: term()}.
+
+% Optional. If doc is not defined, then ddoc_id default action is {skip, St}.
+% If it is defined, the default action is {ok, St}.
+-callback doc_id(St :: term(), DocId :: binary(), Db :: term()) ->
+    {ok | skip | stop, St1 :: term()}.
+
+% Optional.
+-callback doc(St :: term(), Db :: term(), #doc{}) ->
+    {ok | stop, St1 :: term()}.
+
+% Optional.
+-callback db_closing(St :: term(), Db :: term()) ->
+    {ok, St1 :: term()}.
+
+-optional_callbacks([
+    complete/1,
+    checkpoint/1,
+    ddoc/3,
+    shards/2,
+    db_opened/2,
+    doc_id/3,
+    doc/3,
+    db_closing/2
+]).
+
+-define(CALLBACKS, [
+    {start, 2, fun required_callback/3},
+    {resume, 2, fun required_callback/3},
+    {complete, 1, fun default_complete/3},
+    {checkpoint, 1, fun default_checkpoint/3},
+    {db, 2, fun required_callback/3},
+    {ddoc, 3, fun default_ddoc/3},
+    {shards, 2, fun default_shards/3},
+    {db_opened, 2, fun default_db_opened/3},
+    {doc_id, 3, fun default_doc_id/3},
+    {doc, 3, fun default_doc/3},
+    {db_closing, 2, fun default_db_closing/3}
+]).
+
+-define(CHECKPOINT_INTERVAL_SEC, 10).
+-define(STOP_TIMEOUT_SEC, 5).
+
+-record(st, {
+    id,
+    rlimiter,
+    scan_id,
+    mod,
+    callbacks = #{},
+    pst,
+    dbname,
+    cursor,
+    shards_db,
+    db,
+    checkpoint_sec = 0,
+    start_sec = 0,
+    skip_dbs,
+    skip_ddocs,
+    skip_docs
+}).
+
+spawn_link(Id) ->
+    proc_lib:spawn_link(?MODULE, run, [Id]).
+
+stop(Pid) when is_pid(Pid) ->
+    unlink(Pid),
+    Ref = erlang:monitor(process, Pid),
+    Pid ! stop,
+    receive
+        {'DOWN', Ref, _, _, _} -> ok
+    after ?STOP_TIMEOUT_SEC * 1000 ->
+        exit(Pid, kill),
+        receive
+            {'DOWN', Ref, _, _, _} -> ok
+        end
+    end,
+    ok.
+
+% Main run function
+
+run(Id) ->
+    RLimiter = couch_scanner_rate_limiter:get(),
+    {Mod, Callbacks} = plugin_mod(Id),
+    St = #st{
+        id = Id,
+        mod = Mod,
+        callbacks = Callbacks,
+        rlimiter = RLimiter
+    },
+    St1 = init_config(St),
+    St2 = init_from_checkpoint(St1),
+    St3 = scan_dbs(St2),
+    finalize(St3).
+
+% Private functions
+
+init_config(#st{mod = Mod} = St) ->
+    St#st{
+        skip_dbs = config_match_patterns(Mod, "skip_dbs"),
+        skip_ddocs = config_match_patterns(Mod, "skip_ddocs"),
+        skip_docs = config_match_patterns(Mod, "skip_docs")
+    }.
+
+init_from_checkpoint(#st{} = St) ->
+    #st{id = Id, mod = Mod, callbacks = Cbks} = St,
+    case couch_scanner_checkpoint:read(Id) of
+        #{
+            <<"state">> := <<"running">>,
+            <<"cursor">> := Cur,
+            <<"scan_id">> := SId,
+            <<"pst">> := EJsonPSt,
+            <<"start_sec">> := StartSec
+        } ->
+            Now = tsec(),
+            PSt = resume_callback(Cbks, SId, EJsonPSt),
+            St#st{
+                pst = PSt,
+                cursor = Cur,
+                checkpoint_sec = Now,
+                start_sec = StartSec,
+                scan_id = SId
+            };
+        not_found ->
+            SId = couch_scanner_util:new_scan_id(),
+            Now = tsec(),
+            LastStartSec = 0,
+            Cur = <<>>,
+            PSt = start_callback(Mod, Cbks, Now, SId, LastStartSec, #{}),
+            ok = start_checkpoint(Id, Cbks, Now, SId, Cur, PSt),
+            St#st{
+                pst = PSt,
+                cursor = Cur,
+                checkpoint_sec = 0,
+                start_sec = Now,
+                scan_id = SId
+            };
+        #{
+            <<"state">> := <<"finished">>,
+            <<"pst">> := EJson,
+            <<"start_sec">> := LastStartSec
+        } ->
+            SId = couch_scanner_util:new_scan_id(),
+            Now = tsec(),
+            Cur = <<>>,
+            PSt = start_callback(Mod, Cbks, Now, SId, LastStartSec, EJson),
+            ok = start_checkpoint(Id, Cbks, Now, SId, Cur, PSt),
+            St#st{
+                pst = PSt,
+                cursor = Cur,
+                checkpoint_sec = Now,
+                start_sec = Now,
+                scan_id = SId
+            }
+    end.
+
+scan_dbs(#st{cursor = Cursor} = St) ->
+    ShardsDbName = mem3_sync:shards_db(),
+    ioq:set_io_priority({system, ShardsDbName}),
+    {ok, Db} = mem3_util:ensure_exists(ShardsDbName),
+    St1 = St#st{shards_db = Db},
+    Opts = [{start_key, Cursor}],
+    try
+        {ok, St2} = couch_db:fold_docs(Db, fun scan_dbs_fold/2, St1, Opts),
+        St2#st{shards_db = undefined}
+    after
+        couch_db:close(Db)
+    end.
+
+scan_dbs_fold(#full_doc_info{} = FDI, #st{shards_db = Db} = Acc) ->
+    Acc1 = Acc#st{cursor = FDI#full_doc_info.id},
+    Acc2 = maybe_checkpoint(Acc1),
+    case couch_db:open_doc(Db, FDI, [ejson_body]) of
+        {ok, #doc{deleted = true}} ->
+            {ok, Acc2};
+        {ok, #doc{id = DbName, body = Body}} ->
+            Shards = shards(DbName, Body),
+            Acc3 = Acc2#st{dbname = DbName},
+            {Go, Acc4} = scan_db(Shards, Acc3),
+            {Go, Acc4#st{dbname = undefined}};
+        {not_found, _} ->
+            {ok, Acc2}
+    end.
+
+scan_db([], #st{} = St) ->
+    {ok, St};
+scan_db([_ | _] = Shards, #st{} = St) ->
+    #st{dbname = DbName, callbacks = Cbks, pst = PSt, skip_dbs = Skip} = St,
+    #{db := DbCbk} = Cbks,
+    case match_skip_pat(DbName, Skip) of
+        false ->
+            {Go, PSt1} = DbCbk(PSt, DbName),
+            St1 = St#st{pst = PSt1},
+            case Go of
+                ok ->
+                    St2 = rate_limit(St1, db),
+                    St3 = fold_ddocs(fun scan_ddocs_fold/2, St2),
+                    {Shards1, St4} = shards_callback(St3, Shards),
+                    St5 = scan_shards(Shards1, St4),
+                    {ok, St5};
+                skip ->
+                    {ok, St1};
+                stop ->
+                    {stop, St1}
+            end;
+        true ->
+            {ok, St}
+    end.
+
+scan_ddocs_fold({meta, _}, #st{} = Acc) ->
+    {ok, Acc};
+scan_ddocs_fold({row, RowProps}, #st{} = Acc) ->
+    DDoc = couch_util:get_value(doc, RowProps),
+    scan_ddoc(couch_doc:from_json_obj(DDoc), Acc);
+scan_ddocs_fold(complete, #st{} = Acc) ->
+    {ok, Acc};
+scan_ddocs_fold({error, Error}, _Acc) ->
+    exit({shutdown, {scan_ddocs_fold, Error}}).
+
+scan_shards([], #st{} = St) ->
+    St;
+scan_shards([#shard{} = Shard | Rest], #st{} = St) ->
+    St1 = scan_docs(St, Shard),
+    scan_shards(Rest, St1).
+
+scan_ddoc(#doc{id = DDocId} = DDoc, #st{} = St) ->
+    #st{dbname = DbName, callbacks = Cbks, pst = PSt, skip_ddocs = Skip} = St,
+    #{ddoc := DDocCbk} = Cbks,
+    case match_skip_pat(DDocId, Skip) of
+        false ->
+            {Go, PSt1} = DDocCbk(PSt, DbName, DDoc),
+            St1 = St#st{pst = PSt1},
+            case Go of
+                ok -> {ok, St1};
+                stop -> {stop, St1}
+            end;
+        true ->
+            {ok, St}
+    end.
+
+scan_docs(#st{} = St, #shard{name = ShardDbName}) ->
+    St1 = rate_limit(St, shard),
+    case couch_db:open_int(ShardDbName, [?ADMIN_CTX]) of
+        {ok, Db} ->
+            St2 = St1#st{db = Db},
+            St3 = db_opened_callback(St2),
+            {ok, St4} = couch_db:fold_docs(Db, fun scan_docs_fold/2, St3, []),
+            St5 = db_closing_callback(St4),
+            couch_db:close(Db),
+            erlang:garbage_collect(),
+            St5#st{db = undefined};
+        {not_found, _} ->
+            St1
+    end.
+
+scan_docs_fold(#full_doc_info{id = Id} = FDI, #st{} = St) ->
+    #st{db = Db, callbacks = Cbks, pst = PSt, skip_docs = Skip} = St,
+    #{doc_id := DocIdCbk} = Cbks,
+    case match_skip_pat(Id, Skip) of
+        false ->
+            {Go, PSt1} = DocIdCbk(PSt, Id, Db),
+            St1 = St#st{pst = PSt1},
+            case Go of
+                ok -> scan_doc(FDI, St1);
+                skip -> {ok, St1};
+                stop -> {stop, St1}
+            end;
+        true ->
+            {ok, St}
+    end.
+
+scan_doc(#full_doc_info{} = FDI, #st{} = St) ->
+    #st{db = Db, callbacks = Cbks, pst = PSt} = St,
+    St1 = rate_limit(St, doc),
+    {ok, #doc{} = Doc} = couch_db:open_doc(Db, FDI, [ejson_body]),
+    #{doc := DocCbk} = Cbks,
+    {Go, PSt1} = DocCbk(PSt, Db, Doc),
+    case Go of
+        ok -> {ok, St1#st{pst = PSt1}};
+        stop -> {stop, St1#st{pst = PSt1}}
+    end.
+
+maybe_checkpoint(#st{checkpoint_sec = LastCheckpointTSec} = St) ->
+    receive
+        stop -> exit({shutdown, stop})
+    after 0 -> ok
+    end,
+    erlang:garbage_collect(),
+    case tsec() - LastCheckpointTSec > ?CHECKPOINT_INTERVAL_SEC of
+        true -> checkpoint(St);
+        false -> St
+    end.
+
+rate_limit(#st{rlimiter = RLimiter} = St, Type) ->
+    {WaitMSec, RLimiter1} = couch_scanner_rate_limiter:update(RLimiter, Type),
+    receive
+        stop -> exit({shutdown, stop})
+    after WaitMSec -> St#st{rlimiter = RLimiter1}
+    end.
+
+checkpoint(#st{} = St) ->
+    #st{
+        id = Id,
+        callbacks = Cbks,
+        pst = PSt,
+        cursor = Cursor,
+        start_sec = StartSec,
+        scan_id = SId
+    } = St,
+    EJsonPSt = checkpoint_callback(Cbks, PSt),
+    EJson = #{
+        <<"cursor">> => Cursor,
+        <<"pst">> => EJsonPSt,
+        <<"state">> => <<"running">>,
+        <<"scan_id">> => SId,
+        <<"start_sec">> => StartSec
+    },
+    ok = couch_scanner_checkpoint:write(Id, EJson),
+    St#st{checkpoint_sec = tsec()}.
+
+finalize(#st{} = St) ->
+    #st{
+        id = Id,
+        mod = Mod,
+        callbacks = Cbks,
+        pst = PSt,
+        start_sec = StartSec,
+        scan_id = SId
+    } = St,
+    #{complete := CompleteCbk} = Cbks,
+    {ok, #{} = PStEJson} = CompleteCbk(PSt),
+    EJson = #{
+        <<"cursor">> => <<>>,
+        <<"pst">> => couch_scanner_util:ejson_map(PStEJson),
+        <<"state">> => <<"finished">>,
+        <<"scan_id">> => SId,
+        <<"start_sec">> => StartSec
+    },
+    ok = couch_scanner_checkpoint:write(Id, EJson),
+    case schedule_time(Mod, StartSec, tsec()) of
+        infinity -> ok;
+        TSec when is_integer(TSec) -> exit_resched(TSec)
+    end.
+
+exit_resched(reset) ->
+    % Reset the checkpoint and restart with a fresh config
+    exit({shutdown, reset});
+exit_resched(infinity) ->
+    exit({shutdown, {reschedule, infinity}});
+exit_resched(TimeSec) when is_integer(TimeSec) ->
+    exit({shutdown, {reschedule, TimeSec}}).
+
+% Call plugin module API functions
+
+start_callback(Mod, Cbks, Now, ScanId, LastStartSec, #{} = EJson) when
+    is_atom(Mod), is_binary(ScanId), is_integer(LastStartSec)
+->
+    case schedule_time(Mod, LastStartSec, Now) of
+        infinity ->
+            exit_resched(infinity);
+        TSec when is_integer(TSec), TSec =< Now ->
+            #{start := StartCbk} = Cbks,
+            case StartCbk(ScanId, EJson) of
+                {ok, PSt} -> PSt;
+                skip -> exit_resched(infinity);
+                reset -> exit_resched(reset)
+            end;
+        TSec when is_integer(TSec), TSec > Now ->
+            exit_resched(TSec)
+    end.
+
+resume_callback(#{} = Cbks, SId, #{} = EJsonPSt) when is_binary(SId) ->
+    #{resume := ResumeCbk} = Cbks,
+    case ResumeCbk(SId, EJsonPSt) of
+        {ok, PSt} -> PSt;
+        skip -> exit_resched(infinity);
+        reset -> exit_resched(reset)
+    end.
+
+db_opened_callback(#st{pst = PSt, callbacks = Cbks, db = Db} = St) ->
+    #{db_opened := DbOpenedCbk} = Cbks,
+    {ok, PSt1} = DbOpenedCbk(PSt, Db),
+    St#st{pst = PSt1}.
+
+db_closing_callback(#st{pst = PSt, callbacks = Cbks, db = Db} = St) ->
+    #{db_closing := DbClosingCbk} = Cbks,
+    {ok, PSt1} = DbClosingCbk(PSt, Db),
+    St#st{pst = PSt1}.
+
+shards_callback(#st{pst = PSt, callbacks = Cbks} = St, Shards) ->
+    #{shards := ShardsCbk} = Cbks,
+    {Shards1, PSt1} = ShardsCbk(PSt, Shards),
+    {Shards1, St#st{pst = PSt1}}.
+
+start_checkpoint(Id, #{} = Cbks, StartSec, ScanId, Cur, PSt) when
+    is_binary(Id), is_binary(ScanId), is_integer(StartSec)
+->
+    EJsonPSt = checkpoint_callback(Cbks, PSt),
+    EJson = #{
+        <<"cursor">> => Cur,
+        <<"pst">> => EJsonPSt,
+        <<"state">> => <<"running">>,
+        <<"scan_id">> => ScanId,
+        <<"start_sec">> => StartSec
+    },
+    ok = couch_scanner_checkpoint:write(Id, EJson).
+
+checkpoint_callback(#{} = Cbks, PSt) ->
+    #{checkpoint := CheckpointCbk} = Cbks,
+    case CheckpointCbk(PSt) of
+        {ok, #{} = EJsonPSt} -> couch_scanner_util:ejson_map(EJsonPSt);
+        reset -> exit_resched(reset)
+    end.
+
+% Plugin discovery, loading and validation
+
+plugin_mod(<<Plugin/binary>>) ->
+    Mod = binary_to_atom(Plugin),
+    case code:ensure_loaded(Mod) of
+        {module, _} ->
+            lists:foldl(fun callback_fold/2, {Mod, #{}}, ?CALLBACKS);
+        {error, Error} ->
+            error({?MODULE, {missing_plugin_module, Mod, Error}})
+    end.
+
+callback_fold({F, A, Spec}, {Mod, Acc}) ->
+    case is_exported(Mod, F, A) of
+        true -> {Mod, Acc#{F => fun Mod:F/A}};
+        false -> {Mod, Acc#{F => Spec(Mod, F, A)}}
+    end.
+
+required_callback(Mod, F, A) ->
+    error({?MODULE, {undefined_plugin_fun, Mod, F, A}}).
+
+default_complete(Mod, _F, _A) when is_atom(Mod) ->
+    fun(_St) -> {ok, #{}} end.
+
+default_checkpoint(Mod, _F, _A) when is_atom(Mod) ->
+    fun(_St) -> {ok, #{}} end.
+
+default_ddoc(Mod, _F, _A) when is_atom(Mod) ->
+    fun(St, _DbName, _Doc) -> {stop, St} end.
+
+default_shards(Mod, _F, _A) when is_atom(Mod) ->
+    % If any subsequent callbacks are
+    % defined, then the default function is to
+    % traverse all shards, otherwise if they are
+    % not defined, the default action is to skip
+    % opening shard files
+    case
+        is_exported(Mod, db_opened, 2) orelse
+            is_exported(Mod, doc_id, 3) orelse
+            is_exported(Mod, doc, 3) orelse
+            is_exported(Mod, db_closing, 2)
+    of
+        true -> fun(St, Shards) -> {Shards, St} end;
+        false -> fun(St, _Shards) -> {[], St} end
+    end.
+
+default_db_opened(Mod, _F, _A) when is_atom(Mod) ->
+    fun(St, _Db) -> {ok, St} end.
+
+default_doc_id(Mod, _F, _A) when is_atom(Mod) ->
+    case is_exported(Mod, doc, 3) of
+        true -> fun(St, _DocId, _Db) -> {ok, St} end;
+        false -> fun(St, _DocId, _Db) -> {skip, St} end
+    end.
+
+default_doc(Mod, _F, _A) when is_atom(Mod) ->
+    fun(St, _Db, _Doc) -> {ok, St} end.
+
+default_db_closing(Mod, _F, _A) when is_atom(Mod) ->
+    fun(St, _Db) -> {ok, St} end.
+
+is_exported(Mod, F, A) ->
+    erlang:function_exported(Mod, F, A).
+
+% Shard selection
+
+shards(DbName, {Props = [_ | _]}) ->
+    Shards = lists:sort(mem3_util:build_shards(DbName, Props)),
+    Fun = fun({R, SList}) ->
+        case mem3_util:rotate_list({DbName, R}, SList) of
+            [#shard{node = N} = S | _] when N =:= node() ->
+                {true, S};
+            [_ | _] ->
+                false
+        end
+    end,
+    lists:filtermap(Fun, shards_by_range(lists:sort(Shards))).
+
+shards_by_range(Shards) ->
+    Fun = fun(#shard{range = R} = S, Acc) -> orddict:append(R, S, Acc) end,
+    Dict = lists:foldl(Fun, orddict:new(), Shards),
+    orddict:to_list(Dict).
+
+% Design doc fetching helper
+
+fold_ddocs(Fun, #st{dbname = DbName} = Acc) ->
+    QArgs = #mrargs{
+        include_docs = true,
+        extra = [{namespace, <<"_design">>}]
+    },
+    try
+        {ok, Acc1} = fabric:all_docs(DbName, [?ADMIN_CTX], Fun, Acc, QArgs),
+        Acc1
+    catch
+        error:database_does_not_exist ->
+            Acc
+    end.
+
+% Skip patterns
+
+% Build the skip patterns from a config section
+config_match_patterns(Module, Type) ->
+    Section = atom_to_list(Module) ++ "." ++ Type,
+    RegexKVs = config:get(Section),
+    Regexes = couch_scanner_util:load_regexes(RegexKVs),
+    couch_scanner_util:compile_regexes(Regexes).
+
+% Match skip patterns. If no pattern specified we don't skip
+% i.e. skip returns `false`
+match_skip_pat(<<_/binary>>, #{} = Pats) when map_size(Pats) == 0 ->
+    false;
+match_skip_pat(<<_/binary>> = Bin, #{} = Pats) ->
+    case couch_scanner_util:match_regexes(Bin, Pats) of
+        {match, _} -> true;
+        nomatch -> false
+    end.
+
+cfg(Mod, Key, Default) when is_list(Key) ->
+    Section = atom_to_list(Mod),
+    config:get(Section, Key, Default).
+
+schedule_time(Mod, LastSec, NowSec) ->
+    After = cfg(Mod, "after", "restart"),
+    Repeat = cfg(Mod, "repeat", "restart"),
+    Restart = couch_scanner_util:restart_tsec(),
+    couch_scanner_util:schedule_time(NowSec, LastSec, Restart, After, Repeat).
+
+tsec() ->
+    erlang:system_time(second).

--- a/src/couch_scanner/src/couch_scanner_plugin_ddoc_features.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin_ddoc_features.erl
@@ -1,0 +1,235 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+% Scanner plugin to detect various design document features
+%
+% By default when enabled it will scan design documents for features slated to be
+% deprecated in 4.0 such as: rewrites, lists, shows, updates. There are options
+% to enable other feature checks: custom JS reducers, JS libraries, VDU functions,
+% and JS filters.
+%
+% By default the scanning will start and run on the first node of the cluster only.
+% It's possible to make the plugin run on all the and each node will pick a fraction
+% of dbs to scan. That will make the scan go fast but might consume more resources. That options
+% is contorlled via the run_on_first_node boolean setting.
+%
+% When features are detected they are aggregated per database and reported once all the
+% design documents for a particular database have been processed. To get details about
+% the specific design document enable the ddoc_report = true setting.
+%
+
+-module(couch_scanner_plugin_ddoc_features).
+-behaviour(couch_scanner_plugin).
+
+-export([
+    start/2,
+    resume/2,
+    complete/1,
+    checkpoint/1,
+    db/2,
+    ddoc/3
+]).
+
+-include_lib("couch_scanner/include/couch_scanner_plugin.hrl").
+
+-record(st, {
+    sid,
+    dbname,
+    report = #{},
+    opts = #{},
+    run_on_first_node = true,
+    ddoc_report = false
+}).
+
+-define(UPDATES, <<"updates">>).
+-define(SHOWS, <<"shows">>).
+-define(LISTS, <<"lists">>).
+-define(REWRITES, <<"rewrites">>).
+-define(FILTERS, <<"filters">>).
+-define(REDUCE, <<"reduce">>).
+-define(VDU, <<"validate_doc_update">>).
+-define(VIEWS, <<"views">>).
+
+-define(OPTS, #{
+    ?UPDATES => true,
+    ?SHOWS => true,
+    ?LISTS => true,
+    ?REWRITES => true,
+    ?FILTERS => false,
+    ?REDUCE => false,
+    ?VDU => false
+}).
+
+% Behavior callbacks
+
+start(SId, #{}) ->
+    St = init_config(#st{sid = SId}),
+    case should_run(St) of
+        true ->
+            ?INFO("Starting.", [], #{sid => SId}),
+            {ok, St};
+        false ->
+            ?INFO("Not starting. Not on first node.", [], #{sid => SId}),
+            skip
+    end.
+
+resume(SId, #{<<"opts">> := OldOpts}) ->
+    St = init_config(#st{sid = SId}),
+    case {OldOpts == St#st.opts, should_run(St)} of
+        {true, true} ->
+            ?INFO("Resuming.", [], #{sid => SId}),
+            {ok, St};
+        {false, true} ->
+            ?INFO("Resetting. Config changed.", [], #{sid => SId}),
+            reset;
+        {_, false} ->
+            ?INFO("Not resuming. Not on first node.", [], #{sid => SId}),
+            skip
+    end.
+
+complete(#st{sid = SId, dbname = DbName, report = Report} = St) ->
+    report_per_db(St, DbName, Report),
+    ?INFO("Completed", [], #{sid => SId}),
+    {ok, #{}}.
+
+checkpoint(#st{sid = SId, opts = Opts}) ->
+    case Opts == opts() of
+        true ->
+            {ok, #{<<"opts">> => Opts}};
+        false ->
+            ?INFO("Resetting. Config changed.", [], #{sid => SId}),
+            reset
+    end.
+
+db(#st{} = St, DbName) ->
+    case St#st.run_on_first_node of
+        true ->
+            {ok, St};
+        false ->
+            % If we run on all nodes spread db checks across nodes
+            case couch_scanner_util:consistent_hash_nodes(DbName) of
+                true -> {ok, St};
+                false -> {skip, St}
+            end
+    end.
+
+ddoc(#st{} = St, _DbName, #doc{id = <<"_design/_", _/binary>>}) ->
+    % These are auto-inserted ddocs _design/_auth, etc.
+    {ok, St};
+ddoc(#st{} = St, DbName, #doc{} = DDoc) ->
+    #doc{body = {Props = [_ | _]}} = DDoc,
+    case couch_util:get_value(<<"language">>, Props, <<"javascript">>) of
+        <<"javascript">> -> {ok, check_ddoc(St, DbName, DDoc)};
+        _ -> {ok, St}
+    end.
+
+% Private
+
+init_config(#st{} = St) ->
+    St#st{
+        opts = opts(),
+        run_on_first_node = cfg_bool("run_on_first_node", St#st.run_on_first_node),
+        ddoc_report = cfg_bool("ddoc_report", St#st.ddoc_report)
+    }.
+
+should_run(#st{run_on_first_node = true}) ->
+    couch_scanner_util:on_first_node();
+should_run(#st{run_on_first_node = false}) ->
+    true.
+
+check_ddoc(#st{opts = Opts} = St, DbName, #doc{} = DDoc0) ->
+    #doc{id = DDocId, body = Body} = DDoc0,
+    DDoc = couch_scanner_util:ejson_map(Body),
+    {_Opts, Report} = maps:fold(fun check/3, {Opts, #{}}, DDoc),
+    report(St, DbName, DDocId, Report).
+
+check(?UPDATES, #{} = Obj, {#{?UPDATES := true} = Opts, Rep}) ->
+    {Opts, bump(?UPDATES, map_size(Obj), Rep)};
+check(?REWRITES, <<_/binary>>, {#{?REWRITES := true} = Opts, Rep}) ->
+    {Opts, bump(?REWRITES, 1, Rep)};
+check(?REWRITES, Arr, {#{?REWRITES := true} = Opts, Rep}) when is_list(Arr) ->
+    {Opts, bump(?REWRITES, length(Arr), Rep)};
+check(?SHOWS, #{} = Obj, {#{?SHOWS := true} = Opts, Rep}) ->
+    {Opts, bump(?SHOWS, map_size(Obj), Rep)};
+check(?LISTS, #{} = Obj, {#{?LISTS := true} = Opts, Rep}) ->
+    {Opts, bump(?LISTS, map_size(Obj), Rep)};
+check(?FILTERS, #{} = Obj, {#{?FILTERS := true} = Opts, Rep}) ->
+    {Opts, bump(?FILTERS, map_size(Obj), Rep)};
+check(?VDU, <<_/binary>>, {#{?VDU := true} = Opts, Rep}) ->
+    {Opts, bump(?VDU, 1, Rep)};
+check(?VIEWS, #{} = Views, {#{?REDUCE := true} = Opts, Rep}) ->
+    {_, Rep1} = maps:fold(fun check_view/3, {Opts, Rep}, Views),
+    {Opts, Rep1};
+check(<<_/binary>>, _, {#{} = Opts, #{} = Rep}) ->
+    {Opts, Rep}.
+
+check_view(_Name, #{?REDUCE := <<"_", _/binary>>}, {#{} = Opts, #{} = Rep}) ->
+    % Built-in reducers
+    {Opts, Rep};
+check_view(_Name, #{?REDUCE := <<_/binary>>}, {#{} = Opts, #{} = Rep}) ->
+    {Opts, bump(?REDUCE, 1, Rep)};
+check_view(_Name, _, {#{} = Opts, #{} = Rep}) ->
+    {Opts, Rep}.
+
+bump(Field, N, #{} = Rep) ->
+    maps:update_with(Field, fun(V) -> V + N end, N, Rep).
+
+report(#st{} = St, _, _, #{} = Report) when map_size(Report) == 0 ->
+    St;
+report(#st{} = St, DbName, DDocId, #{} = Report) ->
+    #st{report = Total, dbname = PrevDbName} = St,
+    report_per_ddoc(#st{} = St, DbName, DDocId, Report),
+    case is_binary(PrevDbName) andalso DbName =/= PrevDbName of
+        true ->
+            % We switched dbs, so report stats for old db
+            % and make the new one the current one
+            report_per_db(St, PrevDbName, Total),
+            St#st{report = Report, dbname = DbName};
+        false ->
+            % Keep accumulating per-db stats
+            St#st{report = merge_report(Total, Report), dbname = DbName}
+    end.
+
+merge_report(#{} = Total, #{} = Update) ->
+    Fun = fun(_K, V1, V2) -> V1 + V2 end,
+    maps:merge_with(Fun, Total, Update).
+
+report_per_db(#st{sid = SId}, DbName, #{} = Report) when
+    map_size(Report) > 0, is_binary(DbName)
+->
+    {Fmt, Args} = report_fmt(Report),
+    Meta = #{sid => SId, db => DbName},
+    ?WARN(Fmt, Args, Meta);
+report_per_db(#st{}, _, _) ->
+    ok.
+
+report_per_ddoc(#st{ddoc_report = false}, _DbName, _DDocId, _Report) ->
+    ok;
+report_per_ddoc(#st{ddoc_report = true, sid = SId}, DbName, DDocId, Report) ->
+    {Fmt, Args} = report_fmt(Report),
+    Meta = #{sid => SId, db => DbName, ddoc => DDocId},
+    ?WARN(Fmt, Args, Meta).
+
+report_fmt(Report) ->
+    Sorted = lists:sort(maps:to_list(Report)),
+    FmtArgs = [{"~s:~p ", [K, V]} || {K, V} <- Sorted],
+    {Fmt1, Args1} = lists:unzip(FmtArgs),
+    Fmt2 = lists:flatten(Fmt1),
+    Args2 = lists:flatten(Args1),
+    {Fmt2, Args2}.
+
+opts() ->
+    Fun = fun(Key, Default) -> cfg_bool(binary_to_list(Key), Default) end,
+    maps:map(Fun, ?OPTS).
+
+cfg_bool(Key, Default) when is_list(Key), is_boolean(Default) ->
+    config:get_boolean(atom_to_list(?MODULE), Key, Default).

--- a/src/couch_scanner/src/couch_scanner_plugin_find.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin_find.erl
@@ -1,0 +1,135 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+% Scanner plugin to find document contents matching a regular experssion.
+%
+
+-module(couch_scanner_plugin_find).
+
+-behaviour(couch_scanner_plugin).
+
+-export([
+    start/2,
+    resume/2,
+    complete/1,
+    checkpoint/1,
+    db/2,
+    ddoc/3,
+    shards/2,
+    db_opened/2,
+    doc_id/3,
+    doc/3,
+    db_closing/2
+]).
+
+-include_lib("couch_scanner/include/couch_scanner_plugin.hrl").
+
+-record(st, {
+    sid,
+    regexes = #{},
+    compiled_regexes = #{}
+}).
+
+% Behavior callbacks
+
+start(SId, #{}) ->
+    ?INFO("Starting.", [], #{sid => SId}),
+    St = #st{sid = SId, regexes = regexes()},
+    {ok, compile_regexes(St)}.
+
+resume(SId, #{<<"regexes">> := OldRegexes}) ->
+    Regexes = regexes(),
+    case OldRegexes == Regexes of
+        true ->
+            ?INFO("Resuming.", [], #{sid => SId}),
+            St = #st{sid = SId, regexes = Regexes},
+            {ok, compile_regexes(St)};
+        false ->
+            ?INFO("Resetting. Config changed.", [], #{sid => SId}),
+            reset
+    end.
+
+complete(#st{sid = SId}) ->
+    ?INFO("Completed", [], #{sid => SId}),
+    {ok, #{}}.
+
+checkpoint(#st{sid = SId, regexes = CurRegexes}) ->
+    case CurRegexes == regexes() of
+        true ->
+            {ok, #{<<"regexes">> => CurRegexes}};
+        false ->
+            ?INFO("Resetting. Config changed.", [], #{sid => SId}),
+            reset
+    end.
+
+db(#st{} = St, DbName) ->
+    #st{sid = SId, compiled_regexes = Pats} = St,
+    Meta = #{sid => SId, db => DbName},
+    report_match(DbName, Pats, Meta),
+    {ok, St}.
+
+ddoc(#st{} = St, _DbName, #doc{} = _DDoc) ->
+    % We'll check doc bodies during the shard scan
+    % so no need to keep inspecting ddocs
+    {stop, St}.
+
+shards(#st{sid = SId} = St, Shards) ->
+    case debug() of
+        true -> ?DEBUG(" ~p shards", [length(Shards)], #{sid => SId});
+        false -> ok
+    end,
+    {Shards, St}.
+
+db_opened(#st{sid = SId} = St, Db) ->
+    case debug() of
+        true -> ?DEBUG("", [], #{sid => SId, db => Db});
+        false -> ok
+    end,
+    {ok, St}.
+
+doc_id(#st{} = St, DocId, Db) ->
+    #st{sid = SId, compiled_regexes = Pats} = St,
+    Meta = #{sid => SId, doc => DocId, db => Db},
+    report_match(DocId, Pats, Meta),
+    {ok, St}.
+
+doc(#st{} = St, Db, #doc{id = DocId, body = Body}) ->
+    #st{sid = SId, compiled_regexes = Pats} = St,
+    Meta = #{sid => SId, doc => DocId, db => Db},
+    report_match(Body, Pats, Meta),
+    {ok, St}.
+
+db_closing(#st{sid = SId} = St, Db) ->
+    case debug() of
+        true -> ?DEBUG("", [], #{sid => SId, db => Db});
+        false -> ok
+    end,
+    {ok, St}.
+
+% Private
+
+regexes() ->
+    Section = atom_to_list(?MODULE) ++ ".regexes",
+    couch_scanner_util:load_regexes(config:get(Section)).
+
+compile_regexes(#st{regexes = Regexes} = St) ->
+    Compiled = couch_scanner_util:compile_regexes(Regexes),
+    St#st{compiled_regexes = Compiled}.
+
+report_match(Obj, Pats, Meta) ->
+    case couch_scanner_util:match_regexes(Obj, Pats) of
+        {match, PatId} -> ?WARN("found regex ~s", [PatId], Meta);
+        nomatch -> ok
+    end.
+
+debug() ->
+    config:get_boolean(atom_to_list(?MODULE), "debug", false).

--- a/src/couch_scanner/src/couch_scanner_rate_limiter.erl
+++ b/src/couch_scanner/src/couch_scanner_rate_limiter.erl
@@ -1,0 +1,229 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+% Basic leaky bucket and AIMD algorithm [1] to rate limit plugins:
+%
+%  * rate limiter gen_server periodically refills the configured
+%    number of token in each db, shard, and doc buckets.
+%
+%  * couch_scanner_plugin calls update/2 function when performing operations.
+%    It updates it's own backoff value and uses that to determine how much it
+%    should sleep for that particular type of operation.
+%
+% [1] https://en.wikipedia.org/wiki/Additive_increase/multiplicative_decrease
+%
+
+-module(couch_scanner_rate_limiter).
+
+-behavior(gen_server).
+
+-export([
+    start_link/0,
+    get/0,
+    update/2
+]).
+
+% gen_server callbacks
+%
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+% AIMD parameters
+%
+-define(MULTIPLICATIVE_FACTOR, 1.2).
+-define(ADDITIVE_FACTOR, 0.5).
+
+% Initial, minimal and maximum backoffs
+%
+-define(INIT_BACKOFF, 10).
+-define(MIN_BACKOFF, 0.001).
+-define(MAX_BACKOFF, 500).
+
+% Limit the rate of the backoff updates This smooths out updates when the
+% backoff interval is small (a few milliseconds only).
+%
+-define(SENSITIVITY_MSEC, 100).
+
+% Default rates
+%
+-define(DB_RATE_DEFAULT, 25).
+-define(SHARD_RATE_DEFAULT, 50).
+-define(DOC_RATE_DEFAULT, 1000).
+
+% Atomic ref indices. They start at 1.
+-define(INDICES, #{db => 1, shard => 2, doc => 3}).
+
+% Record maintained by the clients. Each client will have one of these handles.
+% With each update/2 call they will update their own backoff values.
+%
+-record(client_st, {
+    ref,
+    % db|shard|doc => {Backoff, UpdateTStamp}
+    backoffs = #{}
+}).
+
+-record(st, {
+    ref,
+    tref
+}).
+
+get() ->
+    Ref = gen_server:call(?MODULE, get, infinity),
+    NowMSec = erlang:monotonic_time(millisecond),
+    Backoffs = maps:from_keys([db, shard, doc], {?INIT_BACKOFF, NowMSec}),
+    #client_st{ref = Ref, backoffs = Backoffs}.
+
+update(#client_st{ref = Ref, backoffs = Backoffs} = St, Type) when
+    Type =:= db orelse Type =:= shard orelse Type =:= doc
+->
+    AtLimit = atomics:sub_get(Ref, map_get(Type, ?INDICES), 1) =< 0,
+    {Backoff, TStamp} = map_get(Type, Backoffs),
+    NowMSec = erlang:monotonic_time(millisecond),
+    case NowMSec - TStamp > ?SENSITIVITY_MSEC of
+        true ->
+            Backoff1 = update_backoff(AtLimit, Backoff),
+            St1 = St#client_st{backoffs = Backoffs#{Type := {Backoff1, NowMSec}}},
+            {floor(Backoff1), St1};
+        false ->
+            {floor(Backoff), St}
+    end.
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+% Gen server callbacks
+
+init(_Args) ->
+    St = #st{ref = atomics:new(map_size(?INDICES), [])},
+    {ok, refill(St)}.
+
+handle_call(get, _From, #st{} = St) ->
+    {reply, St#st.ref, St};
+handle_call(refill, _From, #st{} = St) ->
+    % Used for testing mainly
+    {reply, ok, refill(St)};
+handle_call(Msg, _From, #st{} = St) ->
+    couch_log:error("~p : unknown call ~p", [?MODULE, Msg]),
+    {reply, {error, {invalid_call, Msg}}, St}.
+
+handle_cast(Msg, #st{} = St) ->
+    couch_log:error("~p : unknown cast ~p", [?MODULE, Msg]),
+    {noreply, St}.
+
+handle_info(refill, #st{} = St) ->
+    {noreply, refill(St)};
+handle_info(Msg, St) ->
+    couch_log:error("~p : unknown info message ~p", [?MODULE, Msg]),
+    {noreply, St}.
+
+% Private functions
+
+schedule_refill(#st{tref = TRef} = St) when is_reference(TRef) ->
+    erlang:cancel_timer(TRef),
+    schedule_refill(St#st{tref = undefined});
+schedule_refill(#st{tref = undefined} = St) ->
+    TRef = erlang:send_after(1000, self(), refill),
+    St#st{tref = TRef}.
+
+refill(#st{ref = Ref} = St) ->
+    ok = atomics:put(Ref, map_get(db, ?INDICES), db_limit()),
+    ok = atomics:put(Ref, map_get(shard, ?INDICES), shard_limit()),
+    ok = atomics:put(Ref, map_get(doc, ?INDICES), doc_limit()),
+    schedule_refill(St).
+
+update_backoff(true, 0) ->
+    ?MIN_BACKOFF;
+update_backoff(true, Backoff) ->
+    min(?MAX_BACKOFF, Backoff * ?MULTIPLICATIVE_FACTOR);
+update_backoff(false, Backoff) ->
+    max(0, Backoff - ?ADDITIVE_FACTOR).
+
+db_limit() ->
+    cfg_int("db_rate_limit", ?DB_RATE_DEFAULT).
+
+shard_limit() ->
+    cfg_int("shard_rate_limit", ?SHARD_RATE_DEFAULT).
+
+doc_limit() ->
+    cfg_int("doc_rate_limit", ?DOC_RATE_DEFAULT).
+
+cfg_int(Key, Default) when is_list(Key), is_integer(Default) ->
+    config:get_integer("couch_scanner", Key, Default).
+
+-ifdef(TEST).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+couch_scanner_rate_limiter_test_() ->
+    {
+        foreach,
+        fun setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(t_init),
+            ?TDEF_FE(t_update),
+            ?TDEF_FE(t_refill)
+        ]
+    }.
+
+t_init(_) ->
+    ClientSt = ?MODULE:get(),
+    ?assertEqual(ok, refill()),
+    ?assertMatch({Val, #client_st{}} when is_number(Val), update(ClientSt, db)),
+    ?assertMatch({Val, #client_st{}} when is_number(Val), update(ClientSt, shard)),
+    ?assertMatch({Val, #client_st{}} when is_number(Val), update(ClientSt, doc)).
+
+t_update(_) ->
+    ClientSt = ?MODULE:get(),
+    Fun = fun(_, Acc) ->
+        {_, Acc1} = update(Acc, db),
+        reset_time(Acc1, db)
+    end,
+    ClientSt1 = lists:foldl(Fun, ClientSt, lists:seq(1, 500)),
+    {Backoff, _} = update(ClientSt1, db),
+    ?assertEqual(?MAX_BACKOFF, Backoff).
+
+t_refill(_) ->
+    ClientSt = ?MODULE:get(),
+    Fun = fun(_, Acc) ->
+        refill(),
+        {_, Acc1} = update(Acc, db),
+        reset_time(Acc1, db)
+    end,
+    ClientSt1 = lists:foldl(Fun, ClientSt, lists:seq(1, 500)),
+    {Backoff, _} = update(ClientSt1, db),
+    ?assertEqual(0, Backoff).
+
+setup() ->
+    meck:new(config, [passthrough]),
+    meck:expect(config, get, fun(_, _, Default) -> Default end),
+    {ok, Pid} = start_link(),
+    Pid.
+
+teardown(Pid) when is_pid(Pid) ->
+    gen_server:stop(Pid),
+    meck:unload().
+
+refill() ->
+    gen_server:call(?MODULE, refill, infinity).
+
+reset_time(#client_st{backoffs = Backoffs} = ClientSt, Type) ->
+    #{Type := {Backoff, TStamp}} = Backoffs,
+    TStamp1 = TStamp - 1000,
+    Backoffs1 = Backoffs#{Type := {Backoff, TStamp1}},
+    ClientSt#client_st{backoffs = Backoffs1}.
+
+-endif.

--- a/src/couch_scanner/src/couch_scanner_server.erl
+++ b/src/couch_scanner/src/couch_scanner_server.erl
@@ -1,0 +1,306 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+% Scanner plugin server.
+%
+% This gen_server starts, stops and reschedules plugin processes.
+%
+
+-module(couch_scanner_server).
+
+-behavior(gen_server).
+-behavior(config_listener).
+
+-export([
+    start_link/0,
+    status/0,
+    stop/0,
+    resume/0
+]).
+
+% gen_server callbacks
+%
+-export([
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+% config listener callbacks
+%
+-export([
+    handle_config_change/5,
+    handle_config_terminate/3
+]).
+
+-define(INTERVAL_SEC, 15).
+-define(MIN_PENALTY_SEC, 30).
+-define(MAX_PENALTY_SEC, 8 * 3600).
+-define(HEAL_THRESHOLD_SEC, 5 * 60).
+-define(TIMEOUT, timeout).
+
+-record(sched, {
+    start_time = 0,
+    error_count = 0,
+    reschedule = 0
+}).
+
+-record(st, {
+    stopped = false,
+    % #{Id => Pid}
+    pids = #{},
+    % #{Id => #sched{}}
+    scheduling = #{},
+    tref
+}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+status() ->
+    gen_server:call(?MODULE, status, infinity).
+
+stop() ->
+    gen_server:call(?MODULE, stop, infinity).
+
+resume() ->
+    gen_server:call(?MODULE, resume, infinity).
+
+% Gen server callbacks
+
+init(_Args) ->
+    process_flag(trap_exit, true),
+    {ok, subscribe_for_config(#st{}), 0}.
+
+terminate(_Reason, #st{pids = Pids} = St) ->
+    ToStop = maps:keys(Pids),
+    lists:foldl(fun stop_plugin/2, St, ToStop),
+    ok.
+
+handle_call(status, _From, #st{} = St) ->
+    #st{pids = Pids, stopped = Stopped} = St,
+    Fun = fun(_, Sched) ->
+        #{
+            start_time => Sched#sched.start_time,
+            error_count => Sched#sched.error_count,
+            reschedule => Sched#sched.reschedule
+        }
+    end,
+    Scheds = maps:map(Fun, St#st.scheduling),
+    {reply, #{pids => Pids, scheduling => Scheds, stopped => Stopped}, St};
+handle_call(stop, _From, #st{} = St) ->
+    St1 = St#st{stopped = true},
+    St2 = stop_in_maintenance(St1),
+    {reply, ok, St2};
+handle_call(resume, _From, #st{} = St) ->
+    St1 = start_stop(St#st{stopped = false}),
+    {reply, ok, St1};
+handle_call(Msg, _From, #st{} = St) ->
+    couch_log:error("~p : unknown call ~p", [?MODULE, Msg]),
+    {reply, {error, {invalid_call, Msg}}, St}.
+
+handle_cast(Msg, #st{} = St) ->
+    couch_log:error("~p : unknown cast ~p", [?MODULE, Msg]),
+    {noreply, St}.
+
+handle_info(?TIMEOUT, #st{} = St) ->
+    St1 = cancel_timeout(St),
+    St2 = start_stop(St1),
+    St3 = schedule_timeout(St2),
+    {noreply, St3};
+handle_info({'EXIT', Pid, Reason}, #st{pids = Pids} = St) ->
+    case maps:filter(fun(_, P) -> P =:= Pid end, Pids) of
+        Map when map_size(Map) == 1 ->
+            [{Id, Pid}] = maps:to_list(Map),
+            St1 = St#st{pids = maps:remove(Id, Pids)},
+            {noreply, handle_exit(Id, Reason, St1)};
+        Map when map_size(Map) == 0 ->
+            {noreply, St}
+    end;
+handle_info({reschedule, Id}, #st{} = St) ->
+    {noreply, reschedule(Id, St)};
+handle_info(restart_config_listener, #st{} = St) ->
+    {noreply, subscribe_for_config(St)};
+handle_info(Msg, St) ->
+    couch_log:error("~p : unknown info message ~p", [?MODULE, Msg]),
+    {noreply, St}.
+
+% Config changes callbacks
+
+handle_config_change("couchdb", "maintenance_mode", _Val, _Persist, Pid) ->
+    Pid ! ?TIMEOUT,
+    {ok, Pid};
+handle_config_change("couch_scanner", _Key, _Val, _Persist, Pid) ->
+    Pid ! ?TIMEOUT,
+    {ok, Pid};
+handle_config_change("couch_scanner_plugins", _Key, _Val, _Persist, Pid) ->
+    Pid ! ?TIMEOUT,
+    {ok, Pid};
+handle_config_change(Id, "after", _Val, _Persist, Pid) ->
+    Pid ! {reschedule, list_to_binary(Id)},
+    {ok, Pid};
+handle_config_change(Id, "repeat", _Val, _Persist, Pid) ->
+    Pid ! {reschedule, list_to_binary(Id)},
+    {ok, Pid};
+handle_config_change(_Section, _Key, _Val, _Persist, Pid) ->
+    {ok, Pid}.
+
+handle_config_terminate(_Server, stop, _Pid) ->
+    ok;
+handle_config_terminate(_Server, _Reason, Pid) ->
+    erlang:send_after(1000, Pid, restart_config_listener).
+
+% Private
+
+subscribe_for_config(#st{} = St) ->
+    ok = config:listen_for_changes(?MODULE, self()),
+    St.
+
+stop_in_maintenance(#st{pids = Pids} = St) ->
+    case map_size(Pids) > 0 of
+        true ->
+            couch_log:info("~p stopping in maintenance mode", [?MODULE]),
+            lists:foldl(fun stop_plugin/2, St, maps:keys(Pids));
+        false ->
+            St
+    end.
+
+start_stop(#st{stopped = Stopped} = St) ->
+    case in_maintenance() orelse Stopped of
+        true -> stop_in_maintenance(St);
+        false -> start_stop_cfg(St)
+    end.
+
+start_stop_cfg(#st{pids = Pids, scheduling = Scheduling} = St) ->
+    PluginIds = plugins(),
+    RunningIds = maps:keys(Pids),
+    ToStart = PluginIds -- RunningIds,
+    ToStop = RunningIds -- PluginIds,
+    St1 = lists:foldl(fun stop_plugin/2, St, ToStop),
+    lists:foreach(fun couch_scanner_checkpoint:reset/1, ToStop),
+    ToRemove = maps:keys(Scheduling) -- PluginIds,
+    St2 = St1#st{scheduling = maps:without(ToRemove, Scheduling)},
+    lists:foreach(fun couch_scanner_checkpoint:reset/1, ToRemove),
+    lists:foldl(fun start_plugin/2, St2, ToStart).
+
+stop_plugin(Id, #st{} = St) ->
+    #st{pids = Pids, scheduling = Scheduling} = St,
+    {Pid, Pids1} = maps:take(Id, Pids),
+    #{Id := #sched{} = Sched} = Scheduling,
+    couch_log:info("~p : stopping ~s", [?MODULE, Id]),
+    ok = couch_scanner_plugin:stop(Pid),
+    Sched1 = Sched#sched{start_time = 0, reschedule = 0},
+    Scheduling1 = Scheduling#{Id := Sched1},
+    St#st{pids = Pids1, scheduling = Scheduling1}.
+
+start_plugin(Id, #st{} = St) ->
+    #st{pids = Pids, scheduling = Scheduling} = St,
+    Sched = maps:get(Id, Scheduling, #sched{}),
+    Now = tsec(),
+    case Now >= Sched#sched.reschedule of
+        true ->
+            couch_log:info("~p : starting ~s", [?MODULE, Id]),
+            Pids1 = Pids#{Id => couch_scanner_plugin:spawn_link(Id)},
+            Sched1 = Sched#sched{
+                start_time = Now,
+                reschedule = 0
+            },
+            Scheduling1 = Scheduling#{Id => Sched1},
+            St#st{pids = Pids1, scheduling = Scheduling1};
+        false ->
+            St
+    end.
+
+reschedule(Id, #st{scheduling = Scheduling} = St) ->
+    % Reschedule if it's a plugin which is not running
+    case {is_map_key(Id, St#st.pids), Scheduling} of
+        {false, #{Id := #sched{} = Sched}} ->
+            Sched1 = Sched#sched{reschedule = tsec(), error_count = 0},
+            St#st{scheduling = Scheduling#{Id := Sched1}};
+        {_, _} ->
+            St
+    end.
+
+plugins() ->
+    Fun = fun
+        ({Module, "true"}, Acc) -> [list_to_binary(Module) | Acc];
+        ({_, _}, Acc) -> Acc
+    end,
+    lists:foldl(Fun, [], config:get("couch_scanner_plugins")).
+
+handle_exit(Id, Reason, #st{} = St) ->
+    #st{scheduling = Scheduling} = St,
+    #{Id := Sched} = Scheduling,
+    Sched1 = sched_exit_update(Id, Sched, Reason),
+    St#st{scheduling = Scheduling#{Id := Sched1}}.
+
+sched_exit_update(Id, #sched{} = Sched, {shutdown, {reschedule, TSec}}) ->
+    couch_log:notice("~p : ~s rescheduled after ~p", [?MODULE, Id, TSec]),
+    Sched#sched{start_time = 0, error_count = 0, reschedule = TSec};
+sched_exit_update(Id, #sched{} = Sched, {shutdown, reset}) ->
+    couch_log:warning("~p : resetting plugin ~s", [?MODULE, Id]),
+    couch_scanner_checkpoint:reset(Id),
+    Sched#sched{start_time = 0, error_count = 0, reschedule = tsec()};
+sched_exit_update(Id, #sched{} = Sched, Norm) when
+    Norm == shutdown; Norm == normal
+->
+    couch_log:notice("~p : ~s finished", [?MODULE, Id]),
+    Sched#sched{start_time = 0, error_count = 0, reschedule = infinity};
+sched_exit_update(Id, #sched{} = Sched, Error) ->
+    couch_log:error("~p : ~s exited with error ~p", [?MODULE, Id, Error]),
+    #sched{start_time = Start, error_count = ErrorCount} = Sched,
+    Sched1 = Sched#sched{start_time = 0},
+    Now = tsec(),
+    % If process has been running successfully for a while without crashing
+    % reset (forgive) its previous errors.
+    case Now - Start =< heal_threshold_sec() of
+        true -> penalize(Now, Sched1#sched{error_count = 1});
+        false -> penalize(Now, Sched1#sched{error_count = ErrorCount + 1})
+    end.
+
+penalize(Now, #sched{error_count = ErrorCount} = Sched) ->
+    Penalty = min_penalty_sec() * (1 bsl (ErrorCount - 1)),
+    Penalty1 = min(Penalty, max_penalty_sec()),
+    Sched#sched{reschedule = Now + Penalty1}.
+
+in_maintenance() ->
+    "false" /= config:get("couchdb", "maintenance_mode", "false").
+
+tsec() ->
+    erlang:system_time(second).
+
+cancel_timeout(#st{tref = undefined} = St) ->
+    St;
+cancel_timeout(#st{tref = TRef} = St) when is_reference(TRef) ->
+    erlang:cancel_timer(TRef),
+    St#st{tref = undefined}.
+
+schedule_timeout(#st{tref = undefined} = St) ->
+    TRef = erlang:send_after(1000 * interval_sec(), self(), timeout),
+    St#st{tref = TRef}.
+
+interval_sec() ->
+    cfg_int("interval_sec", ?INTERVAL_SEC).
+
+heal_threshold_sec() ->
+    cfg_int("heal_threshold_sec", ?HEAL_THRESHOLD_SEC).
+
+min_penalty_sec() ->
+    cfg_int("min_penalty_sec", ?MIN_PENALTY_SEC).
+
+max_penalty_sec() ->
+    cfg_int("max_penalty_sec", ?MAX_PENALTY_SEC).
+
+cfg_int(Key, Default) when is_list(Key), is_integer(Default) ->
+    config:get_integer("couch_scanner", Key, Default).

--- a/src/couch_scanner/src/couch_scanner_sup.erl
+++ b/src/couch_scanner/src/couch_scanner_sup.erl
@@ -1,0 +1,39 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_scanner_sup).
+
+-behaviour(supervisor).
+
+-export([
+    start_link/0,
+    init/1
+]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    Children = [
+        #{
+            id => couch_scanner_rate_limiter,
+            start => {couch_scanner_rate_limiter, start_link, []},
+            shutdown => 5000
+        },
+        #{
+            id => couch_scanner_server,
+            start => {couch_scanner_server, start_link, []},
+            shutdown => 5000
+        }
+    ],
+    SupFlags = #{strategy => rest_for_one, intensity => 25, period => 1},
+    {ok, {SupFlags, Children}}.

--- a/src/couch_scanner/src/couch_scanner_util.erl
+++ b/src/couch_scanner/src/couch_scanner_util.erl
@@ -1,0 +1,379 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_scanner_util).
+
+-export([
+    new_scan_id/0,
+    log/5,
+    ejson_map/1,
+    restart_tsec/0,
+    schedule_time/5,
+    load_regexes/1,
+    compile_regexes/1,
+    match_regexes/2,
+    on_first_node/0,
+    consistent_hash_nodes/1
+]).
+
+-define(SECOND, 1).
+-define(MINUTE, 60 * ?SECOND).
+-define(HOUR, 60 * ?MINUTE).
+-define(DAY, 24 * ?HOUR).
+-define(WEEK, 7 * ?DAY).
+-define(MONTH, 30 * ?DAY).
+
+new_scan_id() ->
+    TSec = integer_to_binary(erlang:system_time(second)),
+    Rand = string:lowercase(binary:encode_hex(crypto:strong_rand_bytes(6))),
+    <<TSec/binary, "-", Rand/binary>>.
+
+log(Level, Mod, Fmt, Args, #{} = Meta) when
+    is_atom(Level), is_atom(Mod), is_list(Fmt), is_list(Args)
+->
+    {MFmt, MArgs} = log_format_meta(Mod, Meta),
+    couch_log:Level(lists:flatten([MFmt, Fmt]), MArgs ++ Args).
+
+ejson_map(Obj) ->
+    jiffy:decode(jiffy:encode(Obj), [return_maps]).
+
+restart_tsec() ->
+    % Seconds since node started. To help run once after restart
+    Native = erlang:system_info(start_time) + erlang:time_offset(),
+    erlang:convert_time_unit(Native, native, second).
+
+on_first_node() ->
+    hd(mem3_util:live_nodes()) =:= node().
+
+consistent_hash_nodes(Item) ->
+    Nodes = mem3_util:live_nodes(),
+    hd(mem3_util:rotate_list(Item, Nodes)) =:= node().
+
+schedule_time(Now, Last, Restart, AfterCfg, RepeatCfg) when
+    is_integer(Now), is_integer(Restart), is_integer(Last)
+->
+    RepeatPeriod = repeat_period(Now, Last, parse_repeat(RepeatCfg)),
+    case {parse_after(AfterCfg), RepeatPeriod} of
+        {undefined, undefined} when Last >= Restart ->
+            % Run after restart, and already ran
+            infinity;
+        {undefined, undefined} when Last < Restart ->
+            % Run after restart, but haven't run yet
+            Now;
+        {After, undefined} when is_integer(After), Last >= After ->
+            % Run after an absolute timestamp, and already ran
+            infinity;
+        {After, undefined} when is_integer(After), Last < After ->
+            % Run once, haven't run yet, schedule to run
+            max(Now, After);
+        {undefined, Period} ->
+            % No after time, just period. Either need to wait
+            % since last time it ran, or is actually ready to run
+            max(Now, Last + Period);
+        {After, Period} ->
+            % Both after time set and a period. Wait for whichever
+            % takes the longest
+            lists:max([Now, After, Last + Period])
+    end.
+
+load_regexes(KVs) when is_list(KVs) ->
+    lists:foldl(fun regex_fold/2, #{}, KVs).
+
+compile_regexes(Regexes = #{}) ->
+    Fun = fun(_PatId, PatVal) ->
+        {ok, Regex} = re:compile(PatVal),
+        Regex
+    end,
+    maps:map(Fun, Regexes).
+
+match_regexes(Obj, #{} = Regexes) ->
+    try
+        match(Obj, Regexes)
+    catch
+        throw:{match, Id} ->
+            {match, Id}
+    end.
+
+match(Str, #{} = Pats) when is_binary(Str) ->
+    Fun = fun(PatId, PatVal) ->
+        case re:run(Str, PatVal, [{capture, none}]) of
+            match -> throw({match, PatId});
+            nomatch -> nomatch
+        end
+    end,
+    maps:foreach(Fun, Pats),
+    nomatch;
+match({Props}, #{} = Pats) when is_list(Props) ->
+    match(Props, Pats);
+match(#{} = Map, #{} = Pats) ->
+    Fun = fun(K, V) ->
+        nomatch = match(K, Pats),
+        nomatch = match(V, Pats)
+    end,
+    maps:foreach(Fun, Map),
+    nomatch;
+match([], _Pats) ->
+    nomatch;
+match([{K, V} | Rest], #{} = Pats) ->
+    nomatch = match(K, Pats),
+    nomatch = match(V, Pats),
+    match(Rest, Pats);
+match([V | Rest], #{} = Pats) ->
+    nomatch = match(V, Pats),
+    match(Rest, Pats);
+match(Num, _Pats) when is_number(Num) ->
+    nomatch;
+match(Atom, _Pats) when is_atom(Atom) ->
+    nomatch.
+
+regex_fold({K, V}, #{} = Acc) ->
+    PatId = list_to_binary(K),
+    PatVal = list_to_binary(V),
+    try re:compile(PatVal) of
+        {ok, _} -> Acc#{PatId => PatVal};
+        _ -> Acc
+    catch
+        _Tag:_Err ->
+            Acc
+    end.
+
+repeat_period(_Now, _Last, undefined) ->
+    undefined;
+repeat_period(Now, Last, {weekday, WeekdayNum}) ->
+    {NowDate, {H, M, S}} = calendar:system_time_to_universal_time(Now, second),
+    case abs(calendar:day_of_the_week(NowDate) - WeekdayNum) rem 7 of
+        0 ->
+            % It's today. Run only if it hasn't started yet
+            DayStartUnixTSec = Now - H * 3600 + M * 60 + S,
+            case Last > DayStartUnixTSec of
+                true -> ?WEEK;
+                false -> 0
+            end;
+        Days ->
+            ?DAY * Days
+    end;
+repeat_period(_Now, _Last, Period) when is_integer(Period), Period > 0 ->
+    Period.
+
+parse_after(Time) when is_list(Time), length(Time) >= 7 ->
+    case string:uppercase(Time) of
+        "RESTART" ->
+            undefined;
+        [_, _, _, _, $-, _, _, $-, _, _] = T ->
+            parse_rfc3339(T ++ "T00:00:00Z");
+        [_, _, _, _, $-, _, _, $-, _, _, $T, _, _] = T ->
+            parse_rfc3339(T ++ ":00:00Z");
+        [_, _, _, _, $-, _, _, $-, _, _, $T, _, _, $:, _, _] = T ->
+            parse_rfc3339(T ++ ":00Z");
+        [_, _, _, _, $-, _, _, $-, _, _, $T, _, _, $:, _, _, $:, _, _] = T ->
+            parse_rfc3339(T ++ "Z");
+        [_, _, _, _, $-, _, _, $-, _, _, $T, _, _, $:, _, _, $:, _, _ | _] = T ->
+            parse_rfc3339(T);
+        [_ | _] = T ->
+            parse_unix(T)
+    end;
+parse_after(_) ->
+    undefined.
+
+parse_rfc3339(Time) ->
+    try calendar:rfc3339_to_system_time(Time) of
+        Sec when is_integer(Sec), Sec >= 0 ->
+            Sec;
+        Sec when is_integer(Sec) ->
+            undefined
+    catch
+        error:_ ->
+            undefined
+    end.
+
+parse_unix(Time) ->
+    try list_to_integer(Time) of
+        Sec when is_integer(Sec), Sec >= 0 ->
+            Sec;
+        Sec when is_integer(Sec) ->
+            undefined
+    catch
+        error:badarg ->
+            undefined
+    end.
+
+parse_repeat(Repeat) when is_list(Repeat) ->
+    % Numbering follows https://www.erlang.org/doc/man/calendar#day_of_the_week-1
+    case string:lowercase(Repeat) of
+        "restart" -> undefined;
+        "mon" ++ _ -> {weekday, 1};
+        "tue" ++ _ -> {weekday, 2};
+        "wed" ++ _ -> {weekday, 3};
+        "thu" ++ _ -> {weekday, 4};
+        "fri" ++ _ -> {weekday, 5};
+        "sat" ++ _ -> {weekday, 6};
+        "sun" ++ _ -> {weekday, 7};
+        Val -> parse_non_weekday_period(Val)
+    end.
+
+parse_non_weekday_period(Period) ->
+    case string:split(Period, "_") of
+        [NumStr, UnitStr] ->
+            Unit = parse_period_unit(UnitStr),
+            % 10_hours -> ["10", "hours"] -> 10 * ?HOUR
+            try {Unit, list_to_integer(NumStr)} of
+                {undefined, _} ->
+                    undefined;
+                {_, Num} when is_integer(Num), Num > 0 ->
+                    Num * Unit;
+                {_, Num} when is_integer(Num) ->
+                    undefined
+            catch
+                error:badarg ->
+                    undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+parse_period_unit(Period) when is_list(Period) ->
+    case Period of
+        "sec" ++ _ -> ?SECOND;
+        "min" ++ _ -> ?MINUTE;
+        "hour" ++ _ -> ?HOUR;
+        "day" ++ _ -> ?DAY;
+        "week" ++ _ -> ?WEEK;
+        "month" ++ _ -> ?MONTH;
+        _ -> undefined
+    end.
+
+% Logging bits
+
+log_format_meta(Mod, #{} = Meta) ->
+    SId = {"s:~s ", maps:get(sid, Meta, undefined)},
+    Fun = {"f:~s ", maps:get(fn, Meta, undefined)},
+    Db = {"db:~s ", format_db(maps:get(db, Meta, undefined))},
+    DDocId = {"ddoc:~s ", maps:get(ddoc, Meta, undefined)},
+    DocId = {"doc:~s ", maps:get(doc, Meta, undefined)},
+    FmtArgs = [{"~s ", Mod}, SId, Fun, Db, DDocId, DocId],
+    lists:unzip([{Fmt, Arg} || {Fmt, Arg} <- FmtArgs, Arg /= undefined]).
+
+format_db(undefined) ->
+    undefined;
+format_db(Db) when is_list(Db) ->
+    format_db(list_to_binary(Db));
+format_db(Db) when is_tuple(Db) ->
+    format_db(couch_db:name(Db));
+format_db(<<"shards/", B:8/binary, "-", E:8/binary, "/", Rest/binary>>) ->
+    [Db, _] = binary:split(Rest, <<".">>),
+    <<Db/binary, "/", B/binary, "-", E/binary>>;
+format_db(<<Db/binary>>) ->
+    Db.
+
+-ifdef(TEST).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+parse_after_test() ->
+    ?assertEqual(undefined, parse_after("restart")),
+    ?assertEqual(undefined, parse_after("x")),
+    ?assertEqual(0, parse_after("0000000")),
+    ?assertEqual(undefined, parse_after("-0000001")),
+    ?assertEqual(undefined, parse_after("foobarbaz10")),
+    ?assertEqual(10000000, parse_after("10000000")),
+    ?assertEqual(0, parse_after("1970-01-01T00:00:00")),
+    ?assertEqual(1, parse_after("1970-01-01T00:00:01")),
+    ?assertEqual(0, parse_after("1970-01-01T00:00:00Z")),
+    ?assertEqual(1, parse_after("1970-01-01T00:00:01Z")),
+    ?assertEqual(0, parse_after("1970-01-01T00:00")),
+    ?assertEqual(0, parse_after("1970-01-01T00")),
+    ?assertEqual(0, parse_after("1970-01-01")).
+
+parse_repeat_test() ->
+    ?assertEqual(undefined, parse_repeat("foo")),
+    ?assertEqual(undefined, parse_repeat("ReStarT")),
+    ?assertEqual({weekday, 1}, parse_repeat("mon")),
+    ?assertEqual({weekday, 1}, parse_repeat("Monday")),
+    ?assertEqual({weekday, 2}, parse_repeat("tuesday")),
+    ?assertEqual({weekday, 3}, parse_repeat("wed")),
+    ?assertEqual({weekday, 4}, parse_repeat("thurs.")),
+    ?assertEqual({weekday, 5}, parse_repeat("Fri")),
+    ?assertEqual({weekday, 6}, parse_repeat("sAt")),
+    ?assertEqual({weekday, 7}, parse_repeat("sundays")),
+    ?assertEqual(1, parse_repeat("1_sec")),
+    ?assertEqual(1, parse_repeat("1_second")),
+    ?assertEqual(1, parse_repeat("1_sec")),
+    ?assertEqual(2, parse_repeat("2_sec")),
+    ?assertEqual(3, parse_repeat("3_seconds")),
+    ?assertEqual(60, parse_repeat("1_min")),
+    ?assertEqual(2 * 60, parse_repeat("2_minutes")),
+    ?assertEqual(60 * 60, parse_repeat("1_hour")),
+    ?assertEqual(24 * 60 * 60, parse_repeat("1_day")),
+    ?assertEqual(7 * 24 * 60 * 60, parse_repeat("1_week")),
+    ?assertEqual(30 * 24 * 60 * 60, parse_repeat("1_month")).
+
+repeat_period_test() ->
+    %Fri, May 31, 2024 16:08:37
+    Now = 1717171717,
+    ?assertEqual(undefined, repeat_period(0, 42, undefined)),
+    ?assertEqual(42, repeat_period(1, 2, 42)),
+    ?assertEqual(0, repeat_period(Now, Now - 999999, {weekday, 5})),
+    ?assertEqual(?WEEK, repeat_period(Now, Now - 1, {weekday, 5})),
+    ?assertEqual(1 * ?DAY, repeat_period(Now, Now - 999999, {weekday, 6})).
+
+regex_compile_test() ->
+    KVs = [{"x", "a[d-f]"}, {"y", "**"}],
+    Regexes = load_regexes(KVs),
+    ?assertMatch(#{<<"x">> := <<"a[d-f]">>}, Regexes),
+    Compiled = compile_regexes(Regexes),
+    ?assertMatch(#{<<"x">> := Tup} when is_tuple(Tup), Compiled).
+
+regex_match_test() ->
+    KVs = [{"x", "abc"}, {"y", "^de"}, {"z", "k(l|m)$"}],
+    Pats = compile_regexes(load_regexes(KVs)),
+    ?assertEqual(nomatch, match_regexes(1, Pats)),
+    ?assertEqual(nomatch, match_regexes(1.0, Pats)),
+    ?assertEqual(nomatch, match_regexes(null, Pats)),
+    ?assertEqual(nomatch, match_regexes(false, Pats)),
+    ?assertEqual(nomatch, match_regexes(true, Pats)),
+    ?assertEqual({match, <<"x">>}, match_regexes(<<"qabcr">>, Pats)),
+    ?assertEqual({match, <<"y">>}, match_regexes(<<"dex">>, Pats)),
+    ?assertEqual(nomatch, match_regexes(<<"xdef">>, Pats)),
+    ?assertEqual({match, <<"z">>}, match_regexes(<<"qkl">>, Pats)),
+    ?assertEqual(nomatch, match_regexes(<<"klx">>, Pats)),
+    ?assertEqual({match, <<"x">>}, match_regexes([<<"g">>, <<"qabcq">>], Pats)),
+    ?assertEqual({match, <<"x">>}, match_regexes({[{<<"a">>, <<"abc">>}]}, Pats)),
+    ?assertEqual({match, <<"y">>}, match_regexes(#{a => <<"de">>}, Pats)).
+
+log_format_test() ->
+    ?assertEqual("mod db:x ", tlog(#{db => <<"x">>})),
+    ?assertEqual("mod s:y f:z db:x ", tlog(#{db => "x", sid => y, fn => z})),
+    Shard = <<"shards/80000000-ffffffff/db.1712291766">>,
+    ?assertEqual("mod db:db/80000000-ffffffff ", tlog(#{db => Shard})).
+
+tlog(Meta) ->
+    {Fmt, Args} = log_format_meta(mod, Meta),
+    lists:flatten(io_lib:format(lists:flatten(Fmt), lists:flatten(Args))).
+
+node_picking_test_() ->
+    {
+        foreach,
+        fun() -> test_util:start_couch([mem3]) end,
+        fun(Ctx) -> test_util:stop_couch(Ctx) end,
+        [
+            ?TDEF_FE(t_first_node),
+            ?TDEF_FE(t_consistent_hash_nodes)
+        ]
+    }.
+
+t_first_node(_) ->
+    ?assert(on_first_node()).
+
+t_consistent_hash_nodes(_) ->
+    ?assert(consistent_hash_nodes(<<"foo">>)).
+
+-endif.

--- a/src/couch_scanner/test/eunit/couch_scanner_test.erl
+++ b/src/couch_scanner/test/eunit/couch_scanner_test.erl
@@ -1,0 +1,286 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_scanner_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+couch_scanner_test_() ->
+    {
+        foreach,
+        fun setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(t_top_level_api),
+            ?TDEF_FE(t_start_stop),
+            ?TDEF_FE(t_run_through_all_callbacks_basic, 10),
+            ?TDEF_FE(t_find_reporting_works, 10),
+            ?TDEF_FE(t_ddoc_features_works, 20),
+            ?TDEF_FE(t_config_skips, 10),
+            ?TDEF_FE(t_resume_after_error, 10),
+            ?TDEF_FE(t_reset, 10),
+            ?TDEF_FE(t_schedule_repeat, 10),
+            ?TDEF_FE(t_schedule_after, 15)
+        ]
+    }.
+
+-define(DOC1, <<"scanner_test_doc1">>).
+-define(DOC2, <<"_design/scanner_test_doc2">>).
+-define(DOC3, <<"scanner_test_doc3">>).
+-define(DOC4, <<"_design/scanner_test_doc4">>).
+
+-define(FIND_PLUGIN, couch_scanner_plugin_find).
+-define(FEATURES_PLUGIN, couch_scanner_plugin_ddoc_features).
+
+setup() ->
+    {module, _} = code:ensure_loaded(?FIND_PLUGIN),
+    meck:new(?FIND_PLUGIN, [passthrough]),
+    meck:new(couch_scanner_server, [passthrough]),
+    meck:new(couch_scanner_util, [passthrough]),
+    Ctx = test_util:start_couch([fabric, couch_scanner]),
+    DbName1 = <<"dbname1", (?tempdb())/binary>>,
+    DbName2 = <<"dbname2", (?tempdb())/binary>>,
+    ok = fabric:create_db(DbName1, [{q, "2"}, {n, "1"}]),
+    ok = fabric:create_db(DbName2, [{q, "2"}, {n, "1"}]),
+    ok = add_doc(DbName1, ?DOC1, #{foo1 => bar}),
+    ok = add_doc(DbName1, ?DOC2, #{
+        foo2 => baz,
+        views => #{
+            v1 => #{
+                map => <<"function(doc) {emit(1,2);}">>,
+                reduce => <<"function(ks, vs, rereduce) {return {};}">>
+            },
+            v2 => #{
+                map => <<"function(doc) {emit(3,4);}">>,
+                reduce => <<"_count">>
+            }
+        },
+        filters => #{f1 => <<"function(d){return true;}">>},
+        shows => #{s1 => <<"function(d,r){return " ";}">>},
+        lists => #{l1 => <<"function(h,r){return " ";}">>},
+        rewrites => [
+            #{from => <<"/a/b">>, to => <<"/c/d">>},
+            #{from => <<"x">>, to => <<"y">>}
+        ],
+        updates => #{u1 => <<"function(d,r){return [];}">>},
+        validate_doc_update => <<"function(n,o,u,s){return true;">>
+    }),
+    ok = add_doc(DbName2, ?DOC3, #{foo3 => bax}),
+    ok = add_doc(DbName2, ?DOC4, #{foo4 => baw}),
+    couch_scanner:reset_checkpoints(),
+    {Ctx, {DbName1, DbName2}}.
+
+teardown({Ctx, {DbName1, DbName2}}) ->
+    config:delete("couch_scanner", "maintenance_mode", false),
+    config_delete_section("couch_scanner"),
+    config_delete_section("couch_scanner_plugins"),
+    config_delete_section(atom_to_list(?FEATURES_PLUGIN)),
+    config_delete_section(atom_to_list(?FIND_PLUGIN)),
+    lists:foreach(
+        fun(Subsection) ->
+            config_delete_section(atom_to_list(?FIND_PLUGIN) ++ "." ++ Subsection)
+        end,
+        ["skip_dbs", "skip_ddoc", "skip_docs", "regexes"]
+    ),
+    couch_scanner:reset_checkpoints(),
+    couch_scanner:resume(),
+    fabric:delete_db(DbName1),
+    fabric:delete_db(DbName2),
+    test_util:stop_couch(Ctx),
+    meck:unload().
+
+t_top_level_api(_) ->
+    ?assertMatch(#{}, couch_scanner:checkpoints()),
+    ?assertMatch(#{stopped := false}, couch_scanner:status()),
+    ?assertMatch(#{}, couch_scanner:reset_checkpoints()),
+    ?assertEqual(#{}, couch_scanner:checkpoints()),
+    ?assertEqual(ok, couch_scanner:resume()).
+
+t_start_stop(_) ->
+    ?assertMatch(#{stopped := false}, couch_scanner:status()),
+    ?assertEqual(ok, couch_scanner:stop()),
+    ?assertMatch(#{stopped := true}, couch_scanner:status()),
+    ?assertEqual(ok, couch_scanner:stop()),
+    ?assertMatch(#{stopped := true}, couch_scanner:status()),
+    ?assertEqual(ok, couch_scanner_server:resume()),
+    ?assertMatch(#{stopped := false}, couch_scanner:status()),
+    ?assertEqual(ok, couch_scanner_server:resume()),
+    ?assertMatch(#{stopped := false}, couch_scanner:status()).
+
+t_run_through_all_callbacks_basic({_, {DbName1, DbName2}}) ->
+    % Run the "find" plugin without any regexes
+    meck:reset(couch_scanner_server),
+    config:set("couch_scanner_plugins", atom_to_list(?FIND_PLUGIN), "true", false),
+    wait_exit(10000),
+    % Check that all callbacks we expected to be called were called
+    ?assertEqual(1, num_calls(start, 2)),
+    ?assertEqual(0, num_calls(resume, 2)),
+    ?assertEqual(1, num_calls(complete, 1)),
+    ?assertEqual(2, num_calls(checkpoint, 1)),
+    ?assertEqual(1, num_calls(db, ['_', DbName1])),
+    ?assertEqual(1, num_calls(db, ['_', DbName2])),
+    ?assertEqual(1, num_calls(ddoc, ['_', DbName1, '_'])),
+    ?assertEqual(1, num_calls(ddoc, ['_', DbName2, '_'])),
+    ?assert(num_calls(shards, 2) >= 2),
+    DbOpenedCount = num_calls(db_opened, 2),
+    ?assert(DbOpenedCount >= 4),
+    ?assertEqual(1, num_calls(doc_id, ['_', ?DOC1, '_'])),
+    ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
+    ?assertEqual(1, num_calls(doc_id, ['_', ?DOC3, '_'])),
+    ?assertEqual(1, num_calls(doc_id, ['_', ?DOC4, '_'])),
+    ?assert(num_calls(doc, 3) >= 4),
+    DbClosingCount = num_calls(db_closing, 2),
+    ?assertEqual(DbOpenedCount, DbClosingCount),
+    ?assertEqual(0, log_calls(warning)).
+
+t_find_reporting_works(_) ->
+    % Run the "find" plugin with some regexes
+    Plugin = atom_to_list(?FIND_PLUGIN),
+    config:set(Plugin ++ ".regexes", "foo14", "foo(1|4)", false),
+    config:set(Plugin ++ ".regexes", "baz", "baz", false),
+    meck:reset(couch_scanner_server),
+    config:set("couch_scanner_plugins", Plugin, "true", false),
+    wait_exit(10000),
+    % doc2 should have a baz and doc1 and doc4 matches foo14
+    ?assertEqual(3, log_calls(warning)).
+
+t_ddoc_features_works({_, {_, DbName2}}) ->
+    % Run the "ddoc_features" plugin
+    Plugin = atom_to_list(?FEATURES_PLUGIN),
+    config:set(Plugin, "filters", "true", false),
+    config:set(Plugin, "reduce", "true", false),
+    config:set(Plugin, "validate_doc_update", "true", false),
+    meck:reset(couch_scanner_server),
+    meck:reset(couch_scanner_util),
+    config:set("couch_scanner_plugins", Plugin, "true", false),
+    wait_exit(10000),
+    LogArgs = [warning, ?FEATURES_PLUGIN, '_', '_', '_'],
+    ?assertEqual(1, meck:num_calls(couch_scanner_util, log, LogArgs)),
+    % Add a detectable feature to the second db.
+    % Expect two reports written
+    ok = add_doc(DbName2, <<"_design/doc42">>, #{
+        rewrites => <<"function(r) {return r;}">>
+    }),
+    config:set("couch_scanner", "interval_sec", "1", false),
+    couch_scanner:resume(),
+    meck:reset(couch_scanner_server),
+    meck:reset(couch_scanner_util),
+    Now = erlang:system_time(second),
+    TStamp = calendar:system_time_to_rfc3339(Now + 1, [{offset, "Z"}]),
+    config:set(Plugin, "after", TStamp, false),
+    wait_exit(10000),
+    ?assertEqual(2, meck:num_calls(couch_scanner_util, log, LogArgs)).
+
+t_config_skips({_, {DbName1, DbName2}}) ->
+    Plugin = atom_to_list(?FIND_PLUGIN),
+    config:set(Plugin ++ ".skip_dbs", "x", binary_to_list(DbName2), false),
+    config:set(Plugin ++ ".skip_docs", "y", binary_to_list(?DOC1), false),
+    config:set(Plugin ++ ".skip_ddocs", "z", binary_to_list(?DOC2), false),
+    meck:reset(couch_scanner_server),
+    config:set("couch_scanner_plugins", Plugin, "true", false),
+    wait_exit(10000),
+    % Some should not be called we skipped DbName2 and some docs
+    ?assertEqual(1, num_calls(start, 2)),
+    ?assertEqual(0, num_calls(resume, 2)),
+    ?assertEqual(1, num_calls(complete, 1)),
+    ?assertEqual(2, num_calls(checkpoint, 1)),
+    ?assertEqual(1, num_calls(db, ['_', DbName1])),
+    ?assertEqual(0, num_calls(db, ['_', DbName2])),
+    ?assertEqual(0, num_calls(ddoc, ['_', DbName1, '_'])),
+    ?assertEqual(0, num_calls(ddoc, ['_', DbName2, '_'])),
+    DbOpenedCount = num_calls(db_opened, 2),
+    ?assert(DbOpenedCount >= 2),
+    ?assertEqual(0, num_calls(doc_id, ['_', ?DOC1, '_'])),
+    ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
+    ?assertEqual(0, num_calls(doc_id, ['_', ?DOC3, '_'])),
+    ?assertEqual(0, num_calls(doc_id, ['_', ?DOC4, '_'])),
+    DbClosingCount = num_calls(db_closing, 2),
+    ?assertEqual(DbOpenedCount, DbClosingCount).
+
+t_resume_after_error(_) ->
+    meck:reset(?FIND_PLUGIN),
+    meck:expect(
+        ?FIND_PLUGIN,
+        shards,
+        2,
+        meck:seq([
+            meck:passthrough(),
+            meck:raise(error, oops),
+            meck:passthrough()
+        ])
+    ),
+    Plugin = atom_to_list(?FIND_PLUGIN),
+    config:set("couch_scanner", "min_penalty_sec", "1", false),
+    config:set("couch_scanner", "interval_sec", "1", false),
+    couch_scanner:resume(),
+    config:set("couch_scanner_plugins", Plugin, "true", false),
+    meck:wait(?FIND_PLUGIN, resume, 2, 10000).
+
+t_reset(_) ->
+    meck:reset(?FIND_PLUGIN),
+    meck:expect(
+        ?FIND_PLUGIN,
+        checkpoint,
+        1,
+        meck:seq([
+            meck:passthrough(),
+            meck:val(reset),
+            meck:passthrough()
+        ])
+    ),
+    Plugin = atom_to_list(?FIND_PLUGIN),
+    config:set("couch_scanner", "interval_sec", "1", false),
+    couch_scanner:resume(),
+    config:set("couch_scanner_plugins", Plugin, "true", false),
+    % Start called twice because of the reset
+    meck:wait(2, ?FIND_PLUGIN, start, 2, 10000).
+
+t_schedule_repeat(_) ->
+    meck:reset(?FIND_PLUGIN),
+    Plugin = atom_to_list(?FIND_PLUGIN),
+    config:set("couch_scanner", "interval_sec", "1", false),
+    couch_scanner:resume(),
+    config:set(Plugin, "repeat", "2_sec", false),
+    config:set("couch_scanner_plugins", Plugin, "true", false),
+    meck:wait(2, ?FIND_PLUGIN, start, 2, 10000).
+
+t_schedule_after(_) ->
+    meck:reset(?FIND_PLUGIN),
+    Plugin = atom_to_list(?FIND_PLUGIN),
+    config:set("couch_scanner", "interval_sec", "1", false),
+    couch_scanner:resume(),
+    Now = erlang:system_time(second),
+    TStamp = calendar:system_time_to_rfc3339(Now + 3, [{offset, "Z"}]),
+    config:set(Plugin, "after", TStamp, false),
+    config:set("couch_scanner_plugins", Plugin, "true", false),
+    meck:wait(?FIND_PLUGIN, start, 2, 10000).
+
+config_delete_section(Section) ->
+    [config:delete(K, V, false) || {K, V} <- config:get(Section)].
+
+add_doc(DbName, DocId, Body) ->
+    {ok, _} = fabric:update_doc(DbName, mkdoc(DocId, Body), [?ADMIN_CTX]),
+    ok.
+
+mkdoc(Id, #{} = Body) ->
+    Body1 = Body#{<<"_id">> => Id},
+    jiffy:decode(jiffy:encode(Body1)).
+
+num_calls(Fun, Args) ->
+    meck:num_calls(?FIND_PLUGIN, Fun, Args).
+
+log_calls(Level) ->
+    meck:num_calls(couch_scanner_util, log, [Level, ?FIND_PLUGIN, '_', '_', '_']).
+
+wait_exit(MSec) ->
+    meck:wait(couch_scanner_server, handle_info, [{'EXIT', '_', '_'}, '_'], MSec).

--- a/src/docs/src/config/index.rst
+++ b/src/docs/src/config/index.rst
@@ -24,6 +24,7 @@ Configuration
     cluster
     couch-peruser
     disk-monitor
+    scanner
     http
     auth
     compaction

--- a/src/docs/src/config/scanner.rst
+++ b/src/docs/src/config/scanner.rst
@@ -1,0 +1,231 @@
+.. Licensed under the Apache License, Version 2.0 (the "License"); you may not
+.. use this file except in compliance with the License. You may obtain a copy of
+.. the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+.. WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+.. License for the specific language governing permissions and limitations under
+.. the License.
+
+.. default-domain:: config
+.. highlight:: ini
+
+=======
+Scanner
+=======
+
+Configure background scanning plugins.
+
+.. _config/scanner:
+
+.. versionadded:: 3.4
+
+Scanner Options
+===============
+
+.. config:section:: couch_scanner :: Scanner Options
+
+    .. config:option:: interval_sec
+
+        How often to check for configuration changes and start/stop plugins.
+        The default is 5 seconds. ::
+
+            [couch_scanner]
+            interval_sec = 5
+
+    .. config:option:: min_penalty_sec
+
+        Minimum time to force a plugin to wait before running again after a
+        crash. Defaults to 30 seconds. ::
+
+            [couch_scanner]
+            min_penalty_sec = 30
+
+    .. config:option:: max_penalty_sec
+
+        Maximum time to force a plugin to wait after repeated crashes. The
+        default is 8 hours (in seconds). ::
+
+            [couch_scanner]
+            min_penalty_sec = 28800
+
+    .. config:option:: heal_threshold_sec
+
+        If plugin runs successfully without crashing for this long, reset its
+        repeated error count. Defaults to 5 minutes (in seconds). ::
+
+            [couch_scanner]
+            heal_threshold_sec = 300
+
+    .. config:option:: db_rate_limit
+
+        Database processing rate limit. This will also be the rate at which
+        design documents are fetched. The rate is shared across all running
+        plugins. ::
+
+            [couch_scanner]
+            db_rate_limit = 25
+
+    .. config:option:: shard_rate_limit
+
+       Limits the rate at which plugins may open db shard files on a node. The
+       rate is shared across all running plugins. ::
+
+            [couch_scanner]
+            db_shard_limit = 50
+
+    .. config:option:: doc_rate_limit
+
+        Limit the rate at which plugins open documents. The rate is shared
+        across all running plugins. ::
+
+            [couch_scanner]
+            doc_rate_limit = 1000
+
+.. config:section:: couch_scanner_plugins :: Enable Scanner Plugins
+
+    .. config:option:: $plugin
+
+        Which plugins are enabled. By default plugins are disabled. ::
+
+            [couch_scanner_plugins]
+            couch_scanner_plugin_ddoc_features = false
+            couch_scanner_plugin_find = false
+
+.. config:section:: $plugin :: General Plugin Settings
+
+These settings apply to all the plugins. Some plugins may also have individual
+settings in their ``[$plugin]`` section.
+
+    .. config:option:: after
+
+        Run plugin on or after this time. The default is to run once after the
+        node starts. Possible time formats are: unix seconds
+        (ex. ``1712338014``) or date/time: ``YYYY-MM-DD``, ``YYYY-MM-DDTHH``,
+        ``YYYY-MM-DDTHH:MM``. Times are in UTC. ::
+
+         [$plugin]
+         after = restart
+
+    .. config:option:: repeat
+
+        Run the plugin periodically. By default it will run once after node the
+        node starts. Possible period formats are: ``$num_$timeunit`` (ex.:
+        ``1000_sec``, ``30_min``, ``8_hours``, ``24_hour``, ``2_days``,
+        ``3_weeks``, ``1_month``) or ``$weekday`` (ex.: ``mon``, ``monday``,
+        ``Thu``, etc.) ::
+
+          [$plugin]
+          repeat = restart
+
+.. config:section:: $plugin.skip_dbs :: Skip databases
+
+    .. config:option:: $string
+
+        Skip over databases if their names contain any of the strings in this section. ::
+
+            [$plugin.skip_dbs]
+            string1 = true
+            string2 = true
+
+.. config:section:: $plugin.skip_ddocs :: Skip design documents
+
+    .. config:option:: $string
+
+        Skip over design documents if their DocIDs contain any of the strings in this section. ::
+
+            [$plugin.skip_ddocs]
+            string1 = true
+            string2 = true
+
+.. config:section:: $plugin.skip_docs :: Skip documents
+
+    .. config:option:: $string
+
+        Skip over documents if their DocIds contain any of the strings in this section. ::
+
+            [$plugin.skip_docs]
+            string1 = true
+            string2 = true
+
+.. config:section:: couch_scanner_plugin_find.regexes :: Configure the "Find" plugin
+
+    .. config:option:: $tag
+
+        Configure regular expressions to find. The format is $tag = $regex
+        Reports will be emitted to the log as warnings mentioning only their
+        tag. By default, no regular expressions are defined and the plugin will
+        run but won't report anything. ::
+
+            [couch_scanner_plugin_find.regexes]
+            regex1 = s3cret(1|2|3)
+            regex2 = n33dl3
+
+.. config:section:: couch_scanner_plugin_ddoc_features :: Configure the "Design doc features" plugin
+
+    .. config:option:: updates
+
+        Report if design documents have update handlers. Enabled by default. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            updates = true
+
+    .. config:option:: shows
+
+        Report if design documents have shows. Enabled by default. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            shows = true
+
+    .. config:option:: rewrites
+
+        Report if design documents have rewrites. Enabled by default. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            rewrites = true
+
+    .. config:option:: filters
+
+        Report if design documents have Javascript filters. Disabled by default. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            filters = false
+
+    .. config:option:: reduce
+
+        Report if design documents have Javascript reduce functions. Disabled by default. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            reduce = false
+
+    .. config:option:: validate_doc_update
+
+        Report if design documents have validate document update functions.
+        Disabled by default. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            validate_doc_update = false
+
+    .. config:option:: run_on_first_node
+
+        Run plugin on the first node or all the nodes. The default is to run
+        only on the first node of the cluster. If the value is "false" each
+        node of the cluster will process a consistent subset of the databases
+        so scanning will go faster but might consume more resources. Report if
+        design documents have validate document update functions. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            run_on_first_node = true
+
+    .. config:option:: ddoc_report
+
+        Emit reports for each design doc or aggregate them per database.
+        Emitting them per design doc will indicate the design document name,
+        however if there are too many design documents, that may generate a lot
+        of logs. The default is to aggregate reports per database. ::
+
+            [couch_scanner_plugin_ddoc_features]
+            ddoc_report = false


### PR DESCRIPTION
An application to scan the cluster with a plugin system to report various things about databases and documents. The initial idea was to have something like this to scan all the javascript design docs to check for compatibility with the new QuickJS engine. It had since been split apart from the QuickJS branch and made into a separate pull request.

The current implementation includes two plugins:
  * couch_scanner_plugin_find : scan for regexes in doc bodies
  * couch_scanner_ddoc_features : report various design doc features

A more detailed description is in the README.md file. The plugin API is defined in the `couch_scanner_plugin` module. There are additional details in the comments in the included Erlang modules. What follows is as summary description
of some of the implementation details and features.

Plugins are managed as individual process by the `couch_scanner_server` with the `start_link/1` and `stop/1` functions. After a plugin runner process is spawned, `couch_scanner_server` wait for it to exit. A process may exit with an error, then it will be penalized with an exponential back-off, or it may also exit with a special `{shutdown, {reschedule, TSec}}` value, in which case it will be rescheduled to run again on or after the `TSec` time.

After the plugin process process starts, it will load and validate its plugin module. Then, it will start scanning all the dbs and docs on the local node. Shard ranges will be scanned only on one of the cluster nodes to avoid duplicating work. For instance, if there are 2 shard ranges, `0-7`, `8-f`, with copies on nodes `n1`, `n2`, `n3`. Then, `0-7` might be scanned on `n1` only, and `8-f` on `n3`.

During various events the plugin process will call into the plugin module: on startup, when resuming from a checkpoint, when checkpointing, when processing a new db, design doc, a document, and when completing a scan. The plugin may accumulate reporting data, or may indicate that some parts of the scan should be skipped, or that the scanning session should be reset.

By default all plugins are disabled. Plugins are enabled and managed via the config system. To enable a plugin, add a `$plugin = true` entry in the `[couch_scanner_plugins]` section. For example:
```ini
[couch_scanner_plugins]
couch_scanner_plugin_ddoc_features = true
```

Plugins can be configured to run on or after a particular date and time or to run periodically. That can be configured via `[$plugin] after = ...` and `[$plugin] repeat = ...` settings. For instance, to run after `2024-03-20T15:00` and then run every Monday:
```ini
[couch_scanner_plugin_ddoc_features]
after = 2024-03-20T15:00
repeat = monday
```

The default values for `after` and `repeat` is ` = restart`, meaning to run once after the node starts up.

To prevent the plugins from consuming too may resources. There is a simple rate limiter which limits how many databases, shard and documents should e processed by all the plugins. Rate limits are configurable:
```ini
[couch_scanner]
db_rate_limit = 50
shard_rate_limit = 50
doc_rate_limit = 500
```
