### PR TITLE
nouveau: fix rexi_DOWN clause

### DIFF
--- a/src/nouveau/src/nouveau_fabric_search.erl
+++ b/src/nouveau/src/nouveau_fabric_search.erl
@@ -101,7 +101,7 @@ handle_message({rexi_DOWN, _, {_, NodeRef}, _}, _Shard, State) ->
     #state{counters = Counters0} = State,
     case fabric_util:remove_down_workers(Counters0, NodeRef, []) of
         {ok, Counters1} ->
-            {ok, Counters1};
+            {ok, State#state{counters = Counters1}};
         error ->
             {error, {nodedown, <<"progress not possible">>}}
     end;


### PR DESCRIPTION
reported in https://github.com/apache/couchdb/issues/5002

the badrecord is because we execute the second clause of handle_message and mess up the internal state (just returning the Counters rather than a state record around it)
