### PR TITLE
use PointsConfigMap so numeric query and numeric range query work cleanly

### DIFF
--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/core/ser/NullWrapper.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/core/ser/NullWrapper.java
@@ -1,0 +1,21 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.couchdb.nouveau.core.ser;
+
+public class NullWrapper extends PrimitiveWrapper<Void> {
+
+    public NullWrapper() {
+        super(null);
+    }
+}

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/core/ser/PrimitiveWrapper.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/core/ser/PrimitiveWrapper.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
     @JsonSubTypes.Type(value = IntWrapper.class, name = "int"),
     @JsonSubTypes.Type(value = LongWrapper.class, name = "long"),
     @JsonSubTypes.Type(value = StringWrapper.class, name = "string"),
+    @JsonSubTypes.Type(value = NullWrapper.class, name = "null"),
 })
 public class PrimitiveWrapper<T> {
 

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9IndexSchema.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9IndexSchema.java
@@ -1,0 +1,115 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.couchdb.nouveau.lucene9;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response.Status;
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import org.apache.couchdb.nouveau.api.DoubleField;
+import org.apache.couchdb.nouveau.api.Field;
+import org.apache.couchdb.nouveau.api.StringField;
+import org.apache.couchdb.nouveau.api.TextField;
+import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
+
+final class Lucene9IndexSchema {
+
+    public enum Type {
+        STRING,
+        TEXT,
+        DOUBLE;
+
+        private static Type fromField(final Field field) {
+            if (field instanceof StringField) {
+                return STRING;
+            } else if (field instanceof TextField) {
+                return TEXT;
+            } else if (field instanceof DoubleField) {
+                return DOUBLE;
+            }
+            throw new IllegalArgumentException(field + " not supported");
+        }
+    }
+
+    private final ConcurrentMap<String, Type> map;
+
+    private Lucene9IndexSchema(Map<String, Type> map) {
+        this.map = new ConcurrentHashMap<>(map);
+        this.map.put("_id", Type.STRING);
+    }
+
+    public static Lucene9IndexSchema emptySchema() {
+        return new Lucene9IndexSchema(new HashMap<String, Type>());
+    }
+
+    public static Lucene9IndexSchema fromString(final String schemaStr) {
+        Objects.requireNonNull(schemaStr);
+        if (schemaStr.isEmpty()) {
+            return emptySchema();
+        }
+        var map = Arrays.stream(schemaStr.split(","))
+                .collect(Collectors.toMap(i -> i.split(":")[0], i -> Type.valueOf(i.split(":")[1])));
+        return new Lucene9IndexSchema(map);
+    }
+
+    public void update(final Collection<Field> fields) {
+        Objects.requireNonNull(fields);
+        for (var field : fields) {
+            map.putIfAbsent(field.getName(), Type.fromField(field));
+            assertType(field);
+        }
+    }
+
+    public Type getType(final String fieldName) {
+        return map.get(fieldName);
+    }
+
+    public void assertType(final Field field) {
+        Objects.requireNonNull(field);
+        var expectedType = Type.fromField(field);
+        var actualType = map.get(field.getName());
+        if (actualType == null) {
+            throw new WebApplicationException("Unknown field " + field.getName(), Status.BAD_REQUEST);
+        }
+        if (expectedType != actualType) {
+            throw new WebApplicationException(
+                    String.format("field %s is of type %s not %s", field.getName(), expectedType, actualType),
+                    Status.BAD_REQUEST);
+        }
+    }
+
+    public Map<String, PointsConfig> toPointsConfigMap(final Locale locale) {
+        Objects.requireNonNull(locale);
+        var numberFormat = NumberFormat.getInstance(locale);
+        var doublePointsConfig = new PointsConfig(numberFormat, Double.class);
+        return map.entrySet().stream()
+                .filter(e -> e.getValue() == Type.DOUBLE)
+                .collect(Collectors.toMap(e -> e.getKey(), e -> doublePointsConfig));
+    }
+
+    @Override
+    public String toString() {
+        return map.entrySet().stream()
+                .map(e -> String.format("%s:%s", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(","));
+    }
+}

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/NouveauQueryParser.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/NouveauQueryParser.java
@@ -13,172 +13,33 @@
 
 package org.apache.couchdb.nouveau.lucene9;
 
-import java.text.NumberFormat;
-import java.text.ParseException;
-import java.util.List;
-import java.util.Locale;
+import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.flexible.core.QueryNodeException;
 import org.apache.lucene.queryparser.flexible.core.QueryParserHelper;
-import org.apache.lucene.queryparser.flexible.core.nodes.FieldQueryNode;
-import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
-import org.apache.lucene.queryparser.flexible.core.nodes.RangeQueryNode;
-import org.apache.lucene.queryparser.flexible.core.processors.NoChildOptimizationQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessorImpl;
-import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessorPipeline;
-import org.apache.lucene.queryparser.flexible.core.processors.RemoveDeletedQueryNodesProcessor;
 import org.apache.lucene.queryparser.flexible.standard.builders.StandardQueryTreeBuilder;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.queryparser.flexible.standard.config.StandardQueryConfigHandler;
 import org.apache.lucene.queryparser.flexible.standard.config.StandardQueryConfigHandler.ConfigurationKeys;
-import org.apache.lucene.queryparser.flexible.standard.nodes.PointQueryNode;
-import org.apache.lucene.queryparser.flexible.standard.nodes.PointRangeQueryNode;
-import org.apache.lucene.queryparser.flexible.standard.nodes.TermRangeQueryNode;
 import org.apache.lucene.queryparser.flexible.standard.parser.StandardSyntaxParser;
-import org.apache.lucene.queryparser.flexible.standard.processors.AllowLeadingWildcardProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.AnalyzerQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.BooleanQuery2ModifierNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.BooleanSingleChildOptimizationQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.BoostQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.DefaultPhraseSlopQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.FuzzyQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.IntervalQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.MatchAllDocsQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.MultiFieldQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.MultiTermRewriteMethodProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.OpenRangeQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.PhraseSlopQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.RegexpQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.RemoveEmptyNonLeafQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.TermRangeQueryNodeProcessor;
-import org.apache.lucene.queryparser.flexible.standard.processors.WildcardQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.StandardQueryNodeProcessorPipeline;
 import org.apache.lucene.search.Query;
 
 public final class NouveauQueryParser extends QueryParserHelper {
 
-    public NouveauQueryParser(final Analyzer analyzer, final Locale locale) {
+    public NouveauQueryParser(final Analyzer analyzer, final Map<String, PointsConfig> pointsConfigMap) {
         super(
                 new StandardQueryConfigHandler(),
                 new StandardSyntaxParser(),
-                new NouveauQueryNodeProcessorPipeline(locale),
+                new StandardQueryNodeProcessorPipeline(null),
                 new StandardQueryTreeBuilder());
         getQueryConfigHandler().set(ConfigurationKeys.ENABLE_POSITION_INCREMENTS, true);
         getQueryConfigHandler().set(ConfigurationKeys.ANALYZER, analyzer);
+        getQueryConfigHandler().set(ConfigurationKeys.POINTS_CONFIG_MAP, pointsConfigMap);
     }
 
     @Override
     public Query parse(String query, String defaultField) throws QueryNodeException {
         return (Query) super.parse(query, defaultField);
-    }
-
-    /**
-     * Same pipeline as StandardQueryParser but we substitute
-     * PointQueryNodeProcessor and PointRangeQueryNodeProcessor for
-     * NouveauPointProcessor below.
-     */
-    public static class NouveauQueryNodeProcessorPipeline extends QueryNodeProcessorPipeline {
-
-        public NouveauQueryNodeProcessorPipeline(final Locale locale) {
-            super(null);
-            add(new WildcardQueryNodeProcessor());
-            add(new MultiFieldQueryNodeProcessor());
-            add(new FuzzyQueryNodeProcessor());
-            add(new RegexpQueryNodeProcessor());
-            add(new MatchAllDocsQueryNodeProcessor());
-            add(new OpenRangeQueryNodeProcessor());
-            add(new NouveauPointProcessor(locale));
-            add(new TermRangeQueryNodeProcessor());
-            add(new AllowLeadingWildcardProcessor());
-            add(new AnalyzerQueryNodeProcessor());
-            add(new PhraseSlopQueryNodeProcessor());
-            add(new BooleanQuery2ModifierNodeProcessor());
-            add(new NoChildOptimizationQueryNodeProcessor());
-            add(new RemoveDeletedQueryNodesProcessor());
-            add(new RemoveEmptyNonLeafQueryNodeProcessor());
-            add(new BooleanSingleChildOptimizationQueryNodeProcessor());
-            add(new DefaultPhraseSlopQueryNodeProcessor());
-            add(new BoostQueryNodeProcessor());
-            add(new MultiTermRewriteMethodProcessor());
-            add(new IntervalQueryNodeProcessor());
-        }
-    }
-
-    /**
-     * If it looks like a number, treat it as a number.
-     */
-    public static class NouveauPointProcessor extends QueryNodeProcessorImpl {
-
-        private final Locale locale;
-
-        NouveauPointProcessor(final Locale locale) {
-            this.locale = locale != null ? locale : Locale.getDefault();
-        }
-
-        @Override
-        protected QueryNode postProcessNode(final QueryNode node) throws QueryNodeException {
-            final var numberFormat = NumberFormat.getInstance(locale);
-            final var pointsConfig = new PointsConfig(numberFormat, Double.class);
-
-            if (node instanceof FieldQueryNode && !(node.getParent() instanceof RangeQueryNode)) {
-                final var fieldNode = (FieldQueryNode) node;
-                String text = fieldNode.getTextAsString();
-                if (text.isEmpty()) {
-                    return node;
-                }
-                final Number number;
-                try {
-                    number = numberFormat.parse(text).doubleValue();
-                } catch (final ParseException e) {
-                    return node;
-                }
-                final var lowerNode = new PointQueryNode(fieldNode.getField(), number, numberFormat);
-                final var upperNode = new PointQueryNode(fieldNode.getField(), number, numberFormat);
-                return new PointRangeQueryNode(lowerNode, upperNode, true, true, pointsConfig);
-            }
-
-            if (node instanceof TermRangeQueryNode) {
-                final var termRangeNode = (TermRangeQueryNode) node;
-                final var lower = termRangeNode.getLowerBound();
-                final var upper = termRangeNode.getUpperBound();
-                final var lowerText = lower.getTextAsString();
-                final var upperText = upper.getTextAsString();
-                Number lowerNumber = null, upperNumber = null;
-
-                if (lowerText.length() > 0 && !lowerText.equals("-Infinity")) {
-                    try {
-                        lowerNumber = numberFormat.parse(lowerText).doubleValue();
-                    } catch (final ParseException e) {
-                        return node;
-                    }
-                }
-
-                if (upperText.length() > 0 && !upperText.equals("Infinity")) {
-                    try {
-                        upperNumber = numberFormat.parse(upperText).doubleValue();
-                    } catch (final ParseException e) {
-                        return node;
-                    }
-                }
-
-                final var lowerNode = new PointQueryNode(termRangeNode.getField(), lowerNumber, numberFormat);
-                final var upperNode = new PointQueryNode(termRangeNode.getField(), upperNumber, numberFormat);
-                final var lowerInclusive = termRangeNode.isLowerInclusive();
-                final var upperInclusive = termRangeNode.isUpperInclusive();
-
-                return new PointRangeQueryNode(lowerNode, upperNode, lowerInclusive, upperInclusive, pointsConfig);
-            }
-
-            return node;
-        }
-
-        @Override
-        protected QueryNode preProcessNode(final QueryNode node) throws QueryNodeException {
-            return node;
-        }
-
-        @Override
-        protected List<QueryNode> setChildrenOrder(final List<QueryNode> children) throws QueryNodeException {
-            return children;
-        }
     }
 }

--- a/nouveau/src/test/java/org/apache/couchdb/nouveau/lucene9/Lucene9IndexTest.java
+++ b/nouveau/src/test/java/org/apache/couchdb/nouveau/lucene9/Lucene9IndexTest.java
@@ -100,7 +100,7 @@ public class Lucene9IndexTest {
             }
             final SearchRequest request = new SearchRequest();
             request.setQuery("*:*");
-            request.setSort(List.of("foo<string>"));
+            request.setSort(List.of("foo"));
             final SearchResults results = index.search(request);
             assertThat(results.getTotalHits()).isEqualTo(count);
         } finally {

--- a/src/docs/src/api/ddoc/nouveau.rst
+++ b/src/docs/src/api/ddoc/nouveau.rst
@@ -62,13 +62,12 @@
         Example: ``{"bar":[{"label":"cheap","min":0,"max":100}]}``
     :query json sort: Specifies the sort order of the results.
         The default sort order is relevance. A JSON string of the form
-        ``"fieldname<type>"`` or ``"-fieldname<type>"`` for descending order, where
-        fieldname is the name of a string or number field, and ``type`` is either
-        ``double`` or ``string``. You can use a single string to sort by one field
-        or an array of strings to sort by several fields in the same order as the
-        array.
-        Some examples are ``"relevance"``, ``"bar<string>"``,
-        ``"-foo<double>"`` and [``"-foo<double>"``, ``"bar<string>"``].
+        ``"fieldname"`` or ``"-fieldname"`` for descending order, where
+        fieldname is the name of a string or double field. You can use a single string
+        to sort by one field or an array of strings to sort by several fields in the
+        same order as the array.
+        Some examples are ``"relevance"``, ``"bar"``, ``"-foo"`` and
+        [``"-foo"``, ``"bar"``].
     :query boolean update: Set to ``false`` to allow the use of an out-of-date index.
 
     :>header Content-Type: - :mimetype:`application/json`

--- a/src/docs/src/ddocs/nouveau.rst
+++ b/src/docs/src/ddocs/nouveau.rst
@@ -94,6 +94,10 @@ Stored
     analysis. The value is returned with search results but you cannot search,
     sort, range or facet over a stored field.
 
+.. warning:: the type of any specific field is determined by the first index
+             call. Attempts to index a different type into the same field will
+             throw an exception and prevent the index from building.
+
 Index functions
 ===============
 

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -309,11 +309,11 @@ range(gt, Arg) ->
     [<<"{">>, value_str(Arg), <<" TO ", Max/binary, "]">>].
 
 get_range(min, Arg) when is_number(Arg) ->
-    <<"-Infinity">>;
+    <<"*">>;
 get_range(min, _Arg) ->
     <<"\"\"">>;
 get_range(max, Arg) when is_number(Arg) ->
-    <<"Infinity">>;
+    <<"*">>;
 get_range(max, _Arg) ->
     <<"\u0x10FFFF">>.
 
@@ -493,8 +493,7 @@ convert_default_test() ->
 
 convert_lt_test() ->
     ?assertEqual(
-        {op_field,
-            {[[<<"field">>], <<":">>, <<"number">>], [<<"[-Infinity TO ">>, <<"42">>, <<"}">>]}},
+        {op_field, {[[<<"field">>], <<":">>, <<"number">>], [<<"[* TO ">>, <<"42">>, <<"}">>]}},
         convert_selector(#{<<"field">> => #{<<"$lt">> => 42}})
     ),
     ?assertEqual(
@@ -514,8 +513,7 @@ convert_lt_test() ->
 
 convert_lte_test() ->
     ?assertEqual(
-        {op_field,
-            {[[<<"field">>], <<":">>, <<"number">>], [<<"[-Infinity TO ">>, <<"42">>, <<"]">>]}},
+        {op_field, {[[<<"field">>], <<":">>, <<"number">>], [<<"[* TO ">>, <<"42">>, <<"]">>]}},
         convert_selector(#{<<"field">> => #{<<"$lte">> => 42}})
     ),
     ?assertEqual(
@@ -566,8 +564,7 @@ convert_ne_test() ->
 
 convert_gte_test() ->
     ?assertEqual(
-        {op_field,
-            {[[<<"field">>], <<":">>, <<"number">>], [<<"[">>, <<"42">>, <<" TO Infinity]">>]}},
+        {op_field, {[[<<"field">>], <<":">>, <<"number">>], [<<"[">>, <<"42">>, <<" TO *]">>]}},
         convert_selector(#{<<"field">> => #{<<"$gte">> => 42}})
     ),
     ?assertEqual(
@@ -587,8 +584,7 @@ convert_gte_test() ->
 
 convert_gt_test() ->
     ?assertEqual(
-        {op_field,
-            {[[<<"field">>], <<":">>, <<"number">>], [<<"{">>, <<"42">>, <<" TO Infinity]">>]}},
+        {op_field, {[[<<"field">>], <<":">>, <<"number">>], [<<"{">>, <<"42">>, <<" TO *]">>]}},
         convert_selector(#{<<"field">> => #{<<"$gt">> => 42}})
     ),
     ?assertEqual(

--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -25,6 +25,7 @@
     "mango (partitioned)",
     "delete",
     "purge",
-    "purge with conflicts"
+    "purge with conflicts",
+    "index same field with different field types"
   ]
 }


### PR DESCRIPTION
## Overview

Nouveau has a (somewhat ugly) extension to the query syntax that auto-detects if the searched _value_ is a number. if so,
it switches to querying the field as a number.

If, however, you've indexed a string that looks like a number, this behaviour prevents you from querying the field correctly.

Instead of that, this PR switches to the 'normal' approach in Lucene, namely the StandardQueryParser with a "points config"
that details which fields are numbers. With this extra information the query parser performs the correct kind of query for text or string fields that happen to have values that look like numbers and double fields, which actually have numbers.

The fundamental problem is that we don't declare a schema ahead of time, so we don't know which fields are numbers and which are not. In this PR the type of a field is determined by the type of value that's indexed into it first, it cannot be changed after that. this information is written into the commit data of the index.

## Testing recommendations

covered by tests

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/4997

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
