### PR TITLE
Fix flaky changes async test

### DIFF
--- a/test/elixir/test/changes_async_test.exs
+++ b/test/elixir/test/changes_async_test.exs
@@ -209,16 +209,18 @@ defmodule ChangesAsyncTest do
     :ok = wait_for_headers(req_id.id, 200)
     create_doc(db_name, %{_id: "rusty", bop: "plankton"})
 
-    changes = process_response(req_id.id, &parse_changes_line_chunk/1)
+    retry_until(fn ->
+      changes = process_response(req_id.id, &parse_changes_line_chunk/1)
 
-    changes_ids =
-      changes
-      |> Enum.filter(fn p -> Map.has_key?(p, "id") end)
-      |> Enum.map(fn p -> p["id"] end)
+      changes_ids =
+        changes
+        |> Enum.filter(fn p -> Map.has_key?(p, "id") end)
+        |> Enum.map(fn p -> p["id"] end)
 
-    assert Enum.member?(changes_ids, "bingo")
-    assert Enum.member?(changes_ids, "rusty")
-    assert length(changes_ids) == 2
+      Enum.member?(changes_ids, "bingo") and
+      Enum.member?(changes_ids, "rusty") and
+      length(changes_ids) == 2
+    end)
   end
 
   @tag :with_db


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Try to prevent failures like:
```
  1) test continuous filtered changes (ChangesAsyncTest)
     src/couchdb/test/elixir/test/changes_async_test.exs:193
     Expected truthy, got false
     code: assert Enum.member?(changes_ids, "rusty")
     arguments:

         # 1
         ["bingo"]

         # 2
         "rusty"

     stacktrace:
       src/couchdb/test/elixir/test/changes_async_test.exs:220: (test)

```

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

`make elixir`
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
