### PR TITLE
Always commit if we upgrade 2.x view files

### DIFF
--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -127,6 +127,7 @@ open(Db, State0) ->
                 {ok, {OldSig, Header}} ->
                     % Matching view signatures.
                     NewSt = init_and_upgrade_state(Db, Fd, State, Header),
+                    ok = commit(NewSt),
                     ensure_local_purge_doc(Db, NewSt),
                     {ok, NewSt};
                 % end of upgrade code for <= 2.x


### PR DESCRIPTION
When we upgrade empty view files from 2.x, we end up skipping the commit. Subsequently, we will see a "wrong signature" error when the view is opened later. The error is benign as we'd end up resetting an empty view, but it may surprise an operator. To avoid this, ensure to always commit after upgrading old views.

Issue: https://github.com/apache/couchdb/issues/4994
