### PR TITLE
Account for possible design docs in shardmap

### DIFF
--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -595,6 +595,9 @@ is_exported(Mod, F, A) ->
 
 % Shard selection
 
+shards(<<?DESIGN_DOC_PREFIX, _/binary>>, {Props}) when is_list(Props) ->
+    % In case the shard map has a design document in it
+    [];
 shards(DbName, {Props = [_ | _]}) ->
     Shards = lists:sort(mem3_util:build_shards(DbName, Props)),
     Fun = fun({R, SList}) ->

--- a/src/mem3/test/eunit/mem3_bdu_test.erl
+++ b/src/mem3/test/eunit/mem3_bdu_test.erl
@@ -38,6 +38,10 @@ start_couch() ->
     test_util:start_couch([mem3, chttpd]).
 
 stop_couch(Ctx) ->
+    % Clear the shards db since we added a design doc
+    % to it and we don't want it to affect other tests
+    ShardsDb = ?l2b(config:get("mem3", "shards_db", "_dbs")),
+    ok = couch_server:delete(ShardsDb, [?ADMIN_CTX]),
     test_util:stop_couch(Ctx).
 
 mem3_bdu_shard_doc_test_() ->


### PR DESCRIPTION
Sometimes eunit tests leave design docs behind and the scanner would crash with a case clause error. Test cleanup is fixed in its own commit, however it's possible for users to have their own design documents, so we should handle that case anyway.
