### PR TITLE
Temporary account lockout for repeated auth failure

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1060,3 +1060,26 @@ url = {{nouveau_url}}
 
 ; Scanner settings to skip dbs and docs would also work:
 ;[couch_quickjs_scanner_plugin.skip_{dbs,ddoc,docs}]
+
+[couch_auth_lockout]
+; CouchDB can temporarily lock out IP addresses that repeatedly fail authentication
+; mode can be set to one of three recognised values;
+; off - CouchDB does not track repeated authentication failures
+; warn - CouchDB will log a warning if repeated authentication failures occur
+; enforce - CouchDB will reject requests with a 403 status code if repeated
+; authentication failures occur
+;mode = off
+
+; The number of authentication failures above which lockout occurs.
+;threshold = 5
+
+; to control memory usage CouchDB will only track authentication failure count
+; for this many username and IP address pairs.
+; note: changing this setting requires a couchdb restart.
+;max_objects = 10000
+
+; The maximum time, in milliseconds, that CouchDB will track repeated authentication
+; failures. The account is automatically unlocked at the end of this time, starting
+; from the _first_ authentication failure.
+; note: changing this setting requires a couchdb restart.
+;max_lifetime = 300000

--- a/src/couch/src/couch_auth_lockout.erl
+++ b/src/couch/src/couch_auth_lockout.erl
@@ -1,0 +1,85 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License.  You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_auth_lockout).
+-include_lib("couch/include/couch_db.hrl").
+
+-define(LRU, couch_lockout_lru).
+
+-export([is_locked_out/3, lockout/3]).
+
+is_locked_out(#httpd{} = Req, UserName, UserSalt) ->
+    case lockout_mode() of
+        off ->
+            false;
+        Mode ->
+            is_locked_out_int(Req, Mode, UserName, UserSalt)
+    end.
+
+is_locked_out_int(#httpd{} = Req, Mode, UserName, UserSalt) ->
+    LockoutThreshold = lockout_threshold(),
+    case peer(Req) of
+        nopeer ->
+            false;
+        Peer ->
+            case ets_lru:lookup_d(?LRU, {Peer, UserName, UserSalt}) of
+                {ok, FailCount} when FailCount >= LockoutThreshold, Mode == enforce ->
+                    true;
+                {ok, FailCount} when FailCount >= LockoutThreshold, Mode == warn ->
+                    couch_log:warning(
+                        "~p: authentication failure threshold reached for ~s from ~s",
+                        [?MODULE, UserName, Peer]
+                    ),
+                    false;
+                {ok, _} ->
+                    false;
+                not_found ->
+                    false
+            end
+    end.
+
+lockout(#httpd{} = Req, UserName, UserSalt) ->
+    case peer(Req) of
+        nopeer ->
+            ok;
+        Peer ->
+            case lockout_mode() of
+                off ->
+                    ok;
+                _ ->
+                    ets_lru:update_counter(?LRU, {Peer, UserName, UserSalt}, 1)
+            end
+    end.
+
+lockout_mode() ->
+    case config:get("couch_auth_lockout", "mode", "off") of
+        "off" ->
+            off;
+        "warn" ->
+            warn;
+        "enforce" ->
+            enforce;
+        _ ->
+            off
+    end.
+
+lockout_threshold() ->
+    config:get_integer("couch_auth_lockout", "threshold", 5).
+
+peer(#httpd{mochi_req = MochiReq}) ->
+    Socket = mochiweb_request:get(socket, MochiReq),
+    case Socket of
+        {remote, _Pid, _Ref} ->
+            nopeer;
+        _ ->
+            mochiweb_request:get(peer, MochiReq)
+    end.

--- a/src/couch/src/couch_primary_sup.erl
+++ b/src/couch/src/couch_primary_sup.erl
@@ -33,6 +33,17 @@ init([]) ->
                         {max_idle, config:get_integer("couch_passwords_cache", "max_idle", 600_000)}
                     ]
                 ]},
+                permanent, 5000, worker, [ets_lru]},
+            {couch_lockout_lru,
+                {ets_lru, start_link, [
+                    couch_lockout_lru,
+                    [
+                        {max_objects,
+                            config:get_integer("couch_auth_lockout", "max_objects", 10_000)},
+                        {max_lifetime,
+                            config:get_integer("couch_auth_lockout", "max_lifetime", 300_000)}
+                    ]
+                ]},
                 permanent, 5000, worker, [ets_lru]}
         ] ++ couch_servers(),
     {ok, {{one_for_one, 10, 3600}, Children}}.

--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -549,3 +549,47 @@ Authentication Configuration
 
         That's all, you are done with the migration from ``roles_claim_name`` to
         ``roles_claim_path`` Easy, isn't it?
+
+.. config:section:: couch_auth_lockout :: Automatic User Lockout
+
+    .. config:option:: mode :: lockout mode
+
+        When set to ``off`` (the default), CouchDB will not track repeated
+        authentication failures.
+
+        When set to ``warn``, CouchDB will log a warning when repeated
+        authentication failures occur for a specific user and client IP address.
+
+        When set to ``enforce``, CouchDB will will reject requests with a
+        403 status code if repeated authentication failures occur for a
+        specific user and client IP address. ::
+
+            [couch_auth_lockout]
+            mode = enforce
+
+    .. config:option:: threshold :: lockout threshold
+
+        When ``threshold`` (default ``5``) number of failed authentication requests
+        happen within the same ``max_lifetime`` period, CouchDB will lock out further
+        authentication attempts for the rest of the ``max_lifetime`` period if
+        ``mode`` is set to ``enforce``. ::
+
+            [couch_auth_lockout]
+            threshold = 5
+
+    .. config:option:: max_objects :: maximum number of username, IP pairs to track
+
+        The maximum number of username+IP pairs that CouchDB will track, to limit
+        memory usage. Defaults to ``10,000``. Changes to this setting are only picked
+        up at CouchDB start or restart time. ::
+
+           [couch_auth_lockout]
+           max_objects = 10000
+
+    .. config:option:: max_lifetime :: maximum duration of lockout period
+
+        The maximum duration of the lockout period, measured in milliseconds.
+        Changes to this setting are only picked up at CouchDB start or restart time. ::
+
+           [couch_auth_lockout]
+           max_lifetime = 300000

--- a/test/elixir/test/auth_lockout_test.exs
+++ b/test/elixir/test/auth_lockout_test.exs
@@ -1,0 +1,65 @@
+defmodule AuthLockoutTest do
+  use CouchTestCase
+
+  @moduletag :authentication
+
+  @moduletag config: [
+               {
+                 "admins",
+                 "couch_auth_lockout",
+                 "bar"
+               }
+             ]
+
+  test "lockout after multiple failed authentications", _context do
+    server_config = [
+      %{
+        :section => "couch_auth_lockout",
+        :key => "mode",
+        :value => "enforce"
+      }
+    ]
+
+    run_on_modified_server(
+      server_config,
+      fn -> test_couch_auth_lockout_enforcement() end
+    )
+  end
+
+  defp test_couch_auth_lockout_enforcement do
+    # exceed the lockout threshold
+    for _n <- 1..5 do
+      resp = Couch.get("/_all_dbs",
+        no_auth: true,
+        headers:  [authorization: "Basic #{:base64.encode("couch_auth_lockout:baz")}"]
+        )
+      assert resp.status_code == 401
+    end
+
+    # locked out?
+    resp = Couch.get("/_all_dbs",
+      no_auth: true,
+      headers:  [authorization: "Basic #{:base64.encode("couch_auth_lockout:baz")}"]
+    )
+    assert resp.status_code == 403
+    assert resp.body["reason"] == "Account is temporarily locked due to multiple authentication failures"
+  end
+
+  defp test_couch_auth_lockout_warning do
+    # exceed the lockout threshold
+    for _n <- 1..5 do
+      resp = Couch.get("/_all_dbs",
+        no_auth: true,
+        headers:  [authorization: "Basic #{:base64.encode("couch_auth_lockout:baz")}"]
+        )
+      assert resp.status_code == 401
+    end
+
+    # warning?
+    resp = Couch.get("/_all_dbs",
+      no_auth: true,
+      headers:  [authorization: "Basic #{:base64.encode("couch_auth_lockout:baz")}"]
+    )
+  end
+
+end

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -46,6 +46,10 @@
   "AuthCacheTest": [
     "auth cache management"
   ],
+  "AuthLockoutTest": [
+    "lockout after multiple failed authentications",
+    "lockout warning after multiple failed authentications"
+  ],
   "BasicsTest": [
     "'+' in document name should encode to '+'",
     "'+' in document name should encode to space",


### PR DESCRIPTION
## Overview

Enhance couchdb to efficiently reject requests for a given user if repeated requests have failed for authentication reasons, from the same IP address. This helps slow brute-force password attacks and is especially helpful if each authentication attempt is very expensive (pbkdf2 with a high iteration count, typically).

## Testing recommendations

will be covered by automated tests

## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
