### PR TITLE
WorksOnArm Amazon instance seems to be gone for good

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -71,18 +71,6 @@ meta = [
     image: "apache/couchdbci-debian:buster-erlang-${ERLANG_VERSION}"
   ],
 
-  // Exclude temporarily until we can fix package cache directory
-  // permissions
-  //
-  // 'bullseye-arm64': [
-  //   name: 'Debian 11 ARM',
-  //   spidermonkey_vsn: '78',
-  //   enable_nouveau: true,
-  //   enable_clouseau: false,
-  //   image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
-  //   node_label: 'arm64v8'
-  // ],
-
   'bullseye-ppc64': [
     name: 'Debian 11 POWER',
     spidermonkey_vsn: '78',


### PR DESCRIPTION
I pinged people at AWS a few times since last year but got no response so far. Remove the entry as it seems the program is either discontinued or they don't want to support Apache CouchDB any longer.
