### PR TITLE
Optimise fabric:all_dbs()

### DIFF
--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -84,19 +84,9 @@ all_dbs() ->
 %% @doc returns a list of all database names
 -spec all_dbs(Prefix :: iodata()) -> {ok, [binary()]}.
 all_dbs(Prefix) when is_binary(Prefix) ->
-    Length = byte_size(Prefix),
-    MatchingDbs = mem3:fold_shards(
-        fun(#shard{dbname = DbName}, Acc) ->
-            case DbName of
-                <<Prefix:Length/binary, _/binary>> ->
-                    [DbName | Acc];
-                _ ->
-                    Acc
-            end
-        end,
-        []
-    ),
-    {ok, lists:usort(MatchingDbs)};
+    FoldFun = fun(DbName, Acc) -> [DbName | Acc] end,
+    DbNames = mem3:fold_dbs(Prefix, FoldFun, []),
+    {ok, lists:reverse(DbNames)};
 %% @equiv all_dbs(list_to_binary(Prefix))
 all_dbs(Prefix) when is_list(Prefix) ->
     all_dbs(list_to_binary(Prefix)).

--- a/src/fabric/src/fabric_bench.erl
+++ b/src/fabric/src/fabric_bench.erl
@@ -109,24 +109,20 @@ go(Db, #{} = Opts0) when is_binary(Db) ->
     ok.
 
 old_enough_db(Db) when is_binary(Db) ->
-    case string:prefix(Db, ?PREFIX) of
-        nomatch ->
-            false;
-        Ts when is_binary(Ts) ->
-            NowUSec = os:system_time(microsecond),
-            try binary_to_integer(Ts) of
-                AgeUSec when (NowUSec - AgeUSec) > ?MAX_DB_AGE_USEC ->
-                    true;
-                _ ->
-                    false
-            catch
-                _:_ ->
-                    false
-            end
+    Ts = string:prefix(Db, ?PREFIX),
+    NowUSec = os:system_time(microsecond),
+    try binary_to_integer(Ts) of
+        AgeUSec when (NowUSec - AgeUSec) > ?MAX_DB_AGE_USEC ->
+            true;
+        _ ->
+            false
+    catch
+        _:_ ->
+            false
     end.
 
 delete_old_dbs() ->
-    {ok, Dbs} = fabric:all_dbs(),
+    {ok, Dbs} = fabric:all_dbs(<<?PREFIX>>),
     [ok = fabric:delete_db(Db) || Db <- Dbs, old_enough_db(Db)],
     ok.
 

--- a/src/mem3/src/mem3.erl
+++ b/src/mem3/src/mem3.erl
@@ -25,6 +25,7 @@
     ushards/1, ushards/2
 ]).
 -export([get_shard/3, local_shards/1, shard_suffix/1, fold_shards/2]).
+-export([fold_dbs/2, fold_dbs/3]).
 -export([sync_security/0, sync_security/1]).
 -export([compare_nodelists/0, compare_shards/1]).
 -export([quorum/1, group_by_proximity/1]).
@@ -217,6 +218,12 @@ shard_creation_time(DbName0) ->
 
 fold_shards(Fun, Acc) ->
     mem3_shards:fold(Fun, Acc).
+
+fold_dbs(Fun, Acc) when is_function(Fun, 2) ->
+    mem3_shards:fold_dbs(<<>>, Fun, Acc).
+
+fold_dbs(<<Prefix/binary>>, Fun, Acc) when is_function(Fun, 2) ->
+    mem3_shards:fold_dbs(Prefix, Fun, Acc).
 
 sync_security() ->
     mem3_sync_security:go().


### PR DESCRIPTION
Previous version was awfully inefficient: we only need the dbname, but we opened each document body, parsed the shards out of it, generated Q*N shards, then put them in a list and usorted them back down to a list of dbnames.

We don't use this in many places (mem3 security sync, fabric bench) but it might be nice to have an efficient version of it anyway.
