### PR TITLE
Create Python virtualenv on Windows for docs

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -477,7 +477,7 @@ config.erl:
 src\docs\build:
 	@echo 'Building docs...'
 ifeq ($(with_docs), 1)
-	@cd src\docs && make.bat html && make.bat man
+	@cd src\docs && setup.bat && make.bat html && make.bat man
 endif
 
 

--- a/src/docs/setup.bat
+++ b/src/docs/setup.bat
@@ -1,0 +1,11 @@
+@echo off
+
+IF NOT EXIST "%CD%\.venv\Scripts\activate" (
+  DEL /S "%CD%\.venv"
+  python "-m" "venv" ".venv"
+  "%CD%\.venv\Scripts\activate.bat"
+  pip "install" "--upgrade" "pip"
+  pip "install" "-r" "requirements.txt"
+) ELSE (
+  "%CD%\.venv\Scripts\activate.bat"
+)


### PR DESCRIPTION
Add an equivalent setup script for Windows to
init python dev environment for building docs.