### PR TITLE
upgrade dropwizard to 4.0.7

### DIFF
--- a/nouveau/build.gradle
+++ b/nouveau/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('io.dropwizard:dropwizard-dependencies:4.0.6')
+    implementation platform('io.dropwizard:dropwizard-dependencies:4.0.7')
     implementation 'io.dropwizard:dropwizard-core'
     implementation 'io.dropwizard:dropwizard-http2'
     implementation 'io.dropwizard.metrics:metrics-core'


### PR DESCRIPTION
## Overview

This release is addressing [CVE-2024-22201](https://github.com/advisories/GHSA-rggv-cv7r-mw98)  via upgrade to Jetty 11.0.20.

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
