### PR TITLE
Update a few deps and improve CI

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -31,6 +31,14 @@ meta = [
     image: "apache/couchdbci-centos:8-erlang-${ERLANG_VERSION}"
   ],
 
+  'centos9': [
+    name: 'CentOS 9',
+    spidermonkey_vsn: '78',
+    enable_nouveau: true,
+    enable_clouseau: true,
+    image: "apache/couchdbci-centos:9-erlang-${ERLANG_VERSION}"
+  ],
+
   'focal': [
     name: 'Ubuntu 20.04',
     spidermonkey_vsn: '68',
@@ -80,6 +88,14 @@ meta = [
     image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}"
   ],
 
+  'bookworm-quickjs': [
+    name: 'Debian 12 with QuickJS',
+    disable_spidermonkey: true,
+    enable_nouveau: true,
+    enable_clouseau: true,
+    image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}"
+  ],
+
   'freebsd-x86_64': [
      name: 'FreeBSD',
      spidermonkey_vsn: '91',
@@ -106,7 +122,11 @@ meta = [
 ]
 
 def String configure(config) {
-  result = "./configure --skip-deps --spidermonkey-version ${config.spidermonkey_vsn}"
+  if (config.disable_spidermonkey) {
+      result = "./configure --skip-deps --disable-spidermonkey"
+  } else {
+      result = "./configure --skip-deps --spidermonkey-version ${config.spidermonkey_vsn}"
+  }
   if (config.enable_nouveau) {
     result += " --enable-nouveau"
   }
@@ -359,24 +379,31 @@ pipeline {
         unstash 'tarball'
         unarchive mapping: ['pkgs/' : '.']
 
-        sh( label: 'Build Debian repo', script: '''
-            mkdir -p $BRANCH_NAME/debian $BRANCH_NAME/el8 $BRANCH_NAME/source
+        sh( label: 'Setup repo dirs', script: '''
+            mkdir -p $BRANCH_NAME/debian $BRANCH_NAME/el8 $BRANCH_NAME/el9 $BRANCH_NAME/source
             git clone https://github.com/apache/couchdb-pkg
-            for plat in bullseye focal
+          ''' )
+
+        sh( label: 'Build Debian repo', script: '''
+            for plat in bullseye bookworm focal
             do
               reprepro -b couchdb-pkg/repo includedeb $plat pkgs/$plat/*.deb
             done
           ''' )
 
-        sh( label: 'Build CentOS repos', script: '''
-            #cp js/centos-8/*rpm pkgs/centos8
-            cd pkgs/centos8 && createrepo_c --database .
+        sh( label: 'Build CentOS 8', script: '''
+            (cd pkgs/centos8 && createrepo_c --database .)
+          ''' )
+
+        sh( label: 'Build CentOS 9', script: '''
+            (cd pkgs/centos9 && createrepo_c --database .)
           ''' )
 
         sh( label: 'Build unified repo', script: '''
             mv couchdb-pkg/repo/pool $BRANCH_NAME/debian
             mv couchdb-pkg/repo/dists $BRANCH_NAME/debian
             mv pkgs/centos8/* $BRANCH_NAME/el8
+            mv pkgs/centos9/* $BRANCH_NAME/el9
             mv apache-couchdb-*.tar.gz $BRANCH_NAME/source
             cd $BRANCH_NAME/source
             ls -1tr | head -n -10 | xargs -d '\n' rm -f --

--- a/src/docs/requirements.txt
+++ b/src/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==7.2.6
+Sphinx==7.3.7
 sphinx-rtd-theme==2.0.0
 sphinxcontrib-httpdomain==1.8.1
 sphinxcontrib-jquery==4.1

--- a/src/mango/requirements.txt
+++ b/src/mango/requirements.txt
@@ -1,5 +1,5 @@
-nose2==0.11.0
-# requests 2.27.1 is the highest supported version
-# on ubuntu 18 and centos 7 CI workers
+# nose2 0.13.0, requests, hypothesis version are driven
+# by the minimum version for python on centos 8 currently
+nose2==0.13.0
 requests==2.27.1
 hypothesis==6.31.6


### PR DESCRIPTION
Some dependencies were held back due to older CentOS and Ubuntu, now we can update them.

Try to replace CentOS7 with CentOS9 in the full CI and use the "no spidermonkey whatsoever" CI variant as well.

Full CI green pass: https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FFullPlatformMatrix/detail/jenkins-update-repos-and-reqs/5/pipeline