### PR TITLE
Update `nose2` to 0.13 to remove the missing method warning.

### DIFF
--- a/src/mango/requirements.txt
+++ b/src/mango/requirements.txt
@@ -1,4 +1,4 @@
-nose2==0.11.0
+nose2==0.13.0
 # requests 2.27.1 is the highest supported version
 # on ubuntu 18 and centos 7 CI workers
 requests==2.27.1


### PR DESCRIPTION
The `unittest.TestCase` class in python 3.12 has a new addDuration method. The nose extends that class without providing the implementation for the method. This has been fixed in following PR https://github.com/nose-devs/nose2/pull/570. The PR was included in 0.13. This version requires python >= 3.5. Which is a minimum required version for CouchDB as well.

The original warning message (for 3.12/3.12.2_1)

```
The python version >= 3.12 doesn't provide
3.12/lib/python3.12/unittest/case.py:580:
  RuntimeWarning: TestResult has no addDuration method
    warnings.warn("TestResult has no addDuration method",
```

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
