### PR TITLE
On ARM64 FreeBSD use QuickJS

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -97,20 +97,20 @@ meta = [
   ],
 
   'freebsd-x86_64': [
-     name: 'FreeBSD',
+     name: 'FreeBSD x86_64',
      spidermonkey_vsn: '91',
      enable_clouseau: false,
      gnu_make: 'gmake'
   ],
 
-  // Disable temporarily until issue 4916
-  // is resolved
-  // 'freebsd-arm64': [
-  //    name: 'FreeBSD',
-  //    spidermonkey_vsn: '91',
-  //    enable_clouseau: false,
-  //    gnu_make: 'gmake'
-  // ],
+  // Spidermonkey 91 has issues on ARM64 FreeBSD
+  // use QuickJS for now
+  'freebsd-arm64': [
+     name: 'FreeBSD ARM64 QuickJS',
+     disable_spidermonkey: true,
+     enable_clouseau: false,
+     gnu_make: 'gmake'
+  ],
 
  'macos': [
     name: 'macOS',


### PR DESCRIPTION
Better than not running any tests at all for now, at least.

FreeBSD ARM64 tests are green in full CI tests again:

<img width="301" alt="Screenshot 2024-05-15 at 9 39 19 PM" src="https://github.com/apache/couchdb/assets/211822/e2bf270c-48b5-40e7-9227-488f83af638f">
