### PR TITLE
JWT: require valid `exp` claim by default

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -225,7 +225,10 @@ bind_address = 127.0.0.1
 ; List of claims to validate
 ; can be the name of a claim like "exp" or a tuple if the claim requires
 ; a parameter
-;required_claims = exp, {iss, "IssuerNameHere"}
+; Example:
+; required_claims = exp, nbf, {iss, "MyCompany"}
+; default value if not set;
+;required_claims = exp
 
 ; roles_claim_name is marked as deprecated. Please use roles_claim_path instead!
 ; Values for ``roles_claim_name`` can only be top-level attributes in the JWT

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -306,7 +306,7 @@ get_roles_claim(Claims) ->
     end.
 
 get_configured_claims() ->
-    Claims = config:get("jwt_auth", "required_claims", ""),
+    Claims = config:get("jwt_auth", "required_claims", "exp"),
     Re = "((?<key1>[a-z]+)|{(?<key2>[a-z]+)\s*,\s*\"(?<val>[^\"]+)\"})",
     case re:run(Claims, Re, [global, {capture, [key1, key2, val], binary}]) of
         nomatch when Claims /= "" ->


### PR DESCRIPTION
## Overview

Users of JWT rightly expect tokens to be considered invalid once they expire. It is a surprise to some that this requires a change to the default configuration. In the interest of security we will now require a valid `exp` claim in tokens. Administrators can disable the check by changing `required_claims` back to the empty string.

We do not add `nbf` as a required claim as it seems to not be set often in practice.

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/5046

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
