### PR TITLE
Handle missing VDU better in In QuickJS scanner plugin

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
+++ b/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
@@ -100,7 +100,7 @@ ddoc(#st{sid = SId} = St, DbName, #doc{id = DDocId} = DDoc) ->
     ?INFO(#{sid => SId, db => DbName, ddoc => DDocId}),
     #st{ddoc_cnt = Cnt} = St,
     St1 = St#st{ddoc_cnt = Cnt + 1},
-    #doc{body = {Props = [_ | _]}} = DDoc,
+    #doc{body = {Props}} = DDoc,
     case couch_util:get_value(<<"language">>, Props, <<"javascript">>) of
         <<"javascript">> -> {ok, process_ddoc(St1, DbName, DDoc)};
         _ -> {ok, St1}
@@ -401,6 +401,9 @@ vdu_load(#st{qjs_proc = Qjs, sm_proc = Sm}, VDU) ->
         false -> throw({validate, {vdu, QjsRes, SmRes}})
     end.
 
+vdu_doc_validate(#st{}, _DDocId, undefined, _Doc) ->
+    % No VDU
+    ok;
 vdu_doc_validate(#st{} = St, DDocId, _VDU, Doc) ->
     #st{qjs_proc = Qjs, sm_proc = Sm} = St,
     QjsRes = vdu_doc(Qjs, DDocId, Doc),

--- a/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
+++ b/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
@@ -21,7 +21,12 @@ couch_quickjs_scanner_plugin_test_() ->
         fun setup/0,
         fun teardown/1,
         [
-            ?TDEF_FE(t_basic, 10)
+            ?TDEF_FE(t_vdu_filter_map, 10),
+            ?TDEF_FE(t_filter_map, 10),
+            ?TDEF_FE(t_map_only, 10),
+            ?TDEF_FE(t_vdu_only, 10),
+            ?TDEF_FE(t_filter_only, 10),
+            ?TDEF_FE(t_empty_ddoc, 10)
         ]
     }.
 
@@ -47,7 +52,266 @@ setup() ->
     ok = add_doc(DbName, ?DOC3, #{a => z}),
     ok = add_doc(DbName, ?DOC4, #{a => w}),
     ok = add_doc(DbName, ?DOC5, #{a => u}),
-    ok = add_doc(DbName, ?DDOC1, #{
+    config:set(atom_to_list(?PLUGIN), "max_batch_items", "1", false),
+    {Ctx, DbName}.
+
+teardown({Ctx, DbName}) ->
+    config_delete_section("couch_scanner"),
+    config_delete_section("couch_scanner_plugins"),
+    config_delete_section(atom_to_list(?PLUGIN)),
+    couch_scanner:reset_checkpoints(),
+    couch_scanner:resume(),
+    fabric:delete_db(DbName),
+    test_util:stop_couch(Ctx),
+    meck:unload().
+
+t_vdu_filter_map({_, DbName}) ->
+    ok = add_doc(DbName, ?DDOC1, ddoc_vdu(ddoc_filter(ddoc_view(#{})))),
+    meck:reset(couch_scanner_server),
+    meck:reset(?PLUGIN),
+    config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
+    wait_exit(10000),
+    ?assertEqual(1, num_calls(start, 2)),
+    case couch_server:with_spidermonkey() of
+        true ->
+            ?assertEqual(1, num_calls(complete, 1)),
+            ?assertEqual(2, num_calls(checkpoint, 1)),
+            ?assertEqual(1, num_calls(db, ['_', DbName])),
+            ?assertEqual(1, num_calls(ddoc, ['_', DbName, '_'])),
+            ?assert(num_calls(shards, 2) >= 1),
+            DbOpenedCount = num_calls(db_opened, 2),
+            ?assert(DbOpenedCount >= 2),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC1, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC3, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC4, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC5, '_'])),
+            ?assert(num_calls(doc, 3) >= 5),
+            DbClosingCount = num_calls(db_closing, 2),
+            ?assertEqual(DbOpenedCount, DbClosingCount),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_error_exits])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_errors])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_exits])),
+            % start, complete and each of the 5 docs should fail = 7 total
+            ?assertEqual(7, log_calls(warning));
+        false ->
+            ok
+    end.
+
+t_filter_map({_, DbName}) ->
+    ok = add_doc(DbName, ?DDOC1, ddoc_filter(ddoc_view(#{}))),
+    meck:reset(couch_scanner_server),
+    meck:reset(?PLUGIN),
+    config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
+    wait_exit(10000),
+    ?assertEqual(1, num_calls(start, 2)),
+    case couch_server:with_spidermonkey() of
+        true ->
+            ?assertEqual(1, num_calls(complete, 1)),
+            ?assertEqual(2, num_calls(checkpoint, 1)),
+            ?assertEqual(1, num_calls(db, ['_', DbName])),
+            ?assertEqual(1, num_calls(ddoc, ['_', DbName, '_'])),
+            ?assert(num_calls(shards, 2) >= 1),
+            DbOpenedCount = num_calls(db_opened, 2),
+            ?assert(DbOpenedCount >= 2),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC1, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC3, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC4, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC5, '_'])),
+            ?assert(num_calls(doc, 3) >= 5),
+            DbClosingCount = num_calls(db_closing, 2),
+            ?assertEqual(DbOpenedCount, DbClosingCount),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_error_exits])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_errors])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_exits])),
+            % start, complete and each of the 4 docs should fail = 6 total
+            ?assertEqual(6, log_calls(warning));
+        false ->
+            ok
+    end.
+
+t_map_only({_, DbName}) ->
+    ok = add_doc(DbName, ?DDOC1, ddoc_view(#{})),
+    meck:reset(couch_scanner_server),
+    meck:reset(?PLUGIN),
+    config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
+    wait_exit(10000),
+    ?assertEqual(1, num_calls(start, 2)),
+    case couch_server:with_spidermonkey() of
+        true ->
+            ?assertEqual(1, num_calls(complete, 1)),
+            ?assertEqual(2, num_calls(checkpoint, 1)),
+            ?assertEqual(1, num_calls(db, ['_', DbName])),
+            ?assertEqual(1, num_calls(ddoc, ['_', DbName, '_'])),
+            ?assert(num_calls(shards, 2) >= 1),
+            DbOpenedCount = num_calls(db_opened, 2),
+            ?assert(DbOpenedCount >= 2),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC1, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC3, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC4, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC5, '_'])),
+            ?assert(num_calls(doc, 3) >= 5),
+            DbClosingCount = num_calls(db_closing, 2),
+            ?assertEqual(DbOpenedCount, DbClosingCount),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_error_exits])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_errors])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_exits])),
+            % start, complete and each of the 3 docs should fail = 5 total
+            ?assertEqual(5, log_calls(warning));
+        false ->
+            ok
+    end.
+
+t_vdu_only({_, DbName}) ->
+    ok = add_doc(DbName, ?DDOC1, ddoc_vdu(#{})),
+    meck:reset(couch_scanner_server),
+    meck:reset(?PLUGIN),
+    config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
+    wait_exit(10000),
+    ?assertEqual(1, num_calls(start, 2)),
+    case couch_server:with_spidermonkey() of
+        true ->
+            ?assertEqual(1, num_calls(complete, 1)),
+            ?assertEqual(2, num_calls(checkpoint, 1)),
+            ?assertEqual(1, num_calls(db, ['_', DbName])),
+            ?assertEqual(1, num_calls(ddoc, ['_', DbName, '_'])),
+            ?assert(num_calls(shards, 2) >= 1),
+            DbOpenedCount = num_calls(db_opened, 2),
+            ?assert(DbOpenedCount >= 2),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC1, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC3, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC4, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC5, '_'])),
+            ?assert(num_calls(doc, 3) >= 5),
+            DbClosingCount = num_calls(db_closing, 2),
+            ?assertEqual(DbOpenedCount, DbClosingCount),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_error_exits])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_errors])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_exits])),
+            % start, complete and 1 vdu only = 3 total
+            ?assertEqual(3, log_calls(warning));
+        false ->
+            ok
+    end.
+
+t_filter_only({_, DbName}) ->
+    ok = add_doc(DbName, ?DDOC1, ddoc_filter(#{})),
+    meck:reset(couch_scanner_server),
+    meck:reset(?PLUGIN),
+    config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
+    wait_exit(10000),
+    ?assertEqual(1, num_calls(start, 2)),
+    case couch_server:with_spidermonkey() of
+        true ->
+            ?assertEqual(1, num_calls(complete, 1)),
+            ?assertEqual(2, num_calls(checkpoint, 1)),
+            ?assertEqual(1, num_calls(db, ['_', DbName])),
+            ?assertEqual(1, num_calls(ddoc, ['_', DbName, '_'])),
+            ?assert(num_calls(shards, 2) >= 1),
+            DbOpenedCount = num_calls(db_opened, 2),
+            ?assert(DbOpenedCount >= 2),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC1, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC3, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC4, '_'])),
+            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC5, '_'])),
+            ?assert(num_calls(doc, 3) >= 5),
+            DbClosingCount = num_calls(db_closing, 2),
+            ?assertEqual(DbOpenedCount, DbClosingCount),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_error_exits])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_errors])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_exits])),
+            % start, complete and one filter only = 3 total
+            ?assertEqual(3, log_calls(warning));
+        false ->
+            ok
+    end.
+
+t_empty_ddoc({_, DbName}) ->
+    ok = add_doc(DbName, ?DDOC1, #{}),
+    meck:reset(couch_scanner_server),
+    meck:reset(?PLUGIN),
+    config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
+    wait_exit(10000),
+    ?assertEqual(1, num_calls(start, 2)),
+    case couch_server:with_spidermonkey() of
+        true ->
+            ?assertEqual(1, num_calls(complete, 1)),
+            ?assertEqual(2, num_calls(checkpoint, 1)),
+            ?assertEqual(1, num_calls(db, ['_', DbName])),
+            ?assertEqual(1, num_calls(ddoc, ['_', DbName, '_'])),
+            ?assert(num_calls(shards, 2) >= 1),
+            ?assertEqual(0, num_calls(db_opened, 2)),
+            ?assertEqual(0, num_calls(doc_id, ['_', ?DOC1, '_'])),
+            ?assertEqual(0, num_calls(doc_id, ['_', ?DOC2, '_'])),
+            ?assertEqual(0, num_calls(doc_id, ['_', ?DOC3, '_'])),
+            ?assertEqual(0, num_calls(doc_id, ['_', ?DOC4, '_'])),
+            ?assertEqual(0, num_calls(doc_id, ['_', ?DOC5, '_'])),
+            ?assertEqual(0, num_calls(db_closing, 2)),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_error_exits])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_errors])),
+            ?assertEqual(0, couch_stats:sample([couchdb, query_server, process_exits])),
+            % start and complete only = 2 total
+            ?assertEqual(2, log_calls(warning));
+        false ->
+            ok
+    end.
+
+config_delete_section(Section) ->
+    [config:delete(K, V, false) || {K, V} <- config:get(Section)].
+
+add_doc(DbName, DocId, Body) ->
+    {ok, _} = fabric:update_doc(DbName, mkdoc(DocId, Body), [?ADMIN_CTX]),
+    ok.
+
+mkdoc(Id, #{} = Body) ->
+    Body1 = Body#{<<"_id">> => Id},
+    jiffy:decode(jiffy:encode(Body1)).
+
+num_calls(Fun, Args) ->
+    meck:num_calls(?PLUGIN, Fun, Args).
+
+log_calls(Level) ->
+    meck:num_calls(couch_scanner_util, log, [Level, ?PLUGIN, '_', '_', '_']).
+
+wait_exit(MSec) ->
+    meck:wait(couch_scanner_server, handle_info, [{'EXIT', '_', '_'}, '_'], MSec).
+
+ddoc_vdu(Doc) ->
+    Doc#{
+        validate_doc_update => <<
+            "function(newdoc, olddoc, userctx, sec){\n"
+            " if(newdoc.a == 'w') {\n"
+            "    newdoc.a.search(/(w+)/);\n"
+            "    if(RegExp.$1 == 'w') {return true} else {throw('forbidden')}\n"
+            " } else {\n"
+            "    return true\n"
+            " }\n"
+            "}"
+        >>
+    }.
+
+ddoc_filter(Doc) ->
+    Doc#{
+        filters => #{
+            f => <<
+                "function(doc, req) {\n"
+                " if(doc.a == 'z') {\n"
+                "   doc.a.search(/(z+)/);\n"
+                "   if(RegExp.$1 == 'z') {return true} else {return false};\n"
+                " } else {\n"
+                "   return true;\n"
+                " }\n"
+                "}"
+            >>
+        }
+    }.
+
+ddoc_view(Doc) ->
+    Doc#{
         views => #{
             v => #{
                 map => <<
@@ -79,89 +343,5 @@ setup() ->
                     "}"
                 >>
             }
-        },
-        filters => #{
-            f => <<
-                "function(doc, req) {\n"
-                " if(doc.a == 'z') {\n"
-                "   doc.a.search(/(z+)/);\n"
-                "   if(RegExp.$1 == 'z') {return true} else {return false};\n"
-                " } else {\n"
-                "   return true;\n"
-                " }\n"
-                "}"
-            >>
-        },
-        validate_doc_update => <<
-            "function(newdoc, olddoc, userctx, sec){\n"
-            " if(newdoc.a == 'w') {\n"
-            "    newdoc.a.search(/(w+)/);\n"
-            "    if(RegExp.$1 == 'w') {return true} else {throw('forbidden')}\n"
-            " } else {\n"
-            "    return true\n"
-            " }\n"
-            "}"
-        >>
-    }),
-    couch_scanner:reset_checkpoints(),
-    config:set(atom_to_list(?PLUGIN), "max_batch_items", "1", false),
-    {Ctx, DbName}.
-
-teardown({Ctx, DbName}) ->
-    config_delete_section("couch_scanner"),
-    config_delete_section("couch_scanner_plugins"),
-    config_delete_section(atom_to_list(?PLUGIN)),
-    couch_scanner:reset_checkpoints(),
-    couch_scanner:resume(),
-    fabric:delete_db(DbName),
-    test_util:stop_couch(Ctx),
-    meck:unload().
-
-t_basic({_, DbName}) ->
-    meck:reset(couch_scanner_server),
-    meck:reset(?PLUGIN),
-    config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
-    wait_exit(10000),
-    ?assertEqual(1, num_calls(start, 2)),
-    case couch_server:with_spidermonkey() of
-        true ->
-            ?assertEqual(1, num_calls(complete, 1)),
-            ?assertEqual(2, num_calls(checkpoint, 1)),
-            ?assertEqual(1, num_calls(db, ['_', DbName])),
-            ?assertEqual(1, num_calls(ddoc, ['_', DbName, '_'])),
-            ?assert(num_calls(shards, 2) >= 1),
-            DbOpenedCount = num_calls(db_opened, 2),
-            ?assert(DbOpenedCount >= 2),
-            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC1, '_'])),
-            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC2, '_'])),
-            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC3, '_'])),
-            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC4, '_'])),
-            ?assertEqual(1, num_calls(doc_id, ['_', ?DOC5, '_'])),
-            ?assert(num_calls(doc, 3) >= 5),
-            DbClosingCount = num_calls(db_closing, 2),
-            ?assertEqual(DbOpenedCount, DbClosingCount),
-            % start, complete and each of the 5 docs should fail = 7 total
-            ?assertEqual(7, log_calls(warning));
-        false ->
-            ok
-    end.
-
-config_delete_section(Section) ->
-    [config:delete(K, V, false) || {K, V} <- config:get(Section)].
-
-add_doc(DbName, DocId, Body) ->
-    {ok, _} = fabric:update_doc(DbName, mkdoc(DocId, Body), [?ADMIN_CTX]),
-    ok.
-
-mkdoc(Id, #{} = Body) ->
-    Body1 = Body#{<<"_id">> => Id},
-    jiffy:decode(jiffy:encode(Body1)).
-
-num_calls(Fun, Args) ->
-    meck:num_calls(?PLUGIN, Fun, Args).
-
-log_calls(Level) ->
-    meck:num_calls(couch_scanner_util, log, [Level, ?PLUGIN, '_', '_', '_']).
-
-wait_exit(MSec) ->
-    meck:wait(couch_scanner_server, handle_info, [{'EXIT', '_', '_'}, '_'], MSec).
+        }
+    }.


### PR DESCRIPTION
Previously we tried to run the VDU query prompt even if there was not VDU. That would have yielded a match anyway as both result in an error, but it added noise to the logs.

Handle the missing VDU like we handle the missing filters in filter_doc_validate.
