### PR TITLE
Cleanup a few clauses in fabric_view_changes

### DIFF
--- a/src/fabric/include/fabric.hrl
+++ b/src/fabric/include/fabric.hrl
@@ -41,7 +41,6 @@
 }).
 
 -record(view_row, {key, id, value, doc, worker}).
--record(change, {key, id, value, deleted=false, doc, worker}).
 
 -type row_property_key() :: id | key | value | doc | worker.
 -type row_properties() :: [{row_property_key(), any()}].


### PR DESCRIPTION
`#changes{}` record and old `complete` format was deprecated 10 years ago [1].

While at it, cleanup un-necessarily long arg per line call formats.

Coincidentally, this also improve code coverage a bit:

```
fabric_view_changes           :  72% (pr)
fabric_view_changes           :  71% (main)
```

[1] https://github.com/apache/couchdb/commit/865b5555771e6099c9b34b1b14d2428ce02e50c3
