### PR TITLE
Fix duplicate keys in find query

### DIFF
--- a/src/docs/src/api/database/find.rst
+++ b/src/docs/src/api/database/find.rst
@@ -543,9 +543,7 @@ example used with an index on the field ``"year"``:
 
     {
         "year": {
-            "$gte": 1900
-        },
-        "year": {
+            "$gte": 1900,
             "$lte": 1903
         },
         "$not": {
@@ -564,15 +562,13 @@ example used with an index on the field ``"year"``:
 
     {
         "year": {
-            "$gte": 1900
-        },
-        "year": {
+            "$gte": 1900.
             "$lte": 1910
         },
         "$nor": [
             { "year": 1901 },
             { "year": 1905 },
-            {  "year": 1907 }
+            { "year": 1907 }
         ]
     }
 


### PR DESCRIPTION
RFC-8259 discourages using duplicate keys in JS/JSON, and the ECMA-262 standard explicitly says that the last key will overwrite the first key.

This probably means these never actually worked!
