### PR TITLE
Enable Erlang/OTP 27

### DIFF
--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ basename=`basename $0`
 
 PACKAGE_AUTHOR_NAME="The Apache Software Foundation"
 
-REBAR3_BRANCH="3.21.0"
+REBAR3_BRANCH="3.23.0"
 ERLFMT_VERSION="v1.3.0"
 
 # TEST=0

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -160,10 +160,10 @@ DepDescs = [
                    {tag, "v1.3.0"}, [raw]},
 %% Third party deps
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-5"}},
-{jiffy,            "jiffy",            {tag, "CouchDB-1.0.9-2"}},
-{mochiweb,         "mochiweb",         {tag, "v3.2.1"}},
-{meck,             "meck",             {tag, "0.9.2"}},
+{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-6"}},
+{jiffy,            "jiffy",            {tag, "1.1.1"}},
+{mochiweb,         "mochiweb",         {tag, "v3.2.2"}},
+{meck,             "meck",             {tag, "CouchDB-0.9.2-1"}},
 {recon,            "recon",            {tag, "2.5.3"}}
 ].
 
@@ -194,7 +194,7 @@ end.
 AddConfig = [
     {cover_enabled, true},
     {cover_print_enabled, true},
-    {require_otp_vsn, "24|25|26"},
+    {require_otp_vsn, "24|25|26|27"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},

--- a/src/couch_scanner/include/couch_scanner_plugin.hrl
+++ b/src/couch_scanner/include/couch_scanner_plugin.hrl
@@ -21,4 +21,4 @@
 -define(WARN(FMT, ARGS), ?LOG(warning, FMT, ARGS, #{})).
 -define(WARN(FMT, ARGS, META), ?LOG(warning, FMT, ARGS, META)).
 -define(DEBUG(FMT, ARGS), ?LOG(debug, FMT, ARGS, #{fn => ?FUNCTION_NAME})).
--define(DEBUG(FMT, ARGS, META), ?LOG(debug, FMT, ARGS, META#{fn => ?FUNCTION_NAME})).
+-define(DEBUG(FMT, ARGS, META), ?LOG(debug, FMT, ARGS, maps:merge(META, #{fn => ?FUNCTION_NAME}))).

--- a/src/mango/src/mango.hrl
+++ b/src/mango/src/mango.hrl
@@ -22,7 +22,7 @@
 
 -define(MANGO_ERROR(R), throw({mango_error, ?MODULE, R})).
 
--type maybe(A) :: A | undefined.
+-type possibly(A) :: A | undefined.
 
 -type abstract_text_selector() :: {'op_and', [abstract_text_selector()]}
 				| {'op_or', [abstract_text_selector()]}

--- a/src/mango/src/mango_cursor_view.erl
+++ b/src/mango/src/mango_cursor_view.erl
@@ -52,7 +52,7 @@
     #{
         selector => selector(),
         fields => fields(),
-        covering_index => 'maybe'(#idx{})
+        covering_index => possibly(#idx{})
     }.
 
 -type mrargs_extra_item() ::
@@ -67,7 +67,7 @@
 -spec viewcbargs_new(Selector, Fields, CoveringIndex) -> ViewCBArgs when
     Selector :: selector(),
     Fields :: fields(),
-    CoveringIndex :: 'maybe'(#idx{}),
+    CoveringIndex :: possibly(#idx{}),
     ViewCBArgs :: viewcbargs().
 viewcbargs_new(Selector, Fields, CoveringIndex) ->
     #{
@@ -76,7 +76,7 @@ viewcbargs_new(Selector, Fields, CoveringIndex) ->
         covering_index => CoveringIndex
     }.
 
--spec viewcbargs_get(Key, Args) -> 'maybe'(term()) when
+-spec viewcbargs_get(Key, Args) -> possibly(term()) when
     Key :: selector | fields | covering_index,
     Args :: viewcbargs().
 viewcbargs_get(selector, Args) when is_map(Args) ->
@@ -468,7 +468,7 @@ view_cb(ok, ddoc_updated) ->
 -spec match_and_extract_doc(Doc, Selector, Fields) -> Result when
     Doc :: ejson(),
     Selector :: selector(),
-    Fields :: 'maybe'(fields()),
+    Fields :: possibly(fields()),
     Result :: {match, term()} | {no_match, undefined}.
 match_and_extract_doc(Doc, Selector, Fields) ->
     case mango_selector:match(Selector, Doc) of


### PR DESCRIPTION
 * Updates a few dependencies
 * Don't use maybe as a type name, it's a reserved keyword
 * Don't update map literals in a row, it now emits a warning
