### PR TITLE
Fix flakiness in fabric_bench

### DIFF
--- a/src/fabric/src/fabric_bench.erl
+++ b/src/fabric/src/fabric_bench.erl
@@ -182,6 +182,9 @@ all_docs_cb({row, Row}, Acc) ->
 all_docs_cb({meta, _}, Acc) ->
     {ok, Acc};
 all_docs_cb(complete, Acc) ->
+    {ok, Acc};
+all_docs_cb(Error, Acc) ->
+    io:format(standard_error, "~n! error in all_docs_cb: ~p!~n", [Error]),
     {ok, Acc}.
 
 get_changes(Db, Opts) ->

--- a/src/fabric/test/eunit/fabric_bench_test.erl
+++ b/src/fabric/test/eunit/fabric_bench_test.erl
@@ -36,12 +36,12 @@ teardown(Ctx) ->
     test_util:stop_couch(Ctx).
 
 t_default_doc_size(_Ctx) ->
-    Opts = #{docs => 100, individual_docs => 5},
+    Opts = #{docs => 50, individual_docs => 5},
     % The goal is to just have it not crash
     ?assertEqual(ok, fabric_bench:go(Opts)).
 
 t_small_doc_size(_Ctx) ->
-    Opts = #{q => 4, docs => 100, doc_size => small, individual_docs => 5},
+    Opts = #{q => 4, docs => 50, doc_size => small, individual_docs => 5},
     % The goal is to just have it not crash
     ?assertEqual(ok, fabric_bench:go(Opts)).
 


### PR DESCRIPTION
`{error, timeout}` sometimes fails, especially on FreeBSD workers.

So handle errors in the docs callback and also half the batch size.

Example of error:
```
module 'fabric_bench_test'
 fabric_bench_test:99: -with/1-fun-1- (t_default_doc_size)...*failed*
   in function fabric_bench:all_docs_cb/2 (src/fabric_bench.erl, line 179)
     called as all_docs_cb({error,timeout},7)
```
