### PR TITLE
Prevent release from generating ez archives

### DIFF
--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -1,0 +1,24 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+% OTP 26 removed the excl_archive option from reltool.config. However, for <26
+% if we don't specify {excl_archive,..} we end up with small silly *.ez
+% archives instead of ebin directories.
+%
+case erlang:system_info(otp_release) of
+     Ver when Ver =:= "24"; Ver =:= "25" ->
+        {sys, SysProps} = lists:keyfind(sys, 1, CONFIG),
+        SysProps1 = SysProps ++ [{excl_archive_filters, [".*"]}],
+        lists:keyreplace(sys, 1, CONFIG, {sys, SysProps1});
+     Ver when is_list(Ver) ->
+        CONFIG
+end.


### PR DESCRIPTION
Erlang 26 removed the ability to create ez archive files in releases. We had to remove the `excl_archive_filters` option from our reltool.config file [1], as otherwise we couldn't make releases on 26 (`make release` barfed). However, that meant on 24 and 25 our releases would be generated with beam files packed in lots of silly .ez archives, which is not great.

Sadly, since 26, refuses to silently ignore `excl_archive_filters` we have to use a script file and only apply the config on <26 versions.

[1] https://github.com/apache/couchdb/commit/a4bbb87d11d40dfee9808a7d5025a65845c6a4cd
