### PR TITLE
Make sure to unload mecked modules in fabric_view

### DIFF
--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -760,8 +760,8 @@ t_detach_partition_no_partition_map(_) ->
 get_next_row_test_() ->
     {
         foreach,
-        fun() -> ok end,
-        fun(_) -> ok end,
+        fun() -> meck:new([rexi, couch_query_servers]) end,
+        fun(_) -> meck:unload() end,
         [
             ?TDEF_FE(t_get_next_row_end),
             ?TDEF_FE(t_get_next_row_map),


### PR DESCRIPTION
Since we use meck:expect(...) in a few places in the test suite, we should run `meck:unload()` in teardown. To make it more obvious we're mocking things, explicitly use meck:new() in setup as well.
