### PR TITLE
Move priv direcotry gitignore from quickjs app to main gitignore

### DIFF
--- a/src/couch_quickjs/.gitignore
+++ b/src/couch_quickjs/.gitignore
@@ -19,3 +19,5 @@
 /quickjs/test_fib.c
 /quickjs/.github
 compile_commands.json
+priv/bundle_*.js
+priv/couchjs_*

--- a/src/couch_quickjs/build_js.escript
+++ b/src/couch_quickjs/build_js.escript
@@ -43,7 +43,7 @@ main(["compile"]) ->
             ok
     end;
 main(["clean"]) ->
-    rm("priv/bundle_*.js"),
+    file:del_dir_r("priv"),
     rm("c_src/couchjs_*_bytecode.c");
 main(Arg) ->
     io:format(standard_error, "Expected a 'compile' or 'clean' arg. Got:~p", [Arg]),
@@ -98,6 +98,7 @@ cp_if_different(From, To) ->
 concat(Sources, Target) ->
     SourceBins = [fread(P) || P <- Sources],
     TargetBin =  iolist_to_binary(["(function () {\n"] ++ SourceBins ++ ["})();\n"]),
+    ok = filelib:ensure_dir(Target),
     fwrite(Target, TargetBin).
 
 fread(Path) ->

--- a/src/couch_quickjs/priv/.gitignore
+++ b/src/couch_quickjs/priv/.gitignore
@@ -1,2 +1,0 @@
-bundle_*.js
-couchjs_*


### PR DESCRIPTION
Previously, the `.gitignore` file in priv was mainly there to keep the directory around in git. But that's a bit dirty as the debian packager will complain if we package the `.gitignore`, as it packages the whole `priv` directory.

To fix, move the `.gitignore` entries to the app's main `.gitignore`, and make sure to create and clean the whole priv directory as needed.
