### PR TITLE
Make app and release versions uniform

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -12,7 +12,7 @@
 
 {sys, [
     {lib_dirs, ["../src"]},
-    {rel, "couchdb", "3.3.3", [
+    {rel, "couchdb", "", [
         %% stdlib
         asn1,
         compiler,

--- a/src/setup/src/setup.app.src
+++ b/src/setup/src/setup.app.src
@@ -12,7 +12,7 @@
 
 {application, setup, [
     {description, "Implements `_cluster_setup` and manages the setup of a CouchDB cluster"},
-    {vsn, "1"},
+    {vsn, git},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
Previously, some apps/release used `git` version others had a fixed version number. Each approach has it's benefits and downsides but since we're using git in most cases, let's be uniform and use that uniformly.
