### PR TITLE
Ensure index is up to date when querying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,7 +563,7 @@ nouveau-test: nouveau-test-gradle nouveau-test-elixir
 .PHONY: nouveau-test-gradle
 nouveau-test-gradle: couch nouveau
 ifeq ($(with_nouveau), true)
-	@cd nouveau && ./gradlew test --info
+	@cd nouveau && ./gradlew test --info --rerun
 endif
 
 .PHONY: nouveau-test-elixir

--- a/Makefile.win
+++ b/Makefile.win
@@ -526,7 +526,7 @@ nouveau-test: nouveau-test-gradle nouveau-test-elixir
 .PHONY: nouveau-test-gradle
 nouveau-test-gradle: couch nouveau
 ifeq ($(with_nouveau), true)
-	@cd nouveau && .\gradlew test --info
+	@cd nouveau && .\gradlew test --info --rerun
 endif
 
 .PHONY: nouveau-test-elixir

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/SearchRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/SearchRequest.java
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,6 +32,12 @@ public class SearchRequest {
 
     @NotNull
     private String query;
+
+    @PositiveOrZero
+    private long minUpdateSeq;
+
+    @PositiveOrZero
+    private long minPurgeSeq;
 
     private Locale locale;
 
@@ -62,6 +69,24 @@ public class SearchRequest {
     @JsonProperty
     public String getQuery() {
         return query;
+    }
+
+    public void setMinUpdateSeq(final long minUpdateSeq) {
+        this.minUpdateSeq = minUpdateSeq;
+    }
+
+    @JsonProperty
+    public long getMinUpdateSeq() {
+        return minUpdateSeq;
+    }
+
+    public void setMinPurgeSeq(final long minPurgeSeq) {
+        this.minPurgeSeq = minPurgeSeq;
+    }
+
+    @JsonProperty
+    public long getMinPurgeSeq() {
+        return minPurgeSeq;
     }
 
     public void setLocale(final Locale locale) {
@@ -154,7 +179,8 @@ public class SearchRequest {
 
     @Override
     public String toString() {
-        return "SearchRequest [query=" + query + ", locale=" + locale + ", sort=" + sort + ", limit=" + limit
-                + ", after=" + after + ", counts=" + counts + ", ranges=" + ranges + "]";
+        return "SearchRequest [query=" + query + ", min_update_seq=" + minUpdateSeq + ", min_purge_seq=" + minPurgeSeq
+                + ", locale=" + locale + ", sort=" + sort + ", limit=" + limit + ", after=" + after + ", counts="
+                + counts + ", ranges=" + ranges + "]";
     }
 }

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/core/IndexManager.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/core/IndexManager.java
@@ -26,6 +26,7 @@ import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import com.github.benmanes.caffeine.cache.Weigher;
 import io.dropwizard.lifecycle.Managed;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.File;
@@ -68,10 +69,13 @@ public final class IndexManager implements Managed {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexManager.class);
 
+    @PositiveOrZero
     private int maxIndexesOpen;
 
+    @PositiveOrZero
     private int commitIntervalSeconds;
 
+    @PositiveOrZero
     private int idleSeconds;
 
     private Path rootDir;

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/core/StaleIndexException.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/core/StaleIndexException.java
@@ -1,0 +1,28 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.apache.couchdb.nouveau.core;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response.Status;
+
+public final class StaleIndexException extends WebApplicationException {
+
+    public StaleIndexException(final boolean purge, final long minSeq, final long actualSeq) {
+        super(
+                String.format(
+                        "index is stale (%s seq needs to be at least %d but is %d)",
+                        purge ? "purge" : "index", minSeq, actualSeq),
+                Status.CONFLICT);
+    }
+}

--- a/nouveau/src/test/java/org/apache/couchdb/nouveau/health/IndexHealthCheckTest.java
+++ b/nouveau/src/test/java/org/apache/couchdb/nouveau/health/IndexHealthCheckTest.java
@@ -30,9 +30,11 @@ public class IndexHealthCheckTest {
     @Test
     public void testIndexHealthCheck(@TempDir final Path tempDir) throws Exception {
         var manager = new IndexManager();
-        manager.setCommitIntervalSeconds(1);
-        manager.setObjectMapper(new ObjectMapper());
+        manager.setCommitIntervalSeconds(30);
+        manager.setIdleSeconds(60);
+        manager.setMaxIndexesOpen(1);
         manager.setMetricRegistry(new MetricRegistry());
+        manager.setObjectMapper(new ObjectMapper());
         manager.setRootDir(tempDir);
         manager.setScheduler(Scheduler.systemScheduler());
         manager.setSearcherFactory(new SearcherFactory());

--- a/src/nouveau/src/nouveau_api.erl
+++ b/src/nouveau/src/nouveau_api.erl
@@ -174,6 +174,9 @@ search(#index{} = Index, QueryArgs) ->
     case Resp of
         {ok, "200", _, RespBody} ->
             {ok, jiffy:decode(RespBody, [return_maps])};
+        {ok, "409", _, _} ->
+            %% Index was not current enough.
+            {error, stale_index};
         {ok, StatusCode, _, RespBody} ->
             {error, jaxrs_error(StatusCode, RespBody)};
         {error, Reason} ->
@@ -186,6 +189,7 @@ set_update_seq(ConnPid, #index{} = Index, MatchSeq, UpdateSeq) ->
         update_seq => UpdateSeq
     },
     set_seq(ConnPid, Index, ReqBody).
+
 set_purge_seq(ConnPid, #index{} = Index, MatchSeq, PurgeSeq) ->
     ReqBody = #{
         match_purge_seq => MatchSeq,

--- a/src/nouveau/src/nouveau_index_updater.erl
+++ b/src/nouveau/src/nouveau_index_updater.erl
@@ -18,7 +18,7 @@
 -include("nouveau.hrl").
 
 %% public api
--export([outdated/1]).
+-export([outdated/1, get_db_info/1]).
 
 %% callbacks
 -export([update/1]).


### PR DESCRIPTION
Ensure index is up to date when querying

the IndexHealthCheckTest exposed a sequence of events that lead to
test failure, but also point to an undesirable state during production.

Namely;

1) an index is opened
2) an index is updated
3) the IndexManager closes the index due to LRU pressure, and rolls back
the changes in step 2
4) an index is queried, which returns results that don't reflect the
changes made in step 2.

This change modifies the SearchRequest so that the caller can ensure
the index is at least up to a certain sequence.

Some attributes are added to IndexManager member variables to clarify
their valid ranges.

add --rerun to the test goal so we can run the tests again even if
the code under test has not changed.

