### PR TITLE
Bump jiffy to 1.1.2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -160,7 +160,7 @@ DepDescs = [
 %% Third party deps
 {hyper,            "hyper",            {tag, "CouchDB-2.2.0-7"}},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-6"}},
-{jiffy,            "jiffy",            {tag, "1.1.1"}},
+{jiffy,            "jiffy",            {tag, "1.1.2"}},
 {mochiweb,         "mochiweb",         {tag, "v3.2.2"}},
 {meck,             "meck",             {tag, "CouchDB-0.9.2-1"}},
 {recon,            "recon",            {tag, "2.5.3"}}


### PR DESCRIPTION
https://github.com/davisp/jiffy/releases/tag/1.1.2
