### PR TITLE
Use the minSeq check in more places and add a test

### DIFF
--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/health/IndexHealthCheck.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/health/IndexHealthCheck.java
@@ -47,6 +47,7 @@ public final class IndexHealthCheck extends HealthCheck {
 
             final SearchRequest searchRequest = new SearchRequest();
             searchRequest.setQuery("_id:foo");
+            searchRequest.setMinUpdateSeq(1);
 
             final SearchResults searchResults = indexResource.searchIndex(name, searchRequest);
             if (searchResults.getTotalHits() == 1) {


### PR DESCRIPTION
## Overview

Set minSeq so we can tell if the health check fails for conflict versus something else (a conflict can arise if the index was rolled back between the update and the search, by the IndexManager LRU)

## Testing recommendations

covered by tests

## Related Issues or Pull Requests



## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
