### PR TITLE
Use our own logic for index management

### DIFF
--- a/nouveau/build.gradle
+++ b/nouveau/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'io.dropwizard:dropwizard-core'
     implementation 'io.dropwizard:dropwizard-http2'
     implementation 'io.dropwizard.metrics:metrics-core'
-    implementation 'io.dropwizard.metrics:metrics-caffeine'
     implementation 'io.dropwizard.metrics:metrics-jersey2'
     testImplementation 'io.dropwizard:dropwizard-testing'
 

--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/NouveauApplication.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/NouveauApplication.java
@@ -13,7 +13,6 @@
 
 package org.apache.couchdb.nouveau;
 
-import com.github.benmanes.caffeine.cache.Scheduler;
 import io.dropwizard.core.Application;
 import io.dropwizard.core.setup.Environment;
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
@@ -54,13 +53,12 @@ public class NouveauApplication extends Application<NouveauApplicationConfigurat
         indexManager.setCommitIntervalSeconds(configuration.getCommitIntervalSeconds());
         indexManager.setIdleSeconds(configuration.getIdleSeconds());
         indexManager.setMaxIndexesOpen(configuration.getMaxIndexesOpen());
-        indexManager.setMetricRegistry(environment.metrics());
         final ScheduledExecutorService schedulerExecutorService = environment
                 .lifecycle()
                 .scheduledExecutorService("index-manager-%d")
                 .threads(configuration.getSchedulerThreadCount())
                 .build();
-        indexManager.setScheduler(Scheduler.forScheduledExecutorService(schedulerExecutorService));
+        indexManager.setScheduledExecutorService(schedulerExecutorService);
         indexManager.setSearcherFactory(new ParallelSearcherFactory(ForkJoinPool.commonPool()));
         indexManager.setObjectMapper(environment.getObjectMapper());
         indexManager.setRootDir(configuration.getRootDir());

--- a/nouveau/src/test/java/org/apache/couchdb/nouveau/health/IndexHealthCheckTest.java
+++ b/nouveau/src/test/java/org/apache/couchdb/nouveau/health/IndexHealthCheckTest.java
@@ -15,10 +15,9 @@ package org.apache.couchdb.nouveau.health;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.benmanes.caffeine.cache.Scheduler;
 import java.nio.file.Path;
+import java.util.concurrent.Executors;
 import org.apache.couchdb.nouveau.core.IndexManager;
 import org.apache.couchdb.nouveau.resources.IndexResource;
 import org.apache.lucene.search.SearcherFactory;
@@ -33,10 +32,9 @@ public class IndexHealthCheckTest {
         manager.setCommitIntervalSeconds(30);
         manager.setIdleSeconds(60);
         manager.setMaxIndexesOpen(1);
-        manager.setMetricRegistry(new MetricRegistry());
         manager.setObjectMapper(new ObjectMapper());
         manager.setRootDir(tempDir);
-        manager.setScheduler(Scheduler.systemScheduler());
+        manager.setScheduledExecutorService(Executors.newScheduledThreadPool(2));
         manager.setSearcherFactory(new SearcherFactory());
         manager.start();
 


### PR DESCRIPTION
## Overview

Use our own logic for index management
    
Caffeine complaines when eviction is slow (because we might commit the index).
Build our own logic for opening and closing indexes which allows opening and
closing to be very slow, while ensuring we don't close an index that's in use.

## Testing recommendations

covered by tests

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
