### PR TITLE
Simplify couchdb.cmd.in and remove app version

### DIFF
--- a/rel/files/couchdb.cmd.in
+++ b/rel/files/couchdb.cmd.in
@@ -18,7 +18,6 @@ CD "%ROOTDIR%"
 
 SET /P START_ERL= < releases\start_erl.data
 FOR /F "tokens=1" %%G IN ("%START_ERL%") DO SET ERTS_VSN=%%G
-FOR /F "tokens=2" %%G IN ("%START_ERL%") DO SET APP_VSN=%%G
 
 set BINDIR=%ROOTDIR%/erts-%ERTS_VSN%/bin
 set EMU=beam
@@ -29,9 +28,9 @@ IF NOT DEFINED COUCHDB_QUERY_SERVER_JAVASCRIPT SET COUCHDB_QUERY_SERVER_JAVASCRI
 IF NOT DEFINED COUCHDB_QUERY_SERVER_COFFEESCRIPT SET COUCHDB_QUERY_SERVER_COFFEESCRIPT={{prefix}}/bin/couchjs {{prefix}}/share/server/main-coffee.js
 IF NOT DEFINED COUCHDB_FAUXTON_DOCROOT SET COUCHDB_FAUXTON_DOCROOT={{fauxton_root}}
 
-"%BINDIR%\erl" -boot "%ROOTDIR%\releases\%APP_VSN%\couchdb" ^
+"%BINDIR%\erl" -boot "%ROOTDIR%\releases\couchdb" ^
 -args_file "%ROOTDIR%\etc\vm.args" ^
 -epmd "%BINDIR%\epmd.exe" ^
--config "%ROOTDIR%\releases\%APP_VSN%\sys.config" %*
+-config "%ROOTDIR%\releases\sys.config" %*
 
 :: EXIT /B


### PR DESCRIPTION
After removing the version number from `start_erl.data` and updating the startup script in [1], we forgot to update the Windows startup script. Let's make up for this now.

[1] https://github.com/apache/couchdb/pull/5085