### PR TITLE
Use a shorter replicator scheduling interval for tests

### DIFF
--- a/rel/files/eunit.ini
+++ b/rel/files/eunit.ini
@@ -36,3 +36,5 @@ level = notice
 [replicator]
 ; disable jitter to reduce test run times
 startup_jitter = 0
+; use a short interval for tests
+interval = 4000


### PR DESCRIPTION
This interval is used for scheduling jobs as well as for polling in the multidb changes module. Use a shorter default in tests to catch more edge case and possibly avoiding the need to set a per-test shorter interval.
