### PR TITLE
Update xxhash from upstream

### DIFF
--- a/src/exxhash/README.md
+++ b/src/exxhash/README.md
@@ -19,8 +19,10 @@ exxhash:xxhash128(Binary)
 Updating
 ===
 
-xxHash was vendored from https://cyan4973.github.io/xxHash/
+xxHash was originally vendored from https://cyan4973.github.io/xxHash/
 with commit SHA f4bef929aa854e9f52a303c5e58fd52855a0ecfa
+
+Updated on 2024-06-26 from commit SHA 805c00b68fa754200ada0c207ffeaa7a4409377c
 
 Only these two files are used from the original library:
   `c_src/xxhash.h`

--- a/src/exxhash/c_src/xxhash.c
+++ b/src/exxhash/c_src/xxhash.c
@@ -1,6 +1,6 @@
 /*
  * xxHash - Extremely Fast Hash algorithm
- * Copyright (C) 2012-2021 Yann Collet
+ * Copyright (C) 2012-2023 Yann Collet
  *
  * BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
  *
@@ -32,12 +32,11 @@
  *   - xxHash source repository: https://github.com/Cyan4973/xxHash
  */
 
-
 /*
  * xxhash.c instantiates functions defined in xxhash.h
  */
 
-#define XXH_STATIC_LINKING_ONLY   /* access advanced declarations */
-#define XXH_IMPLEMENTATION   /* access definitions */
+#define XXH_STATIC_LINKING_ONLY /* access advanced declarations */
+#define XXH_IMPLEMENTATION      /* access definitions */
 
 #include "xxhash.h"


### PR DESCRIPTION
https://github.com/Cyan4973/xxHash/releases/tag/v0.8.2

Notably there is a speedup improvements and fixes on PowerPC and s390x, as well some ARM variants.

Otherwise, it's mostly comments and doxygen updates.
