### PR TITLE
dev/run: print log dir on startup

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -97,7 +97,7 @@ def main():
                 ctx,
                 cluster_port(ctx, ctx["node_number_seed"]),
                 *ctx["admin"],
-                os.path.join(ctx["devdir"], "logs"),
+                "./" + os.path.relpath(os.path.join(ctx["devdir"], "logs")),
             )
 
 

--- a/dev/run
+++ b/dev/run
@@ -93,7 +93,7 @@ def main():
         if ctx["cmd"]:
             run_command(ctx, ctx["cmd"])
         else:
-            join(ctx, cluster_port(ctx, ctx["node_number_seed"]), *ctx["admin"])
+            join(ctx, cluster_port(ctx, ctx["node_number_seed"]), *ctx["admin"], os.path.join(ctx["devdir"], "logs"))
 
 
 def setup():
@@ -1176,9 +1176,10 @@ def create_system_databases(host, port):
     "Developers cluster is set up at http://127.0.0.1:{lead_port}.\n"
     "Admin username: {user}\n"
     "Password: {password}\n"
+    "Logs: {log_dir}\n"
     "Time to hack!"
 )
-def join(ctx, lead_port, user, password):
+def join(ctx, lead_port, user, password, log_dir):
     while True:
         for proc in ctx["procs"]:
             if proc is not None and proc.returncode is not None:

--- a/dev/run
+++ b/dev/run
@@ -93,7 +93,12 @@ def main():
         if ctx["cmd"]:
             run_command(ctx, ctx["cmd"])
         else:
-            join(ctx, cluster_port(ctx, ctx["node_number_seed"]), *ctx["admin"], os.path.join(ctx["devdir"], "logs"))
+            join(
+                ctx,
+                cluster_port(ctx, ctx["node_number_seed"]),
+                *ctx["admin"],
+                os.path.join(ctx["devdir"], "logs"),
+            )
 
 
 def setup():


### PR DESCRIPTION
## Overview

When running couch from source, logs do not appear on stdout.  The actual location of the logs is not documented.  It would be helpful to make log location clear.

### Before

```
$ ./dev/run
[ * ] Setup environment ... ok
[ * ] Ensure CouchDB is built ... ok
[ * ] Ensure Erlang boot script exists ... ok
[ * ] Prepare configuration files ... ok
[ * ] Start node node1 ... ok
[ * ] Start node node2 ... ok
[ * ] Start node node3 ... ok
[ * ] Check node at http://127.0.0.1:15984/ ... ok
[ * ] Check node at http://127.0.0.1:25984/ ... ok
[ * ] Check node at http://127.0.0.1:35984/ ... ok
[ * ] Running cluster setup ... ok
[ * ] Developers cluster is set up at http://127.0.0.1:15984.
Admin username: root
Password: rfb7saVr
Time to hack! ...
```

### After

```
$ ./dev/run
[ * ] Setup environment ... ok
[ * ] Ensure CouchDB is built ... ok
[ * ] Ensure Erlang boot script exists ... ok
[ * ] Prepare configuration files ... ok
[ * ] Start node node1 ... ok
[ * ] Start node node2 ... ok
[ * ] Start node node3 ... ok
[ * ] Check node at http://127.0.0.1:15984/ ... ok
[ * ] Check node at http://127.0.0.1:25984/ ... ok
[ * ] Check node at http://127.0.0.1:35984/ ... ok
[ * ] Running cluster setup ... ok
[ * ] Developers cluster is set up at http://127.0.0.1:15984.
Admin username: root
Password: asdf1234
Logs: /couchdb/dev/logs
Time to hack! ...
```

## Testing recommendations

Run `./dev/run`.

## Related Issues or Pull Requests

None known.

## Checklist

- [x] Code is written and works correctly
- ~Changes are covered by tests~
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- ~Documentation changes were made in the `src/docs` folder~
- ~Documentation changes were backported (separated PR) to affected branches~

Removed checklist items as I think this change is self-documenting, and does not require tests.