### PR TITLE
remove last remnant of snap install

### DIFF
--- a/configure
+++ b/configure
@@ -49,9 +49,6 @@ ARCH="$(uname -m)"
 ERLANG_VER="$(run_erlang 'io:put_chars(erlang:system_info(otp_release)).')"
 ERLANG_OS="$(run_erlang 'case os:type() of {OS, _} -> io:format("~s~n", [OS]) end.')"
 
-. ${rootdir}/version.mk
-COUCHDB_VERSION=${vsn_major}.${vsn_minor}.${vsn_patch}
-
 display_help () {
     cat << EOF
 Usage: $basename [OPTION]


### PR DESCRIPTION
This was introduced in 99b5331ce9 to support a snap package and not removed when we removed the snap option in e9d703c2139cd
