### PR TITLE
Ensure js files end up in the correct release directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,11 +409,11 @@ release: all
 	@cp bin/weatherreport rel/couchdb/bin/weatherreport
 
 ifeq ($(with_spidermonkey), true)
-	@mkdir rel/couchdb/server
+	@mkdir -p rel/couchdb/share/server
 	@cp src/couch/priv/couchjs rel/couchdb/bin/couchjs
-	@cp share/server/main.js rel/couchdb/server/main.js
-	@cp share/server/main-ast-bypass.js rel/couchdb/server/main-ast-bypass.js
-	@cp share/server/main-coffee.js rel/couchdb/server/main-coffee.js
+	@cp share/server/main.js rel/couchdb/share/server/main.js
+	@cp share/server/main-ast-bypass.js rel/couchdb/share/server/main-ast-bypass.js
+	@cp share/server/main-coffee.js rel/couchdb/share/server/main-coffee.js
 endif
 
 ifeq ($(with_fauxton), 1)

--- a/Makefile.win
+++ b/Makefile.win
@@ -368,11 +368,11 @@ release: all
 	-@rmdir /s/q rel\couchdb >NUL 2>&1 || true
 	@$(REBAR) generate
 ifeq ($(with_spidermonkey), true)
-	@mkdir rel\couchdb\server
+	@mkdir rel\couchdb\share\server
 	@copy src\couch\priv\couchjs.exe rel\couchdb\bin\couchjs.exe
-	@copy share\server\main.js rel\couchdb\server\main.js
-	@copy share\server\main-ast-bypass.js rel\couchdb\server\main-ast-bypass.js
-	@copy share\server\main-coffee.js rel\couchdb\server\main-coffee.js
+	@copy share\server\main.js rel\couchdb\share\server\main.js
+	@copy share\server\main-ast-bypass.js rel\couchdb\share\server\main-ast-bypass.js
+	@copy share\server\main-coffee.js rel\couchdb\share\server\main-coffee.js
 endif
 
 ifeq ($(with_fauxton), 1)


### PR DESCRIPTION
Previously, they were in server but should be in share/server

To verify:
   `./configure && make && make release`
   cd to rel/couchdb
   add admin/pass user to ./etc/local.ini
   start ./bin/couchdb
   goto to `http://localhost:5984/_utils/#/verifyinstall` and run "verify"
   that builds a view which uses the js files

Fixes: https://github.com/apache/couchdb/issues/5112
