### PR TITLE
Validate target doc id for COPY method

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1200,6 +1200,7 @@ db_doc_req(#httpd{method = 'COPY', user_ctx = Ctx} = Req, Db, SourceDocId) ->
         end,
     {TargetDocId0, TargetRevs} = couch_httpd_db:parse_copy_destination_header(Req),
     TargetDocId = list_to_binary(chttpd:unquote(TargetDocId0)),
+    couch_db:validate_docid(Db, TargetDocId),
     % open old doc
     Doc = couch_doc_open(Db, SourceDocId, SourceRev, []),
     % save new doc

--- a/src/couch/src/couch_httpd_db.erl
+++ b/src/couch/src/couch_httpd_db.erl
@@ -685,6 +685,7 @@ db_doc_req(#httpd{method = 'COPY'} = Req, Db, SourceDocId) ->
         end,
     {TargetDocId0, TargetRevs} = parse_copy_destination_header(Req),
     TargetDocId = list_to_binary(mochiweb_util:unquote(TargetDocId0)),
+    couch_db:validate_docid(Db, TargetDocId),
     % open old doc
     Doc = couch_doc_open(Db, SourceDocId, SourceRev, []),
     % save new doc

--- a/test/elixir/test/copy_doc_test.exs
+++ b/test/elixir/test/copy_doc_test.exs
@@ -60,6 +60,16 @@ defmodule CopyDocTest do
       Couch.request(
         :copy,
         "/#{db_name}/doc_to_be_copied2",
+        headers: [Destination: "_invalid_doc_id?rev=#{rev}"]
+      )
+
+    assert resp.status_code == 400
+    assert resp.body["reason"] == "Only reserved document ids may start with underscore."
+
+    resp =
+      Couch.request(
+        :copy,
+        "/#{db_name}/doc_to_be_copied2",
         headers: [Destination: "doc_to_be_overwritten?rev=#{rev}"]
       )
 


### PR DESCRIPTION
closes #5117

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

The COPY handler did not validate the target doc id, allowing the insertion of doc ids that begin with `_`, which is prohibited by all other document creation methods.

## Testing recommendations

unit tests

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/5117

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
