### PR TITLE
More QuickJS scanner improvements

### DIFF
--- a/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
+++ b/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
@@ -336,6 +336,12 @@ ddoc_filter(Doc) ->
 ddoc_view(Doc) ->
     Doc#{
         views => #{
+            lib => #{
+                baz => <<"exports.baz = 'bam';">>,
+                foo => #{
+                    fuzz => <<"exports.foo = 'bar';">>
+                }
+            },
             v1 => #{
                 map => <<
                     "function(doc) {\n"
@@ -382,6 +388,7 @@ ddoc_view(Doc) ->
                     "}"
                 >>
             },
+            v_type_error => #{map => <<"function(doc){emit(doc.missing.foo,1);}">>},
             v_expr_fun1 => #{map => <<"(function(doc) {emit(1,2)})\n">>},
             v_expr_fun2 => #{map => <<"(function(doc) {emit(3,4)});">>},
             v_expr_fun3 => #{map => <<"y=9;\n(function(doc) {emit(5,y)})">>},


### PR DESCRIPTION
 * Fix incorrect handling of view `lib`s. These should be under `views` not at the top level.

 * Reduce false positive log noise when both results fail with a similar errors like compilation errors or a common TypError but their exact message format will be different. An example I noticed was:

```
{error,{throw,{compilation_error,<<"SyntaxError: unexpected token in expression: 'if' ...
{error,{throw,{compilation_error,<<"Expression does not eval to a function. ...
```

 * Make the scanner a bit more resilient and skip unsupported junk like map/views/filters that are not the expected object or types. Previously we assumed if they exist (not undefined) or they will be valid.
