### PR TITLE
Update QuickJS from upstream master

### DIFF
--- a/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
+++ b/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
@@ -1,5 +1,5 @@
---- quickjs-master/quickjs.c	2024-05-09 19:57:55
-+++ quickjs/quickjs.c	2024-05-10 11:38:32
+--- quickjs-master/quickjs.c	2024-05-30 10:41:37
++++ quickjs/quickjs.c	2024-07-05 16:23:27
 @@ -29451,10 +29451,24 @@
      if (s->token.val == TOK_FUNCTION ||
          (token_is_pseudo_keyword(s, JS_ATOM_async) &&

--- a/src/couch_quickjs/quickjs/Makefile
+++ b/src/couch_quickjs/quickjs/Makefile
@@ -524,7 +524,7 @@ test2o-update: run-test262
 	./run-test262 -t -u -c test262o.conf
 endif
 
-ifeq ($(wildcard test262o/tests.txt),)
+ifeq ($(wildcard test262/features.txt),)
 test2 test2-32 test2-update test2-default test2-check:
 	@echo test262 tests not installed
 else

--- a/src/couch_quickjs/quickjs/libregexp.c
+++ b/src/couch_quickjs/quickjs/libregexp.c
@@ -1488,15 +1488,13 @@ static int re_parse_term(REParseState *s, BOOL is_backward_dir)
 
                 if (dbuf_error(&s->byte_code))
                     goto out_of_memory;
-                /* the spec tells that if there is no advance when
-                   running the atom after the first quant_min times,
-                   then there is no match. We remove this test when we
-                   are sure the atom always advances the position. */
-                add_zero_advance_check = re_need_check_advance(s->byte_code.buf + last_atom_start,
-                                                               s->byte_code.size - last_atom_start);
-            } else {
-                add_zero_advance_check = FALSE;
             }
+            /* the spec tells that if there is no advance when
+               running the atom after the first quant_min times,
+               then there is no match. We remove this test when we
+               are sure the atom always advances the position. */
+            add_zero_advance_check = re_need_check_advance(s->byte_code.buf + last_atom_start,
+                                                           s->byte_code.size - last_atom_start);
 
             {
                 int len, pos;

--- a/src/couch_quickjs/quickjs/tests/test262.patch
+++ b/src/couch_quickjs/quickjs/tests/test262.patch
@@ -1,8 +1,8 @@
 diff --git a/harness/atomicsHelper.js b/harness/atomicsHelper.js
-index 9c1217351e..3c24755558 100644
+index 9828b15..4a5919d 100644
 --- a/harness/atomicsHelper.js
 +++ b/harness/atomicsHelper.js
-@@ -227,10 +227,14 @@ $262.agent.waitUntil = function(typedArray, index, expected) {
+@@ -272,10 +272,14 @@ $262.agent.waitUntil = function(typedArray, index, expected) {
   *   }
   */
  $262.agent.timeouts = {
@@ -22,13 +22,13 @@ index 9c1217351e..3c24755558 100644
  
  /**
 diff --git a/harness/regExpUtils.js b/harness/regExpUtils.js
-index be7039fda0..7b38abf8df 100644
+index b55f3c6..396bad4 100644
 --- a/harness/regExpUtils.js
 +++ b/harness/regExpUtils.js
-@@ -6,24 +6,27 @@ description: |
- defines: [buildString, testPropertyEscapes, matchValidator]
+@@ -6,27 +6,30 @@ description: |
+ defines: [buildString, testPropertyEscapes, testPropertyOfStrings, testExtendedCharacterClass, matchValidator]
  ---*/
-
+ 
 +if ($262 && typeof $262.codePointRange === "function") {
 +    /* use C function to build the codePointRange (much faster with
 +       slow JS engines) */
@@ -44,7 +44,12 @@ index be7039fda0..7b38abf8df 100644
 +    }
 +}
 +
- function buildString({ loneCodePoints, ranges }) {
+ function buildString(args) {
+   // Use member expressions rather than destructuring `args` for improved
+   // compatibility with engines that only implement assignment patterns
+   // partially or not at all.
+   const loneCodePoints = args.loneCodePoints;
+   const ranges = args.ranges;
 -  const CHUNK_SIZE = 10000;
 -  let result = Reflect.apply(String.fromCodePoint, null, loneCodePoints);
 -  for (let i = 0; i < ranges.length; i++) {
@@ -58,14 +63,11 @@ index be7039fda0..7b38abf8df 100644
 -        result += Reflect.apply(String.fromCodePoint, null, codePoints);
 -        codePoints.length = length = 0;
 -      }
-+    let result = String.fromCodePoint.apply(null, loneCodePoints);
-+    for (const [start, end] of ranges) {
-+        result += codePointRange(start, end + 1);
-     }
+-    }
 -    result += Reflect.apply(String.fromCodePoint, null, codePoints);
--  }
--  return result;
-+    return result;
++  let result = String.fromCodePoint.apply(null, loneCodePoints);
++  for (const [start, end] of ranges) {
++    result += codePointRange(start, end + 1);
+   }
+   return result;
  }
-
- function testPropertyEscapes(regex, string, expression) {


### PR DESCRIPTION
Relevant fixes:

  * regexp: fix non greedy quantizers with zero length matches https://github.com/bellard/quickjs/commit/36911f0d3ab1a4c190a4d5cbe7c2db225a455389
