### PR TITLE
Update Erlang in CI, support Elixir 1.17

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -14,11 +14,11 @@
 // the License.
 
 // Erlang version embedded in binary packages
-ERLANG_VERSION = '25.3.2.12'
+ERLANG_VERSION = '25.3.2.13'
 
 // Erlang version used for rebar in release process. CouchDB will not build from
 // the release tarball on Erlang versions older than this
-MINIMUM_ERLANG_VERSION = '25.3.2.12'
+MINIMUM_ERLANG_VERSION = '25.3.2.13'
 
 // We create parallel build / test / package stages for each OS using the metadata
 // in this map. Adding a new OS should ideally only involve adding a new entry here.
@@ -55,25 +55,25 @@ meta = [
     image: "apache/couchdbci-ubuntu:jammy-erlang-${ERLANG_VERSION}"
   ],
 
-  'bullseye-ppc64': [
-    name: 'Debian 11 POWER',
+  'bookworm-ppc64': [
+    name: 'Debian POWER',
     spidermonkey_vsn: '78',
     with_nouveau: true,
     with_clouseau: true,
-    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+    image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}",
     node_label: 'ppc64le'
   ],
 
-  'bullseye-s390x': [
-    name: 'Debian 11 s390x',
+  'bookworm-s390x': [
+    name: 'Debian s390x',
     spidermonkey_vsn: '78',
     with_nouveau: true,
-    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+    image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}",
     node_label: 's390x'
   ],
 
   'bullseye': [
-    name: 'Debian 11',
+    name: 'Debian x86_64',
     spidermonkey_vsn: '78',
     with_nouveau: true,
     with_clouseau: true,
@@ -81,7 +81,7 @@ meta = [
   ],
 
   'bookworm': [
-    name: 'Debian 12',
+    name: 'Debian x86_64',
     spidermonkey_vsn: '78',
     with_nouveau: true,
     with_clouseau: true,

--- a/build-aux/Jenkinsfile.pr
+++ b/build-aux/Jenkinsfile.pr
@@ -39,7 +39,7 @@ pipeline {
     GIT_COMMITTER_NAME = 'Jenkins User'
     GIT_COMMITTER_EMAIL = 'couchdb@apache.org'
     // Parameters for the matrix build
-    DOCKER_IMAGE_BASE = 'apache/couchdbci-debian:bullseye-erlang'
+    DOCKER_IMAGE_BASE = 'apache/couchdbci-debian:bookworm-erlang'
     // https://github.com/jenkins-infra/jenkins.io/blob/master/Jenkinsfile#64
     // We need the jenkins user mapped inside of the image
     // npm config cache below deals with /home/jenkins not mapping correctly
@@ -50,7 +50,7 @@ pipeline {
     // Search for ERLANG_VERSION
     // see https://issues.jenkins.io/browse/JENKINS-61047 for why this cannot
     // be done parametrically
-    LOW_ERLANG_VER = '25.3.2.12'
+    LOW_ERLANG_VER = '25.3.2.13'
   }
 
   options {
@@ -247,7 +247,7 @@ pipeline {
         axes {
           axis {
             name 'ERLANG_VERSION'
-            values '25.3.2.12', '26.2.5'
+            values '25.3.2.13', '26.2.5.2'
           }
           axis {
             name 'SM_VSN'

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule CouchDBTest.Mixfile do
       {:jiffy, path: path("jiffy")},
       {:jwtf, path: path("jwtf")},
       {:ibrowse, path: path("ibrowse"), override: true},
-      {:credo, "~> 1.6.4", only: [:dev, :test, :integration], runtime: false}
+      {:credo, "~> 1.7.7", only: [:dev, :test, :integration], runtime: false}
     ]
 
     # Some deps may be missing during source check


### PR DESCRIPTION
Erlang: 25.3.2.13, 26.2.5.2

Elixir was also updated to: 1.17.2 in the images.

[Full CI passes](https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FFullPlatformMatrix/detail/jenkins-erlang-25.3.2.13/1/pipeline/847) with the new images