### PR TITLE
Use permanent node names in more applications

### DIFF
--- a/src/couch_log/src/couch_log_writer_file.erl
+++ b/src/couch_log/src/couch_log_writer_file.erl
@@ -82,7 +82,7 @@ write(Entry, St) ->
     Args = [
         couch_log_util:level_to_string(Level),
         TimeStamp,
-        node(),
+        config:node_name(),
         Pid,
         MsgId
     ],

--- a/src/couch_log/src/couch_log_writer_journald.erl
+++ b/src/couch_log/src/couch_log_writer_journald.erl
@@ -37,7 +37,7 @@ write(Entry, St) ->
     Fmt = "<~B>~s ~p ~s ",
     Args = [
         level_for_journald(Level),
-        node(),
+        config:node_name(),
         Pid,
         MsgId
     ],

--- a/src/couch_log/src/couch_log_writer_stderr.erl
+++ b/src/couch_log/src/couch_log_writer_stderr.erl
@@ -39,7 +39,7 @@ write(#log_entry{} = Entry, St) ->
     Args = [
         couch_log_util:level_to_string(Level),
         TimeStamp,
-        node(),
+        config:node_name(),
         Pid,
         MsgId
     ],

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -89,7 +89,7 @@ changes(DbName, Options, StartVector, DbOptions) ->
     DbOpenOptions = Args#changes_args.db_open_options ++ DbOptions,
     case get_or_create_db(DbName, DbOpenOptions) of
         {ok, Db} ->
-            StartSeq = calculate_start_seq(Db, node(), StartVector),
+            StartSeq = calculate_start_seq(Db, config:node_name(), StartVector),
             Enum = fun changes_enumerator/2,
             Opts = [{dir, Dir}],
             Pending0 =
@@ -406,7 +406,7 @@ read_repair_filter(DbName, Docs, NodeRevs, Options) ->
 % as the read_repair option to update_docs.
 read_repair_filter(Db, Docs, NodeRevs) ->
     [#doc{id = DocId} | _] = Docs,
-    NonLocalNodeRevs = [NR || {N, _} = NR <- NodeRevs, N /= node()],
+    NonLocalNodeRevs = [NR || {N, _} = NR <- NodeRevs, N /= config:node_name()],
     Nodes = lists:usort([Node || {Node, _} <- NonLocalNodeRevs]),
     NodeSeqs = get_node_seqs(Db, Nodes),
 

--- a/src/mem3/src/mem3.erl
+++ b/src/mem3/src/mem3.erl
@@ -131,7 +131,7 @@ shards_int(DbName, Options) ->
             %% and view_all_docs
             [
                 #ordered_shard{
-                    node = node(),
+                    node = config:node_name(),
                     name = ShardDbName,
                     dbname = ShardDbName,
                     range = [0, (2 bsl 31) - 1],
@@ -144,7 +144,7 @@ shards_int(DbName, Options) ->
             %% and view_all_docs
             [
                 #shard{
-                    node = node(),
+                    node = config:node_name(),
                     name = ShardDbName,
                     dbname = ShardDbName,
                     range = [0, (2 bsl 31) - 1],
@@ -363,10 +363,10 @@ group_by_proximity(Shards) ->
 
 group_by_proximity(Shards, ZoneMap) ->
     {Local, Remote} = lists:partition(
-        fun(S) -> mem3:node(S) =:= node() end,
+        fun(S) -> mem3:node(S) =:= config:node_name() end,
         Shards
     ),
-    LocalZone = proplists:get_value(node(), ZoneMap),
+    LocalZone = proplists:get_value(config:node_name(), ZoneMap),
     Fun = fun(S) -> proplists:get_value(mem3:node(S), ZoneMap) =:= LocalZone end,
     {SameZone, DifferentZone} = lists:partition(Fun, Remote),
     {Local, SameZone, DifferentZone}.

--- a/src/mem3/src/mem3_nodes.erl
+++ b/src/mem3/src/mem3_nodes.erl
@@ -100,7 +100,7 @@ initialize_nodelist() ->
     DbName = mem3_sync:nodes_db(),
     {ok, Db} = mem3_util:ensure_exists(DbName),
     {ok, _} = couch_db:fold_docs(Db, fun first_fold/2, Db, []),
-    insert_if_missing(Db, [node() | mem3_seeds:get_seeds()]),
+    insert_if_missing(Db, [config:node_name() | mem3_seeds:get_seeds()]),
     Seq = couch_db:get_update_seq(Db),
     couch_db:close(Db),
     Seq.

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -61,7 +61,7 @@ go(Source, Target) ->
     go(Source, Target, []).
 
 go(DbName, Node, Opts) when is_binary(DbName), is_atom(Node) ->
-    go(#shard{name = DbName, node = node()}, #shard{name = DbName, node = Node}, Opts);
+    go(#shard{name = DbName, node = config:node_name()}, #shard{name = DbName, node = Node}, Opts);
 go(#shard{} = Source0, #shard{} = Target0, Opts) ->
     Source = add_range(Source0),
     Target = add_range(Target0),
@@ -219,7 +219,7 @@ verify_purge_checkpoint(DbName, Props) ->
 find_source_seq(SrcDb, TgtNode, TgtUUIDPrefix, TgtSeq) ->
     case find_repl_doc(SrcDb, TgtUUIDPrefix) of
         {ok, TgtUUID, Doc} ->
-            SrcNode = atom_to_binary(node(), utf8),
+            SrcNode = atom_to_binary(config:node_name(), utf8),
             find_source_seq_int(Doc, SrcNode, TgtNode, TgtUUID, TgtSeq);
         {not_found, _} ->
             couch_log:warning(
@@ -497,7 +497,7 @@ calculate_start_seq(Db, FilterHash, #tgt{shard = TgtShard} = Tgt) ->
     {NewDocId, Doc} = mem3_rpc:load_checkpoint(
         Node,
         Name,
-        node(),
+        config:node_name(),
         UUID,
         FilterHash
     ),
@@ -731,7 +731,7 @@ update_locals(Target, Db, Seq) ->
     #tgt{shard = TgtShard, localid = Id, history = History} = Target,
     #shard{node = Node, name = Name} = TgtShard,
     NewEntry = [
-        {<<"source_node">>, atom_to_binary(node(), utf8)},
+        {<<"source_node">>, atom_to_binary(config:node_name(), utf8)},
         {<<"source_uuid">>, couch_db:get_uuid(Db)},
         {<<"source_seq">>, Seq},
         {<<"timestamp">>, list_to_binary(mem3_util:iso8601_timestamp())}

--- a/src/mem3/src/mem3_reshard.erl
+++ b/src/mem3/src/mem3_reshard.erl
@@ -612,7 +612,7 @@ state_id() ->
 
 -spec job_id(#job{}) -> binary().
 job_id(#job{source = #shard{name = SourceName}}) ->
-    HashInput = [SourceName, atom_to_binary(node(), utf8)],
+    HashInput = [SourceName, atom_to_binary(config:node_name(), utf8)],
     IdHashList = couch_util:to_hex(crypto:hash(sha256, HashInput)),
     IdHash = iolist_to_binary(IdHashList),
     Prefix = iolist_to_binary(io_lib:format("~3..0B", [?JOB_ID_VERSION])),
@@ -646,7 +646,7 @@ target_ranges([Begin, End], Split) when
 
 -spec build_shard([non_neg_integer()], binary(), binary()) -> #shard{}.
 build_shard(Range, DbName, Suffix) ->
-    Shard = #shard{dbname = DbName, range = Range, node = node()},
+    Shard = #shard{dbname = DbName, range = Range, node = config:node_name()},
     mem3_util:name_shard(Shard, <<".", Suffix/binary>>).
 
 -spec running_jobs() -> [#job{}].

--- a/src/mem3/src/mem3_reshard_job.erl
+++ b/src/mem3/src/mem3_reshard_job.erl
@@ -574,7 +574,7 @@ create_artificial_mem3_rep_checkpoints(#job{} = Job, Seq) ->
     ok.
 
 mem3_rep_checkpoint_doc(SourceDb, TargetDb, Timestamp, Seq) ->
-    Node = atom_to_binary(node(), utf8),
+    Node = atom_to_binary(config:node_name(), utf8),
     SourceUUID = couch_db:get_uuid(SourceDb),
     TargetUUID = couch_db:get_uuid(TargetDb),
     History =

--- a/src/mem3/src/mem3_reshard_store.erl
+++ b/src/mem3/src/mem3_reshard_store.erl
@@ -213,7 +213,7 @@ job_from_ejson({Props}) ->
         job_state = binary_to_atom(JobState, utf8),
         split_state = binary_to_atom(SplitState, utf8),
         state_info = state_info_from_ejson(StateInfo),
-        node = node(),
+        node = config:node_name(),
         start_time = TStarted,
         update_time = TUpdated,
         source = mem3_reshard:shard_from_name(Source),
@@ -228,7 +228,7 @@ state_from_ejson(#state{} = State, {Props}) ->
     State#state{
         state = binary_to_atom(StateVal, utf8),
         state_info = state_info_from_ejson(StateInfo),
-        node = node(),
+        node = config:node_name(),
         update_time = TUpdated
     }.
 

--- a/src/mem3/src/mem3_rpc.erl
+++ b/src/mem3/src/mem3_rpc.erl
@@ -116,7 +116,7 @@ load_checkpoint_rpc(DbName, SourceNode, SourceUUID, FilterHash) ->
                 {ok, Doc} ->
                     rexi:reply({ok, {NewId, Doc}});
                 {not_found, _} ->
-                    OldId = mem3_rep:make_local_id(SourceNode, node()),
+                    OldId = mem3_rep:make_local_id(SourceNode, config:node_name()),
                     case couch_db:open_doc(Db, OldId, []) of
                         {ok, Doc} ->
                             rexi:reply({ok, {NewId, Doc}});
@@ -134,7 +134,7 @@ save_checkpoint_rpc(DbName, Id, SourceSeq, NewEntry0, History0) ->
         {ok, Db} ->
             NewEntry = {
                 [
-                    {<<"target_node">>, atom_to_binary(node(), utf8)},
+                    {<<"target_node">>, atom_to_binary(config:node_name(), utf8)},
                     {<<"target_uuid">>, couch_db:get_uuid(Db)},
                     {<<"target_seq">>, couch_db:get_update_seq(Db)}
                 ] ++ NewEntry0

--- a/src/mem3/src/mem3_seeds.erl
+++ b/src/mem3/src/mem3_seeds.erl
@@ -43,8 +43,8 @@ get_seeds() ->
             [];
         List ->
             Nodes = string:tokens(List, ","),
-            Seeds = [list_to_atom(Node) || Node <- Nodes] -- [node()],
-            mem3_util:rotate_list(node(), Seeds)
+            Seeds = [list_to_atom(Node) || Node <- Nodes] -- [config:node_name()],
+            mem3_util:rotate_list(config:node_name(), Seeds)
     end.
 
 get_status() ->

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -160,8 +160,9 @@ get(DbName, Node, Range) ->
 local(DbName) when is_list(DbName) ->
     local(list_to_binary(DbName));
 local(DbName) ->
+    ThisNode = config:node_name(),
     Pred = fun
-        (#shard{node = Node}) when Node == node() -> true;
+        (#shard{node = Node}) when Node == ThisNode -> true;
         (_) -> false
     end,
     lists:filter(Pred, for_db(DbName)).
@@ -403,7 +404,7 @@ changes_callback({change, {Change}, _}, _) ->
                                 create_if_missing(mem3:name(S))
                              || S <-
                                     Shards,
-                                mem3:node(S) =:= node()
+                                mem3:node(S) =:= config:node_name()
                             ]
                     end
             end

--- a/src/mem3/src/mem3_sync.erl
+++ b/src/mem3/src/mem3_sync.erl
@@ -270,9 +270,9 @@ initial_sync() ->
 
 initial_sync(Live) ->
     sync_nodes_and_dbs(),
-    Acc = {node(), Live, []},
+    Acc = {config:node_name(), Live, []},
     {_, _, Shards} = mem3_shards:fold(fun initial_sync_fold/2, Acc),
-    submit_replication_tasks(node(), Live, Shards).
+    submit_replication_tasks(config:node_name(), Live, Shards).
 
 initial_sync_fold(#shard{dbname = Db} = Shard, {LocalNode, Live, AccShards}) ->
     case AccShards of


### PR DESCRIPTION
Continuation of https://github.com/apache/couchdb/pull/5132

Use the persistent node name in cases where the node may end up persisted on disk:
  * shard map (dbs db)
  * nodes db
  * checkpoints (purge, internal replicator, reshard jobs)
  * resharding job ids
  * changes sequences
  * logging
  * nodes database
