### PR TITLE
Bring PPC64LE worker back

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -55,16 +55,14 @@ meta = [
     image: "apache/couchdbci-ubuntu:jammy-erlang-${ERLANG_VERSION}"
   ],
 
-  // Not coming back after upgrade+reboot. Hopefully it needs
-  // a hard reboot, but until then let's skip to keep our CI green.
-  // 'bookworm-ppc64': [
-  //   name: 'Debian POWER',
-  //   spidermonkey_vsn: '78',
-  //   with_nouveau: true,
-  //   with_clouseau: true,
-  //   image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}",
-  //   node_label: 'ppc64le'
-  // ],
+  'bookworm-ppc64': [
+    name: 'Debian POWER',
+    spidermonkey_vsn: '78',
+    with_nouveau: true,
+    with_clouseau: true,
+    image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}",
+    node_label: 'ppc64le'
+  ],
 
   'bookworm-s390x': [
     name: 'Debian s390x',


### PR DESCRIPTION
We got some assistance hard rebooting it.

It turns out my `apt update` was stuck while updating docker. I tried a soft reboot `sudo reboot` and that made it and not come back.

It looks good now after running `dpkg reconfigure ...` to finish package updates, and then did another `apt update &$ upgrade &$ sudo reboot` to make sure it comes back up.
