### PR TITLE
Remove unused external functions and local external calls

### DIFF
--- a/src/couch/src/couch_emsort.erl
+++ b/src/couch/src/couch_emsort.erl
@@ -130,7 +130,7 @@
 %
 
 -export([open/1, open/2, get_fd/1, get_state/1]).
--export([add/2, merge/1, merge/2, sort/1, iter/1, next/1]).
+-export([add/2, merge/2, iter/1, next/1]).
 -export([num_kvs/1, num_merges/1]).
 
 -record(ems, {
@@ -187,13 +187,6 @@ add(Ems, KVs) ->
         num_kvs = Ems#ems.num_kvs + length(KVs),
         num_bb = Ems#ems.num_bb + 1
     }}.
-
-sort(#ems{} = Ems) ->
-    {ok, Ems1} = merge(Ems),
-    iter(Ems1).
-
-merge(Ems) ->
-    merge(Ems, fun(_) -> ok end).
 
 merge(#ems{root = undefined} = Ems, _Reporter) ->
     {ok, Ems};

--- a/src/couch/src/couch_key_tree.erl
+++ b/src/couch/src/couch_key_tree.erl
@@ -57,7 +57,6 @@
     get_full_key_paths/2,
     get_key_leafs/2,
     map/2,
-    map_leafs/2,
     mapfold/3,
     multi_merge/2,
     merge/2,
@@ -474,20 +473,6 @@ mapfold_simple(Fun, Acc, Pos, [{Key, Value, SubTree} | RestTree]) ->
     {SubTree2, Acc3} = mapfold_simple(Fun, Acc2, Pos + 1, SubTree),
     {RestTree2, Acc4} = mapfold_simple(Fun, Acc3, Pos, RestTree),
     {[{Key, Value2, SubTree2} | RestTree2], Acc4}.
-
-map_leafs(_Fun, []) ->
-    [];
-map_leafs(Fun, [{Pos, Tree} | Rest]) ->
-    [NewTree] = map_leafs_simple(Fun, Pos, [Tree]),
-    [{Pos, NewTree} | map_leafs(Fun, Rest)].
-
-map_leafs_simple(_Fun, _Pos, []) ->
-    [];
-map_leafs_simple(Fun, Pos, [{Key, Value, []} | RestTree]) ->
-    Value2 = Fun({Pos, Key}, Value),
-    [{Key, Value2, []} | map_leafs_simple(Fun, Pos, RestTree)];
-map_leafs_simple(Fun, Pos, [{Key, Value, SubTree} | RestTree]) ->
-    [{Key, Value, map_leafs_simple(Fun, Pos + 1, SubTree)} | map_leafs_simple(Fun, Pos, RestTree)].
 
 stem(Trees, Limit) ->
     try

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -19,10 +19,10 @@
 -export([encodeBase64Url/1, decodeBase64Url/1]).
 -export([validate_utf8/1, to_hex/1, to_hex_bin/1, parse_term/1, dict_find/3]).
 -export([get_nested_json_value/2, json_user_ctx/1]).
--export([proplist_apply_field/2, json_apply_field/2]).
+-export([json_apply_field/2]).
 -export([to_binary/1, to_integer/1, to_list/1, url_encode/1]).
 -export([json_encode/1, json_decode/1, json_decode/2]).
--export([verify/2, simple_call/2, shutdown_sync/1]).
+-export([verify/2, shutdown_sync/1]).
 -export([get_value/2, get_value/3, set_value/3]).
 -export([reorder_results/2, reorder_results/3]).
 -export([url_strip_password/1]).
@@ -157,20 +157,6 @@ shutdown_sync(Pid) ->
         erlang:demonitor(MRef, [flush])
     end.
 
-simple_call(Pid, Message) ->
-    MRef = erlang:monitor(process, Pid),
-    try
-        Pid ! {self(), Message},
-        receive
-            {Pid, Result} ->
-                Result;
-            {'DOWN', MRef, _, _, Reason} ->
-                exit(Reason)
-        end
-    after
-        erlang:demonitor(MRef, [flush])
-    end.
-
 validate_utf8(Data) when is_list(Data) ->
     validate_utf8(?l2b(Data));
 validate_utf8(Bin) when is_binary(Bin) ->
@@ -275,10 +261,6 @@ get_nested_json_value(Value, []) ->
     Value;
 get_nested_json_value(_NotJSONObj, _) ->
     throw({not_found, json_mismatch}).
-
-proplist_apply_field(H, L) ->
-    {R} = json_apply_field(H, {L}),
-    R.
 
 json_apply_field(H, {L}) ->
     json_apply_field(H, L, []).

--- a/src/couch_prometheus/src/couch_prometheus_util.erl
+++ b/src/couch_prometheus/src/couch_prometheus_util.erl
@@ -16,8 +16,7 @@
     couch_to_prom/3,
     to_bin/1,
     to_prom/4,
-    to_prom/2,
-    to_prom_summary/2
+    to_prom/2
 ]).
 
 couch_to_prom([couch_log, level, alert], Info, _All) ->

--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -28,7 +28,6 @@
     db_close/1,
     get_db_info/1,
     get_pending_count/2,
-    get_view_info/3,
     update_doc/3,
     update_doc/4,
     update_docs/3,
@@ -153,17 +152,6 @@ get_pending_count(#httpdb{} = Db, Seq) ->
     send_req(Db, Options, fun(200, _, {Props}) ->
         {ok, couch_util:get_value(<<"pending">>, Props, null)}
     end).
-
-get_view_info(#httpdb{} = Db, DDocId, ViewName) ->
-    Path = io_lib:format("~s/_view/~s/_info", [DDocId, ViewName]),
-    send_req(
-        Db,
-        [{path, Path}],
-        fun(200, _, {Props}) ->
-            {VInfo} = couch_util:get_value(<<"view_index">>, Props, {[]}),
-            {ok, VInfo}
-        end
-    ).
 
 ensure_full_commit(#httpdb{} = Db) ->
     send_req(

--- a/src/rexi/src/rexi_utils.erl
+++ b/src/rexi/src/rexi_utils.erl
@@ -12,7 +12,7 @@
 
 -module(rexi_utils).
 
--export([server_id/1, server_pid/1, send/2, recv/6]).
+-export([server_pid/1, send/2, recv/6]).
 
 %% @doc Return a rexi_server id for the given node.
 server_id(Node) ->


### PR DESCRIPTION
Local external calls are fairly simple: it's when we use the function in the module via the external reference. Previously, with hotcode upgrades that might have made sense, but currently it doesn't, maybe even adds a tiny bit of overhead on each call. A couple of these were cleaned up in chttpd module.

Unused externals are functions which are exported but not used anywhere.

In some cases we didn't even use the function at all, like in the case of `stream_init/1,2` or `rexi:stream/1,2,3` we can remove their bodies as well.

Since `stream_init` is removed, update the `init_stream` as per https://github.com/apache/couchdb/issues/5122, where we noticed that the newer `init_stream` doesn't actually update the timeout metric, so before cleaning up `stream_init` move that to the `init_stream`.
