### PR TITLE
Cleanup deprecated and unused functionality in rexi

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -391,7 +391,6 @@ hash_algorithms = sha256, sha
 
 ;[rexi]
 ;buffer_count = 2000
-;server_per_node = true
 ;stream_limit = 5
 ;shard_split_timeout_msec = 600000
 ;shard_split_topoff_batch_size = 500

--- a/src/docs/src/config/cluster.rst
+++ b/src/docs/src/config/cluster.rst
@@ -111,14 +111,6 @@ RPC Performance Tuning
     This flag determines how many messages will be buffered before the local
     server starts dropping messages. Default value is ``2000``.
 
-    .. config:option:: server_per_node :: Enable or disable one local `gen_server` \
-        process per node
-
-    By default, rexi will spawn one local gen_server process for each node in
-    the cluster. Disabling this flag will cause CouchDB to use a single process
-    for all RPC communication, which is not recommended in high throughput
-    deployments.
-
     .. config:option:: stream_limit :: Number of send messages without waiting \
         for acknowledgement from the coordinator
 

--- a/src/fabric/src/fabric_view.erl
+++ b/src/fabric/src/fabric_view.erl
@@ -132,7 +132,7 @@ filter_exact_copies(#shard{range = Range0} = Shard0, Shards, Cb) ->
     ).
 
 stop_worker(#shard{ref = Ref, node = Node}) ->
-    rexi:kill(Node, Ref).
+    rexi:kill_all([{Node, Ref}]).
 
 maybe_send_row(#collector{limit = 0} = State) ->
     #collector{counters = Counters, user_acc = AccIn, callback = Callback} = State,

--- a/src/rexi/src/rexi_server.erl
+++ b/src/rexi/src/rexi_server.erl
@@ -79,6 +79,9 @@ handle_cast({doit, {ClientPid, ClientRef} = From, Nonce, MFA}, State) ->
     },
     {noreply, add_job(Job, State)};
 handle_cast({kill, FromRef}, St) ->
+    % TODO: Compatibility clause. This is left to handle mixed cluster
+    % upgrades. Old nodes may still send {kill, Ref} message from rexi:kill.
+    % Remove in somme future 3.4+ version.
     kill_worker(FromRef, St),
     {noreply, St};
 handle_cast({kill_all, FromRefs}, St) ->

--- a/src/rexi/src/rexi_sup.erl
+++ b/src/rexi/src/rexi_sup.erl
@@ -22,6 +22,9 @@ start_link(Args) ->
 init([]) ->
     {ok,
         {{rest_for_one, 3, 10}, [
+            % TODO: Compatibility clause rexi_server. This was used by
+            % server_per_node=false mode once After 3.4+ releases, this can be
+            % removed.
             {
                 rexi_server,
                 {rexi_server, start_link, [rexi_server]},

--- a/src/rexi/src/rexi_utils.erl
+++ b/src/rexi/src/rexi_utils.erl
@@ -16,12 +16,7 @@
 
 %% @doc Return a rexi_server id for the given node.
 server_id(Node) ->
-    case config:get_boolean("rexi", "server_per_node", true) of
-        true ->
-            list_to_atom("rexi_server_" ++ atom_to_list(Node));
-        _ ->
-            rexi_server
-    end.
+    list_to_atom("rexi_server_" ++ atom_to_list(Node)).
 
 %% @doc Return a {server_id(node()), Node} Pid name for the given Node.
 server_pid(Node) ->


### PR DESCRIPTION
Continuing the cleanup started in #5143

The `server_per_node` setting had been defaulted to `true` for the last 6 years. Default it to `true` always. However, keep the `rexi_server` around for longer so that mixed cluster upgrades continue working.

The `kill_all` optimization has been enabled since 3.3.3. We can remove any calls to rexi:kill/1 and replace with rexi:kill_all/1 leaving the server handling of `{kill, ...}` messages in for longer to allow mixed cluster upgrades from older nodes.

`async_server_call` code is not used anywhere, so that's also cleaned up.

[1] https://github.com/apache/couchdb/pull/1627
