### PR TITLE
Add aggregate rexi server and rexi buffer message queue metrics

### DIFF
--- a/src/rexi/src/rexi.erl
+++ b/src/rexi/src/rexi.erl
@@ -18,6 +18,7 @@
 -export([stream_ack/1]).
 -export([stream2/1, stream_last/1, stream_last/2]).
 -export([ping/0]).
+-export([aggregate_server_queue_len/0, aggregate_buffer_queue_len/0]).
 
 %% @equiv cast(Node, self(), MFA)
 -spec cast(node(), {atom(), atom(), list()}) -> reference().
@@ -158,6 +159,12 @@ stream_ack(Client) ->
 ping() ->
     {Caller, _} = get(rexi_from),
     erlang:send(Caller, {rexi, '$rexi_ping'}).
+
+aggregate_server_queue_len() ->
+    rexi_server_mon:aggregate_queue_len(rexi_server).
+
+aggregate_buffer_queue_len() ->
+    rexi_server_mon:aggregate_queue_len(rexi_buffer).
 
 %% internal functions %%
 


### PR DESCRIPTION
We have aggregate couch_server and index server metrics, but rexi server and buffers, which are also sharded were missing, so this commit adds them.

In addition noticed we didn't have an test for `/_system` test so added one which check most of the functionality: base VM metrics, computed, aggregated and simple message queue length, etc.
