### PR TITLE
Add passively closed client monitoring to search

### DIFF
--- a/src/dreyfus/src/dreyfus_fabric.erl
+++ b/src/dreyfus/src/dreyfus_fabric.erl
@@ -136,6 +136,7 @@ handle_replacement(
             NewCounters = lists:foldl(
                 fun(Repl, CounterAcc) ->
                     NewCounter = start_replacement(StartFun, StartArgs, Repl),
+                    fabric_streams:add_worker_to_cleaner(self(), NewCounter),
                     fabric_dict:store(NewCounter, nil, CounterAcc)
                 end,
                 OldCounters,

--- a/src/dreyfus/src/dreyfus_fabric_group1.erl
+++ b/src/dreyfus/src/dreyfus_fabric_group1.erl
@@ -56,6 +56,8 @@ go(DbName, DDoc, IndexName, #index_query_args{} = QueryArgs) ->
         replacements = Replacements,
         ring_opts = RingOpts
     },
+    ClientReq = chttpd_util:mochiweb_client_req_get(),
+    fabric_streams:spawn_worker_cleaner(self(), Workers, ClientReq),
     try
         rexi_utils:recv(
             Workers,
@@ -67,7 +69,7 @@ go(DbName, DDoc, IndexName, #index_query_args{} = QueryArgs) ->
         )
     after
         rexi_monitor:stop(RexiMon),
-        fabric_util:cleanup(Workers)
+        fabric_streams:cleanup(Workers)
     end;
 go(DbName, DDoc, IndexName, OldArgs) ->
     go(DbName, DDoc, IndexName, dreyfus_util:upgrade(OldArgs)).

--- a/src/dreyfus/src/dreyfus_fabric_group2.erl
+++ b/src/dreyfus/src/dreyfus_fabric_group2.erl
@@ -61,6 +61,8 @@ go(DbName, DDoc, IndexName, #index_query_args{} = QueryArgs) ->
         replacements = Replacements,
         ring_opts = RingOpts
     },
+    ClientReq = chttpd_util:mochiweb_client_req_get(),
+    fabric_streams:spawn_worker_cleaner(self(), Workers, ClientReq),
     try
         rexi_utils:recv(
             Workers,
@@ -72,7 +74,7 @@ go(DbName, DDoc, IndexName, #index_query_args{} = QueryArgs) ->
         )
     after
         rexi_monitor:stop(RexiMon),
-        fabric_util:cleanup(Workers)
+        fabric_streams:cleanup(Workers)
     end;
 go(DbName, DDoc, IndexName, OldArgs) ->
     go(DbName, DDoc, IndexName, dreyfus_util:upgrade(OldArgs)).

--- a/src/dreyfus/src/dreyfus_fabric_search.erl
+++ b/src/dreyfus/src/dreyfus_fabric_search.erl
@@ -113,6 +113,8 @@ go(DbName, DDoc, IndexName, QueryArgs, Counters, Bookmark, RingOpts) ->
         replacements = Replacements,
         ring_opts = RingOpts
     },
+    ClientReq = chttpd_util:mochiweb_client_req_get(),
+    fabric_streams:spawn_worker_cleaner(self(), Workers, ClientReq),
     RexiMon = fabric_util:create_monitors(Workers),
     try
         rexi_utils:recv(
@@ -144,7 +146,7 @@ go(DbName, DDoc, IndexName, QueryArgs, Counters, Bookmark, RingOpts) ->
             {error, Reason}
     after
         rexi_monitor:stop(RexiMon),
-        fabric_util:cleanup(Workers)
+        fabric_streams:cleanup(Workers)
     end.
 
 handle_message({ok, #top_docs{} = NewTopDocs}, Shard, State0) ->

--- a/src/fabric/src/fabric_streams.erl
+++ b/src/fabric/src/fabric_streams.erl
@@ -17,7 +17,9 @@
     start/3,
     start/4,
     start/5,
-    cleanup/1
+    cleanup/1,
+    spawn_worker_cleaner/3,
+    add_worker_to_cleaner/2
 ]).
 
 -include_lib("fabric/include/fabric.hrl").


### PR DESCRIPTION
We added client monitoring [1] for streaming fabric requests (_all_docs, _change, etc), but never added them to dreyfus since it's not using the streams abstraction.

Add client monitoring to dreyfus but exporting a few internal functions from `fabric_stream`, otherwise the pattern is the same:

   * Start a client monitor process with the set of initial workers to monitor the coordinator and the client socket connection state.
   * In case of replacements, update the monitor with the newly spawned replacement workers.
   * On cleanup, call the previous `fabric_stream:cleanup/1` function, and also stop the monitor process.

[1] https://github.com/apache/couchdb/commit/d5701f437183c3742aab5812e298d5bb80cb0c15
