### PR TITLE
fix(dev): Upgrade recon and fix Erlang/OTP 27 compiler warnings

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -161,7 +161,7 @@ DepDescs = [
 {jiffy,            "jiffy",            {tag, "1.1.2"}},
 {mochiweb,         "mochiweb",         {tag, "v3.2.2"}},
 {meck,             "meck",             {tag, "CouchDB-0.9.2-1"}},
-{recon,            "recon",            {tag, "2.5.3"}}
+{recon,            "recon",            {tag, "2.5.5"}}
 ].
 
 WithProper = lists:keyfind(with_proper, 1, CouchConfig) == {with_proper, true}.

--- a/src/couch/src/couch_ejson_size.erl
+++ b/src/couch/src/couch_ejson_size.erl
@@ -32,7 +32,7 @@ encoded_size(List) when is_list(List) ->
     1 + lists:sum([encoded_size(V) + 1 || V <- List]);
 %% Floats.
 
-encoded_size(0.0) ->
+encoded_size(+0.0) ->
     3;
 encoded_size(1.0) ->
     3;


### PR DESCRIPTION
Synced couchdb-recon with upstream ferd/recon to 2.5.5 
Fix compiler warnings for Erlang/OTP 26

Fixes #5153. 