### PR TITLE
Put classpath in main jar manifest

### DIFF
--- a/nouveau/build.gradle
+++ b/nouveau/build.gradle
@@ -49,7 +49,11 @@ java {
 }
 
 jar {
-    manifest.attributes('Multi-Release': 'true')
+    manifest {
+        attributes(
+            'Multi-Release': 'true',
+            "Class-Path": configurations.runtimeClasspath.collect { it.getName() }.join(' '))
+    }
 }
 
 spotless {
@@ -81,4 +85,9 @@ tasks.withType(Javadoc) {
 tasks.withType(AbstractArchiveTask) {
     preserveFileTimestamps = false
     reproducibleFileOrder = true
+}
+
+
+startScripts {
+    classpath = files(jar.archiveFileName)
 }


### PR DESCRIPTION
We encounter issues launching nouveau on Windows as it cAnnoT haNdle LoNG LiNEs iN ScripTs. Instead we list the dependency jars in the manifest and only need to include one jar in the classpath.

NB: I really dislike how I construct the name of the jar file, as I'm sure it must just be available in a variable already.