### PR TITLE
Add section on support policy to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,13 @@ Fauxton. To fix the admin party you have to run ``./dev/run`` with the ``admin``
 flag, e.g. ``./dev/run --admin=username:password``. If you want to have an
 admin-party, just omit the flag.
 
+Support Policy
+--------------
+
+CouchDB supports the current and the last feature release line. For example,
+when a new version (e.g. 3.4) is released, the version two releases prior
+(e.g. 3.2) becomes end-of-life (EOL).
+
 Contributing to CouchDB
 -----------------------
 


### PR DESCRIPTION
## Overview
Adds a new section to the README, with a few notes clarifying the support policy. Essentially, takes the info from this GH issue thread and places it in a more accessible location for anyone else querying in future: https://github.com/apache/couchdb/issues/5159

## Testing recommendations
This is a README update, there is no changes to features or functionality.

## Related Issues or Pull Requests
- https://github.com/apache/couchdb/issues/5159
