### PR TITLE
A few more quickjs scanner fixes

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
+++ b/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
@@ -514,7 +514,11 @@ expected_error(_) ->
 
 expected_error({error, {_, compilation_error, _}}, {error, {_, compilation_error, _}}) ->
     true;
+expected_error({error, {_, {compilation_error, _}}}, {error, {_, {compilation_error, _}}}) ->
+    true;
 expected_error({error, {_, <<"TypeError">>, _}}, {error, {_, <<"TypeError">>, _}}) ->
+    true;
+expected_error({error, {_, {<<"TypeError">>, _}}}, {error, {_, {<<"TypeError">>, _}}}) ->
     true;
 expected_error(_, _) ->
     false.


### PR DESCRIPTION
Noticed a few more expected error clauses we could handle to reduce log noise.

It should handle `{vdu_doc,{error,{throw,{<<"TypeError">>,{Stack..}}}}, ...}` cases.

Also noticed that the scanner might leave a db opened and not close if it throws an exception from a loop, so be more resilient and put it in the `after` clause of a `try`.
