### PR TITLE
Removed unused close_lru gen_server call

### DIFF
--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -520,13 +520,6 @@ open_async_int(Server, DbName, Options) ->
             Error1
     end.
 
-handle_call(close_lru, _From, #server{lru = Lru} = Server) ->
-    case couch_lru:close(Lru) of
-        {true, NewLru} ->
-            {reply, ok, db_closed(Server#server{lru = NewLru}, [])};
-        false ->
-            {reply, {error, all_dbs_active}, Server}
-    end;
 handle_call(open_dbs_count, _From, Server) ->
     {reply, Server#server.dbs_open, Server};
 handle_call({set_update_lru_on_read, UpdateOnRead}, _From, Server) ->


### PR DESCRIPTION
We close the lru via make_room/2 only. Nothing seems to call gen_server call, so let's not keep it around as it's confusing when inspecting the already tricky lru cache logic.

