### PR TITLE
Use persistent node name in a new header

### DIFF
--- a/src/couch/src/couch_bt_engine_header.erl
+++ b/src/couch/src/couch_bt_engine_header.erl
@@ -79,7 +79,7 @@
 new() ->
     #db_header{
         uuid = couch_uuids:random(),
-        epochs = [{node(), 0}]
+        epochs = [{config:node_name(), 0}]
     }.
 
 from(Header0) ->


### PR DESCRIPTION
When updating various places to use persistent node names, we forgot probably one of the most important one: the epoch list in the header.

Continuation of: #5138
