### PR TITLE
Remove replicator stability metric

### DIFF
--- a/src/couch_replicator/priv/stats_descriptions.cfg
+++ b/src/couch_replicator/priv/stats_descriptions.cfg
@@ -54,10 +54,6 @@
     {type, counter},
     {desc, <<"number of replicator workers started">>}
 ]}.
-{[couch_replicator, cluster_is_stable], [
-    {type, gauge},
-    {desc, <<"1 if cluster is stable, 0 if unstable">>}
-]}.
 {[couch_replicator, db_scans], [
     {type, counter},
     {desc, <<"number of times replicator db scans have been started">>}

--- a/src/docs/src/api/server/common.rst
+++ b/src/docs/src/api/server/common.rst
@@ -1762,8 +1762,6 @@ containing only the requested individual statistic.
         couchdb_couch_replicator_checkpoints_failure_total 0
         # TYPE couchdb_couch_replicator_checkpoints_total counter
         couchdb_couch_replicator_checkpoints_total 0
-        # TYPE couchdb_couch_replicator_cluster_is_stable gauge
-        couchdb_couch_replicator_cluster_is_stable 1
         # TYPE couchdb_couch_replicator_connection_acquires_total counter
         couchdb_couch_replicator_connection_acquires_total 0
         # TYPE couchdb_couch_replicator_connection_closes_total counter


### PR DESCRIPTION
The metric is not needed any longer as of #5093 so we're just cleaning it up.
