### PR TITLE
chore(`clouseau`): bump to 2.23.1

### DIFF
--- a/configure
+++ b/configure
@@ -43,7 +43,7 @@ JS_ENGINE=${JS_ENGINE:-"spidermonkey"}
 SM_VSN=${SM_VSN:-"91"}
 CLOUSEAU_MTH=${CLOUSEAU_MTH:-"dist"}
 CLOUSEAU_URI=${CLOUSEAU_URI:-"https://github.com/cloudant-labs/clouseau/releases/download/%s/clouseau-%s-dist.zip"}
-CLOUSEAU_VSN=${CLOUSEAU_VSN:-"2.22.0"}
+CLOUSEAU_VSN=${CLOUSEAU_VSN:-"2.23.1"}
 CLOUSEAU_DIR="$(pwd)"/clouseau
 ARCH="$(uname -m)"
 ERLANG_VER="$(run_erlang 'io:put_chars(erlang:system_info(otp_release)).')"
@@ -111,16 +111,11 @@ parse_opts() {
                 continue
                 ;;
 
-	        --with-clouseau)
-		        if [ "${ERLANG_VER}" -gt 25 ]; then
-		            echo "Warning: Clouseau is not working with OTP 26 or later at the moment, therefore it is not configured.  Continue in 5 seconds..."
-		            sleep 5
-		        else
-		            WITH_CLOUSEAU="true"
-		        fi
-		        shift
-		        continue
-		        ;;
+            --with-clouseau)
+                WITH_CLOUSEAU="true"
+                shift
+                continue
+                ;;
 
             --erlang-md5)
                 ERLANG_MD5="true"
@@ -475,24 +470,35 @@ check_local_clouseau_dir() {
     fi
 }
 
+fetch_file() {
+    _file_name="$1"
+    _file_url="$2"
+
+    if ! curl -sSL --max-redirs 1 -o "$_file_name" "$_file_url"; then
+	printf "ERROR: %s could not be downloaded.\n" "$_file_url" >&2
+	exit 1
+    fi
+}
+
 install_local_clouseau() {
     case "$CLOUSEAU_MTH" in
 	dist)
 	    _DIST_URL=$(printf "$CLOUSEAU_URI" "$CLOUSEAU_VSN" "$CLOUSEAU_VSN")
 	    _MAVEN_BASE_URI=https://repo1.maven.org/maven2
+	    _LOGBACK_DIST_URL="$_MAVEN_BASE_URI"/ch/qos/logback
 
-	    _SLF4J_SIMPLE_VSN=${SLF4J_SIMPLE_VERSION:-1.7.36}
-	    _SLF4J_SIMPLE_JAR=slf4j-simple-"$_SLF4J_SIMPLE_VSN".jar
-	    _SLF4J_SIMPLE_URL="$_MAVEN_BASE_URI"/org/slf4j/slf4j-simple/"$_SLF4J_SIMPLE_VSN"/"$_SLF4J_SIMPLE_JAR"
+	    : "${LOGBACK_VERSION:=1.2.13}"
+	    _LOGBACK_CORE_JAR=logback-core-"$LOGBACK_VERSION".jar
+	    _LOGBACK_CORE_URL="$_LOGBACK_DIST_URL"/logback-core/"$LOGBACK_VERSION"/"$_LOGBACK_CORE_JAR"
+	    _LOGBACK_CLASSIC_JAR=logback-classic-"$LOGBACK_VERSION".jar
+	    _LOGBACK_CLASSIC_URL="$_LOGBACK_DIST_URL"/logback-classic/"$LOGBACK_VERSION"/"$_LOGBACK_CLASSIC_JAR"
 
 	    check_local_clouseau_dir "$CLOUSEAU_DIR"
 	    mkdir -p "$CLOUSEAU_DIR"
 
 	    echo "Fetching Clouseau from $_DIST_URL..."
-	    if ! curl -sSL --max-redirs 1 -o clouseau.zip "$_DIST_URL"; then
-		printf "ERROR: %s could not be downloaded.\n" "$_DIST_URL" >&2
-		exit 1
-	    fi
+
+	    fetch_file clouseau.zip "$_DIST_URL"
 
 	    if ! unzip -q -j clouseau.zip -d "$CLOUSEAU_DIR"; then
 		printf "ERROR: Clouseau distribution package (clouseau.zip) could not be extracted.\n" >&2
@@ -501,10 +507,10 @@ install_local_clouseau() {
 
 	    rm clouseau.zip
 
-	    if ! curl -sSL --max-redirs 1 -o "$CLOUSEAU_DIR"/"$_SLF4J_SIMPLE_JAR" "$_SLF4J_SIMPLE_URL"; then
-		printf "ERROR: %s could not be downloaded.\n" "$_SLF4J_SIMPLE_URL" >&2
-		exit 1
-	    fi
+	    echo "Fetching Logback $LOGBACK_VERSION from $_LOGBACK_DIST_URL..."
+
+	    fetch_file "$CLOUSEAU_DIR"/"$_LOGBACK_CORE_JAR" "$_LOGBACK_CORE_URL"
+	    fetch_file "$CLOUSEAU_DIR"/"$_LOGBACK_CLASSIC_JAR" "$_LOGBACK_CLASSIC_URL"
 	    ;;
 
 	git)

--- a/configure.ps1
+++ b/configure.ps1
@@ -14,9 +14,9 @@
   -CouchDBUser USER          set the username to run as (defaults to current user)
   -SpiderMonkeyVersion VSN   select the version of SpiderMonkey to use (default 91)
   -JSEngine ENGINE           select JS engine to use (spidermonkey or quickjs) (default spidermonkey)
-  -ClouseauVersion VSN       select the version of Clouseau to use (default 2.22.0)
+  -ClouseauVersion VSN       select the version of Clouseau to use (default 2.23.1)
   -ClouseauMethod MTH        method for Clouseau to deploy: git or dist (default dist)
-  -ClouseauUri URI           location for retrieving Clouseau (default https://github.com/cloudant-labs/clouseau/releases/download/2.22.0/clouseau-2.22.0-dist.zip)
+  -ClouseauUri URI           location for retrieving Clouseau (default https://github.com/cloudant-labs/clouseau/releases/download/2.23.1/clouseau-2.23.1-dist.zip)
 
   Installation directories:
   -Prefix PREFIX             install architecture-independent files in PREFIX
@@ -66,9 +66,9 @@ Param(
     [ValidateNotNullOrEmpty()]
     [string]$ClouseauMethod = "dist", # method for Clouseau to deploy: git or dist (default dist)
     [ValidateNotNullOrEmpty()]
-    [string]$ClouseauVersion = "2.22.0", # select the version of Clouseau to use (default 2.22.0)
+    [string]$ClouseauVersion = "2.23.1", # select the version of Clouseau to use (default 2.23.1)
     [ValidateNotNullOrEmpty()]
-    [string]$ClouseauUri = "https://github.com/cloudant-labs/clouseau/releases/download/{0}/clouseau-{0}-dist.zip", # location for retrieving Clouseau (default https://github.com/cloudant-labs/clouseau/releases/download/2.22.0/clouseau-2.22.0-dist.zip)
+    [string]$ClouseauUri = "https://github.com/cloudant-labs/clouseau/releases/download/{0}/clouseau-{0}-dist.zip", # location for retrieving Clouseau (default https://github.com/cloudant-labs/clouseau/releases/download/2.23.1/clouseau-2.23.1-dist.zip)
     [ValidateNotNullOrEmpty()]
     [string]$Prefix = "C:\Program Files\Apache\CouchDB", # install architecture-independent file location (default C:\Program Files\Apache\CouchDB)
     [ValidateNotNullOrEmpty()]
@@ -321,10 +321,12 @@ if ($WithClouseau)
 
 	New-Item -Path $ClouseauDir -ItemType Directory | Out-Null
 
-	$Slf4jVersion = "1.7.36"
+	$LogbackVersion = "1.2.13"
 	$ClouseauDistUrl = $ClouseauUri -f $ClouseauVersion
-	$Slf4jSimpleJar = "slf4j-simple-$Slf4jVersion.jar"
-	$Slf4jSimpleUrl = "https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/$Slf4jVersion/$Slf4jSimpleJar"
+	$LogbackCoreJar = "logback-core-$LogbackVersion.jar"
+	$LogbackCoreJarUrl = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/$LogbackVersion/$LogbackCoreJar"
+	$LogbackClassicJar = "logback-classic-$LogbackVersion.jar"
+	$LogbackClassicJarUrl = "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/$LogbackVersion/$LogbackClassicJar"
 
 	Set-Variable ProgressPreference SilentlyContinue
 	Invoke-WebRequest -MaximumRedirection 1 -OutFile clouseau.zip $ClouseauDistUrl
@@ -342,9 +344,15 @@ if ($WithClouseau)
 	Remove-Item "$ClouseauDir\clouseau-$ClouseauVersion"
 	Remove-Item clouseau.zip
 
-	Invoke-WebRequest -MaximumRedirection 1 -OutFile "$ClouseauDir\$Slf4jSimpleJar" $Slf4jSimpleUrl
+	Invoke-WebRequest -MaximumRedirection 1 -OutFile "$ClouseauDir\$LogbackCoreJar" $LogbackCoreJarUrl
 	If ($LASTEXITCODE -ne 0) {
-	    Write-Output "ERROR: $Slf4jSimpleJarUrl could not be downloaded."
+	    Write-Output "ERROR: $LogbackCoreJarUrl could not be downloaded."
+	    exit 1
+	}
+
+	Invoke-WebRequest -MaximumRedirection 1 -OutFile "$ClouseauDir\$LogbackClassicJar" $LogbackClassicJarUrl
+	If ($LASTEXITCODE -ne 0) {
+	    Write-Output "ERROR: $LogbackClassicJarUrl could not be downloaded."
 	    exit 1
 	}
     }

--- a/dev/run
+++ b/dev/run
@@ -592,14 +592,21 @@ def generate_default_clouseau_ini(path):
         )
 
 
-def generate_default_log4j_properties(path):
-    print("(generate default log4j.properties)")
+def generate_default_logback_properties(path):
+    print("(generate default logback.xml)")
     with open(path, "w") as handle:
         handle.write(
-            """log4j.rootLogger=debug, CONSOLE
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %c [%p] %m%n
+            """<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{ISO8601} %c [%p] %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>
 """
         )
 
@@ -714,9 +721,11 @@ def boot_clouseau(ctx, idx):
     if not os.path.exists(clouseau_ini):
         generate_default_clouseau_ini(clouseau_ini)
 
-    log4j_properties = os.path.join(clouseau_dir, "log4j.properties")
-    if not os.path.exists(log4j_properties):
-        generate_default_log4j_properties(log4j_properties)
+    logback_properties = os.path.join(clouseau_dir, "logback.xml")
+    if not os.path.exists(logback_properties):
+        generate_default_logback_properties(logback_properties)
+
+    classpath = separator.join([classpath, clouseau_dir])  # for logback.xml
 
     clouseau_name = "clouseau{}@127.0.0.1".format(idx)
     clouseau_indexes_dir = os.path.join(ctx["devdir"], "clouseau{}".format(idx), "data")
@@ -745,7 +754,6 @@ def boot_clouseau(ctx, idx):
             "-XX:+CMSParallelRemarkEnabled",
             "-cp",
             classpath,
-            "-Dlog4j.configuration=file:{}".format(log4j_properties),
             "-Dclouseau.name={}".format(clouseau_name),
             "-Dclouseau.dir={}".format(clouseau_indexes_dir),
         ]


### PR DESCRIPTION
The latest version of Clouseau now fixes the incompatibility issue with OTP 26 and later (*), so pull that in and remove the related checks.

At the same time, replace SLF4J Simple with [Logback Classic](https://logback.qos.ch/) since that has been the standard logging backend for a while.  Note that Clouseau is still shipped with SLF4J API 1.7, which supports Logback up to 1.2 only.

(*) Thanks @jaydoane!

## Testing recommendations

Configure with Clouseau enabled (UNIX-like systems, including macOS):

```console
./configure --with-clouseau
```

or on Windows:

```console
.\configure.ps1 -WithClouseau
```


Run the Mango tests (which should automatically utilize Clouseau):

```console
make mango-test
```

Run the Elixir search tests (which should automatically utilize Clouseau):

```console
make elixir-search
```

This should all work with Erlang/OTP 25, 26, and 27.  However, Elixir (1.17.2) did not seem to work for me with OTP 27, but that is a different issue.  The Mango tests still passed for me on OTP 27.

To check if Logback works as expect, you can take a look at the contents of the `dev/logs/clouseau1.log` file after Clouseau has been started up alongside CouchDB, e.g.:

```console
dev/run -a adm:pass -n 1 --with-clouseau
```

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
