### PR TITLE
Update min Elixir version to 1.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule CouchDBTest.Mixfile do
     [
       app: :couchdbtest,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.15",
       lockfile: Path.expand("mix.lock", __DIR__),
       deps_path: Path.expand("src", __DIR__),
       build_path: Path.expand("_build", __DIR__),


### PR DESCRIPTION
This is mostly a min version setting. 1.13 is pretty old by this point. The only time it would fail is when Elixir `< 1.15` or `> 2` would be used.
