### PR TITLE
Remove redundant and racy assertion

### DIFF
--- a/src/couch/test/eunit/couchdb_os_proc_pool.erl
+++ b/src/couch/test/eunit/couchdb_os_proc_pool.erl
@@ -393,8 +393,7 @@ if_no_tagged_process_found_new_must_be_spawned(_) ->
     % After 3rd proc returns to the pool there should
     % be 3 tagged idle processes
     ?assertEqual(ok, stop_client(Client3)),
-    wait_tagged_idle_count(3),
-    ?assertEqual(3, idle_count()).
+    wait_tagged_idle_count(3).
 
 db_tag_none_works(_) ->
     cfg_set("db_tag", "none"),


### PR DESCRIPTION
## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The `wait_tagged_idle_count/1` function already [performs an assertion](https://github.com/apache/couchdb/blob/main/src/couch/test/eunit/couchdb_os_proc_pool.erl#L654) on the idle count, so the final `?assertEqual` is both redundant, and also apparently racy based on this test failure:

```
::in function couchdb_os_proc_pool:if_no_tagged_process_found_new_must_be_spawned/1 (test/eunit/couchdb_os_proc_pool.erl, line 397)
in call from eunit_test:run_testfun/1 (eunit_test.erl, line 71)
in call from eunit_proc:run_test/1 (eunit_proc.erl, line 543)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 368)
in call from eunit_proc:handle_test/2 (eunit_proc.erl, line 526)
in call from eunit_proc:tests_inorder/3 (eunit_proc.erl, line 468)
in call from eunit_proc:with_timeout/3 (eunit_proc.erl, line 358)
in call from eunit_proc:run_group/2 (eunit_proc.erl, line 582)
**error:{assertEqual,[{module,couchdb_os_proc_pool},
              {line,397},
              {expression,"idle_count ( )"},
              {expected,3},
              {value,2}]}
```
It seems that the tagged idle count can also drop from 3 to 2 between the first and second assertion.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->



## Testing recommendations

```
make eunit apps=couch suites=couchdb_os_proc_pool
```

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
