### PR TITLE
fix(`configure.ps1`): do not test SpiderMonkey libs when it is disabled

### DIFF
--- a/configure.ps1
+++ b/configure.ps1
@@ -123,20 +123,22 @@ If ($Test) {
     exit 0
 }
 
-# Use the MSVC linker to determine if the respective SpiderMonkey library
-# is available on the linker path.  This heuristic is taken from
-# src/couch/rebar.config.script, please keep them in sync.
-If ($SpiderMonkeyVersion -eq "1.8.5") {
-    $SpiderMonkeyLib = "mozjs185-1.0.lib"
-}
-else {
-    $SpiderMonkeyLib = "mozjs-$SpiderMonkeyVersion.lib"
-}
+If (-Not $DisableSpiderMonkey) {
+    # Use the MSVC linker to determine if the respective SpiderMonkey library
+    # is available on the linker path.  This heuristic is taken from
+    # src/couch/rebar.config.script, please keep them in sync.
+    If ($SpiderMonkeyVersion -eq "1.8.5") {
+	$SpiderMonkeyLib = "mozjs185-1.0.lib"
+    }
+    else {
+	$SpiderMonkeyLib = "mozjs-$SpiderMonkeyVersion.lib"
+    }
 
-&link $SpiderMonkeyLib /SUBSYSTEM:CONSOLE /NOENTRY /DLL /OUT:NUL *> $null
-If ($LASTEXITCODE -ne 0) {
-    Write-Output "ERROR: SpiderMonkey $SpiderMonkeyVersion is not found. Please specify with -SpiderMonkeyVersion."
-    exit 1
+    &link $SpiderMonkeyLib /SUBSYSTEM:CONSOLE /NOENTRY /DLL /OUT:NUL *> $null
+    If ($LASTEXITCODE -ne 0) {
+	Write-Output "ERROR: SpiderMonkey $SpiderMonkeyVersion is not found. Please specify with -SpiderMonkeyVersion."
+	exit 1
+    }
 }
 
 # Translate ./configure variables to CouchDB variables


### PR DESCRIPTION
When Windows users decide to disable SpiderMonkey, it is likely the case they do not have it installed either.  In those scenarios it makes no sense to check for the presence of the static libraries.  Instead, `configure.ps1` fails to proceed untruly, which has to be fixed.

## Testing recommendations

On Windows the following invocation of `configure.ps1` should just work when no SpiderMonkey is installed:

```console
.\configure.ps1 -DisableSpiderMonkey
```

Note that the current version of [`apache/couchdb-glazier`](https://github.com/apache/couchdb-glazier) will just install SpiderMonkey unconditionally.  Before testing with that, it must be made sure that the SpiderMonkey installation is not accessible.