### PR TITLE
Fix units in replicator cluster_start_period

### DIFF
--- a/src/couch_replicator/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor.erl
@@ -674,7 +674,7 @@ start_delay_msec() ->
     DefaultSec = ?DEFAULT_START_DELAY_MSEC div 1000,
     % We're using a compatiblity config setting (cluster_start_period) to avoid
     % introducting a new config value.
-    MSec = config:get_integer("replicator", "cluster_start_period", DefaultSec),
+    MSec = 1000 * config:get_integer("replicator", "cluster_start_period", DefaultSec),
     max(MSec, ?MIN_START_DELAY_MSEC).
 
 -ifdef(TEST).


### PR DESCRIPTION
The config value uses seconds, it's a legacy value we maintained after updating couch_replicator in [1]. Previously, the value was used as milliseconds when in fact it was seconds.

[1] github.com/apache/couchdb/pull/5093
