### PR TITLE
Clean elixir build artifacts with `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,7 @@ install: release
 # target: clean - Remove build artifacts
 clean:
 	@$(REBAR) -r clean
+	@mix clean --deps
 	@rm -rf .rebar/
 	@rm -f bin/couchjs
 	@rm -f bin/weatherreport

--- a/Makefile.win
+++ b/Makefile.win
@@ -424,6 +424,7 @@ install: release
 # target: clean - Remove build artifacts
 clean:
 	@$(REBAR) -r clean
+	-@mix clean --deps || true
 	-@rmdir /s/q .rebar >NUL 2>&1 || true
 	-@del /f/q bin\couchjs.exe >NUL 2>&1 || true
 	-@rmdir /s/q src\*\ebin >NUL 2>&1 || true


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Stale Elixir dependencies can cause test failures after upgrading Erlang or Elixir, so remove them whenever we `make clean`.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

Confirm it removes Elixir test artifacts.
```
❯ mix deps.compile

❯ tree -L 3 _build/
_build/
└── dev
    └── lib
        ├── b64url
        ├── bunt
        ├── couchdbtest
        ├── credo
        ├── file_system
        ├── httpotion
        ├── ibrowse
        ├── jason
        ├── jiffy
        ├── junit_formatter
        ├── jwtf
        └── ssl_verify_fun

15 directories, 0 files

❯ make clean

❯ tree -L 3 _build/
_build/

0 directories, 0 files
```
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
