### PR TITLE
Exclude clouseau from macos full CI variant

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -113,11 +113,14 @@ meta = [
      gnu_make: 'gmake'
   ],
 
+ // Excluding clouseau for macos. This stopped working as
+ // of https://github.com/apache/couchdb/pull/5180 (bump to 2.23.1)
+ // but works for the other workers.
  'macos': [
     name: 'macOS',
     spidermonkey_vsn: '91',
     with_nouveau: false,
-    with_clouseau: true,
+    with_clouseau: false,
     gnu_make: 'make'
   ]
 ]


### PR DESCRIPTION
It stopped working as of https://github.com/apache/couchdb/pull/5180. It works for all the other CI runners and locally on at least two macos dev machine. We tried to debug it a bit in dev but without a result, there was no clouseau.log file create yet to dump.

It can still be debugged and investigated on a `jenkins-*` branch, but for now, try to restore the CI back to a green state.
