### PR TITLE
Account for another expected error in quickjs scanner

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
+++ b/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
@@ -520,6 +520,8 @@ expected_error({error, {_, <<"TypeError">>, _}}, {error, {_, <<"TypeError">>, _}
     true;
 expected_error({error, {_, {<<"TypeError">>, _}}}, {error, {_, {<<"TypeError">>, _}}}) ->
     true;
+expected_error({error, {_, {<<"unnamed_error">>, _}}}, {error, {_, {<<"unnamed_error">>, _}}}) ->
+    true;
 expected_error(_, _) ->
     false.
 


### PR DESCRIPTION
This is generated by our own dispatch loop [1] as a catch-all. It emits a traceback so will always look different across engine. We handle it as an expected error so it doesn't pollute the logs with false positives.

[1]
https://github.com/apache/couchdb/blob/d38f14f7d777b7cda79b9862ee304150ad3418ea/share/server/loop.js#L159
