### PR TITLE
End continuous feed after emitting limit number of rows

### DIFF
--- a/src/fabric/src/fabric_view_changes.erl
+++ b/src/fabric/src/fabric_view_changes.erl
@@ -99,6 +99,7 @@ keep_sending_changes(DbName, Args, Callback, Seqs, AccIn, Timeout, UpListen, T0)
     MaintenanceMode = config:get("couchdb", "maintenance_mode"),
     NewEpoch = get_changes_epoch() > erlang:get(changes_epoch),
     if
+        Limit2 =< 0, Feed == "continuous";
         Limit > Limit2, Feed == "longpoll";
         MaintenanceMode == "true";
         MaintenanceMode == "nolb";


### PR DESCRIPTION
Fix: #5200
