### PR TITLE
Fix reverse continuous changes feeds with limit greater than total

### DIFF
--- a/src/chttpd/test/eunit/chttpd_changes_test.erl
+++ b/src/chttpd/test/eunit/chttpd_changes_test.erl
@@ -73,6 +73,10 @@ changes_test_() ->
             ?TDEF(t_style_all_docs),
             ?TDEF(t_reverse),
             ?TDEF(t_continuous_reverse),
+            ?TDEF(t_continuous_reverse_limit_0),
+            ?TDEF(t_continuous_reverse_limit_under_total),
+            ?TDEF(t_continuous_reverse_limit_exact_total),
+            ?TDEF(t_continuous_reverse_limit_over_total),
             ?TDEF(t_reverse_limit_zero),
             ?TDEF(t_reverse_limit_one),
             ?TDEF(t_seq_interval),
@@ -363,6 +367,22 @@ t_continuous_reverse({_, DbUrl}) ->
         ],
         Rows
     ).
+
+t_continuous_reverse_limit_0({_, DbUrl}) ->
+    Params = "?feed=continuous&descending=true&limit=0",
+    ?assertEqual({8, 3, []}, changes(DbUrl, Params)).
+
+t_continuous_reverse_limit_under_total({_, DbUrl}) ->
+    Params = "?feed=continuous&descending=true&limit=1",
+    ?assertMatch({8, 2, [{8, _, _}]}, changes(DbUrl, Params)).
+
+t_continuous_reverse_limit_exact_total({_, DbUrl}) ->
+    Params = "?feed=continuous&descending=true&limit=3",
+    ?assertMatch({6, 0, [{8, _, _}, {7, _, _}, {6, _, _}]}, changes(DbUrl, Params)).
+
+t_continuous_reverse_limit_over_total({_, DbUrl}) ->
+    Params = "?feed=continuous&descending=true&limit=999",
+    ?assertMatch({6, 0, [{8, _, _}, {7, _, _}, {6, _, _}]}, changes(DbUrl, Params)).
 
 t_reverse_q8({_, DbUrl}) ->
     Params = "?descending=true",

--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -39,6 +39,14 @@ Breaking Changes
   We recommend adding ``nbf`` as a required claim if you know your tokens will
   include it.
 
+* :ghissue:`5203`: Continuous change feeds with ``descending=true&limit=N``
+
+  Changes requests with ``feed=continuous&descending=true&limit=N``, when ``N``
+  is greater than the number of db updates, will no longer wait on db changes
+  and then repeatedly re-send the first few update sequences. The request will
+  return immediately after all the existing update sequences are streamed back
+  to the client.
+
 Highlights
 ----------
 


### PR DESCRIPTION
Previously, `_changes?feed=continuous&descending=true&limit=N` with `N` greater than total rows would block and wait on database changes. On each change the first few sequence rows (sequences `1-...`, `2-...`) were repeatedly emitted. The new behavior is to return after all the rows are emitted.

Fix: #5203
