### PR TITLE
Abort response when path doesn't start with slash

### DIFF
--- a/src/chttpd/test/eunit/chttpd_invalid_path_test.erl
+++ b/src/chttpd/test/eunit/chttpd_invalid_path_test.erl
@@ -1,0 +1,50 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(chttpd_invalid_path_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+setup_fe() ->
+    meck:expect(couch_stats, increment_counter, 1, ok),
+    Addr = config:get("chttpd", "bind_address", "127.0.0.1"),
+    Port = mochiweb_socket_server:get(chttpd, port),
+    {Addr, Port}.
+
+teardown_fe(_) ->
+    meck:unload().
+
+invalid_path_test_() ->
+    {
+        "chttpd invalid path test",
+        {
+            setup,
+            fun chttpd_test_util:start_couch/0,
+            fun chttpd_test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup_fe/0,
+                fun teardown_fe/1,
+                [
+                    ?TDEF_FE(shutdown_on_invalid_path)
+                ]
+            }
+        }
+    }.
+
+shutdown_on_invalid_path({Addr, Port}) ->
+    {ok, Socket} = gen_tcp:connect(Addr, Port, [binary, {active, true}]),
+    ok = gen_tcp:send(Socket, "GET badpath HTTP/1.0\n\n"),
+    ok = gen_tcp:close(Socket),
+    ok = meck:wait(couch_stats, increment_counter, '_', _TimeoutMillisec = 1000),
+    ExpectArgs = [[couchdb, httpd, aborted_requests]],
+    ?assert(meck:called(couch_stats, increment_counter, ExpectArgs)).


### PR DESCRIPTION
## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Currently a path that doesn't begin with a `/` causes a no match error and crash. This can fill up logs with unwanted junk, and be generally annoying.

```
2024-08-23 17:54:26.603 08/23 17:54:26.603 somehost db13  -              CRASH REPORT Process  (<0.19262.7388>) with 0 neighbors crashed with reason: no match of right hand value {"..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\windows\\win.ini",[],[]} at chttpd:handle_request_int/1(line:239) <= mochiweb_http:headers/6(line:140) <= proc_lib:init_p_do_apply/3(line:240); initial_call: {mochiweb_acceptor,init,['Argument__1','Argument__2',...]}, ancestors: [chttpd,chttpd_sup,<0.1261.0>], message_queue_len: 0, links: [<0.1450.0>,#Port<0.891112>], dictionary: [{couch_rewrite_count,0}], trap_exit: false, status: running, heap_size: 610, stack_size: 28, reductions: 3198

```

This adds a check for path validity, and exits with a shutdown if the path is invalid.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->


## Testing recommendations

```
make eunit apps=chttpd suites=chttpd_invalid_path_test
```
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
