### PR TITLE
enable native access for Lucene

### DIFF
--- a/nouveau/build.gradle
+++ b/nouveau/build.gradle
@@ -52,6 +52,8 @@ jar {
     manifest {
         attributes(
             'Multi-Release': 'true',
+            'Main-Class': application.mainClass,
+            'Enable-Native-Access': 'ALL-UNNAMED',
             "Class-Path": configurations.runtimeClasspath.collect { it.getName() }.join(' '))
     }
 }
@@ -89,5 +91,5 @@ tasks.withType(AbstractArchiveTask) {
 
 
 startScripts {
-    classpath = files(jar.archiveFileName)
+    enabled = false
 }


### PR DESCRIPTION
toggle the native access support for Lucene (requires launching with `java -jar` in packages/scripts though)