### PR TITLE
Another QuickJS expected error

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
+++ b/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
@@ -522,6 +522,8 @@ expected_error({error, {_, {<<"TypeError">>, _}}}, {error, {_, {<<"TypeError">>,
     true;
 expected_error({error, {_, {<<"unnamed_error">>, _}}}, {error, {_, {<<"unnamed_error">>, _}}}) ->
     true;
+expected_error({error, {_, {<<"SyntaxError">>, _}}}, {error, {_, {<<"SyntaxError">>, _}}}) ->
+    true;
 expected_error(_, _) ->
     false.
 

--- a/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
+++ b/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
@@ -418,6 +418,7 @@ ddoc_view(Doc) ->
                 >>
             },
             v_type_error => #{map => <<"function(doc){emit(doc.missing.foo,1);}">>},
+            v_syntax_error => #{map => <<"function(doc){emit(JSON.parse([]),1);}">>},
             v_expr_fun1 => #{map => <<"(function(doc) {emit(1,2)})\n">>},
             v_expr_fun2 => #{map => <<"(function(doc) {emit(3,4)});">>},
             v_expr_fun3 => #{map => <<"y=9;\n(function(doc) {emit(5,y)})">>},


### PR DESCRIPTION
Handle a SyntaxError as expected. This is raised, for instance by `JSON.parse([])`.

