### PR TITLE
fix(`mango`): raise error on running the tests

### DIFF
--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -110,6 +110,7 @@ class Database(object):
 
     def recreate(self):
         NUM_TRIES = 10
+        NON_RECOVERABLE = [401, 402, 403, 412, 413]
 
         for k in range(NUM_TRIES):
             r = self.sess.get(self.url)
@@ -120,7 +121,7 @@ class Database(object):
                     # db exists and it is empty -- exit condition is met
                     return
                 self.delete()
-            else:
+            elif r.status_code in NON_RECOVERABLE:
                 r.raise_for_status()
             self.create()
             time.sleep(k * 0.1)

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -120,6 +120,8 @@ class Database(object):
                     # db exists and it is empty -- exit condition is met
                     return
                 self.delete()
+            else:
+                r.raise_for_status()
             self.create()
             time.sleep(k * 0.1)
         raise Exception(


### PR DESCRIPTION
While creating the databases for testing the Mango interface, HTTP errors are not considered at all.  Although failures will be returned in result, it happens only at the end, and in a generic way (hiding the real cause), after the maximum number of attempts is exceeded.
