### PR TITLE
enhance default security of passwords

### DIFF
--- a/rel/files/eunit.ini
+++ b/rel/files/eunit.ini
@@ -27,6 +27,9 @@ port = 0
 [chttpd]
 port = 0
 
+[chttpd_auth]
+iterations = 5
+
 [log]
 ; log to a file to save our terminals from log spam
 writer = file

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -331,7 +331,7 @@ bind_address = 127.0.0.1
 ;timeout = 600 ; number of seconds before automatic logout
 ;auth_cache_size = 50 ; size is number of cache entries
 ;allow_persistent_cookies = true ; set to false to disallow persistent cookies
-;iterations = 50000 ; iterations for password hashing
+;iterations = 6000000 ; iterations for password hashing
 ;min_iterations = 1
 ;max_iterations = 1000000000
 ;password_scheme = pbkdf2
@@ -1068,7 +1068,7 @@ url = {{nouveau_url}}
 ; warn - CouchDB will log a warning if repeated authentication failures occur
 ; enforce - CouchDB will reject requests with a 403 status code if repeated
 ; authentication failures occur
-;mode = off
+;mode = enforce
 
 ; The number of authentication failures above which lockout occurs.
 ;threshold = 5

--- a/src/couch/src/couch_auth_lockout.erl
+++ b/src/couch/src/couch_auth_lockout.erl
@@ -61,7 +61,7 @@ lockout(#httpd{} = Req, UserName, UserSalt) ->
     end.
 
 lockout_mode() ->
-    case config:get("chttpd_auth_lockout", "mode", "off") of
+    case config:get("chttpd_auth_lockout", "mode", "enforce") of
         "off" ->
             off;
         "warn" ->

--- a/src/couch/src/couch_password_hasher.erl
+++ b/src/couch/src/couch_password_hasher.erl
@@ -117,7 +117,7 @@ needs_upgrade(UserProps) ->
     TargetPRF = ?l2b(chttpd_util:get_chttpd_auth_config("pbkdf2_prf", "sha256")),
     CurrentIterations = couch_util:get_value(<<"iterations">>, UserProps),
     TargetIterations = chttpd_util:get_chttpd_auth_config_integer(
-        "iterations", 50000
+        "iterations", 6000000
     ),
     case {TargetScheme, TargetIterations, TargetPRF} of
         {CurrentScheme, CurrentIterations, _} when CurrentScheme == <<"simple">> ->

--- a/src/couch/src/couch_passwords.erl
+++ b/src/couch/src/couch_passwords.erl
@@ -44,7 +44,7 @@ hash_admin_password("simple", ClearPassword) ->
     ?l2b("-hashed-" ++ couch_util:to_hex(Hash) ++ "," ++ ?b2l(Salt));
 hash_admin_password("pbkdf2", ClearPassword) ->
     PRF = chttpd_util:get_chttpd_auth_config("pbkdf2_prf", "sha256"),
-    Iterations = chttpd_util:get_chttpd_auth_config("iterations", "50000"),
+    Iterations = chttpd_util:get_chttpd_auth_config("iterations", "6000000"),
     Salt = couch_uuids:random(),
     DerivedKey = couch_passwords:pbkdf2(
         list_to_existing_atom(PRF),

--- a/src/couch/src/couch_users_db.erl
+++ b/src/couch/src/couch_users_db.erl
@@ -101,7 +101,7 @@ save_doc(#doc{body = {Body}} = Doc) ->
             ok = validate_password(ClearPassword),
             PRF = chttpd_util:get_chttpd_auth_config("pbkdf2_prf", "sha256"),
             Iterations = chttpd_util:get_chttpd_auth_config_integer(
-                "iterations", 50000
+                "iterations", 6000000
             ),
             DerivedKey = couch_passwords:pbkdf2(
                 list_to_existing_atom(PRF), ClearPassword, Salt, Iterations

--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -104,7 +104,7 @@ Highlights
 
 * :ghissue:`4814`: Introduce PBKDF2-SHA256 for password hashing. The existing
   PBKDF2-SHA1 variant is now deprecated. Increases the default iteration count
-  to ``500000``. Also introduce a password hash in-memory cache with a low
+  to ``6000000``. Also introduce a password hash in-memory cache with a low
   iteration number, to keep interactive requests fast for a fixed time.
 
   Entries in the password hash cache are time-limited, unused entries are
@@ -118,6 +118,9 @@ Highlights
 
 * :ghissue:`4847`: Require auth for ``_replicate`` endpoint. This continues
   the 3.x closed-by-default design goal.
+
+* :ghissue:`5032`: Temporarily block access by client IP for repeated
+  authentication failures. Can be disabled in config.
 
 * Many small small performance improvements, see :ref:`the Performance
   section <performance430>`.


### PR DESCRIPTION
## Overview

* enable the lockout protections against online password attacks
* increase workfactor of new PBKDF2 hashes to protect against offline password attacks

## Testing recommendations


## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
