### PR TITLE
detect admin more reliably

### DIFF
--- a/src/couch/src/couch_password_hasher.erl
+++ b/src/couch/src/couch_password_hasher.erl
@@ -40,7 +40,7 @@
 
 maybe_upgrade_password_hash(AuthModule, UserName, Password, UserProps) ->
     UpgradeEnabled = config:get_boolean("chttpd_auth", "upgrade_hash_on_auth", true),
-    IsAdmin = is_admin(UserProps),
+    IsAdmin = is_admin(UserName),
     NeedsUpgrade = needs_upgrade(UserProps),
     InProgress = in_progress(AuthModule, UserName),
     if
@@ -106,9 +106,8 @@ hash_admin_passwords_int(Persist) ->
         couch_passwords:get_unhashed_admins()
     ).
 
-is_admin(UserProps) ->
-    Roles = couch_util:get_value(<<"roles">>, UserProps, []),
-    lists:member(<<"_admin">>, Roles).
+is_admin(UserName) ->
+    config:get("admins", ?b2l(UserName)) /= undefined.
 
 needs_upgrade(UserProps) ->
     CurrentScheme = couch_util:get_value(<<"password_scheme">>, UserProps),


### PR DESCRIPTION
## Overview

Detect admin status more reliably (in cloudant there's an extension that changes the role name, but in all cases an admin's username is in the admins section of config).

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/4814

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
