### PR TITLE
Bulk get query documentation

### DIFF
--- a/src/docs/src/api/database/bulk-api.rst
+++ b/src/docs/src/api/database/bulk-api.rst
@@ -560,14 +560,15 @@ Sending multiple queries to a database
 
     This method can be called to query several documents in bulk. It is well
     suited for fetching a specific revision of documents, as replicators do for
-    example, or for getting revision history.
+    example, or for getting revision history.  Refer to the
+    :ref:`document endpoint <api/doc>` documentation for  a complete
+    description of the available query parameters.
 
     :param db: Database name
     :<header Accept: - :mimetype:`application/json`
                      - :mimetype:`multipart/related`
                      - :mimetype:`multipart/mixed`
     :<header Content-Type: :mimetype:`application/json`
-    :query boolean revs: Give the revisions history
     :<json array docs: List of document objects, with ``id``, and optionally
       ``rev`` and ``atts_since``
     :>header Content-Type: - :mimetype:`application/json`

--- a/src/docs/src/api/database/bulk-api.rst
+++ b/src/docs/src/api/database/bulk-api.rst
@@ -603,10 +603,10 @@ Sending multiple queries to a database
                     "rev": "1-4a7e4ae49c4366eaed8edeaea8f784ad",
                 },
                 {
-                    "id": "bar",
+                    "id": "bar"
                 }
                 {
-                    "id": "baz",
+                    "id": "baz"
                 }
             ]
         }


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Update the documentation for /{db}/_bulk_get to reference the /{db}/{docid} query parameters.  This code indicates that they share the same query parsing function:

```
 bulk_get_parse_doc_query(Req) ->
    lists:foldl(
        fun({Key, Value}, Args) ->
            ok = validate_query_param(Key),
            parse_doc_query({Key, Value}, Args)
        end,   
        #doc_query_args{},
        chttpd:qs(Req)
    ).
```

## Related Issues or Pull Requests
- https://github.com/apache/couchdb/issues/5236

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
