### PR TITLE
Quote QuickJS path

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs.erl
+++ b/src/couch_quickjs/src/couch_quickjs.erl
@@ -26,12 +26,12 @@
 mainjs_cmd() ->
     Path = filename:join([priv_dir(), "couchjs_mainjs" ++ ext()]),
     check_path(Path),
-    apply_config(Path).
+    apply_config("\"" ++ Path ++ "\"").
 
 coffee_cmd() ->
     Path = filename:join([priv_dir(), "couchjs_coffee" ++ ext()]),
     check_path(Path),
-    apply_config(Path).
+    apply_config("\"" ++ Path ++ "\"").
 
 priv_dir() ->
     case code:priv_dir(couch_quickjs) of


### PR DESCRIPTION
We used to quote the spawnkiller path like this to handle spaces in paths:

```
 "\"" ++ filename:join(PrivDir, "couchspawnkillable") ++ "\""
```

So we stick with the same pattern here as well for QuickJS path.
