### PR TITLE
Fix debug test

### DIFF
--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -1147,7 +1147,13 @@ setup() ->
     tree().
 
 teardown({_InitialPid, Processes, _Tree}) ->
-    [exit(Pid, normal) || Pid <- Processes].
+    [
+        begin
+            (catch unlink(Pid)),
+            exit(Pid, kill)
+        end
+     || Pid <- Processes
+    ].
 
 link_tree_test_() ->
     {

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -1124,7 +1124,7 @@ random_processes(Acc, Depth) ->
                 end);
             open_port ->
                 spawn_link(fun() ->
-                    Port = erlang:open_port({spawn, "sleep 10"}, []),
+                    Port = erlang:open_port({spawn, "sleep 10"}, [hide]),
                     true = erlang:link(Port),
                     Caller ! {Ref, random_processes(Depth - 1)},
                     receive


### PR DESCRIPTION
Fix an annoying terminal pop-up issue on Windows and the test leaving processes behind.