### PR TITLE
Don't fail make clean if hex is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ install: release
 # target: clean - Remove build artifacts
 clean:
 	@$(REBAR) -r clean
-	@mix clean --deps
+	@mix clean --deps || true
 	@rm -rf .rebar/
 	@rm -f bin/couchjs
 	@rm -f bin/weatherreport


### PR DESCRIPTION
`@mix clean --deps` apparently requires hex to be installed. If it's not there, it stops and prompts the user to install it. If configure hasn't run yet, as in the case when building our deb package from the dist tarball, package build fails.

This was mitigated in couchdb-pkg by adding hex to `/home/jenkins/.mix` for CI images, but let's also handle it better in the Makefile.

Makefile.win already has `|| true` added to it so no need to updated it.
