### PR TITLE
[tests]: Increase timeout for producer test

### DIFF
--- a/src/couch/test/eunit/couch_work_queue_tests.erl
+++ b/src/couch/test/eunit/couch_work_queue_tests.erl
@@ -14,7 +14,7 @@
 
 -include_lib("couch/include/couch_eunit.hrl").
 
--define(TIMEOUT, 100).
+-define(TIMEOUT, 200).
 
 setup(Opts) ->
     {ok, Q} = couch_work_queue:new(Opts),


### PR DESCRIPTION
The following test constantly fails in Windows, so double the timeout:

Before:
```
module 'couch_work_queue_tests'
  Single producer and consumer
    Queue with 3 max items
      couch_work_queue_tests:145: -should_have_no_items_for_new_queue/1-fun-1-...ok
      undefined
      *** instantiation of subtests failed ***
**in function couch_work_queue_tests:produce/4 (test/eunit/couch_work_queue_tests.erl, line 379)
in call from couch_work_queue_tests:should_block_producer_on_full_queue_count/1 (test/eunit/couch_work_queue_tests.erl, line 205)
**error:{assertion_failed,[{module,couch_work_queue_tests},
                   {line,382},
                   {reason,"Timeout asking producer to produce an item"}]}
```
After:
```
module 'couch_work_queue_tests'
  Single producer and consumer
    Queue with 3 max items
      couch_work_queue_tests:145: -should_have_no_items_for_new_queue/1-fun-1-...ok
      couch_work_queue_tests:217: -should_block_producer_on_full_queue_count/1-fun-4-...ok
      couch_work_queue_tests:255: -should_receive_first_queued_item/1-fun-2-...ok
```