### PR TITLE
3.4.x

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -336,7 +336,7 @@ bind_address = 127.0.0.1
 ;max_iterations = 1000000000
 ;password_scheme = pbkdf2
 ;pbkdf2_prf = sha256 ; must be one of sha | sha224 | sha256 | sha384 | sha512
-;upgrade_hash_on_auth = true; whether to upgrade password hashes on successful authentication.
+;upgrade_hash_on_auth = false; whether to upgrade password hashes on successful authentication.
 
 ; List of Erlang RegExp or tuples of RegExp and an optional error message.
 ; Where a new password must match all RegExp.

--- a/src/couch/src/couch_password_hasher.erl
+++ b/src/couch/src/couch_password_hasher.erl
@@ -39,7 +39,7 @@
 %%%===================================================================
 
 maybe_upgrade_password_hash(AuthModule, UserName, Password, UserProps) ->
-    UpgradeEnabled = config:get_boolean("chttpd_auth", "upgrade_hash_on_auth", true),
+    UpgradeEnabled = config:get_boolean("chttpd_auth", "upgrade_hash_on_auth", false),
     IsDoc = is_doc(UserProps),
     NeedsUpgrade = needs_upgrade(UserProps),
     InProgress = in_progress(AuthModule, UserName),

--- a/src/couch/test/eunit/couch_work_queue_tests.erl
+++ b/src/couch/test/eunit/couch_work_queue_tests.erl
@@ -14,7 +14,7 @@
 
 -include_lib("couch/include/couch_eunit.hrl").
 
--define(TIMEOUT, 100).
+-define(TIMEOUT, 200).
 
 setup(Opts) ->
     {ok, Q} = couch_work_queue:new(Opts),

--- a/src/docs/src/api/ddoc/nouveau.rst
+++ b/src/docs/src/api/ddoc/nouveau.rst
@@ -24,7 +24,7 @@
     Nouveau endpoints require a running nouveau server.
     See :ref:`Nouveau Server Installation <install/nouveau>` for details.
 
-.. versionadded:: 4.0
+.. versionadded:: 3.4.0
 
 .. http:get:: /{db}/_design/{ddoc}/_nouveau/{index}
     :synopsis: Returns results for the specified nouveau index
@@ -52,7 +52,7 @@
     :query number limit: Limit the number of the returned documents to the specified
         number. For a grouped search, this parameter limits the number of documents per
         group.
-    :query string query: Required. The Lucene query string.
+    :query string q: Required. The Lucene query string.
     :query json ranges: This field defines ranges for numeric search fields. The
         value is a JSON object where the fields names are numeric search fields,
         and the values of the fields are arrays of JSON objects. The objects
@@ -107,7 +107,7 @@
     Nouveau endpoints require a running nouveau server.
     See :ref:`Nouveau Server Installation <install/nouveau>` for details.
 
-.. versionadded:: 4.0
+.. versionadded:: 3.4.0
 
 .. http:get:: /{db}/_design/{ddoc}/_nouveau_info/{index}
     :synopsis: Returns metadata for the specified nouveau index

--- a/src/docs/src/api/server/common.rst
+++ b/src/docs/src/api/server/common.rst
@@ -2191,7 +2191,7 @@ See :ref:`Configuration of Prometheus Endpoint <config/prometheus>` for details.
     Nouveau endpoints require a running nouveau server.
     See :ref:`Nouveau Server Installation <install/nouveau>` for details.
 
-.. versionadded:: 4.0
+.. versionadded:: 3.4.0
 
 .. http:post:: /_nouveau_analyze
     :synopsis: Tests the results of analyzer tokenization

--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -395,7 +395,7 @@ Authentication Configuration
         authentication using the current password hashing settings. ::
 
             [chttpd_auth]
-            upgrade_hash_on_auth = true
+            upgrade_hash_on_auth = false
 
 .. config:section:: jwt_auth :: JWT Authentication
 

--- a/src/docs/src/install/nouveau.rst
+++ b/src/docs/src/install/nouveau.rst
@@ -16,7 +16,7 @@
 Nouveau Server Installation
 ===========================
 
-.. versionadded:: 4.0
+.. versionadded:: 3.4.0
 
 .. highlight:: ini
 

--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -20,10 +20,45 @@
     :depth: 1
     :local:
 
+.. _release/3.4.1:
+
+Version 3.4.1
+=============
+
+Highlights
+----------
+
+* :ghissue:`5255`: Set ``upgrade_hash_on_auth`` to ``false`` to disable
+  automatic password hashing upgrades.
+
 .. _release/3.4.0:
 
 Version 3.4.0
 =============
+
+Warning
+-------
+
+CouchDB version 3.4.0 includes a feature to automatically upgrade password
+hashes to a newer algorithm and a configuration option that enables this feature
+by default. As a consequence, if you are upgrading to CouchDB version 3.4.0 from
+an earlier version and then have to roll back to the earlier version, some of
+your ``_users`` documents might have already automatically ugpraded to the new
+algorithm. Your older version of CouchDB does not understand the resulting
+password hash and cannot authenticate the user any more until the earlier
+password hash is restored manually by an adminstrator.
+
+As a result, the CouchDB team has decided to issue a 3.4.1 release setting the
+configuration option to disable this new auto-upgrade feature.
+
+The issue was found after the formal 3.4.0 release process has concluded, so
+the source release is available normally, but the CouchDB team has not made
+3.4.0 convenience binaries available. The team recommends to upgrade to 3.4.1
+instead when it is available.
+
+The CouchDB team also recommends enabling the feature by setting the
+``upgrade_hash_on_auth`` configuration option to ``true`` as soon as you are
+safely running on 3.4.1 and have no more need to roll back the version.
 
 Breaking Changes
 ----------------

--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -31,6 +31,23 @@ Highlights
 * :ghissue:`5255`: Set ``upgrade_hash_on_auth`` to ``false`` to disable
   automatic password hashing upgrades.
 
+Bufixes
+-------
+
+* :ghissue:`5254`: Handle the case when the QuickJS scanner has no
+  valid views.
+
+Tests
+-----
+
+* :ghissue:`5253`: Increase timeout for couch_work_queue test.
+
+Docs
+----
+
+* :ghissue:`5256`: Explain holding off 3.4.0 binaries and the reason
+  for making a 3.4.1 release.
+
 .. _release/3.4.0:
 
 Version 3.4.0

--- a/test/elixir/test/users_db_security_test.exs
+++ b/test/elixir/test/users_db_security_test.exs
@@ -336,6 +336,14 @@ defmodule UsersDbSecurityTest do
       "3"
     })
 
+    # make changing PRF regenerates derived_key and salt on next
+    # password change
+    set_config({
+      "chttpd_auth",
+      "upgrade_hash_on_auth",
+      "true"
+    })
+
     tom_doc5 = Map.put(tom_doc4, "password", "couch")
     # 201 if the save does the update, 409 if the async password hasher got there first.
     save_as(@users_db, tom_doc5, user: "tom", pwd: "couch", expect_response: [201, 409])

--- a/version.mk
+++ b/version.mk
@@ -1,3 +1,3 @@
 vsn_major=3
 vsn_minor=4
-vsn_patch=0
+vsn_patch=1


### PR DESCRIPTION
This is merging the 3.4.x branch back into main. 

The diff seems misleading as most of the commits are already on main (except the 3.4.1 bump and whatsnew) but since they have different commit shas due to cherry-picking + rebasing they are showing as diffs.
