### PR TITLE
3.4.x merge to main

### DIFF
--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -31,6 +31,23 @@ Highlights
 * :ghissue:`5255`: Set ``upgrade_hash_on_auth`` to ``false`` to disable
   automatic password hashing upgrades.
 
+Bufixes
+-------
+
+* :ghissue:`5254`: Handle the case when the QuickJS scanner has no
+  valid views.
+
+Tests
+-----
+
+* :ghissue:`5253`: Increase timeout for couch_work_queue test.
+
+Docs
+----
+
+* :ghissue:`5256`: Explain holding off 3.4.0 binaries and the reason
+  for making a 3.4.1 release.
+
 .. _release/3.4.0:
 
 Version 3.4.0

--- a/version.mk
+++ b/version.mk
@@ -1,3 +1,3 @@
 vsn_major=3
 vsn_minor=4
-vsn_patch=0
+vsn_patch=1


### PR DESCRIPTION
Merge the two commits from 3.4.x to main.

The way this was generated:

```
$ git checkout -b 3.4.x-merge-to-main
Switched to a new branch '3.4.x-merge-to-main'

$ git rebase main
warning: skipped previously applied commit 84cad523e
warning: skipped previously applied commit ea8add932
warning: skipped previously applied commit 46ec0c82c
warning: skipped previously applied commit 27950e539
warning: skipped previously applied commit 106873ded
hint: use --reapply-cherry-picks to include skipped commits
hint: Disable this message with "git config advice.skippedCherryPicks false"
Successfully rebased and updated refs/heads/3.4.x-merge-to-main.
```

git successfully figured out the rebased commits were already applied except the two new ones.