### PR TITLE
chore(docs): correct default q value in POST /{db}

### DIFF
--- a/src/docs/src/api/database/common.rst
+++ b/src/docs/src/api/database/common.rst
@@ -150,7 +150,7 @@
 
     :param db: Database name
     :query integer q: Shards, aka the number of range partitions. Default is
-      8, unless overridden in the :config:option:`cluster config <cluster/q>`.
+      2, unless overridden in the :config:option:`cluster config <cluster/q>`.
     :query integer n: Replicas. The number of copies of the database in the
       cluster. The default is 3, unless overridden in the
       :config:option:`cluster config <cluster/n>` .


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The default value of q is 2 when creating a database.

## Checklist

- [X] Code is written and works correctly
- [ ] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
