### PR TITLE
Enable supportsConcurrency in TopFieldCollectorManager

### DIFF
--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9Index.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9Index.java
@@ -232,7 +232,7 @@ public class Lucene9Index extends Index {
             fieldDoc = null;
         }
 
-        return new TopFieldCollectorManager(sort, searchRequest.getLimit(), fieldDoc, 1000, false);
+        return new TopFieldCollectorManager(sort, searchRequest.getLimit(), fieldDoc, 1000);
     }
 
     private SortField getLastSortField(final Sort sort) {


### PR DESCRIPTION
embarrassing interpretation of correct usage by me, setting false here causes an error as soon as the index has more than one slice.

fixes: https://github.com/apache/couchdb/issues/5262
