### PR TITLE
_changes: don't stop the request if `heartbeat` is specified

### DIFF
--- a/src/fabric/src/fabric_view_changes.erl
+++ b/src/fabric/src/fabric_view_changes.erl
@@ -101,7 +101,8 @@ keep_sending_changes(DbName, Args, Callback, Seqs, AccIn, Timeout, UpListen, T0)
     PendingCount = pending_count(Offset),
     if
         Dir == rev, is_integer(PendingCount), PendingCount =< 0;
-        Limit2 =< 0, (Feed == "continuous" orelse Feed == "eventsource");
+        Limit2 =< 0, Feed == "continuous", Heartbeat == undefined;
+        Limit2 =< 0, Feed == "eventsource", Heartbeat == undefined;
         Limit > Limit2, Feed == "longpoll";
         MaintenanceMode == "true";
         MaintenanceMode == "nolb";


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
If the `heartbeat` parameter is specified in the `_changes` endpoint,
it will usually override the `timeout` parameter. It also needs to override
the `limit` parameter.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
