### PR TITLE
Improve couch event server

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1083,3 +1083,19 @@ url = {{nouveau_url}}
 ; from the _first_ authentication failure.
 ; note: changing this setting requires a couchdb restart.
 ;max_lifetime = 300000
+
+[off_heap_mqd]
+; Set Erlang process_flag(message_queue_data, off_heap) for the respective
+; module if the setting is true. Off-heap messages do not participate in the
+; process garbage collection. If processes expect to get a large message queue,
+; it usually make sense to set to true, as otherwise GC may take too long.
+; However in some cases that could affect latency as it takes an extra copy
+; step to copy them into the process heap.
+;rexi_server = true
+;couch_log_server = true
+;couch_server = true
+;couch_event_server = true
+;ddoc_cache_lru = true
+;mem3_shards = true
+;nouveau_index_manager = true
+;dreyfus_index_manager = true

--- a/src/couch_event/src/couch_event.erl
+++ b/src/couch_event/src/couch_event.erl
@@ -44,13 +44,13 @@ stop_listener(Pid) ->
     couch_event_listener_mfa:stop(Pid).
 
 register(Pid, DbName) ->
-    gen_server:call(?SERVER, {register, Pid, [DbName]}).
+    gen_server:call(?SERVER, {register, Pid, [DbName]}, infinity).
 
 register_many(Pid, DbNames) when is_list(DbNames) ->
-    gen_server:call(?SERVER, {register, Pid, DbNames}).
+    gen_server:call(?SERVER, {register, Pid, DbNames}, infinity).
 
 register_all(Pid) ->
-    gen_server:call(?SERVER, {register, Pid, [all_dbs]}).
+    gen_server:call(?SERVER, {register, Pid, [all_dbs]}, infinity).
 
 unregister(Pid) ->
-    gen_server:call(?SERVER, {unregister, Pid}).
+    gen_server:call(?SERVER, {unregister, Pid}, infinity).

--- a/src/couch_event/src/couch_event_server.erl
+++ b/src/couch_event/src/couch_event_server.erl
@@ -33,6 +33,7 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, nil, []).
 
 init(_) ->
+    couch_util:set_mqd_off_heap(?MODULE),
     {ok, #st{
         by_pid = #{},
         by_dbname = #{}


### PR DESCRIPTION
There are two improvements to the `couch_event_server` as separate commits:

 * Switch to use an off-heap message queue.
 * Do not rely on the default gen_server timeout, that just made things worse in production.