### PR TITLE
fix(`default.ini`): sync suggested fabric timeout settings with the sources

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -386,8 +386,13 @@ hash_algorithms = sha256, sha
 ;request_timeout = 60000
 ;all_docs_timeout = 10000
 ;attachments_timeout = 60000
-;view_timeout = 3600000
-;partition_view_timeout = 3600000
+;view_timeout = infinity
+;view_permsg_timeout = 3600000
+;partition_view_timeout = infinity
+;search_timeout = infinity
+;search_permsg_timeout = 3600000
+;nouveau_timeout = infinity
+;nouveau_permsg_timeout = 3600000
 
 ;[rexi]
 ;buffer_count = 2000


### PR DESCRIPTION
The default settings for certain fabric timeout actions do not reflect the reality in the comments of `default.ini`.  Adjust those to match with the constants are laid down in the sources.

Note that apparently search requests are also associated with configurable timeouts, so document those as well.
