### PR TITLE
nouveau: Add ?top_n=X query parameter for facets

### DIFF
--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/api/SearchRequest.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/api/SearchRequest.java
@@ -55,7 +55,7 @@ public class SearchRequest {
     private PrimitiveWrapper<?>[] after;
 
     @Min(1)
-    @Max(100)
+    @Max(1000)
     private int topN = 10;
 
     public SearchRequest() {

--- a/nouveau/src/test/java/org/apache/couchdb/nouveau/api/SearchRequestTest.java
+++ b/nouveau/src/test/java/org/apache/couchdb/nouveau/api/SearchRequestTest.java
@@ -51,6 +51,7 @@ public class SearchRequestTest {
         result.setQuery("*:*");
         result.setLimit(10);
         result.setCounts(List.of("bar"));
+        result.setTopN(5);
         result.setRanges(Map.of("foo", List.of(new DoubleRange("0 to 100 inc", 0.0, true, 100.0, true))));
         return result;
     }

--- a/nouveau/src/test/resources/fixtures/SearchRequest.json
+++ b/nouveau/src/test/resources/fixtures/SearchRequest.json
@@ -5,6 +5,7 @@
     "counts": [
         "bar"
     ],
+    "top_n": 5,
     "ranges": {
         "foo": [
             {

--- a/src/docs/src/api/ddoc/nouveau.rst
+++ b/src/docs/src/api/ddoc/nouveau.rst
@@ -50,8 +50,7 @@
         Defaults to the JDK default locale if not specified. Some examples are ``de``
         , ``us``, ``gb``.
     :query number limit: Limit the number of the returned documents to the specified
-        number. For a grouped search, this parameter limits the number of documents per
-        group.
+        number.
     :query string q: Required. The Lucene query string.
     :query json ranges: This field defines ranges for numeric search fields. The
         value is a JSON object where the fields names are numeric search fields,
@@ -68,6 +67,8 @@
         same order as the array.
         Some examples are ``"relevance"``, ``"bar"``, ``"-foo"`` and
         [``"-foo"``, ``"bar"``].
+    :query number top_n: Limit the number of facets returned by group, defaulting to 10
+        with a maximum of 1000.
     :query boolean update: Set to ``false`` to allow the use of an out-of-date index.
 
     :>header Content-Type: - :mimetype:`application/json`

--- a/src/docs/src/ddocs/nouveau.rst
+++ b/src/docs/src/ddocs/nouveau.rst
@@ -636,6 +636,9 @@ field. If you do not create separate indexes for each field, you must include on
 documents that contain all the fields. Verify that the fields exist in each document by
 using a single ``if`` statement.
 
+The ``top_n`` query parameter controls how many facets, per grouping, are returned,
+defaulting to 10, to a maximum of 1000.
+
 *Example if statement to verify that the required fields exist in each document:*
 
 .. code-block:: javascript

--- a/src/nouveau/src/nouveau_int.hrl
+++ b/src/nouveau/src/nouveau_int.hrl
@@ -1,0 +1,16 @@
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+
+-define(TOP_N_DEFAULT, 10).

--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -16,6 +16,7 @@
     "counts",
     "ranges",
     "ranges (open)",
+    "top_n",
     "mango search by number",
     "mango search by string",
     "mango search by text",

--- a/test/elixir/test/nouveau_test.exs
+++ b/test/elixir/test/nouveau_test.exs
@@ -380,6 +380,23 @@ defmodule NouveauTest do
   end
 
   @tag :with_db
+  test "top_n", context do
+    db_name = context[:db_name]
+    create_search_docs(db_name)
+    create_ddoc(db_name)
+
+    url = "/#{db_name}/_design/foo/_nouveau/bar"
+    resp = Couch.post(url, body: %{q: "*:*", ranges: %{bar: [
+      %{label: "cheap", max: 42},
+      %{label: "expensive", min: 42, min_inclusive: false}]},
+      top_n: 1,
+      include_docs: true})
+    assert_status_code(resp, 200)
+    %{:body => %{"ranges" => ranges}} = resp
+    assert ranges == %{"bar" => %{"cheap" => 3}}
+  end
+
+  @tag :with_db
   test "mango search by number", context do
     db_name = context[:db_name]
     create_search_docs(db_name)


### PR DESCRIPTION
## Overview

Add `top_n` to control how many facets are returned by group (up to a limit of 1000 for now).

## Testing recommendations

run the tests

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/5284

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
