### PR TITLE
fix stored fields in search results

### DIFF
--- a/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9IndexSchema.java
+++ b/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene9/Lucene9IndexSchema.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import org.apache.couchdb.nouveau.api.DoubleField;
 import org.apache.couchdb.nouveau.api.Field;
+import org.apache.couchdb.nouveau.api.StoredField;
 import org.apache.couchdb.nouveau.api.StringField;
 import org.apache.couchdb.nouveau.api.TextField;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
@@ -36,7 +37,8 @@ final class Lucene9IndexSchema {
     public enum Type {
         STRING,
         TEXT,
-        DOUBLE;
+        DOUBLE,
+        STORED;
 
         private static Type fromField(final Field field) {
             if (field instanceof StringField) {
@@ -45,6 +47,8 @@ final class Lucene9IndexSchema {
                 return TEXT;
             } else if (field instanceof DoubleField) {
                 return DOUBLE;
+            } else if (field instanceof StoredField) {
+                return STORED;
             }
             throw new IllegalArgumentException(field + " not supported");
         }

--- a/test/elixir/test/nouveau_test.exs
+++ b/test/elixir/test/nouveau_test.exs
@@ -84,6 +84,7 @@ defmodule NouveauTest do
             function (doc) {
               index("string", "foo", doc.foo, {store: true});
               index("double", "bar", doc.bar, {store: true});
+              index("stored", "baz", doc.foo);
             }
           """
         }
@@ -597,15 +598,15 @@ defmodule NouveauTest do
 
     assert hit1["doc"]["_id"] == "doc1"
     assert hit1["doc"]["_rev"] == "1-a"
-    assert hit1["fields"] == %{"bar" => 0.0, "foo" => "baz"}
+    assert hit1["fields"] == %{"bar" => 0.0, "foo" => "baz", "baz" => "baz"}
 
     assert hit2["doc"]["_id"] == "doc3"
     assert hit2["doc"]["_rev"] == "2-c"
-    assert hit2["fields"] == %{"bar" => 13.0, "foo" => "barX"}
+    assert hit2["fields"] == %{"bar" => 13.0, "foo" => "barX", "baz" => "barX"}
 
     assert hit3["doc"]["_id"] == "doc4"
     assert hit3["doc"]["_rev"] == "1-b"
-    assert hit3["fields"] == %{"bar" => 43.0, "foo" => "fooX"}
+    assert hit3["fields"] == %{"bar" => 43.0, "foo" => "fooX", "baz" => "fooX"}
 
     # purge docs
     purge_body = %{
@@ -627,7 +628,7 @@ defmodule NouveauTest do
     # doc1: 2-c deleted was purged, 1-a is still the winner
     assert hit1["doc"]["_id"] == "doc1"
     assert hit1["doc"]["_rev"] == "1-a"
-    assert hit1["fields"] ==  %{"bar" => 0.0, "foo" => "baz"}
+    assert hit1["fields"] ==  %{"bar" => 0.0, "foo" => "baz", "baz" => "baz"}
 
     # doc2: doc was deleted and now it's completely purged
 
@@ -636,7 +637,7 @@ defmodule NouveauTest do
     # doc4: 2-c was purged, 1-a is the new winner
     assert hit2["doc"]["_id"] == "doc4"
     assert hit2["doc"]["_rev"] == "1-a"
-    assert hit2["fields"] == %{"bar" => 42.0, "foo" => "foo"}
+    assert hit2["fields"] == %{"bar" => 42.0, "foo" => "foo", "baz" => "foo"}
 
     resp = Couch.get("/#{db_name}")
     db_purge_seq = resp.body["purge_seq"]


### PR DESCRIPTION
## Overview

a stored field (`index('stored', 'foo', 'bar');`) was not returned in search results and gave a 500 error instead. 

## Testing recommendations

covered by tests

## Related Issues or Pull Requests


## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
