### PR TITLE
chore(dev): Make Gradle script choosable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ include version.mk
 REBAR?=$(CURDIR)/bin/rebar
 REBAR3?=$(CURDIR)/bin/rebar3
 ERLFMT?=$(CURDIR)/bin/erlfmt
+GRADLE?=$(CURDIR)/nouveau/gradlew
 
 # Handle the following scenarios:
 #   1. When building from a tarball, use version.mk.
@@ -437,7 +438,7 @@ endif
 
 ifeq ($(with_nouveau), true)
 	@mkdir rel/couchdb/nouveau
-	@cd nouveau && ./gradlew installDist
+	@cd nouveau && $(GRADLE) installDist
 	@cp -R nouveau/build/install/nouveau rel/couchdb
 endif
 
@@ -481,7 +482,7 @@ clean:
 	@rm -f dev/*.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
 	@rm -f src/couch_dist/certs/out
 ifeq ($(with_nouveau), true)
-	@cd nouveau && ./gradlew clean
+	@cd nouveau && $(GRADLE) clean
 endif
 
 
@@ -549,20 +550,21 @@ derived:
 ################################################################################
 
 .PHONY: nouveau
-# Build nouveau
+# target: nouveau - Build nouveau
 nouveau:
 ifeq ($(with_nouveau), true)
-	@cd nouveau && ./gradlew spotlessApply
-	@cd nouveau && ./gradlew build -x test
+	@cd nouveau && $(GRADLE) spotlessApply
+	@cd nouveau && $(GRADLE) build -x test
 endif
 
 .PHONY: nouveau-test
+# target: nouveau-test - Run nouveau tests
 nouveau-test: nouveau-test-gradle nouveau-test-elixir
 
 .PHONY: nouveau-test-gradle
 nouveau-test-gradle: couch nouveau
 ifeq ($(with_nouveau), true)
-	@cd nouveau && ./gradlew test --info --rerun
+	@cd nouveau && $(GRADLE) test --info --rerun
 endif
 
 .PHONY: nouveau-test-elixir

--- a/Makefile.win
+++ b/Makefile.win
@@ -22,6 +22,7 @@ REBAR?=$(CURDIR)/bin/rebar.cmd
 PYTHON=python.exe
 ERLFMT?=$(CURDIR)/bin/erlfmt.cmd
 MAKE=make -f Makefile.win
+GRADLE?=$(CURDIR)/nouveau/gradlew.bat
 # REBAR?=$(shell where rebar.cmd)
 
 # Handle the following scenarios:
@@ -394,7 +395,7 @@ endif
 
 ifeq ($(with_nouveau), true)
 	-@mkdir rel\couchdb\nouveau
-	@cd nouveau && .\gradlew installDist
+	@cd nouveau && $(GRADLE) installDist
 	@xcopy nouveau\build\install\nouveau rel\couchdb\nouveau /E /I
 endif
 
@@ -440,7 +441,7 @@ clean:
 	-@del /f/q src\couch\priv\couch_js\config.h >NUL 2>&1 || true
 	-@del /f/q dev\boot_node.beam dev\pbkdf2.pyc log\crash.log >NUL 2>&1 || true
 ifeq ($(with_nouveau), true)
-	@cd nouveau && .\gradlew clean
+	@cd nouveau && $(GRADLE) clean
 endif
 
 .PHONY: distclean
@@ -517,7 +518,8 @@ derived:
 # target: nouveau - Build nouveau
 nouveau:
 ifeq ($(with_nouveau), true)
-	@cd nouveau && .\gradlew build -x test
+	@cd nouveau && $(GRADLE) spotlessApply
+	@cd nouveau && $(GRADLE) build -x test
 endif
 
 .PHONY: nouveau-test
@@ -527,7 +529,8 @@ nouveau-test: nouveau-test-gradle nouveau-test-elixir
 .PHONY: nouveau-test-gradle
 nouveau-test-gradle: couch nouveau
 ifeq ($(with_nouveau), true)
-	@cd nouveau && .\gradlew test --info --rerun
+	@cd nouveau && $(GRADLE) test --info --rerun
+	
 endif
 
 .PHONY: nouveau-test-elixir


### PR DESCRIPTION
By default, use the shipped Gradle wrapper script to build Nouveau.

As an option, we can now override the GRADLE variable to point to another gradle script, e.g. what the system provides.
