### PR TITLE
return time spent waiting to update index before query starts

### DIFF
--- a/src/nouveau/priv/stats_descriptions.cfg
+++ b/src/nouveau/priv/stats_descriptions.cfg
@@ -19,3 +19,8 @@
     {type, counter},
     {desc, <<"number of active search requests">>}
 ]}.
+
+{[nouveau, update_latency], [
+    {type, histogram},
+    {desc, <<"Distribution of time during search waiting for the index to be updated">>}
+]}.

--- a/src/nouveau/src/nouveau_fabric_search.erl
+++ b/src/nouveau/src/nouveau_fabric_search.erl
@@ -145,6 +145,9 @@ merge_search_results(A, B, #state{} = State) ->
         ),
         <<"ranges">> => merge_facets(
             maps:get(<<"ranges">>, A, null), maps:get(<<"ranges">>, B, null)
+        ),
+        update_latency => max(
+            maps:get(update_latency, A, 0), maps:get(update_latency, B, 0)
         )
     }.
 

--- a/src/nouveau/src/nouveau_httpd.erl
+++ b/src/nouveau/src/nouveau_httpd.erl
@@ -113,7 +113,8 @@ handle_search_req(#httpd{} = Req, DbName, DDoc, IndexName, QueryArgs, Retry) ->
                     DbName, maps:get(<<"hits">>, SearchResults), IncludeDocs
                 ),
                 <<"counts">> => maps:get(<<"counts">>, SearchResults, null),
-                <<"ranges">> => maps:get(<<"ranges">>, SearchResults, null)
+                <<"ranges">> => maps:get(<<"ranges">>, SearchResults, null),
+                <<"update_latency">> => maps:get(update_latency, SearchResults)
             },
             HitCount = length(maps:get(<<"hits">>, RespBody)),
             incr_stats(HitCount, IncludeDocs),

--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -29,6 +29,7 @@
     "purge",
     "purge with conflicts",
     "index same field with different field types",
-    "index not found"
+    "index not found",
+    "meta"
   ]
 }

--- a/test/elixir/test/nouveau_test.exs
+++ b/test/elixir/test/nouveau_test.exs
@@ -682,6 +682,18 @@ defmodule NouveauTest do
     assert_status_code(resp, 404)
   end
 
+  @tag :with_db
+  test "meta", context do
+    db_name = context[:db_name]
+    create_search_docs(db_name)
+    create_ddoc(db_name)
+
+    url = "/#{db_name}/_design/foo/_nouveau/bar"
+    resp = Couch.get(url, query: %{q: "*:*", include_docs: true})
+    assert_status_code(resp, 200)
+    assert resp.body["update_latency"] > 0
+  end
+
   def seq(str) do
     String.to_integer(hd(Regex.run(~r/^[0-9]+/, str)))
   end


### PR DESCRIPTION
## Overview

Return the amount of time in a nouveau query spent waiting for the index to be updated to current.

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
