### PR TITLE
feat(quickjs): LTO and static linking pthreads on Win

### DIFF
--- a/src/couch_quickjs/rebar.config.script
+++ b/src/couch_quickjs/rebar.config.script
@@ -18,7 +18,7 @@ Msys = "msys2_shell.cmd -defterm -no-start -ucrt64 -here -lc ".
 PreHooks = [
     {"(linux|darwin)", compile, "make CONFIG_LTO=y -C quickjs -j8 libquickjs.lto.a qjsc"},
     {"freebsd", compile, "gmake -C quickjs -j8 libquickjs.a qjsc"},
-    {"win32", compile, Msys ++ "'make -C quickjs qjsc'"},
+    {"win32", compile, Msys ++ "'make CONFIG_LTO=y -C quickjs -j8 libquickjs.lto.a qjsc'"},
     {"(linux|darwin|freebsd|win32)", compile, "escript build_js.escript compile"}
 ].
 
@@ -49,7 +49,8 @@ FreeBSDEnv  = [
 ] ++ ResetFlags.
 
 WindowsEnv = [
-    {"CFLAGS", "-D_GNU_SOURCE -DCONFIG_BIGNUM -O2 -fwrapv -DCONFIG_VERSION=\\\"0\\\" -Iquickjs"},
+    {"CFLAGS", "-flto -D_GNU_SOURCE -DCONFIG_BIGNUM -DCONFIG_LTO=y -O2 -fwrapv -DCONFIG_VERSION=\\\"0\\\" -Iquickjs"},
+    {"LDFLAGS", "$LDFLAGS -flto -lm -Wl,-Bstatic -lpthread quickjs/libquickjs.lto.a"},
     {"EXE_CC_TEMPLATE", "gcc.exe -g -c $CFLAGS $PORT_IN_FILES -o $PORT_OUT_FILE"},
     {"EXE_LINK_TEMPLATE", "gcc.exe -g -lm $PORT_IN_FILES $LDFLAGS -o $PORT_OUT_FILE"}
 ].


### PR DESCRIPTION
Enable link-time-optimization for QuickJS on Windows and link pthreads static into couchjs_*.exe.

Reduced binary sizes of ~1.3 MB per couchjs_*.exe.

Before:
```
PS C:\Users\couchdb\Documents\couchdb-otp25> ls .\src\couch_quickjs\priv\


    Directory: C:\Users\couchdb\Documents\couchdb-otp25\src\couch_quickjs\priv


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        12.10.2024     14:29         204581 bundle_coffee.js
-a----        12.10.2024     14:29          42578 bundle_mainjs.js
-a----        12.10.2024     14:30        5392102 couchjs_coffee.exe
-a----        12.10.2024     14:30        5225702 couchjs_mainjs.exe


PS C:\Users\couchdb\Documents\couchdb-otp25> dumpbin.exe /dependents .\src\couch_quickjs\priv\couchjs_mainjs.exe
Microsoft (R) COFF/PE Dumper Version 14.41.34120.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\src\couch_quickjs\priv\couchjs_mainjs.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    KERNEL32.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-environment-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-private-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-time-l1-1-0.dll
    libwinpthread-1.dll

  Summary

        1000 .CRT
        1000 .bss
        1000 .data
        7000 .debug_abbrev
        1000 .debug_aranges
       1A000 .debug_frame
      193000 .debug_info
       C7000 .debug_line
        3000 .debug_line_str
      135000 .debug_loclists
       2A000 .debug_rnglists
        2000 .debug_str
        2000 .idata
        5000 .pdata
       1E000 .rdata
        1000 .reloc
        1000 .rsrc
       D5000 .text
        1000 .tls
        6000 .xdata
```

After:
```
PS C:\Users\couchdb\Documents\couchdb-otp25> ls .\src\couch_quickjs\priv\


    Directory: C:\Users\couchdb\Documents\couchdb-otp25\src\couch_quickjs\priv


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        12.10.2024     14:37         204581 bundle_coffee.js
-a----        12.10.2024     14:37          42578 bundle_mainjs.js
-a----        12.10.2024     14:39        3992605 couchjs_coffee.exe
-a----        12.10.2024     14:38        3826205 couchjs_mainjs.exe


PS C:\Users\couchdb\Documents\couchdb-otp25> dumpbin.exe /dependents .\src\couch_quickjs\priv\couchjs_mainjs.exe
Microsoft (R) COFF/PE Dumper Version 14.41.34120.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\src\couch_quickjs\priv\couchjs_mainjs.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    KERNEL32.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-environment-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-private-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-time-l1-1-0.dll
    api-ms-win-crt-utility-l1-1-0.dll

  Summary

        1000 .CRT
        1000 .bss
        1000 .data
        9000 .debug_abbrev
        1000 .debug_aranges
       11000 .debug_frame
       FC000 .debug_info
       8E000 .debug_line
        4000 .debug_line_str
       E9000 .debug_loclists
       22000 .debug_rnglists
        2000 .debug_str
        2000 .idata
        3000 .pdata
       1C000 .rdata
        1000 .reloc
        1000 .rsrc
       AA000 .text
        1000 .tls
        4000 .xdata
```