### PR TITLE
Add type specs to clouseau_rpc

### DIFF
--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -24,31 +24,137 @@
 -export([set_purge_seq/2, get_purge_seq/1, get_root_dir/0]).
 -export([connected/0]).
 
+%% string represented as binary
+-type string_as_binary(_Value) :: nonempty_binary().
+
+-type shard() :: string_as_binary(_).
+-type path() :: string_as_binary(_).
+
+-type error() :: any().
+
+-type analyzer_name() :: string_as_binary(_).
+
+-type field_name() :: string_as_binary(_).
+
+-type seq() :: non_neg_integer().
+-type commit_seq() :: seq().
+-type purge_seq() :: seq().
+-type committed_seq() :: seq().
+-type pending_seq() :: seq().
+-type update_seq() :: seq().
+
+-type analyzer_fields() :: [{field_name(), analyzer_name() | [analyzer_name()]}].
+
+-type indexer_pid() :: pid().
+
+%% Example of the message
+%%   {[
+%%       {<<"name">>,<<"perfield">>},
+%%       {<<"default">>,<<"keyword">>},
+%%       {<<"fields">>,{[
+%%           {<<"$default">>,<<"standard">>}
+%%       ]}}
+%%   ]}
+-type analyzer() ::
+    analyzer_name()
+    | [
+        {string_as_binary(name), analyzer_name()}
+        | {string_as_binary(default), analyzer()}
+        | {string_as_binary(fields), {analyzer_fields()}}
+        | {string_as_binary(stopwords), [field_name()]}
+    ].
+
+-spec open_index(Peer :: pid(), Path :: shard(), Analyzer :: analyzer()) ->
+    {ok, indexer_pid()} | error().
 open_index(Peer, Path, Analyzer) ->
     rpc({main, clouseau()}, {open, Peer, Path, Analyzer}).
 
+-spec disk_size(Path :: shard()) ->
+    {ok, {disk_size, non_neg_integer()}} | error().
+
 disk_size(Path) ->
     rpc({main, clouseau()}, {disk_size, Path}).
+
+-spec get_root_dir() ->
+    {ok, path()} | error().
+
 get_root_dir() ->
     rpc({main, clouseau()}, {get_root_dir}).
+
+%% not used ???
+-spec await(Ref :: indexer_pid(), MinSeq :: commit_seq()) ->
+    ok | error().
 
 await(Ref, MinSeq) ->
     rpc(Ref, {await, MinSeq}).
 
+%% deprecated
+-spec commit(Ref :: indexer_pid(), NewCommitSeq :: commit_seq()) ->
+    ok | error().
+
 commit(Ref, NewCommitSeq) ->
     rpc(Ref, {commit, NewCommitSeq}).
+
+-type info_result_item() ::
+    {disk_size, non_neg_integer()}
+    | {doc_count, non_neg_integer()}
+    | {doc_del_count, non_neg_integer()}
+    | {pending_seq, pending_seq()}
+    | {committed_seq, committed_seq()}
+    | {purge_seq, purge_seq()}.
+
+-spec info(Ref :: indexer_pid()) ->
+    {ok, [info_result_item()]} | error().
 
 info(Ref) ->
     rpc(Ref, info).
 
+-spec get_update_seq(Ref :: indexer_pid()) ->
+    {ok, update_seq()} | error().
+
 get_update_seq(Ref) ->
     rpc(Ref, get_update_seq).
+
+-spec set_purge_seq(Ref :: indexer_pid(), Seq :: purge_seq()) ->
+    ok | error().
 
 set_purge_seq(Ref, Seq) ->
     rpc(Ref, {set_purge_seq, Seq}).
 
+-spec get_purge_seq(Ref :: indexer_pid()) ->
+    {ok, purge_seq()} | error().
+
 get_purge_seq(Ref) ->
     rpc(Ref, get_purge_seq).
+
+-type query() :: string_as_binary(_).
+-type range_name() :: string_as_binary(_).
+-type range_label() :: string_as_binary(_).
+-type range_query() :: string_as_binary(_).
+-type partition() :: string_as_binary(_).
+
+-type limit() :: non_neg_integer().
+-type bookmark() :: string_as_binary(_).
+
+-type search_arg() ::
+    {query, query()}
+    | {partition, partition()}
+    | {limit, limit()}
+    | {refresh, boolean()}
+    | {'after', bookmark()}
+    | {sort, group_sort()}
+    | {include_fields, [field_name()]}
+    | {counts, [field_name()]}
+    | {ranges, [{range_name(), [{range_label(), range_query()}]}]}
+    | {highlight_fields, [field_name()]}
+    | {highlight_pre_tag, string_as_binary(_)}
+    | {highlight_post_tag, string_as_binary(_)}
+    | {highlight_number, pos_integer()}
+    | {highlight_size, pos_integer()}
+    | {legacy, boolean()}.
+
+-spec search(Ref :: indexer_pid(), Args :: [search_arg()]) ->
+    {ok, #top_docs{}} | error().
 
 search(Ref, Args) ->
     case rpc(Ref, {search, Args}) of
@@ -64,32 +170,122 @@ search(Ref, Args) ->
             Else
     end.
 
+-type offset() :: non_neg_integer().
+-type group_sort() ::
+    relevance
+    | field_name()
+    | [field_name()].
+
+-spec group1(
+    Ref :: indexer_pid(),
+    Query :: query(),
+    GroupBy :: field_name(),
+    Refresh :: boolean(),
+    Sort :: group_sort(),
+    Offset :: offset(),
+    Limit :: limit()
+) -> {ok, [{field_name(), sort_values()}]} | error().
+
 group1(Ref, Query, GroupBy, Refresh, Sort, Offset, Limit) ->
     rpc(Ref, {group1, Query, GroupBy, Refresh, Sort, Offset, Limit}).
+
+-type group_name() :: string_as_binary(_) | null.
+-type sort_values() :: [string_as_binary(_) | null].
+-type groups() :: [{group_name(), sort_values()}].
+
+-type query_arg() ::
+    {query, string_as_binary(_)}
+    | {field, field_name()}
+    | {refresh, boolean()}
+    | {groups, groups()}
+    | {group_sort, group_sort()}
+    | {sort, group_sort()}
+    | {limit, limit()}
+    | {include_fields, [field_name()]}
+    | {highlight_fields, [field_name()]}
+    | {highlight_pre_tag, string_as_binary(_)}
+    | {highlight_post_tag, string_as_binary(_)}
+    | {highlight_number, pos_integer()}
+    | {highlight_size, pos_integer()}.
+
+-type grouped_results() :: [{field_name(), TotalHits :: non_neg_integer(), [#hit{}]}].
+-spec group2(Ref :: indexer_pid(), Args :: [query_arg()]) ->
+    {ok, {TotalHits :: non_neg_integer(), TotalGroupedHits :: non_neg_integer(), grouped_results()}}.
 
 group2(Ref, Args) ->
     rpc(Ref, {group2, Args}).
 
+-spec delete(Ref :: indexer_pid(), Id :: docid()) ->
+    ok.
+
 delete(Ref, Id) ->
     rpc(Ref, {delete, couch_util:to_binary(Id)}).
 
+-type docid() :: string_as_binary(_).
+
+-type field_value() ::
+    string_as_binary(_)
+    | boolean()
+    | number().
+
+-type field_option() ::
+    {string_as_binary(store), yes_or_no()}
+    | {string_as_binary(boost), number()}
+    | {string_as_binary(index), boolean()}
+    | {string_as_binary(term_vector), yes_or_no()}
+    | {string_as_binary(facet), boolean()}.
+
+-type yes_or_no() :: string_as_binary(yes) | string_as_binary(no).
+
+-spec update(
+    Ref :: indexer_pid(), Id :: docid(), Fields :: [{field_name(), field_value(), [field_option()]}]
+) ->
+    ok.
 update(Ref, Id, Fields) ->
     rpc(Ref, {update, Id, Fields}).
 
+-spec cleanup(DbName :: string_as_binary(_)) -> ok.
 cleanup(DbName) ->
     gen_server:cast({cleanup, clouseau()}, {cleanup, DbName}).
 
+-spec rename(DbName :: string_as_binary(_)) -> ok.
 rename(DbName) ->
     gen_server:cast({cleanup, clouseau()}, {rename, DbName}).
+
+-type sig() :: string_as_binary(_).
+
+%% `Sig` in `ActiveSigs` list here is a hashed version of an index function
+%% and an analyzer represented in a Javascript function in a design document.
+%% `Sig` is used to check if an index description is changed,
+%% and the index needs to be reconstructed.
+-spec cleanup(DbName :: string_as_binary(_), ActiveSigs :: [sig()]) ->
+    ok.
 
 cleanup(DbName, ActiveSigs) ->
     gen_server:cast({cleanup, clouseau()}, {cleanup, DbName, ActiveSigs}).
 
+%% a binary with value <<"tokens">>
+-type tokens_tag() :: string_as_binary(_).
+
+% Example
+%  {ok, {[
+%      {<<"tokens">>, [
+%          <<"ablanks@renovations.com">>
+%      ]}
+%  ]}}
+
+-spec analyze(Analyzer :: analyzer(), Text :: string_as_binary(_)) ->
+    {ok, [{tokens_tag(), [string_as_binary(_)]}]} | error().
+
 analyze(Analyzer, Text) ->
     rpc({analyzer, clouseau()}, {analyze, Analyzer, Text}).
 
+-spec version() -> string_as_binary(_).
+
 version() ->
     rpc({main, clouseau()}, version).
+
+-spec connected() -> boolean().
 
 connected() ->
     HiddenNodes = erlang:nodes(hidden),


### PR DESCRIPTION
## Overview

This PR serves as a code documentation since we don't run type checks during CI. It doesn't modify existing code just adding type specs.
 
## Testing recommendations

Since we don't run dyalizer during CI and given the fact that it fails on main. There is no good way to test correctness of the spec other than comparing the output of dilayzer on main and on the current branch.

on *main* branch

```
couchdb on *main* 
❯ make
...
couchdb on *main*
❯ make dialyze apps=dreyfus
==> dreyfus (build-plt)
WARN:  ''build-plt'' command does not apply to directory /Users/iilyak/Code/couchdb/rel
WARN:  ''build-plt'' command does not apply to directory /Users/iilyak/Code/couchdb
==> dreyfus (dialyze)
src/dreyfus_bookmark.erl:61:29: Record construction
          #shard{name :: '_', ref :: '_', opts :: '_'} violates the declared type of field opts ::
          'undefined' | [any()]
src/dreyfus_httpd.erl:59:21: The pattern
          {'ok', Bookmark0, TotalHits, Hits0} can never match the type
          {'error', _} | {'ok', _, _, _, _, _}
src/dreyfus_index.erl:110:1: The inferred return type of init/1
         ('ok') has nothing in common with
          'ignore' |
          {'ok', _} |
          {'stop', _} |
          {'ok', _,
           'hibernate' | 'infinity' |
           non_neg_integer() |
           {'continue', _}}, which is the expected return type for the callback of the gen_server behaviour
src/dreyfus_index.erl:152:36: The created fun has no local return
src/dreyfus_index.erl:231:36: The created fun has no local return
src/dreyfus_index_updater.erl:23:1: Function update/2 has no local return
ERROR: dialyze failed while processing /Users/iilyak/Code/couchdb/src/dreyfus: rebar_abort
make: *** [dialyze] Error 1
```

on *add-specs-to-clouseau_rpc* branch

```
couchdb on *add-specs-to-clouseau_rpc* 
❯ make
...
couchdb on *add-specs-to-clouseau_rpc*
❯ make dialyze apps=dreyfus
==> dreyfus (build-plt)
WARN:  ''build-plt'' command does not apply to directory /Users/iilyak/Code/couchdb/rel
WARN:  ''build-plt'' command does not apply to directory /Users/iilyak/Code/couchdb
==> dreyfus (dialyze)
src/dreyfus_bookmark.erl:61:29: Record construction
          #shard{name :: '_', ref :: '_', opts :: '_'} violates the declared type of field opts ::
          'undefined' | [any()]
src/dreyfus_httpd.erl:59:21: The pattern
          {'ok', Bookmark0, TotalHits, Hits0} can never match the type
          {'error', _} | {'ok', _, _, _, _, _}
src/dreyfus_index.erl:110:1: The inferred return type of init/1
         ('ok') has nothing in common with
          'ignore' |
          {'ok', _} |
          {'stop', _} |
          {'ok', _,
           'hibernate' | 'infinity' |
           non_neg_integer() |
           {'continue', _}}, which is the expected return type for the callback of the gen_server behaviour
src/dreyfus_index.erl:152:36: The created fun has no local return
src/dreyfus_index.erl:231:36: The created fun has no local return
src/dreyfus_index.erl:297:17: The variable Error can never match since previous clauses completely covered the type
          {'ok', non_neg_integer()}
src/dreyfus_index_updater.erl:23:1: Function update/2 has no local return
ERROR: dialyze failed while processing /Users/iilyak/Code/couchdb/src/dreyfus: rebar_abort
make: *** [dialyze] Error 1
```

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
