### PR TITLE
Handle another expected error in the scanner

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
+++ b/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
@@ -544,6 +544,8 @@ expected_error({error, {_, {<<"unnamed_error">>, _}}}, {error, {_, {<<"unnamed_e
     true;
 expected_error({error, {_, {<<"SyntaxError">>, _}}}, {error, {_, {<<"SyntaxError">>, _}}}) ->
     true;
+expected_error({error, {_, {<<"ReferenceError">>, _}}}, {error, {_, {<<"ReferenceError">>, _}}}) ->
+    true;
 expected_error(_, _) ->
     false.
 


### PR DESCRIPTION
It's the same idea as `SyntaxError` and `TypeError` above.

While at it improve the filter test to use individual ddocs for each error. This way one error or crash won't influence the others.

