### PR TITLE
Add quickjs to the list of welcome features

### DIFF
--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -68,15 +68,10 @@ handle_welcome_req(Req, _) ->
     send_method_not_allowed(Req, "GET,HEAD").
 
 get_features() ->
-    case dreyfus:available() of
-        true -> [search];
-        false -> []
-    end ++
-        case nouveau:enabled() of
-            true -> [nouveau];
-            false -> []
-        end ++
-        config:features().
+    HasSearch = [search || dreyfus:available()],
+    HasNouveau = [nouveau || nouveau:enabled()],
+    JsEngine = [E || (E = couch_server:get_js_engine()) /= <<"spidermonkey">>],
+    HasSearch ++ HasNouveau ++ JsEngine ++ config:features().
 
 handle_favicon_req(Req) ->
     handle_favicon_req(Req, get_docroot()).

--- a/src/chttpd/test/eunit/chttpd_misc_test.erl
+++ b/src/chttpd/test/eunit/chttpd_misc_test.erl
@@ -32,6 +32,7 @@ teardown(_Url) ->
     Persist = false,
     ok = config:delete("couchdb", "maintenance_mode", Persist = false),
     ok = config:delete("cluster", "seedlist", Persist = false),
+    ok = config:delete("couchdb", "js_engine", Persist = false),
     ok = config:delete("admins", ?USER, Persist = false).
 
 welcome_test_() ->
@@ -88,7 +89,12 @@ should_have_features(Url) ->
     {ok, 200, _, Body2} = req_get(Url),
     #{<<"features">> := Features2} = Body2,
     ?assert(is_list(Features2)),
-    ?assertNot(lists:member(<<"snek">>, Features2)).
+    ?assertNot(lists:member(<<"snek">>, Features2)),
+    config:set("couchdb", "js_engine", "quickjs", false),
+    {ok, 200, _, Body3} = req_get(Url),
+    #{<<"features">> := Features3} = Body3,
+    ?assert(lists:member(<<"quickjs">>, Features3)),
+    config:delete("couchdb", "js_engine", false).
 
 up_test_() ->
     {

--- a/src/docs/src/api/server/common.rst
+++ b/src/docs/src/api/server/common.rst
@@ -21,7 +21,12 @@
 
     Accessing the root of a CouchDB instance returns meta information about the
     instance. The response is a JSON structure containing information about the
-    server, including a welcome message and the version of the server.
+    server, including a welcome message, version of the server, and a list of
+    ``features``. The ``features`` elements may change depending on which
+    configuration options are enabled (for example, ``quickjs`` if it's set as
+    the default JavasScript engine), or which additional components are
+    installed and configured (for example the ``nouveau`` text indexing
+    application).
 
     :<header Accept: - :mimetype:`application/json`
                      - :mimetype:`text/plain`
@@ -42,20 +47,26 @@
     .. code-block:: http
 
         HTTP/1.1 200 OK
-        Cache-Control: must-revalidate
-        Content-Length: 179
+        Content-Length: 247
         Content-Type: application/json
-        Date: Sat, 10 Aug 2013 06:33:33 GMT
-        Server: CouchDB (Erlang/OTP)
+        Date: Mon, 21 Oct 2024 21:53:51 GMT
+        Server: CouchDB/3.4.2 (Erlang OTP/25)
 
         {
             "couchdb": "Welcome",
-            "uuid": "85fb71bf700c17267fef77535820e371",
+            "features": [
+                "access-ready",
+                "partitioned",
+                "pluggable-storage-engines",
+                "reshard",
+                "scheduler"
+            ],
+            "git_sha": "6e5ad2a5c",
+            "uuid": "9ddf59457dbb8772316cf06fc5e5a2e4",
             "vendor": {
-                "name": "The Apache Software Foundation",
-                "version": "1.3.1"
+                "name": "The Apache Software Foundation"
             },
-            "version": "1.3.1"
+            "version": "3.4.2"
         }
 
 .. _api/server/active_tasks:


### PR DESCRIPTION
Since we have nouveau and clouseau there, it makes sense to add quickjs as well. Otherwise, unless a user is a server a admin, there is no way for them to figure out if their views will be built with QuickJS or SpiderMonkey.

Also, it looks like our welcome message in the docs is quite old so take the opportunity to update it with the latest version.
