### PR TITLE
allow client to specify request id

### DIFF
--- a/src/docs/src/api/basics.rst
+++ b/src/docs/src/api/basics.rst
@@ -180,6 +180,16 @@ Request Headers
 
   The use of the ``Content-type`` on a request is highly recommended.
 
+- ``X-Couch-Request-ID``
+
+  (Optional) CouchDB will add a ``X-Couch-Request-ID`` header to every response
+  in order to help users correlate any problem with the CouchDB log.
+
+  If this header is present on the request (as long as the header value is
+  no longer than 10 hexadecimal characters) this value will be used internally
+  as the request ``nonce``, which appears in logs, and will also be returned as
+  the ``X-Couch-Request-ID`` response header.
+
 Response Headers
 ----------------
 

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -381,4 +381,10 @@ defmodule BasicsTest do
     assert head_response.headers["X-Couch-Request-ID"]
     assert head_response.headers["X-CouchDB-Body-Time"]
   end
+
+  @tag :with_db
+  test "request ID can be specified at the client", context do
+    resp = Couch.get("/", headers: ["X-Couch-Request-ID": "123abc"])
+    assert resp.headers["X-Couch-Request-ID"] == "123abc"
+  end
 end

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -81,7 +81,8 @@
     "Welcome endpoint",
     "_all_docs POST error when multi-get is not a {'key': [...]} structure",
     "_bulk_docs POST error when body not an object",
-    "oops, the doc id got lost in code nirwana"
+    "oops, the doc id got lost in code nirwana",
+    "request ID can be specified at the client"
   ],
   "BatchSaveTest": [
     "batch post",


### PR DESCRIPTION
## Overview

This allows tracing of requests that fail to start in a timely manner when using a load balancer in front.

## Testing recommendations

covered by an integration test.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
