### PR TITLE
expand x-couch-request-id to allow uuids

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -435,10 +435,10 @@ nonce(MochiReq) ->
     case MochiReq:get_header_value("X-Couch-Request-ID") of
         undefined ->
             new_nonce();
-        Value when length(Value) > 10 ->
+        Value when length(Value) > 36 ->
             new_nonce();
         Value ->
-            case lists:all(fun is_hex/1, Value) of
+            case lists:all(fun is_valid_nonce_char/1, Value) of
                 true ->
                     Value;
                 false ->
@@ -449,14 +449,15 @@ nonce(MochiReq) ->
 new_nonce() ->
     couch_util:to_hex(crypto:strong_rand_bytes(5)).
 
-%% copied from mochiweb_util.erl
-is_hex(C) when
-    ((C >= $0 andalso C =< $9) orelse
-        (C >= $a andalso C =< $f) orelse
-        (C >= $A andalso C =< $F))
+is_valid_nonce_char(C) when
+    (C >= $0 andalso C =< $9) orelse
+        (C >= $a andalso C =< $z) orelse
+        (C >= $A andalso C =< $Z) orelse
+        C == $- orelse
+        C == $_
 ->
     true;
-is_hex(_) ->
+is_valid_nonce_char(_) ->
     false.
 
 catch_error(_HttpReq, throw, {http_head_abort, Resp}, _Stack) ->

--- a/src/docs/src/api/basics.rst
+++ b/src/docs/src/api/basics.rst
@@ -186,9 +186,9 @@ Request Headers
   in order to help users correlate any problem with the CouchDB log.
 
   If this header is present on the request (as long as the header value is
-  no longer than 10 hexadecimal characters) this value will be used internally
-  as the request ``nonce``, which appears in logs, and will also be returned as
-  the ``X-Couch-Request-ID`` response header.
+  no longer than 36 characters from the set ``0-9a-zA-z-_``) this value will be
+  used internally as the request ``nonce``, which appears in logs, and will also
+  be returned as the ``X-Couch-Request-ID`` response header.
 
 Response Headers
 ----------------

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -384,7 +384,8 @@ defmodule BasicsTest do
 
   @tag :with_db
   test "request ID can be specified at the client", context do
-    resp = Couch.get("/", headers: ["X-Couch-Request-ID": "123abc"])
-    assert resp.headers["X-Couch-Request-ID"] == "123abc"
+    uuid = "E7498DE1-B661-42FA-943D-17F890143068"
+    resp = Couch.get("/", headers: ["X-Couch-Request-ID": uuid])
+    assert resp.headers["X-Couch-Request-ID"] == uuid
   end
 end


### PR DESCRIPTION
## Overview

X-Couch-Request-Id has always been hardcoded to 5 random bytes, expressed as hex. This is perfectly fine for pretty much everyone but is overly prescriptive. Allow up to 36 alphanumeric characters plus underscore and dash, so as to accommodate a UUID as well as other patterns.

## Testing recommendations

covered by test

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
