### PR TITLE
Prevent inserting illegal ddocs via mango

### DIFF
--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -87,6 +87,7 @@ handle_index_req(#httpd{method = 'POST', path_parts = [_, _]} = Req, Db) ->
     {ok, DDoc} = mango_util:load_ddoc(Db, mango_idx:ddoc(Idx), DbOpts),
     Id = Idx#idx.ddoc,
     Name = Idx#idx.name,
+    ok = couch_doc:validate_docid(DDoc#doc.id, couch_db:name(Db)),
     Status =
         case mango_idx:add(DDoc, Idx) of
             {ok, DDoc} ->

--- a/src/mango/test/01-index-crud-test.py
+++ b/src/mango/test/01-index-crud-test.py
@@ -80,7 +80,7 @@ class IndexCrudTests(mango.DbPerClass):
                 raise AssertionError("bad create index")
 
     def test_bad_ddocs(self):
-        bad_ddocs = ["", True, False, 1.5, {"foo": "bar"}, [None, False]]
+        bad_ddocs = ["", "_design/", True, False, 1.5, {"foo": "bar"}, [None, False]]
         for bd in bad_ddocs:
             try:
                 self.db.create_index(["foo"], ddoc=bd)


### PR DESCRIPTION
Mango indexes allow specifying a custom ddoc ID in the `_index` POST request. Previously it was possible to insert `_design/` which is an illegal doc ID.

