### PR TITLE
Fix mango tests using custom db name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ mango-test: devclean all
 		--admin=adm:pass \
 		--no-eval "\
 COUCH_USER=adm COUCH_PASS=pass \
-src/mango/.venv/bin/nose2 -s src/mango/test -c src/mango/unittest.cfg $(MANGO_TEST_OPTS)"
+src/mango/.venv/bin/nose2 -F -s src/mango/test -c src/mango/unittest.cfg $(MANGO_TEST_OPTS)"
 
 
 .PHONY: weatherreport-test

--- a/Makefile.win
+++ b/Makefile.win
@@ -310,7 +310,7 @@ mango-test: devclean all
 		--admin=adm:pass \
 		"\
 env COUCH_USER=adm COUCH_PASS=pass \
-src\mango\.venv\Scripts\nose2 -s src\mango\test -c src\mango\unittest.cfg $(MANGO_TEST_OPTS)"
+src\mango\.venv\Scripts\nose2 -F -s src\mango\test -c src\mango\unittest.cfg $(MANGO_TEST_OPTS)"
 
 
 ################################################################################

--- a/src/mango/test/01-index-crud-test.py
+++ b/src/mango/test/01-index-crud-test.py
@@ -25,7 +25,7 @@ DOCS = [
 
 class IndexCrudTests(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
 
     def test_bad_fields(self):
         bad_fields = [
@@ -352,7 +352,7 @@ class IndexCrudTests(mango.DbPerClass):
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class IndexCrudTextTests(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
 
     def test_create_text_idx(self):
         fields = [

--- a/src/mango/test/12-use-correct-index-test.py
+++ b/src/mango/test/12-use-correct-index-test.py
@@ -50,7 +50,7 @@ DOCS = [
 
 class ChooseCorrectIndexForDocs(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))
 
     def test_choose_index_with_one_field_in_index(self):

--- a/src/mango/test/13-stable-update-test.py
+++ b/src/mango/test/13-stable-update-test.py
@@ -35,7 +35,7 @@ DOCS1 = [
 
 class SupportStableAndUpdate(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         # Hack to prevent auto-indexer from foiling update=False test
         # https://github.com/apache/couchdb/issues/2313
         self.db.save_doc(

--- a/src/mango/test/14-json-pagination-test.py
+++ b/src/mango/test/14-json-pagination-test.py
@@ -33,7 +33,7 @@ DOCS = [
 
 class PaginateJsonDocs(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))
 
     def test_all_docs_paginate_to_end(self):

--- a/src/mango/test/16-index-selectors-test.py
+++ b/src/mango/test/16-index-selectors-test.py
@@ -82,7 +82,7 @@ oldschoolddoctext = {
 
 class IndexSelectorJson(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))
 
     def test_saves_partial_filter_selector_in_index(self):
@@ -189,7 +189,7 @@ class IndexSelectorJson(mango.DbPerClass):
 @unittest.skipUnless(mango.has_text_service(), "requires text service")
 class IndexSelectorText(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))
 
     def test_saves_partialfilterselector_in_index(self):

--- a/src/mango/test/17-multi-type-value-test.py
+++ b/src/mango/test/17-multi-type-value-test.py
@@ -52,7 +52,7 @@ class MultiValueFieldTests:
 
 class MultiValueFieldJSONTests(mango.DbPerClass, MultiValueFieldTests):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))
         self.db.create_index(["name"])
         self.db.create_index(["age", "name"])
@@ -65,5 +65,5 @@ class MultiValueFieldJSONTests(mango.DbPerClass, MultiValueFieldTests):
 
 class MultiValueFieldAllDocsTests(mango.DbPerClass, MultiValueFieldTests):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))

--- a/src/mango/test/18-json-sort.py
+++ b/src/mango/test/18-json-sort.py
@@ -25,7 +25,7 @@ DOCS = [
 
 class JSONIndexSortOptimisations(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))
 
     def test_works_for_basic_case(self):

--- a/src/mango/test/19-find-conflicts.py
+++ b/src/mango/test/19-find-conflicts.py
@@ -20,7 +20,7 @@ CONFLICT = [{"_id": "doc", "_rev": "1-23202479633c2b380f79507a776743d5", "a": 1}
 
 class ChooseCorrectIndexForDocs(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOC))
         self.db.save_docs_with_conflicts(copy.deepcopy(CONFLICT))
 

--- a/src/mango/test/20-no-timeout-test.py
+++ b/src/mango/test/20-no-timeout-test.py
@@ -17,7 +17,7 @@ import unittest
 
 class LongRunningMangoTest(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         docs = []
         for i in range(100000):
             docs.append({"_id": str(i), "another": "field"})

--- a/src/mango/test/24-text-paginated-test.py
+++ b/src/mango/test/24-text-paginated-test.py
@@ -24,7 +24,7 @@ class PaginatedResultsTest(mango.DbPerClass):
     UPDATES = 25
 
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.create_text_index(
             analyzer="keyword",
             default_field={},

--- a/src/mango/test/25-beginswith-test.py
+++ b/src/mango/test/25-beginswith-test.py
@@ -28,7 +28,7 @@ def to_utf8_bytes(list):
 
 class BeginsWithOperator(mango.DbPerClass):
     def setUp(self):
-        self.db.recreate()
+        super().setUp(db_per_test=True)
         self.db.save_docs(copy.deepcopy(DOCS))
         self.db.create_index(["location"])
         self.db.create_index(["name", "location"])


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

When running mango tests, sometimes get `org.apache.lucene.store.NoSuchDirectoryException` error. This is because each test in the same class used the same database name, and in the setUp function always delete and recreate it, which caused a race condition. Using custom database names should solve it.

- Makefile: Add `-F, --failfast` to stop mango tests early on failures
- Add `setUp()` and `teardown()` to create/delete db for each test to  
  avoid `org.apache.lucene.store.NoSuchDirectory Exception` errors.
- Replace `self.db.recreate()` with `super().setUp(db_per_test=True)`

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

`make mango-test`
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->
  

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
