### PR TITLE
Allow empty doc fields in the scanner

### DIFF
--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -641,7 +641,7 @@ fold_ddocs(Fun, #st{dbname = DbName} = Acc) ->
 % We just got these docs from the cluster, they are already saved on disk.
 ejson_to_doc({[_ | _] = Props}) ->
     {value, {_, DocId}, Props1} = lists:keytake(<<"_id">>, 1, Props),
-    Props2 = [{K, V} || {K, V} <- Props1, binary:first(K) =/= $_],
+    Props2 = [{K, V} || {K, V} <- Props1, K =:= <<>> orelse binary:first(K) =/= $_],
     #doc{id = DocId, body = {Props2}}.
 
 % Skip patterns

--- a/src/couch_scanner/test/eunit/couch_scanner_test.erl
+++ b/src/couch_scanner/test/eunit/couch_scanner_test.erl
@@ -76,7 +76,7 @@ setup() ->
         validate_doc_update => <<"function(n,o,u,s){return true;">>
     }),
     ok = add_doc(DbName2, ?DOC3, #{foo3 => bax}),
-    ok = add_doc(DbName2, ?DOC4, #{foo4 => baw}),
+    ok = add_doc(DbName2, ?DOC4, #{foo4 => baw, <<>> => this_is_ok_apparently}),
     couch_scanner:reset_checkpoints(),
     {Ctx, {DbName1, DbName2}}.
 


### PR DESCRIPTION
Apparently `""` is a valid doc field and `binary:first(<<>>)` was crashing on it, so make sure to handle that case.

