### PR TITLE
 Improve the QuickJS update function scanning

### DIFF
--- a/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
+++ b/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
@@ -651,7 +651,17 @@ ddoc_update(Doc) ->
                 "    return [null, 'got_dollar_one'];\n"
                 "  }\n"
                 "}"
-            >>
+            >>,
+            u2 => <<
+                "function(doc, req) {\n"
+                "  if (typeof(req.form) === 'object') {\n"
+                "    return [null, 'has_form']; \n"
+                "  } else { \n"
+                "    return [null, 'no_form'];\n"
+                "  }\n"
+                "}"
+            >>,
+            u3 => <<"function(doc, req) {throw('Potato')}">>
         }
     }.
 


### PR DESCRIPTION
Improve the QuickJS update function scanning

 * Noticed some design documents crashing because they are missing some of the expected `req` fields. When an early `TypeError("req.form is undefined")` error is thrown, it shortcuts the evaluation and we're missing covering that ddoc. To fix it, fill out [1] more of the mock request object so we get better coverage in the scanner.

 * Handle error raised from the update function similar to how we handle other such errors in other function. From update functions they look like `render_error`.

[1] https://docs.couchdb.org/en/stable/json-structure.html#request-object