### PR TITLE
Mango-tests: remove `-F, --failfast` option from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ mango-test: devclean all
 		--admin=adm:pass \
 		--no-eval "\
 COUCH_USER=adm COUCH_PASS=pass \
-src/mango/.venv/bin/nose2 -F -s src/mango/test -c src/mango/unittest.cfg $(MANGO_TEST_OPTS)"
+src/mango/.venv/bin/nose2 -s src/mango/test -c src/mango/unittest.cfg $(MANGO_TEST_OPTS)"
 
 
 .PHONY: weatherreport-test

--- a/Makefile.win
+++ b/Makefile.win
@@ -310,7 +310,7 @@ mango-test: devclean all
 		--admin=adm:pass \
 		"\
 env COUCH_USER=adm COUCH_PASS=pass \
-src\mango\.venv\Scripts\nose2 -F -s src\mango\test -c src\mango\unittest.cfg $(MANGO_TEST_OPTS)"
+src\mango\.venv\Scripts\nose2 -s src\mango\test -c src\mango\unittest.cfg $(MANGO_TEST_OPTS)"
 
 
 ################################################################################


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

Related PR: https://github.com/apache/couchdb/pull/5341

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
