### PR TITLE
Disable SpiderMonkey on macOS CI builder until >91 support lands

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -117,7 +117,8 @@ meta = [
  // but works for the other workers.
  'macos': [
     name: 'macOS',
-    spidermonkey_vsn: '91',
+    // spidermonkey_vsn: '91',
+    disable_spidermonkey: true, // tmp disable until SM>91 support lands
     with_nouveau: false,
     with_clouseau: false,
     gnu_make: 'make'


### PR DESCRIPTION
Disable SpiderMonkey on macOS CI builder until >91 support lands