### PR TITLE
Bring FreeBSD AMD64 worker back

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -96,13 +96,12 @@ meta = [
     image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}"
   ],
 
-  // Temp disable until worker is back
-  // 'freebsd-x86_64': [
-  //    name: 'FreeBSD x86_64',
-  //    spidermonkey_vsn: '91',
-  //    with_clouseau: false,
-  //    gnu_make: 'gmake'
-  // ],
+  'freebsd-x86_64': [
+      name: 'FreeBSD x86_64',
+      spidermonkey_vsn: '91',
+      with_clouseau: false,
+      gnu_make: 'gmake'
+  ],
 
   // Spidermonkey 91 has issues on ARM64 FreeBSD
   // use QuickJS for now


### PR DESCRIPTION
Successful build: https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/jenkins-bring-freebsd-amd64-worker-back/3/pipeline-console/

<img width="938" alt="Screenshot 2024-12-09 at 1 24 43 PM" src="https://github.com/user-attachments/assets/fc5051ab-eecf-446a-80a8-ec1f66810f29">
