### PR TITLE
Bring FreeBSD AMD64 worker back

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -96,13 +96,12 @@ meta = [
     image: "apache/couchdbci-debian:bookworm-erlang-${ERLANG_VERSION}"
   ],
 
-  // Temp disable until worker is back
-  // 'freebsd-x86_64': [
-  //    name: 'FreeBSD x86_64',
-  //    spidermonkey_vsn: '91',
-  //    with_clouseau: false,
-  //    gnu_make: 'gmake'
-  // ],
+  'freebsd-x86_64': [
+      name: 'FreeBSD x86_64',
+      spidermonkey_vsn: '91',
+      with_clouseau: false,
+      gnu_make: 'gmake'
+  ],
 
   // Spidermonkey 91 has issues on ARM64 FreeBSD
   // use QuickJS for now


### PR DESCRIPTION
Moved from the original PR https://github.com/apache/couchdb/pull/5356 since macos fail in the full CI currently

