### PR TITLE
feat(dev): Use `brew --prefix` to find ICU paths on macOS

### DIFF
--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -262,12 +262,31 @@ CouchJSEnv = case SMVsn of
         ]
 end.
 
+BrewIcuPrefixCmd = "brew --prefix icu4c".
+GenericIcuIncludePaths = "-I/usr/local/opt/icu4c/include -I/opt/homebrew/opt/icu4c/include".
+GenericIcuLibPaths = "-L/usr/local/opt/icu4c/lib -L/opt/homebrew/opt/icu4c/lib".
+
+WithBrew = case os:find_executable("brew") of
+    false -> false;
+    _ -> true
+end.
+
+IcuIncludePath = case WithBrew of
+    false -> GenericIcuIncludePaths;
+    true -> "-I" ++ string:strip(os:cmd(BrewIcuPrefixCmd), right, $\n) ++ "/include"
+end.
+
+IcuLibPath = case WithBrew of
+    false -> GenericIcuLibPaths;
+    true -> "-L" ++ string:strip(os:cmd(BrewIcuPrefixCmd), right, $\n) ++ "/lib"
+end.
+
 IcuEnv = [{"DRV_CFLAGS",  "$DRV_CFLAGS -DPIC -O2 -fno-common"},
           {"DRV_LDFLAGS", "$DRV_LDFLAGS -lm -licuuc -licudata -licui18n -lpthread"},
           {"LDFLAGS", "$LDFLAGS"},
           {"CFLAGS", "$CFLAGS"}].
-IcuDarwinEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/opt/icu4c/include -I/opt/homebrew/opt/icu4c/include"},
-                {"LDFLAGS", "-L/usr/local/opt/icu4c/lib -L/opt/homebrew/opt/icu4c/lib"}].
+IcuDarwinEnv = [{"CFLAGS", "-DXP_UNIX " ++ IcuIncludePath},
+                {"LDFLAGS", IcuLibPath}].
 IcuBsdEnv = [{"CFLAGS", "-DXP_UNIX -I/usr/local/include"},
              {"LDFLAGS", "-L/usr/local/lib"}].
 IcuWinEnv = [{"CFLAGS", "$DRV_CFLAGS /DXP_WIN"},


### PR DESCRIPTION
The Homebrew package `icu4c` is keg-only and not linked into the standard path on macOS after installation.
Use the command `brew --prefix` for finding the location of the library.