### PR TITLE
fix(dev): Add compiler flags for MSVC

### DIFF
--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -222,17 +222,17 @@ end.
         };
     {win32, _} when SMVsn == "102" ->
         {
-            "/std:c++17 /DXP_WIN",
+            "/std:c++17 /DXP_WIN /Zc:preprocessor /utf-8",
             "$LDFLAGS mozjs-102.lib"
          };
     {win32, _} when SMVsn == "115" ->
         {
-            "/std:c++17 /DXP_WIN",
+            "/std:c++17 /DXP_WIN /Zc:preprocessor /utf-8",
             "$LDFLAGS mozjs-115.lib"
         };
     {win32, _} when SMVsn == "128" ->
         {
-            "/std:c++17 /DXP_WIN",
+            "/std:c++17 /DXP_WIN /Zc:preprocessor /utf-8",
             "$LDFLAGS mozjs-128.lib"
         }
 end.


### PR DESCRIPTION
To get `couchjs` compiled on Windows with newer
SpiderMonkeys (102, 115 and 128), we need to tell
the MS compiler (cl.exe) to compile macros with
`__VA_ARGS__` correctly. To get this, we need to
add an extra compile flag `/Zc:preprocessor`.

Add `/utf-8` to correctly parse source files.

Fixes #5322.