### PR TITLE
fix(chttpd): Always show browser login popup

### DIFF
--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -1235,13 +1235,17 @@ error_headers(#httpd{mochi_req = MochiReq} = Req, 401 = Code, ErrorStr, ReasonSt
                                 undefined ->
                                     {Code, []};
                                 AuthRedirect ->
-                                    case
+                                    RequireValidUser =
                                         chttpd_util:get_chttpd_config_boolean(
                                             "require_valid_user", false
-                                        )
-                                    of
+                                        ) or
+                                            chttpd_util:get_chttpd_config_boolean(
+                                                "require_valid_user_except_for_up", false
+                                            ),
+                                    case RequireValidUser of
                                         true ->
-                                            % send the browser popup header no matter what if we are require_valid_user
+                                            % send the browser popup header no matter what
+                                            % if we are require_valid_user or require_valid_user_except_up
                                             {Code, [{"WWW-Authenticate", "Basic realm=\"server\""}]};
                                         false ->
                                             case


### PR DESCRIPTION
Always show the browser login popup, no matter
which option of `require_valid_user` or
`require_valid_user_except_up` is set.