### PR TITLE
chore(docs): Correct default setting of lockout mode

### DIFF
--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -564,13 +564,13 @@ Authentication Configuration
 
     .. config:option:: mode :: lockout mode
 
-        When set to ``off`` (the default), CouchDB will not track repeated
+        When set to ``off``, CouchDB will not track repeated
         authentication failures.
 
         When set to ``warn``, CouchDB will log a warning when repeated
         authentication failures occur for a specific user and client IP address.
 
-        When set to ``enforce``, CouchDB will will reject requests with a
+        When set to ``enforce`` (the default), CouchDB will will reject requests with a
         403 status code if repeated authentication failures occur for a
         specific user and client IP address. ::
 


### PR DESCRIPTION
Set the correct default setting description of `mode` in `[chttpd_auth_lockout]` from `off` to `enforce` to match the [code](https://github.com/apache/couchdb/blob/0713b51b89e82bd690bec5feb36d620f365f65ff/src/couch/src/couch_auth_lockout.erl#L64) and the setting in [default.ini](https://github.com/apache/couchdb/blob/0713b51b89e82bd690bec5feb36d620f365f65ff/rel/overlay/etc/default.ini#L1076).