### PR TITLE
chore(dev): Don't wipe documentation source files on `distclean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,6 +483,7 @@ clean:
 	@rm -f src/couch/priv/couch_js/config.h
 	@rm -f dev/*.beam dev/devnode.* dev/pbkdf2.pyc log/crash.log
 	@rm -f src/couch_dist/certs/out
+	@rm -rf src/docs/build src/docs/.venv
 ifeq ($(with_nouveau), true)
 	@cd nouveau && $(GRADLE) clean
 endif
@@ -494,12 +495,10 @@ distclean: clean
 	@rm -f install.mk
 	@rm -f config.erl
 	@rm -f rel/couchdb.config
-ifneq ($(IN_RELEASE), true)
-# when we are in a release, don’t delete the
-# copied sources, generated docs, or fauxton
 	@rm -rf rel/couchdb
+ifneq ($(IN_RELEASE), true)
+	# when we are in a release, don’t delete Fauxton
 	@rm -rf share/www
-	@rm -rf src/docs
 endif
 
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -442,6 +442,7 @@ clean:
 	-@rmdir /s/q src\mango\.venv >NUL 2>&1 || true
 	-@del /f/q src\couch\priv\couch_js\config.h >NUL 2>&1 || true
 	-@del /f/q dev\boot_node.beam dev\pbkdf2.pyc log\crash.log >NUL 2>&1 || true
+	-@rmdir /s/q src\docs\build src\docs\.venv >NUL 2>&1 || true
 ifeq ($(with_nouveau), true)
 	@cd nouveau && $(GRADLE) clean
 endif
@@ -452,12 +453,10 @@ distclean: clean
 	-@del install.mk >NUL 2>&1 || true
 	-@del config.erl >NUL 2>&1 || true
 	-@del rel\couchdb.config >NUL 2>&1 || true
-ifneq ($(IN_RELEASE), true)
-# when we are in a release, don’t delete the
-# copied sources, generated docs, or fauxton
 	-@rmdir /s/q rel\couchdb >NUL 2>&1 || true
+ifneq ($(IN_RELEASE), true)
+    # when we are in a release, don’t delete Fauxton
 	-@rmdir /s/q share\www >NUL 2>&1 || true
-	-@rmdir /s/q src\docs >NUL 2>&1 || true
 endif
 
 


### PR DESCRIPTION
When running `make distclean` the docs source folder is fully wiped, if not run from a dist tarball. Since the docs are now included in the couchdb source, it's a leftover, where the docs were in a separate repository.