### PR TITLE
Elixir: Fix negative steps

### DIFF
--- a/test/elixir/test/uuids_test.exs
+++ b/test/elixir/test/uuids_test.exs
@@ -88,7 +88,7 @@ defmodule UUIDsTest do
 
     Enum.reduce(resp.body["uuids"], fn curr, acc ->
       assert String.length(curr) == 14 + String.length(@utc_id_suffix)
-      assert String.slice(curr, 14..-1//-1) == @utc_id_suffix
+      assert String.slice(curr, 14..-1//1) == @utc_id_suffix
       assert curr > acc
       curr
     end)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Fix the following warnings

```
warning: negative steps are not supported in String.slice/2, pass 14..-1//1 instead
  (elixir 1.17.3) lib/string.ex:2404: String.slice/2
  test/elixir/test/uuids_test.exs:91: anonymous fn/2 in UUIDsTest."test utc_id uuids are correct"/1
  (elixir 1.17.3) lib/enum.ex:2531: Enum."-reduce/2-lists^foldl/2-1-"/3
  test/elixir/test/uuids_test.exs:89: UUIDsTest."test utc_id uuids are correct"/1
  (ex_unit 1.17.3) lib/ex_unit/runner.ex:485: ExUnit.Runner.exec_test/2
  (stdlib 4.3.1.5) timer.erl:235: :timer.tc/1
  (ex_unit 1.17.3) lib/ex_unit/runner.ex:407: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
```

Related PR: https://github.com/apache/couchdb/pull/5372
Related issue: https://github.com/apache/couchdb/issues/5386
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
`make elixir`

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
