### PR TITLE
clarify RHEL9 caveats

### DIFF
--- a/src/docs/src/install/unix.rst
+++ b/src/docs/src/install/unix.rst
@@ -31,7 +31,7 @@ to install CouchDB is to use the convenience binary packages:
 
 * CentOS/RHEL 7
 * CentOS/RHEL 8
-* CentOS/RHEL 9 (with caveats)
+* CentOS/RHEL 9 (with caveats: depends on EPEL repository)
 * Debian 10 (buster)
 * Debian 11 (bullseye)
 * Debian 12 (bookworm)


### PR DESCRIPTION
## Overview

This PR adds a little comment to the documentation to clarify what the caveats are for deployment on RHEL 9.

## Testing recommendations

n/a

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/5353

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
