### PR TITLE
Remove idle check timeout

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -30,8 +30,6 @@
     decref/1,
     monitored_by/1,
 
-    last_activity/1,
-
     get_compacted_seq/1,
     get_del_doc_count/1,
     get_disk_version/1,
@@ -211,9 +209,6 @@ monitored_by(St) ->
         _ ->
             []
     end.
-
-last_activity(#st{fd = Fd}) ->
-    couch_file:last_read(Fd).
 
 get_compacted_seq(#st{header = Header}) ->
     couch_bt_engine_header:get(Header, compacted_seq).

--- a/src/couch/src/couch_db_engine.erl
+++ b/src/couch/src/couch_db_engine.erl
@@ -180,14 +180,6 @@
 -callback decref(DbHandle :: db_handle()) -> ok.
 -callback monitored_by(DbHande :: db_handle()) -> [pid()].
 
-% This is called in the context of couch_db_updater:handle_info/2
-% and should return the timestamp of the last activity of
-% the database. If a storage has no notion of activity or the
-% value would be hard to report its ok to just return the
-% result of os:timestamp/0 as this will just disable idle
-% databases from automatically closing.
--callback last_activity(DbHandle :: db_handle()) -> erlang:timestamp().
-
 % All of the get_* functions may be called from many
 % processes concurrently.
 
@@ -673,8 +665,6 @@
     decref/1,
     monitored_by/1,
 
-    last_activity/1,
-
     get_engine/1,
     get_compacted_seq/1,
     get_del_doc_count/1,
@@ -790,10 +780,6 @@ decref(#db{} = Db) ->
 monitored_by(#db{} = Db) ->
     #db{engine = {Engine, EngineState}} = Db,
     Engine:monitored_by(EngineState).
-
-last_activity(#db{} = Db) ->
-    #db{engine = {Engine, EngineState}} = Db,
-    Engine:last_activity(EngineState).
 
 get_engine(#db{} = Db) ->
     #db{engine = {Engine, _}} = Db,

--- a/src/couch/test/eunit/couch_file_tests.erl
+++ b/src/couch/test/eunit/couch_file_tests.erl
@@ -95,7 +95,6 @@ read_write_test_() ->
                     ?TDEF_FE(should_catch_pread_failure),
                     ?TDEF_FE(should_truncate),
                     ?TDEF_FE(should_set_db_pid),
-                    ?TDEF_FE(should_update_last_read_time),
                     ?TDEF_FE(should_open_read_only),
                     ?TDEF_FE(should_apply_overwrite_create_option),
                     ?TDEF_FE(should_error_on_creation_if_exists),
@@ -244,15 +243,6 @@ should_set_db_pid(Fd) ->
         100
     ),
     ?assertNot(is_process_alive(Fd)).
-
-should_update_last_read_time(Fd) ->
-    {ok, Pos, _} = couch_file:append_term(Fd, foo),
-    ReadTs1 = couch_file:last_read(Fd),
-    ?assertMatch({_, _, _}, ReadTs1),
-    {ok, foo} = couch_file:pread_term(Fd, Pos),
-    ReadTs2 = couch_file:last_read(Fd),
-    ?assertMatch({_, _, _}, ReadTs2),
-    ?assert(ReadTs2 > ReadTs1).
 
 should_open_read_only(Fd) ->
     {_, Path} = couch_file:process_info(Fd),


### PR DESCRIPTION
7 years ago we added an idle-check timeout to force idle system shard to close [1]. It seemed like a relevant setting for Cloudant, where at the time we had a large number of open `_replicator` dbs per server. However, at Cloudant we only
enabled it once, it failed as it closed too many shards too quickly, and then they had to be re-opened, which added extra load, we disabled ran with `infinity` ever since.

We also never documented it anywhere so let's remove it.

[1] https://github.com/apache/couchdb-couch/pull/236
