### PR TITLE
Fix contributing and api/database/changes minor typos documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,7 +318,7 @@ some commit message conventions.
 [9]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53
 [10]: https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide
 [11]: mailto:security@couchdb.apache.org?subject=Security
-[12]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[12]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [13]: https://help.github.com/fork-a-repo
 [14]: https://github.com/apache/couchdb/tree/main/src/docs
 [15]: https://help.github.com/articles/using-pull-requests

--- a/src/docs/src/api/database/changes.rst
+++ b/src/docs/src/api/database/changes.rst
@@ -779,14 +779,14 @@ amount of duplicated code.
     they are ready to handle documents with *alien* structure without panic.
 
 .. note::
-    Using ``_view`` filter doesn't queries the view index files, so you cannot
+    Using ``_view`` filter doesn't query the view index files, so you cannot
     use common :ref:`view query parameters <api/ddoc/view>` to additionally
     filter the changes feed by index key. Also, CouchDB doesn't returns
     the result instantly as it does for views - it really uses the specified
     map function as filter.
 
     Moreover, you cannot make such filters dynamic e.g. process the request
-    query parameters or handle the :ref:`userctx_object` - the map function is
+    query parameters or handle the :ref:`userctx_object` - the map function
     only operates with the document.
 
 **Request**:


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Extremely minor changes:
- Fix the wrong tense on the last note of api/database/changes
- Fix the wrong use of two verbs in that last paragraph of the last note of api/database/changes
- Fix a broken link in CONTRIBUTING.rst

## Testing recommendations

Test documentation generation in various formats

## Related Issues or Pull Requests

Fixes #5403

## Checklist

As these are extremely minor fixes to documentation, I don't think they affect the listed checklist?

- [X] Code is written and works correctly
- [X] Changes are covered by tests
- [X] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [X] Documentation changes were made in the `src/docs` folder
- [X] Documentation changes were backported (separated PR) to affected branches
