### PR TITLE
Extract the response of `_versions` endpoint

### DIFF
--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -16,6 +16,7 @@
 -export([
     handle_node_req/1,
     get_stats/0,
+    get_versions/0,
     run_queues/0,
     message_queues/0,
     db_pid_stats/0
@@ -46,48 +47,10 @@ handle_node_req(#httpd{method = 'GET', path_parts = [_, _Node, <<"_smoosh">>, <<
 handle_node_req(#httpd{path_parts = [_, _Node, <<"_smoosh">>, <<"status">>]} = Req) ->
     send_method_not_allowed(Req, "GET");
 % GET /_node/$node/_versions
-handle_node_req(#httpd{method = 'GET', path_parts = [_, _Node, <<"_versions">>]} = Req) ->
-    IcuVer = couch_ejson_compare:get_icu_version(),
-    UcaVer = couch_ejson_compare:get_uca_version(),
-    ColVer = couch_ejson_compare:get_collator_version(),
-    Hashes = crypto:supports(hashs),
-    EngineName = couch_server:get_js_engine(),
-    JsEngine =
-        case EngineName of
-            <<"spidermonkey">> ->
-                #{
-                    name => EngineName,
-                    version => couch_server:get_spidermonkey_version()
-                };
-            _Other ->
-                #{name => EngineName}
-        end,
-    ClouseauResponse =
-        case clouseau_rpc:version() of
-            {ok, Version} ->
-                #{
-                    clouseau => #{
-                        version => Version
-                    }
-                };
-            _ ->
-                #{}
-        end,
-    BaseResponse = #{
-        erlang => #{
-            version => ?l2b(?COUCHDB_ERLANG_VERSION),
-            supported_hashes => Hashes
-        },
-        collation_driver => #{
-            name => <<"libicu">>,
-            library_version => couch_util:version_to_binary(IcuVer),
-            collation_algorithm_version => couch_util:version_to_binary(UcaVer),
-            collator_version => couch_util:version_to_binary(ColVer)
-        },
-        javascript_engine => JsEngine
-    },
-    Response = maps:merge(BaseResponse, ClouseauResponse),
-    send_json(Req, 200, Response);
+handle_node_req(#httpd{method = 'GET', path_parts = [_, Node, <<"_versions">>]} = Req) ->
+    Versions = call_node(Node, chttpd_node, get_versions, []),
+    EJSON = couch_stats_httpd:to_ejson(Versions),
+    send_json(Req, EJSON);
 handle_node_req(#httpd{path_parts = [_, _Node, <<"_versions">>]} = Req) ->
     send_method_not_allowed(Req, "GET");
 % GET /_node/$node/_config
@@ -338,6 +301,48 @@ get_stats() ->
         {distribution, {get_distribution_stats()}},
         {distribution_events, mem3_distribution:events()}
     ].
+
+get_versions() ->
+    IcuVer = couch_ejson_compare:get_icu_version(),
+    UcaVer = couch_ejson_compare:get_uca_version(),
+    ColVer = couch_ejson_compare:get_collator_version(),
+    Hashes = crypto:supports(hashs),
+    EngineName = couch_server:get_js_engine(),
+    JsEngine =
+        case EngineName of
+            <<"spidermonkey">> ->
+                #{
+                    name => EngineName,
+                    version => couch_server:get_spidermonkey_version()
+                };
+            _Other ->
+                #{name => EngineName}
+        end,
+    ClouseauResponse =
+        case clouseau_rpc:version() of
+            {ok, Version} when is_binary(Version) ->
+                #{
+                    clouseau => #{
+                        version => Version
+                    }
+                };
+            _ ->
+                #{}
+        end,
+    BaseResponse = #{
+        erlang => #{
+            version => ?l2b(?COUCHDB_ERLANG_VERSION),
+            supported_hashes => Hashes
+        },
+        collation_driver => #{
+            name => <<"libicu">>,
+            library_version => couch_util:version_to_binary(IcuVer),
+            collation_algorithm_version => couch_util:version_to_binary(UcaVer),
+            collator_version => couch_util:version_to_binary(ColVer)
+        },
+        javascript_engine => JsEngine
+    },
+    maps:merge(BaseResponse, ClouseauResponse).
 
 db_pid_stats_formatted() ->
     {CF, CDU} = db_pid_stats(),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

When running with old version of Clouseau, it will return `{ok, null}`
when we call `clouseau_rpc:version().`. So add `is_binary/1` to prevent
`badarg` errors. Also simplify the code by extracting the response to
`get_versions/0` function.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
