### PR TITLE
Ensure we always map the documents in order map mrview updater

### DIFF
--- a/src/couch_mrview/src/couch_mrview_updater.erl
+++ b/src/couch_mrview/src/couch_mrview_updater.erl
@@ -132,7 +132,7 @@ process_doc(#doc{id = Id} = Doc, Seq, #mrst{doc_acc = Acc} = State) ->
 finish_update(#mrst{doc_acc = Acc} = State) ->
     if
         Acc /= [] ->
-            couch_work_queue:queue(State#mrst.doc_queue, Acc);
+            couch_work_queue:queue(State#mrst.doc_queue, lists:reverse(Acc));
         true ->
             ok
     end,


### PR DESCRIPTION
Previously, we reversed Acc in `process_doc/3` but not in `finish_update/1`. So were processing elements out of order. For example: 1,2,...,22,32,31,...,23.

The view still build correctly but let's make it tidier and more consistent.
