### PR TITLE
Add a version check to clouseau connected() function

### DIFF
--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -294,7 +294,21 @@ connected() ->
             true;
         false ->
             % We might have just booted up, so let's ping
-            pong == net_adm:ping(clouseau())
+            case net_adm:ping(clouseau()) of
+                pong ->
+                    % We can ping, but is the main process up?
+                    %
+                    % In versions 2.x (at least) this was a possibility
+                    %  > clouseau_rpc:version().
+                    %     {'EXIT',noconnection}
+                    %
+                    case (catch version()) of
+                        {ok, _} -> true;
+                        _ -> false
+                    end;
+                _ ->
+                    false
+            end
     end.
 
 rpc(Ref, Msg) ->


### PR DESCRIPTION
A ping is not enough. A clouseau instance is not usable if we it's just connected, it's main process should be up and running as well.

We have observed that it is possible for the clouseau node to be connected and respond to pings, but the main process was down. We want to alert or catch cases when that happens so we ask the main process for the version.
