### PR TITLE
Kill all couchjs processes right after updating the engine setting

### DIFF
--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -288,6 +288,11 @@ handle_config_change("query_server_config", _, _, _, _) ->
     {ok, undefined};
 handle_config_change("couchdb", "js_engine", _, _, _) ->
     gen_server:cast(?MODULE, reload_config),
+    % Besides reloading the config to switch the engine for the new procs, run
+    % reload to kill all free and then released procs in the pool. This way we
+    % ensure all the procs will be recycled and using the new engine as soon as
+    % possible
+    spawn(fun() -> reload() end),
     {ok, undefined};
 handle_config_change(_, _, _, _, _) ->
     {ok, undefined}.


### PR DESCRIPTION
Previously, we set the default JS engine dynamically, so that newly spawned processes would use the new setting. However, we didn't actively try to kill the old JS processes. Since a quiet cluster, without much concurrent indexing activity, could hang on to the same set of spawned processes for a while, it may take an indeterminate amount of time until the couchjs processes actually switch to the new engine.

To fix that let's force a `reload()` as well, which will immediately kill all the free (available) processes and then kill the acquired processes when the user is done with them and releases them back to the process manager.

