### PR TITLE
Scanner improvements

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
+++ b/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
@@ -75,7 +75,7 @@
         <<"sizes">> => #{<<"active">> => 42, <<"disk">> => 42, <<"external">> => 42}
     },
     <<"query">> => #{},
-    <<"body">> => #{},
+    <<"body">> => <<"{}">>,
     <<"method">> => <<"POST">>,
     <<"headers">> => #{},
     <<"form">> => #{},
@@ -814,12 +814,16 @@ nouveau_add_fun(#proc{}, _) ->
     ok.
 
 clouseau_index_doc(#proc{} = Proc, {[_ | _]} = Doc) ->
-    [Fields | _] = prompt(Proc, [<<"index_doc">>, Doc]),
-    lists:sort(Fields).
+    case prompt(Proc, [<<"index_doc">>, Doc]) of
+        [Fields | _] -> lists:sort(Fields);
+        [] -> []
+    end.
 
 nouveau_index_doc(#proc{} = Proc, {[_ | _]} = Doc) ->
-    [Fields | _] = prompt(Proc, [<<"nouveau_index_doc">>, Doc]),
-    lists:sort(Fields).
+    case prompt(Proc, [<<"nouveau_index_doc">>, Doc]) of
+        [Fields | _] -> lists:sort(Fields);
+        [] -> []
+    end.
 
 filter_doc(#proc{} = Proc, DDocId, FName, {[_ | _]} = Doc) ->
     % Add a mock request object so param access doesn't throw a TypeError

--- a/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
+++ b/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
@@ -692,6 +692,7 @@ ddoc_update(Doc) ->
         updates => #{
             u1 => <<
                 "function(doc, req) {\n"
+                "  body = JSON.parse(req.body) \n"
                 "  doc.a.search(/(x+)/); \n"
                 "  if (RegExp.$1 === undefined) {\n"
                 "    return [null, 'no_dollar_one']; \n"
@@ -702,6 +703,7 @@ ddoc_update(Doc) ->
             >>,
             u2 => <<
                 "function(doc, req) {\n"
+                "  body = JSON.parse(req.body) \n"
                 "  if (typeof(req.form) === 'object') {\n"
                 "    return [null, 'has_form']; \n"
                 "  } else { \n"

--- a/src/couch_scanner/src/couch_scanner_util.erl
+++ b/src/couch_scanner/src/couch_scanner_util.erl
@@ -269,9 +269,9 @@ format_db(Db) when is_list(Db) ->
     format_db(list_to_binary(Db));
 format_db(Db) when is_tuple(Db) ->
     format_db(couch_db:name(Db));
-format_db(<<"shards/", B:8/binary, "-", E:8/binary, "/", Rest/binary>>) ->
+format_db(<<"shards/", _:8/binary, "-", _:8/binary, "/", Rest/binary>>) ->
     [Db, _] = binary:split(Rest, <<".">>),
-    <<Db/binary, "/", B/binary, "-", E/binary>>;
+    Db;
 format_db(<<Db/binary>>) ->
     Db.
 
@@ -354,7 +354,7 @@ log_format_test() ->
     ?assertEqual("mod db:x ", tlog(#{db => <<"x">>})),
     ?assertEqual("mod s:y f:z db:x ", tlog(#{db => "x", sid => y, fn => z})),
     Shard = <<"shards/80000000-ffffffff/db.1712291766">>,
-    ?assertEqual("mod db:db/80000000-ffffffff ", tlog(#{db => Shard})).
+    ?assertEqual("mod db:db ", tlog(#{db => Shard})).
 
 tlog(Meta) ->
     {Fmt, Args} = log_format_meta(mod, Meta),


### PR DESCRIPTION
* In the scanner, emit just the db name in the `db:...` field and skip the range. After processing scan results for months I never once needed or used the range, it just adds extra noise, so let's remove it.

* In the QuickJS doc update scanner, the mock request body should be string not an object [1].

* Expect search indexes to be broken so there may not be any valid fields  returned. In that case don't crash the scanner with a `{badmatch, []}`

[1] https://docs.couchdb.org/en/stable/json-structure.html#request-object