### PR TITLE
Fix wrong link in example within CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ If you never created a pull request before, welcome :tada: :smile:
 2. Clone the repo and create a branch.
 
    ```bash
-   git clone https://github.com/couchdb/couchdb
+   git clone https://github.com/apache/couchdb
    # or git clone https://gitbox.apache.org/repos/asf/couchdb.git
    cd couchdb
    git checkout -b <topic-branch-name>


### PR DESCRIPTION
## Overview

This PR fixes a typo in the examples in CONTRIBUTING.md

## Testing recommendations

None

## Related Issues or Pull Requests

None

## Checklist

- ~~[ ] Code is written and works correctly~~
- ~~[ ] Changes are covered by tests~~
- ~~[ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`~~
- ~~[ ] Documentation changes were made in the `src/docs` folder~~
- ~~[ ] Documentation changes were backported (separated PR) to affected branches~~
