### PR TITLE
Add simple+pbkdf2 migration password scheme

### DIFF
--- a/src/couch/include/couch_js_functions.hrl
+++ b/src/couch/include/couch_js_functions.hrl
@@ -64,7 +64,7 @@
             });
         }
 
-        var available_schemes = [\"simple\", \"pbkdf2\"];
+        var available_schemes = [\"simple\", \"pbkdf2\", \"simple+pbkdf2\"];
         if (newDoc.password_scheme
                 && available_schemes.indexOf(newDoc.password_scheme) == -1) {
             throw({


### PR DESCRIPTION
## Overview

Introduces a new password scheme intended to help administrators transitioning from the legacy "simple" scheme to the strong "pbkdf2" scheme. By wrapping existing simple credentials with pbkdf2 we protect them better until such times as they are used (at which point they will be upgraded to the currently configured scheme).

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
