### PR TITLE
Restore the ability to return error object from maps

### DIFF
--- a/share/server/views.js
+++ b/share/server/views.js
@@ -84,7 +84,7 @@ var Views = (function() {
   return {
     // view helper functions
     emit : function(key, value) {
-      map_results.push([key, value]);
+      map_results.push([key, error_to_json(value)]);
     },
     sum : function(values) {
       var rv = 0;

--- a/src/couch/test/eunit/couch_js_tests.erl
+++ b/src/couch/test/eunit/couch_js_tests.erl
@@ -18,12 +18,20 @@ couch_js_test_() ->
         "Test couchjs",
         {
             setup,
-            fun() -> test_util:start_couch([config]) end,
-            fun test_util:stop_couch/1,
+            fun() ->
+                test_util:start_couch(),
+                meck:new(couch_log, [passthrough])
+            end,
+            fun(Ctx) ->
+                meck:unload(),
+                test_util:stop_couch(Ctx)
+            end,
             with([
                 ?TDEF(should_create_sandbox),
                 ?TDEF(should_reset_properly),
                 ?TDEF(should_freeze_doc_object),
+                ?TDEF(should_emit_error_details),
+                ?TDEF(should_log_error_details),
                 ?TDEF(should_roundtrip_utf8),
                 ?TDEF(should_roundtrip_modified_utf8),
                 ?TDEF(should_replace_broken_utf16),
@@ -101,6 +109,56 @@ should_freeze_doc_object(_) ->
     ?assertEqual([[[null, 1041], [null, 1041]]], Result1),
     Result2 = prompt(Proc, [<<"map_doc">>, Doc]),
     ?assertEqual([[[null, 1041], [null, 1041]]], Result2),
+    couch_query_servers:ret_os_process(Proc).
+
+%% erlfmt-ignore
+should_emit_error_details(_) ->
+    Src = <<"
+        function(doc) {
+            try {
+               non_existent.fun_call
+            } catch (e) {
+               emit('err', e);
+            }
+        }
+    ">>,
+    Proc = couch_query_servers:get_os_process(<<"javascript">>),
+    true = prompt(Proc, [<<"add_fun">>, Src]),
+    Result = prompt(Proc, [<<"map_doc">>,  {[{<<"foo">>, 42}]}]),
+    ?assertMatch([[[<<"err">>, {[_ | _]}]]], Result),
+    [[[<<"err">>, {ErrProps}]]] = Result,
+    ?assertEqual(<<"ReferenceError">>, couch_util:get_value(<<"error">>, ErrProps)),
+    ?assertMatch(<<_/binary>>, couch_util:get_value(<<"message">>, ErrProps)),
+    couch_query_servers:ret_os_process(Proc).
+
+%% erlfmt-ignore
+should_log_error_details(_) ->
+    Src = <<"
+        function(doc) {
+            try {
+               non_existent.fun_call
+            } catch (e) {
+               log(e);
+               emit('err', 1);
+            }
+        }
+    ">>,
+    Proc = couch_query_servers:get_os_process(<<"javascript">>),
+    true = prompt(Proc, [<<"add_fun">>, Src]),
+    meck:reset(couch_log),
+    % Don't check too specifically just that we emitted ReferenceError somewhere
+    % in there, otherwise each engine has its own error message format
+    meck:expect(couch_log, info, fun
+        ("OS Process " ++ _, [_Port, <<Msg/binary>>]) ->
+            ?assertNotEqual(nomatch, binary:match(Msg, [<<"ReferenceError">>])),
+            ok;
+        (_, _) ->
+            ok
+    end),
+    Result = prompt(Proc, [<<"map_doc">>,  {[{<<"foo">>, 42}]}]),
+    ?assertEqual([[[<<"err">>, 1]]], Result),
+    ?assert(meck:num_calls(couch_log, info, 2) >= 1),
+    meck:expect(couch_log, info, 2, meck:passthrough()),
     couch_query_servers:ret_os_process(Proc).
 
 %% erlfmt-ignore


### PR DESCRIPTION
~~In Javascript 1.8.5 we were able to just emit an error and it would serialized to json with a name, message and stacktrace. That can help during debugging.~~

~~With later Spidermonkey versions and now QuickJS, the error is serialized to "{}". That is expected based on [1] as Error fields are not enumerable ("Only enumerable own properties are visited"). But we could still do it perhaps if we detect that we have an Error in our emit wrapper and serialize it there to a string. But somehow `intanceof` doesn't work in the wrapper.~~

The mystery is solved (thanks, @janl!) I updated the PR and the new commit message is:

In views we drop any rows which throw errors. Sometimes users may want to either record which docs throw errors and build an error "key space" by doing `emit(['error', doc._id], e)` or something similar.

This used to work in Spidermonkey 1.8.5, where `Error` objects were json stringified as objects with `message` and `name` fields. Newer Javascript engines like Spidermonkey 91 and QuickJS, however, stringify `Error` objects as `{}`. That's expected according to the Javascript standard, but is not as nice for users who want to debug their map functions.

Users can of course still do `e.toString()` to stringify the error before emitting it, or emit the `.message` or `.name` separately, but since simply emitting or logging the error used to work, we can try bringing it back and let users to the same with the newer JS engines.

Implementation-wise, the initial attempt of using `value instanceof Error` unexpectedly failed, and Jan had solved the mystery - since `emit()` functions run in a sandbox, the `Error` object in the sandbox wasn't the same as the `Error` object in our emit wrapper code, so that always returned `false`. To solve that issue we opted to use some duck-typing, and see if the value is an object, is not null (`in` operator doesn't work on nulls), and then has the expected `Error` properties.

The same thing applies to the `log()` function so we can try to do the check there.

Thanks to Will Holley for noticing this issue and suggesting the solution, and to Jan Lehnardt for solving the `instanceof` sandbox mystery.

