### PR TITLE
Improve default chttpd server options

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -149,9 +149,8 @@ couch = couch_bt_engine
 ; These settings affect the main, clustered port (5984 by default).
 port = {{cluster_port}}
 bind_address = 127.0.0.1
-;backlog = 512
 ;socket_options = [{sndbuf, 262144}, {nodelay, true}]
-;server_options = [{recbuf, undefined}]
+;server_options = [{recbuf, undefined}, {acceptor_pool_size, 32}, {max, 65536}]
 ;require_valid_user = false
 ;require_valid_user_except_for_up = false
 

--- a/src/chttpd/src/chttpd.erl
+++ b/src/chttpd/src/chttpd.erl
@@ -20,6 +20,7 @@
 -export([
     start_link/0, start_link/1, start_link/2,
     stop/0,
+    get_default_server_options/0,
     handle_request/1,
     handle_request_int/1,
     primary_header_value/2,
@@ -93,7 +94,7 @@
     buffer_response = false
 }).
 
--define(DEFAULT_SERVER_OPTIONS, "[{recbuf, undefined}]").
+-define(DEFAULT_SERVER_OPTIONS, "[{recbuf, undefined}, {acceptor_pool_size, 32}, {max, 65536}]").
 -define(DEFAULT_SOCKET_OPTIONS, "[{sndbuf, 262144}, {nodelay, true}]").
 
 start_link() ->
@@ -201,6 +202,9 @@ start_link(Name, Options) ->
             io:format("Failure to start Mochiweb: ~s~n", [Reason]),
             {error, Reason}
     end.
+
+get_default_server_options() ->
+    ?DEFAULT_SERVER_OPTIONS.
 
 get_server_options(Module) ->
     ServerOptsCfg =

--- a/src/chttpd/src/chttpd_sup.erl
+++ b/src/chttpd/src/chttpd_sup.erl
@@ -23,7 +23,6 @@
 
 %% Helper macro for declaring children of supervisor
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 100, Type, [I]}).
--define(DEFAULT_BACKLOG, 512).
 -define(DEFAULT_SERVER_OPTIONS, "[{recbuf, undefined}]").
 
 start_link(Args) ->
@@ -60,8 +59,6 @@ handle_config_change("chttpd", "bind_address", Value, _, Settings) ->
     maybe_replace(bind_address, Value, Settings);
 handle_config_change("chttpd", "port", Value, _, Settings) ->
     maybe_replace(port, Value, Settings);
-handle_config_change("chttpd", "backlog", Value, _, Settings) ->
-    maybe_replace(backlog, Value, Settings);
 handle_config_change("chttpd", "server_options", Value, _, Settings) ->
     maybe_replace(server_options, Value, Settings);
 handle_config_change(_, _, _, _, Settings) ->
@@ -71,16 +68,11 @@ handle_config_terminate(_Server, _Reason, _State) ->
     ok.
 
 settings() ->
+    DefaultOpts = chttpd:get_default_server_options(),
     [
         {bind_address, config:get("chttpd", "bind_address")},
         {port, config:get("chttpd", "port")},
-        {backlog, config:get_integer("chttpd", "backlog", ?DEFAULT_BACKLOG)},
-        {server_options,
-            config:get(
-                "chttpd",
-                "server_options",
-                ?DEFAULT_SERVER_OPTIONS
-            )}
+        {server_options, config:get("chttpd", "server_options", DefaultOpts)}
     ].
 
 maybe_replace(Key, Value, Settings) ->

--- a/src/chttpd/test/eunit/chttpd_util_test.erl
+++ b/src/chttpd/test/eunit/chttpd_util_test.erl
@@ -30,7 +30,6 @@ setup() ->
         "{couch_httpd_auth, default_authentication_handler}",
         Persist
     ),
-    ok = config:set("httpd", "backlog", "512", Persist),
     ok = config:set("chttpd", "require_valid_user", "false", Persist),
     ok = config:set("httpd", "both_exist", "get_in_httpd", Persist),
     ok = config:set("chttpd", "both_exist", "get_in_chttpd", Persist),
@@ -44,7 +43,6 @@ setup() ->
 teardown(_) ->
     Persist = false,
     ok = config:delete("httpd", "authentication_handlers", Persist),
-    ok = config:delete("httpd", "backlog", Persist),
     ok = config:delete("chttpd", "require_valid_user", Persist),
     ok = config:delete("httpd", "both_exist", Persist),
     ok = config:delete("chttpd", "both_exist", Persist),

--- a/src/docs/src/api/server/configuration.rst
+++ b/src/docs/src/api/server/configuration.rst
@@ -79,12 +79,11 @@ interact with the local node's configuration.
             },
             "chttpd": {
                 "allow_jsonp": "false",
-                "backlog": "512",
                 "bind_address": "0.0.0.0",
                 "port": "5984",
                 "require_valid_user": "false",
                 "socket_options": "[{sndbuf, 262144}, {nodelay, true}]",
-                "server_options": "[{recbuf, undefined}]",
+                "server_options": "[{recbuf, undefined}, {acceptor_pool_size, 32}, {max, 65536}]",
                 "secure_rewrites": "true"
             },
             "httpd": {

--- a/src/docs/src/maintenance/performance.rst
+++ b/src/docs/src/maintenance/performance.rst
@@ -205,14 +205,14 @@ Connection limit
 ----------------
 
 `MochiWeb`_ handles CouchDB requests.
-The default maximum number of connections is 2048. To change this limit, use the
+The default maximum number of connections is 65535. To change this limit, use the
 ``server_options`` configuration variable. ``max`` indicates maximum number of
 connections.
 
 .. code-block:: ini
 
     [chttpd]
-    server_options = [{backlog, 128}, {acceptor_pool_size, 16}, {max, 4096}]
+    server_options = [{backlog, 128}, {acceptor_pool_size, 32}, {max, 262144}]
 
 .. _MochiWeb: https://github.com/mochi/mochiweb
 


### PR DESCRIPTION
Discussing with Jan in CouchDB slack, he reported benchmarking a recent release of Apache CouchDB and noticing a large difference in performance using these chttpd mochiweb server options:

```
[chttpd]
server_options = [{backlog, 128}, {acceptor_pool_size, 32}, {max, 65536}]
```

Let's make those the new defaults, and also remove the unused separate `backlog` setting. We diligently documented and carried it along for many years a while it turns out it doesn't do anything.

Only the `backlog` from `server_options` changes the backlog, and that default is 128, so we've been running with 128 all these years anyway.
