### PR TITLE
Fix purge_infos when exceeding purged_infos_limit

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -112,6 +112,7 @@
     fold_changes/4,
     fold_changes/5,
     count_changes_since/2,
+    fold_purge_infos/3,
     fold_purge_infos/4,
     fold_purge_infos/5,
 
@@ -1804,6 +1805,10 @@ fold_changes(Db, StartSeq, UserFun, UserAcc) ->
 
 fold_changes(Db, StartSeq, UserFun, UserAcc, Opts) ->
     couch_db_engine:fold_changes(Db, StartSeq, UserFun, UserAcc, Opts).
+
+fold_purge_infos(Db, Fun, Acc) ->
+    StartPurgeSeq = max(0, couch_db:get_oldest_purge_seq(Db) - 1),
+    fold_purge_infos(Db, StartPurgeSeq, Fun, Acc, []).
 
 fold_purge_infos(Db, StartPurgeSeq, Fun, Acc) ->
     fold_purge_infos(Db, StartPurgeSeq, Fun, Acc, []).

--- a/src/couch/src/couch_db_split.erl
+++ b/src/couch/src/couch_db_split.erl
@@ -331,8 +331,7 @@ copy_meta(#state{source_db = SourceDb, targets = Targets} = State) ->
     State#state{targets = Targets1}.
 
 copy_purge_info(#state{source_db = Db} = State) ->
-    Seq = max(0, couch_db:get_oldest_purge_seq(Db) - 1),
-    {ok, NewState} = couch_db:fold_purge_infos(Db, Seq, fun purge_cb/2, State),
+    {ok, NewState} = couch_db:fold_purge_infos(Db, fun purge_cb/2, State),
     Targets = maps:map(
         fun(_, #target{} = T) ->
             commit_purge_infos(T)

--- a/src/couch_index/src/couch_index_updater.erl
+++ b/src/couch_index/src/couch_index_updater.erl
@@ -215,7 +215,10 @@ purge_index(Db, Mod, IdxState) ->
                         []
                     )
                 catch
-                    error:{invalid_start_purge_seq, _} ->
+                    error:{invalid_start_purge_seq, StartSeqErr, MinSeqErr} ->
+                        DbName = couch_db:name(Db),
+                        ErrMsg = "~p : ~p db:~p resetting index min purge seq: ~p start seq:~p",
+                        couch_log:error(ErrMsg, [?MODULE, Mod, DbName, MinSeqErr, StartSeqErr]),
                         exit({reset, self()})
                 end,
             Mod:update_local_purge_doc(Db, NewStateAcc),

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -302,7 +302,7 @@ update_docs(DbName, Docs0, Options) ->
 
 get_purged_infos(DbName) ->
     FoldFun = fun({_Seq, _UUID, Id, Revs}, Acc) -> {ok, [{Id, Revs} | Acc]} end,
-    with_db(DbName, [], {couch_db, fold_purge_infos, [0, FoldFun, []]}).
+    with_db(DbName, [], {couch_db, fold_purge_infos, [FoldFun, []]}).
 
 get_purge_seq(DbName, Options) ->
     with_db(DbName, Options, {couch_db, get_purge_seq, []}).


### PR DESCRIPTION
Previously, when the number of purges exceeded the `purged_infos_limit`, and the database was compacted, `purged_infos` would crash because it would always fold purges starting at 0 instead of the minimal start sequence. In all the other places like mem3, shard splitter, etc we looked up the minimal sequence and started from there, but we didnt' for purge_infos.

To fix it, add a helper couch_db API to always do the start sequence lookup at the minimal sequence. Also, explain in the couch_bt_engine in a comment why we validate the minimal sequence and ensure if/when we throw assert we show the minimal value in addition to the start sequence.

To ensure we don't miss this again add a test to set a low purged infos limit, compact and fetch purged infos.

Fix: #5438
