### PR TITLE
fix arithmetic mean in _prometheus

### DIFF
--- a/src/couch_prometheus/src/couch_prometheus_util.erl
+++ b/src/couch_prometheus/src/couch_prometheus_util.erl
@@ -173,7 +173,7 @@ to_prom_summary(Path, Info) ->
         Percentiles
     ),
     SumMetric = path_to_name(Path ++ ["seconds", "sum"]),
-    SumStat = to_prom(SumMetric, Count * Mean),
+    SumStat = to_prom(SumMetric, (Count * Mean) / 1000),
     CountMetric = path_to_name(Path ++ ["seconds", "count"]),
     CountStat = to_prom(CountMetric, Count),
     to_prom(Metric, summary, desc(Info), Quantiles) ++ [SumStat, CountStat].


### PR DESCRIPTION
## Overview

Incoming metrics are in milliseconds (e.g, [couchdb, dbinfo] is a diff of os:timestamp's divided by 1000) but we claim they are seconds in prometheus response. note that we correctly divided by a further 1000 for the percentiles but not the arithmetic mean.

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/5446

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
