### PR TITLE
Optimise config to use persistent terms

### DIFF
--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -21,7 +21,6 @@
 -define(SIZE_BLOCK, 16#1000).
 -define(PREFIX_SIZE, 5).
 -define(DEFAULT_READ_COUNT, 1024).
--define(WRITE_XXHASH_CHECKSUMS_KEY, {?MODULE, write_xxhash_checksums}).
 -define(WRITE_XXHASH_CHECKSUMS_DEFAULT, false).
 
 -define(USE_CFILE_DEFAULT, true).
@@ -57,9 +56,6 @@
 
 %% helper functions
 -export([process_info/1]).
-
-% test helper functions
--export([reset_checksum_persistent_term_config/0]).
 
 %%----------------------------------------------------------------------
 %% Args:   Valid Options are [create] and [create,overwrite].
@@ -937,22 +933,9 @@ legacy_checksums_stats_update() ->
         false -> ok
     end.
 
-reset_checksum_persistent_term_config() ->
-    persistent_term:erase(?WRITE_XXHASH_CHECKSUMS_KEY).
-
 generate_xxhash_checksums() ->
-    % Caching the config value here as we'd need to call this per file chunk
-    % and also from various processes (not just couch_file pids). Node must be
-    % restarted for the new value to take effect.
-    case persistent_term:get(?WRITE_XXHASH_CHECKSUMS_KEY, not_cached) of
-        not_cached ->
-            Default = ?WRITE_XXHASH_CHECKSUMS_DEFAULT,
-            Val = config:get_boolean("couchdb", "write_xxhash_checksums", Default),
-            persistent_term:put(?WRITE_XXHASH_CHECKSUMS_KEY, Val),
-            Val;
-        Val when is_boolean(Val) ->
-            Val
-    end.
+    Default = ?WRITE_XXHASH_CHECKSUMS_DEFAULT,
+    config:get_boolean("couchdb", "write_xxhash_checksums", Default).
 
 % couch_cfile handling
 %

--- a/src/couch/test/eunit/couch_file_tests.erl
+++ b/src/couch/test/eunit/couch_file_tests.erl
@@ -753,8 +753,7 @@ setup_checksum() ->
 teardown_checksum({Ctx, Path}) ->
     file:delete(Path),
     meck:unload(),
-    test_util:stop_couch(Ctx),
-    couch_file:reset_checksum_persistent_term_config().
+    test_util:stop_couch(Ctx).
 
 t_write_read_xxhash_checksums({_Ctx, Path}) ->
     enable_xxhash(),
@@ -893,12 +892,10 @@ t_can_detect_block_corruption_with_legacy_checksum({_Ctx, Path}) ->
     catch couch_file:close(Fd1).
 
 enable_xxhash() ->
-    couch_file:reset_checksum_persistent_term_config(),
     reset_legacy_checksum_stats(),
     config:set("couchdb", "write_xxhash_checksums", "true", _Persist = false).
 
 disable_xxhash() ->
-    couch_file:reset_checksum_persistent_term_config(),
     reset_legacy_checksum_stats(),
     config:set("couchdb", "write_xxhash_checksums", "false", _Persist = false).
 

--- a/src/couch_replicator/src/couch_replicator_parse.erl
+++ b/src/couch_replicator/src/couch_replicator_parse.erl
@@ -701,8 +701,8 @@ t_parse_db_url(_) ->
 
 t_parse_db_invalid_protocol(_) ->
     MeckFun = fun
-        ("replicator", "valid_endpoint_protocols", _) -> "https";
-        (_, _, Default) -> Default
+        ("replicator", "valid_endpoint_protocols") -> "https";
+        (K, V) -> meck:passthrough([K, V])
     end,
     meck:expect(config, get, MeckFun),
     PUrl = <<"http://x">>,
@@ -717,8 +717,8 @@ t_parse_db_invalid_protocol(_) ->
 
 t_parse_proxy_invalid_protocol(_) ->
     MeckFun = fun
-        ("replicator", "valid_proxy_protocols", _) -> "socks5";
-        (_, _, Default) -> Default
+        ("replicator", "valid_proxy_protocols") -> "socks5";
+        (K, V) -> meck:passthrough([K, V])
     end,
     meck:expect(config, get, MeckFun),
     Url = <<"http://a">>,

--- a/src/smoosh/src/smoosh_utils.erl
+++ b/src/smoosh/src/smoosh_utils.erl
@@ -286,6 +286,6 @@ meck_from_to(From, To) ->
     end).
 
 meck_chans(Type, Channels) ->
-    meck:expect(config, get, fun("smoosh", T, _) when T =:= Type -> Channels end).
+    meck:expect(config, get, fun("smoosh", T) when T =:= Type -> Channels end).
 
 -endif.


### PR DESCRIPTION
When toggling the xxHash checksum setting we noticed that it was kind of annoying that we had to restart the nodes for it to take effect. The setting was optimised to be cached in a persistent term [1], so instead of making some extra process monitor or extra config listener, let's instead optimise all the config settings to use persistent terms. We may get a tiny bit of a performance boost from lookup, and maybe less memory pressure as persistent terms are referenced instead of copied unlike those read from an ets table (which are copied, unless they are refc binaries).

The change was smaller than expected, it's just swapping out internal ets operations for the persistent term ones. The external API stays the same.

The changes in the smoosh and replicator tests are because they were mocking config so they needed a few fixups. 

couch_file was cleaned up so xxHash setting now is read directly from the config.

While at it, found a few gaps in our config test suite so improved the coverage a bit as well.

[1] persistent terms are recommended for this exact usage -- config values which would be read often, and but rarely updated. The internal Erlang/OTP logger settings, for instance, are kept in persistent terms, we keep our features map like that as well.
