### PR TITLE
BigInt support for QuickJS

### DIFF
--- a/src/couch_quickjs/c_src/couchjs.c
+++ b/src/couch_quickjs/c_src/couchjs.c
@@ -94,6 +94,7 @@ static void add_cx_methods(JSContext* cx) {
   JS_AddIntrinsicRegExp(cx);
   JS_AddIntrinsicMapSet(cx);
   JS_AddIntrinsicDate(cx);
+  JS_AddIntrinsicBigInt(cx);
 }
 
 // Creates a new JSContext with only the provided sandbox function


### PR DESCRIPTION
Literals have the `n` suffix: `0n`, `-20n`. They can be parsed from a string:(ex: `x = BigInt("12..34")`) and serialized back to a string with `toString()` (ex: `emit(x.toString())`).

Currently this is a minimal, standards compliant implementation which doesn't do automatic JSON parsing directly to BigInts or automatically serializing to JSON. It should be possible to introduce that in the future, but it's better to start from something simpler first.
