### PR TITLE
Make sure terminate/2 is called in config

### DIFF
--- a/src/config/src/config.erl
+++ b/src/config/src/config.erl
@@ -276,6 +276,8 @@ subscribe_for_changes(Subscription) ->
     config_notifier:subscribe(Subscription).
 
 init(IniFilesDirs) ->
+    % trap exits to make sure terminate/2 gets called
+    process_flag(trap_exit, true),
     enable_early_features(),
     erase_all(),
     IniFiles = expand_dirs(IniFilesDirs),


### PR DESCRIPTION
The callback was not called as we didn't trap exits. This is not a big deal at runtime, as the process would go down anyway after config app terminates, and even if it restarts, we'd clean up all the config values anyway in init. However, when running tests this could leave config value set from the previous config app run.
