### PR TITLE
upgrade clause for fabric_doc_update

### DIFF
--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -72,6 +72,15 @@ go(DbName, AllDocs0, Opts) ->
         rexi_monitor:stop(RexiMon)
     end.
 
+% upgrade clause
+handle_message(Msg, Worker, {WaitingCount, DocCount, W, GroupedDocs, Reply}) ->
+    handle_message(Msg, Worker, #acc{
+        waiting_count = WaitingCount,
+        doc_count = DocCount,
+        w = W,
+        grouped_docs = GroupedDocs,
+        reply = Reply
+    });
 handle_message({rexi_DOWN, _, {_, NodeRef}, _}, _Worker, #acc{} = Acc0) ->
     #acc{grouped_docs = GroupedDocs} = Acc0,
     NewGrpDocs = [X || {#shard{node = N}, _} = X <- GroupedDocs, N =/= NodeRef],


### PR DESCRIPTION
## Overview

acc record introduced in d3eb273060958ee39cb2fc1bc32cfe487094de22

add a clause so an upgraded node can receive a message from a not-yet-upgraded node during a cluster upgrade


## Testing recommendations

Confirm doc updates work in a cluster with and without the d3eb273060958ee39cb2fc1bc32cfe487094de22 commit

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/5385
https://github.com/apache/couchdb/pull/5371 (#5385 is a prereq)

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
