### PR TITLE
nouveau: base64 only takes binaries

### DIFF
--- a/src/nouveau/src/nouveau_bookmark.erl
+++ b/src/nouveau/src/nouveau_bookmark.erl
@@ -50,7 +50,7 @@ unpack(_DbName, Empty) when Empty == undefined; Empty == nil; Empty == null ->
 unpack(DbName, PackedBookmark) when is_list(PackedBookmark) ->
     unpack(DbName, list_to_binary(PackedBookmark));
 unpack(DbName, PackedBookmark) when is_binary(PackedBookmark) ->
-    Bookmark = jiffy:decode(base64:decode(PackedBookmark), [return_maps]),
+    Bookmark = jiffy:decode(b64url:decode(PackedBookmark), [return_maps]),
     maps:from_list([{range_of(DbName, V), V} || V <- Bookmark]).
 
 pack(nil) ->
@@ -58,7 +58,7 @@ pack(nil) ->
 pack({EJson}) when is_list(EJson) ->
     pack(from_ejson(EJson));
 pack(UnpackedBookmark) when is_map(UnpackedBookmark) ->
-    base64:encode(jiffy:encode(maps:values(UnpackedBookmark))).
+    b64url:encode(jiffy:encode(maps:values(UnpackedBookmark))).
 
 %% legacy use of ejson within mango
 from_ejson({Props}) ->


### PR DESCRIPTION
## Overview

jiffy may return an iolist but base64:encode() cannot take iolists as input. since we also want urlsafe encoding we switch base64:encode to b64url:encode/1 as it will accept iolists. this matches dreyfus behaviour too.

closes #5453

## Testing recommendations

Run test suite

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/5453

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
