### PR TITLE
Couch scanner plugin: conflict finder

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1003,6 +1003,7 @@ url = {{nouveau_url}}
 [couch_scanner_plugins]
 ;couch_scanner_plugin_ddoc_features = false
 ;couch_scanner_plugin_find = false
+;couch_scanner_plugin_conflict_finder = false
 ;couch_quickjs_scanner_plugin = false
 
 ; The following [$plugin*] settings apply to all plugins
@@ -1069,6 +1070,20 @@ url = {{nouveau_url}}
 ; are too many design documents, that may generate a lot of logs. The default
 ; is to aggregate reports per database.
 ;ddoc_report = false
+
+[couch_scanner_plugin_conflict_finder]
+; Which types of conflicting docs to scan.
+;conflicts = true
+;deleted_conflicts = true
+
+; Emit reports for each conflicted doc or aggregate them per database.
+; If doc_report is set to true, the report will indicate doc name and revs info.
+; Otherwise, only conflicted doc numbers are accumulated.
+;doc_report = true
+
+; Limit the number of revs shown in the doc report.
+; To see the full list, please try `GET /{db}/{docid}?conflicts=true&deleted_conflicts=true`
+;max_revs = 10
 
 [couch_quickjs_scanner_plugin]
 ; Limit the number of ddocs processed per db

--- a/src/couch_scanner/README.md
+++ b/src/couch_scanner/README.md
@@ -88,7 +88,7 @@ checkpoint document. Plugin modules may implement the optional `checkpoint/1`
 API and save some plugin specific data alongside the database traversal
 checkpoint which gets saved automatically. For instance, it maybe useful for
 plugins to save their start up configuration to detect when it changes so they
-could restart their scanning. Or, it they want to accumulate some statistics
+could restart their scanning. Or, if they want to accumulate some statistics
 and only emit them at the end of the scan.
 
 Reading and writing to checkpoints is done in the

--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -35,7 +35,7 @@
 % calls will be called with the same St object, and may return an updated
 % version of it.
 %
-% If the plugin hasn't completed runing and has resumed running after the node
+% If the plugin hasn't completed running and has resumed running after the node
 % was restarted or an error happened, the resume/2 function will be called.
 % That's the difference between start and resume: start/2 is called when the
 % scan starts from the beginning (first db, first shard, ...), and resume/2 is
@@ -52,7 +52,7 @@
 % checkpoint map value.
 %
 % The complete/1 callback is called when the scan has finished. The complete
-% callback should return final checkpoint map object. The last checkoint will
+% callback should return final checkpoint map object. The last checkpoint will
 % be written and then it will be passed to the start/2 callback if the plugin
 % runs again.
 %

--- a/src/couch_scanner/src/couch_scanner_plugin_conflict_finder.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin_conflict_finder.erl
@@ -1,0 +1,212 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_scanner_plugin_conflict_finder).
+-behaviour(couch_scanner_plugin).
+
+-export([
+    start/2,
+    resume/2,
+    complete/1,
+    checkpoint/1,
+    db/2,
+    doc_id/3
+]).
+
+-include_lib("couch_scanner/include/couch_scanner_plugin.hrl").
+
+-record(st, {
+    sid,
+    opts = #{},
+    dbname,
+    report = #{},
+    doc_report = true,
+    max_revs = 10
+}).
+
+-define(CONFLICTS, <<"conflicts">>).
+-define(DELETED_CONFLICTS, <<"deleted_conflicts">>).
+
+-define(OPTS, #{
+    ?CONFLICTS => true,
+    ?DELETED_CONFLICTS => true
+}).
+
+% Behavior callbacks
+
+start(SId, #{}) ->
+    St = init_config(#st{sid = SId}),
+    ?INFO("Starting.", [], #{sid => SId}),
+    {ok, St}.
+
+resume(SId, #{<<"opts">> := OldOpts}) ->
+    St = init_config(#st{sid = SId}),
+    case OldOpts == St#st.opts of
+        true ->
+            ?INFO("Resuming.", [], #{sid => SId}),
+            {ok, St};
+        false ->
+            ?INFO("Resetting. Config changed.", [], #{sid => SId}),
+            reset
+    end.
+
+complete(#st{sid = SId, dbname = DbName, report = Report} = St) ->
+    report_per_db(St, DbName, Report),
+    ?INFO("Completed", [], #{sid => SId}),
+    {ok, #{}}.
+
+checkpoint(#st{sid = SId, opts = Opts}) ->
+    case Opts == opts() of
+        true ->
+            {ok, #{<<"opts">> => Opts}};
+        false ->
+            ?INFO("Resetting. Config changed.", [], #{sid => SId}),
+            reset
+    end.
+
+db(#st{} = St, _DbName) ->
+    {ok, St}.
+
+doc_id(#st{} = St, <<?DESIGN_DOC_PREFIX, _/binary>>, _Db) ->
+    {skip, St};
+doc_id(#st{} = St, DocId, Db) ->
+    {ok, #doc_info{revs = Revs}} = couch_db:get_doc_info(Db, DocId),
+    DbName = mem3:dbname(couch_db:name(Db)),
+    {ok, check(St, DbName, DocId, Revs)}.
+
+% Private
+
+init_config(#st{} = St) ->
+    St#st{
+        opts = opts(),
+        doc_report = cfg_bool("doc_report", St#st.doc_report),
+        max_revs = cfg_int("max_revs", St#st.max_revs)
+    }.
+
+cfg_int(Key, Default) when is_list(Key), is_integer(Default) ->
+    config:get_integer(atom_to_list(?MODULE), Key, Default).
+
+cfg_bool(Key, Default) when is_list(Key), is_boolean(Default) ->
+    config:get_boolean(atom_to_list(?MODULE), Key, Default).
+
+opts() ->
+    Fun = fun(Key, Default) -> cfg_bool(binary_to_list(Key), Default) end,
+    maps:map(Fun, ?OPTS).
+
+check(#st{} = St, _, _, Revs) when length(Revs) =< 1 ->
+    St;
+check(#st{doc_report = true, max_revs = Max, opts = Opts} = St, DbName, DocId, Revs) ->
+    {DeletedConflicts, Conflicts} = lists:partition(fun(R) -> R#rev_info.deleted end, Revs),
+    ConflictsReport = gen_report(doc, ?CONFLICTS, Opts, Conflicts, Max),
+    DeletedConflictsReport = gen_report(doc, ?DELETED_CONFLICTS, Opts, DeletedConflicts, Max),
+    DocReport = maps:merge(ConflictsReport, DeletedConflictsReport),
+    report_per_doc(#st{} = St, DbName, DocId, DocReport),
+    DbReport = maps:map(
+        fun(_K, V) ->
+            case V of
+                V when is_list(V) -> length(V);
+                N when is_number(N) -> N
+            end
+        end,
+        DocReport
+    ),
+    report(#st{} = St, DbName, DbReport);
+check(#st{max_revs = _Max, opts = Opts} = St, DbName, _DocId, Revs) ->
+    {DeletedConflicts, Conflicts} =
+        lists:partition(fun(R) -> R#rev_info.deleted end, Revs),
+    ConflictsReport = gen_report(db, ?CONFLICTS, Opts, Conflicts, _Max),
+    DeletedConflictsReport = gen_report(db, ?DELETED_CONFLICTS, Opts, DeletedConflicts, _Max),
+    DbReport = maps:merge(ConflictsReport, DeletedConflictsReport),
+    report(#st{} = St, DbName, DbReport).
+
+gen_report(doc, ?CONFLICTS, #{?CONFLICTS := true}, Revs, Max) when length(Revs) =< Max ->
+    #{?CONFLICTS => [?b2l(couch_doc:rev_to_str(R#rev_info.rev)) || R <- Revs]};
+gen_report(doc, ?DELETED_CONFLICTS, #{?DELETED_CONFLICTS := true}, Revs, Max) when
+    length(Revs) =< Max
+->
+    #{?DELETED_CONFLICTS => [?b2l(couch_doc:rev_to_str(R#rev_info.rev)) || R <- Revs]};
+gen_report(_ReportType, ?CONFLICTS, #{?CONFLICTS := true}, Revs, _Max) ->
+    #{?CONFLICTS => length(Revs)};
+gen_report(_ReportType, ?DELETED_CONFLICTS, #{?DELETED_CONFLICTS := true}, Revs, _Max) ->
+    #{?DELETED_CONFLICTS => length(Revs)};
+gen_report(_ReportType, _Key, #{} = _Opts, _Revs, _Max) ->
+    #{}.
+
+report(#st{} = St, DbName, Report) ->
+    #st{report = Total, dbname = PrevDbName} = St,
+    case is_binary(PrevDbName) andalso DbName =/= PrevDbName of
+        true ->
+            % We switched dbs, so report stats for old db
+            % and make the new one the current one
+            report_per_db(St, PrevDbName, Total),
+            St#st{report = Report, dbname = DbName};
+        false ->
+            % Keep accumulating per-db stats
+            St#st{report = merge_report(Total, Report), dbname = DbName}
+    end.
+
+merge_report(#{} = Total, #{} = Update) ->
+    Fun = fun(_K, V1, V2) -> V1 + V2 end,
+    maps:merge_with(Fun, Total, Update).
+
+report_per_db(#st{sid = SId}, DbName, #{} = Report) when
+    map_size(Report) > 0, is_binary(DbName)
+->
+    {Fmt, Args} = report_fmt(Report),
+    Meta = #{sid => SId, db => DbName},
+    ?WARN(Fmt, Args, Meta);
+report_per_db(#st{}, _, _) ->
+    ok.
+
+report_per_doc(#st{sid = SId}, DbName, DocId, Report) when
+    map_size(Report) > 0, is_binary(DbName)
+->
+    {Fmt, Args} = report_fmt(Report),
+    Meta = #{sid => SId, db => DbName, doc => DocId},
+    ?WARN(Fmt, Args, Meta);
+report_per_doc(#st{}, _, _, _) ->
+    ok.
+
+report_fmt(Report) ->
+    Sorted = lists:sort(maps:to_list(Report)),
+    FmtArgs = [{"~s:~p ", [K, V]} || {K, V} <- Sorted],
+    {Fmt1, Args1} = lists:unzip(FmtArgs),
+    Fmt2 = lists:flatten(Fmt1),
+    Args2 = flatten_one_level(Args1),
+    {Fmt2, Args2}.
+
+flatten_one_level(List) when is_list(List) ->
+    case lists:flatten(List) =:= List of
+        true ->
+            List;
+        false ->
+            lists:append([
+                case is_list(E) of
+                    true -> E;
+                    false -> [E]
+                end
+             || E <- List
+            ])
+    end.
+
+-ifdef(TEST).
+-include_lib("couch/include/couch_eunit.hrl").
+flatten_one_level_test() ->
+    ?assertEqual([1, 2, 3], flatten_one_level([1, 2, 3])),
+    ?assertEqual([1, 2, 3], flatten_one_level([[1], 2, 3])),
+    ?assertEqual([1, 2, 3], flatten_one_level([[1, 2], 3])),
+    ?assertEqual([1, 2, 3], flatten_one_level([[1], 2, [3]])),
+    ?assertEqual([1, [2], 3], flatten_one_level([[1, [2]], 3])),
+    ?assertEqual([1, [2], 3], flatten_one_level([[1, [2]], [3]])),
+    ?assertEqual([1, [2, [3]]], flatten_one_level([1, [[2, [3]]]])),
+    ?assertError(function_clause, flatten_one_level(wrong)).
+-endif.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Add `couch_scanner_plugin_conflict_finder` to find conflicting docs
in the database.

- If `doc_report` is set to true, the report will show doc name and
revision information.
e.g.: `couch_scanner_plugin_conflict_finder s:1742238038-9e432378f2f1 db:db doc:d1 conflicts:["2-y","2-x"] deleted_conflicts:["2-d"]`

- Otherwise, only conflicted revision numbers are accumulated.
e.g.: `couch_scanner_plugin_conflict_finder s:1742238038-9e432378f2f1 db:db conflicts:2 deleted_conflicts:1`

- If `max_revs = 1`, and the document has more than 1 revision, the
doc report will only show the length of the revs info, without the
details. By default, `max_revs = 10`.
e.g.: `couch_scanner_plugin_conflict_finder s:1742238038-9e432378f2f1 db:db doc:d1 conflicts:2 deleted_conflicts:["2-d"]`

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

Create a conflict document:
```bash
curl -X PUT http://adm:pass@127.0.0.1:15984/db
{"ok":true}

curl -X POST http://adm:pass@127.0.0.1:15984/db/_bulk_docs \
  -H 'Content-Type: application/json' \
  --data '{
    "new_edits": false,
    "docs": [
      {"_id":"d1","_revisions":{"start": 2,"ids":["x","z"]}},
      {"_id":"d1","_revisions":{"start": 2,"ids":["y","z"]}},
      {"_id":"d1","_deleted": true,"_revisions":{"start": 2,"ids":["d","z"]}}
    ]}'
[]
```

Enable couch scanner conflict finder plugin in `default.ini`:
```
[couch_scanner_plugins]
couch_scanner_plugin_conflict_finder = true

[couch_scanner_plugin_conflict_finder]
conflicts = true
deleted_conflicts = true
doc_report = true
max_revs = 10
```

Restart CouchDB, and check the logs for `warning`:
```logs
[warning] 2025-03-17T19:37:46.679537Z node1@127.0.0.1 <0.641.0> -------- couch_scanner_plugin_conflict_finder s:1742240266-8d4180ab2ba2 db:db doc:d1 conflicts:["2-y","2-x"] deleted_conflicts:["2-d"]
[warning] 2025-03-17T19:37:46.699397Z node1@127.0.0.1 <0.641.0> -------- couch_scanner_plugin_conflict_finder s:1742240266-8d4180ab2ba2 db:db conflicts:2 deleted_conflicts:1 
```

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

https://github.com/apache/couchdb/issues/5393

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
