### PR TITLE
Resolves #5456

### DIFF
--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -20,6 +20,24 @@
     :depth: 1
     :local:
 
+.. _release/3.4.x/upgrade:
+
+Upgrade Notes
+=============
+
+* When upgrading from 3.x to 3.4.x, if you have not customized your
+  node name in ``vm.args``, be sure to retain your original ``vm.args``
+  file. The default node name has changed from ``couchdb@localhost`` to
+  ``couchdb@127.0.0.1``, which can prevent CouchDB from accessing existing
+  databases on the system. You may also change the name option back to the
+  old value by setting ``-name couchdb@localhost`` in ``etc/vm.args`` by
+  hand. The default has changed to meet new guidelines and to provide
+  additional functionality in the future.
+
+  If you receive errors in the logfile, such as
+  ``internal_server_error : No DB shards could be opened.`` or in Fauxton,
+  such as ``This database failed to load.`` you need to make this change.
+
 .. _release/3.4.2:
 
 Version 3.4.2

--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -69,8 +69,8 @@ Features
 * :ghissue:`5294`: Return time spent waiting to update Nouveau index
   before query starts.
 
-Bufixes
--------
+Bugfixes
+--------
 * :ghissue:`5274`: Use normal Lucene syntax for unbounded ranges in
   Nouveau.
 * :ghissue:`5270`: Do not generate conflicts from the replicator


### PR DESCRIPTION
## Overview

Add upgrade notes for 3.x to 3.4.x to highlight the default node name has changed which may result in unwanted behaviour for users who left the CouchDB vm.args files unchanged from default

## Testing recommendations

Documentation validity checked as per https://github.com/apache/couchdb/tree/main/src/docs with:
```
make html
make check
```

## Related Issues or Pull Requests

Mentioned in issue [#5456](https://github.com/apache/couchdb/issues/5456#issuecomment-2704648877)

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
