### PR TITLE
nouveau: add a metric for connection_closed errors

### DIFF
--- a/src/nouveau/priv/stats_descriptions.cfg
+++ b/src/nouveau/priv/stats_descriptions.cfg
@@ -24,3 +24,8 @@
     {type, histogram},
     {desc, <<"Distribution of time during search waiting for the index to be updated">>}
 ]}.
+
+{[nouveau, connection_closed_errors], [
+    {type, counter},
+    {desc, <<"number of times we've retried a request after a connection_closed response">>}
+]}.

--- a/src/nouveau/src/nouveau_api.erl
+++ b/src/nouveau/src/nouveau_api.erl
@@ -344,6 +344,7 @@ retry_if_connection_closes(_Fun, 0) ->
 retry_if_connection_closes(Fun, N) when is_integer(N), N > 0 ->
     case Fun() of
         {error, connection_closed} ->
+            couch_stats:increment_counter([nouveau, connection_closed_errors]),
             timer:sleep(1000),
             retry_if_connection_closes(Fun, N - 1);
         Else ->


### PR DESCRIPTION
## Overview

add a metric for connection_closed errors

## Testing recommendations

N/A

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/5469

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
