### PR TITLE
Try to enable discussions again

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -84,6 +84,7 @@ notifications:
   commits: commits@couchdb.apache.org
   issues: notifications@couchdb.apache.org
   pullrequests: notifications@couchdb.apache.org
+  discussions: notifications@couchdb.apache.org
   # This would send new/closed PR notifications to dev@
   #pullrequests_status: dev@couchdb.apache.org
   # This would send individual PR comments/reviews to notifications@


### PR DESCRIPTION
It turns out we need to set up a notification ML target

Otherwise it doesn't work. See [1] for more details

[1] https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#repo_features