### PR TITLE
All 3.4.2 to 3.4.3 commits on 3.4.x

### DIFF
--- a/src/docs/src/install/unix.rst
+++ b/src/docs/src/install/unix.rst
@@ -32,12 +32,11 @@ to install CouchDB is to use the convenience binary packages:
 * CentOS/RHEL 7
 * CentOS/RHEL 8
 * CentOS/RHEL 9 (with caveats: depends on EPEL repository)
-* Debian 10 (buster)
 * Debian 11 (bullseye)
 * Debian 12 (bookworm)
-* Ubuntu 18.04 (bionic)
 * Ubuntu 20.04 (focal)
 * Ubuntu 22.04 (jammy)
+* Ubuntu 24.04 (noble)
 
 These RedHat-style rpm packages and Debian-style deb packages will install CouchDB at
 ``/opt/couchdb`` and ensure CouchDB is run at system startup by the appropriate init
@@ -161,7 +160,7 @@ You should have the following installed:
 * `Erlang OTP (25, 26, 27)      <http://erlang.org/>`_
 * `ICU                          <http://icu-project.org/>`_
 * `OpenSSL                      <http://www.openssl.org/>`_
-* `Mozilla SpiderMonkey (1.8.5, 60, 68, 78, 91) <https://spidermonkey.dev/>`_
+* `Mozilla SpiderMonkey (1.8.5, 60, 68, 78, 91, 102, 115, 128) <https://spidermonkey.dev/>`_
 * `GNU Make                     <http://www.gnu.org/software/make/>`_
 * `GNU Compiler Collection      <http://gcc.gnu.org/>`_
 * `help2man                     <http://www.gnu.org/s/help2man/>`_

--- a/src/docs/src/whatsnew/3.4.rst
+++ b/src/docs/src/whatsnew/3.4.rst
@@ -20,6 +20,103 @@
     :depth: 1
     :local:
 
+.. _release/3.4.3:
+
+Version 3.4.3
+=============
+
+Highlights
+----------
+
+* :ghissue:`5347`: Fix attachment size calculation. This could lead to shards
+  not being scheduled for compaction correctly.
+
+Performance
+-----------
+
+* :ghissue:`5437`: Fix ``atts_since`` functionality for document ``GET``
+  requests. Avoids re-replicating attachment bodies on doc updates.
+
+Features
+--------
+
+* :ghissue:`5439`: Nouveau: upgrade ``dropwizard`` to 4.0.12.
+* :ghissue:`5424`: Scanner: reduce log noise, fix QuickJS plugin mocks,
+  gracefully handle broken search indexes.
+* :ghissue:`5421`: Nouveau: upgrade Lucene to 9.12.1.
+* :ghissue:`5414`: Remove unused ``multi_workers`` option from
+  ``couch_work_queue``.
+* :ghissue:`5385`: Clean up ``fabric_doc_update`` by introducing an ``#acc``
+  record.
+* :ghissue:`5372`: Upgrade to Elixir 1.17.
+* :ghissue:`5351`: Clouseau: show version in ``/_version`` endpoint.
+* :ghissue:`5338`: Scanner: add Nouveau and Clouseau design doc validation.
+* :ghissue:`5335`: Nouveau: support reading older Lucene 9x indexes.
+* :ghissue:`5327`, :ghissue:`5329`, :ghissue:`5419`: Allow switching JavaScript
+  engines at runtime.
+* :ghissue:`5326`, :ghissue:`5328`: Allow clients to specify HTTP request ID,
+  including UUIDs.
+* :ghissue:`5321`, :ghissue:`5366`, :ghissue:`5413`: Add support for
+  SpiderMonkey versions 102, 115 and 128.
+* :ghissue:`5317`: Add `quickjs` to the list of welcome features.
+* :ghissue:`5471`: Add ``nouveau.connection_closed_errors`` metric. Bumped when
+  ``nouveau`` retries closed connections.
+
+Bugfixes
+--------
+
+* :ghissue:`5447`: Fix arithmetic mean in ``_prometheus``.
+* :ghissue:`5440`: Fix ``_purged_infos`` when exceeding ``purged_infos_limit``.
+* :ghissue:`5431`: Restore the ability to return ``Error`` objects from `map()`.
+* :ghissue:`5417`: Clouseau: add a version check to ``connected()`` function to
+  reliably detect if a Clouseau node is ready to be used.
+* :ghissue:`5416`: Ensure we always map the documents in order in
+  ``couch_mrview_updater``. While views still built correctly, this behaviour
+  simplifies debugging.
+* :ghissue:`5373`: Fix checksumming in ``couch_file``, consolidate similar
+  functions and bring test coverage from 66% to 90%.
+* :ghissue:`5367`: Scanner: be more resilient in the face of non-deterministic
+  functions.
+* :ghissue:`5345`: Scanner: be more resilient in the face of incomplete sample
+  data.
+* :ghissue:`5344`: Scanner: allow empty doc fields.
+* :ghissue:`5341`: Improve Mango test reliability.
+* :ghissue:`5337`: Prevent a broken ``mem3`` app from permanently failing
+  replication.
+* :ghissue:`5334`: Fix QuickJS scanner ``function_clause`` error.
+* :ghissue:`5332`: Skip deleted documents in the scanner.
+* :ghissue:`5331`: Skip validation for design docs in the scanner.
+* :ghissue:`5330`: Prevent inserting illegal design docs via Mango.
+* :ghissue:`5463`, :ghissue:`5453`: Fix Nouveau bookmark badarith error.
+* :ghissue:`5469`: Retry closed ``nouveau`` connections.
+
+Docs
+----
+
+* :ghissue:`5433`: Mango: document Nouveau index type.
+* :ghissue:`5433`: Nouveau: document Mango index type.
+* :ghissue:`5428`: Fix wrong link in example in ``CONTRIBUTING.md``.
+* :ghissue:`5400`: Clarify RHEL9 installation caveats.
+* :ghissue:`5380`, :ghissue:`5404`: Fix various typos.
+* :ghissue:`5338`: Clouseau: document version in ``/_version`` endpoint.
+* :ghissue:`5340`, :ghissue:`5412`: Nouveau: document search cleanup API.
+* :ghissue:`5316`, :ghissue:`5325`, :ghissue:`5426`, :ghissue:`5442`,
+  :ghissue:`5445`: Document various JavaScript engine incompatibilities,
+  including SpiderMonkey 1.8.5 vs. newer SpiderMonkey and SpiderMonkey vs.
+  QuickJS.
+* :ghissue:`5320`, :ghissue:`5374`: Improve auto-lockout feature documentation.
+* :ghissue:`5323`: Nouveau: improve install instructions.
+* :ghissue:`5434`: Document use of Nouveau docker image
+
+Tests
+_____
+
+* :ghissue:`5397`: Fix negative-steps error in Elixir tests.
+
+Builds
+------
+* :ghissue:`5360`: Use ``brew --prefix`` to find ICU paths on macOS.
+
 .. _release/3.4.2:
 
 Version 3.4.2

--- a/version.mk
+++ b/version.mk
@@ -1,3 +1,3 @@
 vsn_major=3
-vsn_minor=5
-vsn_patch=0
+vsn_minor=4
+vsn_patch=3


### PR DESCRIPTION
Squash all 3.4.2 to 3.4.3 commits on 3.4.x to bring them into main.

Start commit is:

```
commit 6e5ad2a5c5479cb09722b4a7d13b3d59b7bb2a23
Author: Nick Vatamaniuc <vatamane@gmail.com>
Date:   Mon Oct 14 14:21:20 2024

    Bump version to 3.4.2
```

Squash with command below and apply fixups

```
git rebase -i 6e5ad2a5c5479cb09722b4a7d13b3d59b7bb2a23
```
