### PR TITLE
Add "erlang" to the set of allowed languages in ken

### DIFF
--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -25,7 +25,8 @@
     new_proc/1,
     reload/0,
     terminate_stale_procs/0,
-    get_servers_from_env/1
+    get_servers_from_env/1,
+    native_query_server_enabled/0
 ]).
 
 -export([

--- a/src/ken/src/ken_server.erl
+++ b/src/ken/src/ken_server.erl
@@ -603,7 +603,12 @@ allowed_languages() ->
     Config =
         couch_proc_manager:get_servers_from_env("COUCHDB_QUERY_SERVER_") ++
             couch_proc_manager:get_servers_from_env("COUCHDB_NATIVE_QUERY_SERVER_"),
-    Allowed = [list_to_binary(string:to_lower(Lang)) || {Lang, _Cmd} <- Config],
+    Allowed0 = [list_to_binary(string:to_lower(Lang)) || {Lang, _Cmd} <- Config],
+    Allowed =
+        case couch_proc_manager:native_query_server_enabled() of
+            true -> [<<"erlang">> | Allowed0];
+            _Else -> Allowed0
+        end,
     [<<"query">> | Allowed].
 
 config(Key, Default) ->


### PR DESCRIPTION
## Overview

We discovered that `ken` was not indexing `erlang` design documents in the background, because it was relying on the old environment variables to determine that the native query server is enabled. This patch adds `erlang` to its list of allowed languages, if the native query server is enabled.

## Testing recommendations

I checked this by creating a database with these two design docs in it:

```json
  {
    "views": {
      "by-n": {
        "map": "function (doc) { emit(doc.n) }"
      }
    }
  }

  {
    "language": "erlang",
    "views": {
      "by-n": {
        "map": "fun({Doc}) -> N = proplists:get_value(<<\"n\">>, Doc, null), Emit(N, null) end."
      }
    }
  }
```

Before this fix, the `_info` endpoint for each doc shows that `updates_pending` remains high for the Erlang view, when the JS one goes to zero. The index files on disk for the Erlang view do not get updated when docs are added to the DB.

After this fix, `_info` on either view shows `updates_pending` eventually going to zero, and the files on disk get updated.

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
