### PR TITLE
Allow admin to configure ssl options for nouveau requests

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -936,6 +936,21 @@ port = {{prometheus_port}}
 enable = {{nouveau_enable}}
 url = {{nouveau_url}}
 
+; The following attributes configure CouchDB to present a client
+; certificate when communicating with a remote nouveau server over TLS.
+
+; Path to file containing the client key (required).
+;ssl_key_file =
+
+; Path to a file containing the client certificate (required).
+;ssl_cert_file =
+
+; Path to file containing the password to the client key (optional).
+;ssl_password =
+
+; Path to file containing CA certificate for the remote nouveau server (optional).
+;ssl_cacert_file =
+
 [disk_monitor]
 ;enable = false
 ;background_view_indexing_threshold = 80

--- a/src/docs/src/install/nouveau.rst
+++ b/src/docs/src/install/nouveau.rst
@@ -71,6 +71,67 @@ not essential and you may safely kill the JVM without letting it do
 this, though any uncommitted changes are necessarily lost. Once the
 JVM is started again this indexing work will be attempted again.
 
+Securing Nouveau
+================
+
+By default Nouveau uses HTTP without client authentication as it is commonly
+deployed on the same server as CouchDB itself. It is however possible to deploy
+Nouveau with robust security and this is strongly recommended when Nouveau is
+running on a separate server, even over a private network you trust.
+
+To enforce secure communications between CouchDB and the Nouveau server you need
+to modify configuration in both.
+
+We use mutual TLS to achieve private communication and ensure the identity of
+client and server.
+
+Configuring CouchDB to authenticate to Nouveau
+----------------------------------------------
+
+You can configure CouchDB to connect to a secured Nouveau server as follows;
+
+  .. code-block:: ini
+
+    [nouveau]
+    url = https://hostname:port
+    ssl_key_file = path to keyfile
+    ssl_cert_file = path to certfile
+    ssl_cacert_file = path to cacertfile
+    ssl_password = password
+
+You must set ``ssl_key_file`` and ``ssl_cert_file`` to activate client
+certificates. You might also need to set ``ssl_password`` if the
+``ssl_key_file`` is password-protected and might need to set ``ssl_cacert_file``
+if the Nouveau server's certificate is signed by a private CA.
+
+Configuring Nouveau to authenticate clients
+-------------------------------------------
+
+Nouveau is built on the dropwizard framework, which directly supports the `HTTPS
+<https://www.dropwizard.io/en/stable/manual/configuration.html#https>` transports.
+
+Acquiring or generating client and server certificates are out of scope of this
+documentation and we assume they have been created from here onward. We further
+assume the user can construct a Java keystore.
+
+in ``nouveau.yaml`` you should remove all connectors of type ``http`` and add new
+ones using ``https``;
+
+  .. code-block:: yaml
+
+    server:
+      applicationConnectors:
+        - type: https
+          port: 5987
+          keyStorePath: <path to keystore>
+          keyStorePassword: <password to keystore>
+          needClientAuth: true
+          validateCerts: true
+          validatePeers: true
+
+If you're using self-generated certificates you will also need to set the
+``trustStorePath`` and ``trustStorePassword`` attributes.
+
 Docker
 ======
 


### PR DESCRIPTION
## Overview

Allow an administrator to configure ssl options, in particular to add a client certificate, so that communication between couchdb and nouveau can be secured and authenticated when nouveau is deployed remotely.

Nouveau itself can be configured to listen with TLS and can be configured to require a valid client certificate on all requests.

https://www.dropwizard.io/en/stable/manual/configuration.html#https

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
