### PR TITLE
chore(`ci`): enable Clouseau for FreeBSD

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -107,7 +107,8 @@ meta = [
   'freebsd-x86_64': [
       name: 'FreeBSD x86_64',
       spidermonkey_vsn: '91',
-      with_clouseau: false,
+      with_clouseau: true,
+      clouseau_java_home: '/usr/local/openjdk8-jre',
       gnu_make: 'gmake'
   ],
 
@@ -116,7 +117,8 @@ meta = [
   'freebsd-arm64': [
      name: 'FreeBSD ARM64 QuickJS',
      disable_spidermonkey: true,
-     with_clouseau: false,
+     with_clouseau: true,
+     clouseau_java_home: '/usr/local/openjdk8-jre',
      gnu_make: 'gmake'
   ],
 


### PR DESCRIPTION
Java 8 has now been installed to both FreeBSD workers, so enable the Clouseau integration for them.  Kudos to @dch for making this happen!