### PR TITLE
Implement top_N/bottom_N built-in reducers

### DIFF
--- a/src/docs/src/ddocs/ddocs.rst
+++ b/src/docs/src/ddocs/ddocs.rst
@@ -161,6 +161,21 @@ Additionally, CouchDB has a set of built-in reduce functions. These are
 implemented in Erlang and run inside CouchDB, so they are much faster than the
 equivalent JavaScript functions.
 
+.. data:: _top_N
+
+.. versionadded:: 3.5
+
+Top ``N`` values, where ``N`` can be any number between ``1`` and ``100``
+inclusive. For instance, ``_top_5`` returns the list of the top 5 values.
+
+.. data:: _bottom_N
+
+.. versionadded:: 3.5
+
+Bottom ``N`` values where ``N`` can be any number between ``1`` and ``100``
+inclusive. For instance, ``_bottom_10`` returns the list of the bottom 10
+values.
+
 .. data:: _approx_count_distinct
 
 .. versionadded:: 2.2

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -438,7 +438,8 @@
   "ReduceBuiltinTest": [
     "Builtin count and sum reduce for key as array",
     "Builtin reduce functions",
-    "Builtin reduce functions with trailings"
+    "Builtin reduce functions with trailings",
+    "Invalid built-in reduce functions"
   ],
   "ReduceFalseTest": [
     "Basic reduce functions"


### PR DESCRIPTION
These should work with the already existing grouping functionality to keep track of last update times, or top sales numbers or anything of that sort.

For example, with a map function with a compound key like: 
```
function(doc){
   emit([doc.year, doc.month], doc.sales);
}
```

We can make requests like these:
```
http $DB/db/_design/d1/_view/top_1'?group=true&group_level=2&start_key=[2021]&limit=3'

{
    "rows": [
        {"key": [2021, 1], "value": [145.47625983483155]},
        {"key": [2021, 2], "value": [250.70341326647355]},
        {"key": [2021, 3], "value": [4484.3909590737285]}
    ]
}
```
