### PR TITLE
Fix missing documentation section title for _top_N reducer

### DIFF
--- a/src/docs/src/ddocs/ddocs.rst
+++ b/src/docs/src/ddocs/ddocs.rst
@@ -177,6 +177,8 @@ Return the value of the last row in group. For example, for a view like
 ``[a,1] : x, [a,2] : y``, queried with ``group_level=1``, it would return ``[a]
 : y``.
 
+.. data:: _top_N
+
 .. versionadded:: 3.5
 
 Top ``N`` values, where ``N`` can be any number between ``1`` and ``100``


### PR DESCRIPTION
I had messed up the docs update in the previous PR

Before:

<img width="616" alt="Screenshot 2025-04-05 at 3 24 26 PM" src="https://github.com/user-attachments/assets/ba6a4118-1845-4e66-a8f7-32ce29ce570f" />

After:

<img width="631" alt="Screenshot 2025-04-05 at 3 23 54 PM" src="https://github.com/user-attachments/assets/ec6851be-2132-4016-808a-d7333f3d9f2f" />
