### PR TITLE
Bring in latest QuickJS fixes

### DIFF
--- a/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
+++ b/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
@@ -1,6 +1,6 @@
---- quickjs-master/quickjs.c	2025-03-31 07:37:37
-+++ quickjs/quickjs.c	2025-04-03 11:48:29
-@@ -29117,10 +29117,24 @@
+--- quickjs-master/quickjs.c	2025-04-07 13:01:30
++++ quickjs/quickjs.c	2025-04-07 18:37:55
+@@ -29256,10 +29256,24 @@
      if (s->token.val == TOK_FUNCTION ||
          (token_is_pseudo_keyword(s, JS_ATOM_async) &&
           peek_token(s, TRUE) == TOK_FUNCTION)) {

--- a/src/couch_quickjs/quickjs/Changelog
+++ b/src/couch_quickjs/quickjs/Changelog
@@ -1,3 +1,11 @@
+- removed the bignum extensions and qjscalc
+- new BigInt implementation optimized for small numbers
+- added WeakRef, FinalizationRegistry and symbols as weakrefs
+- added builtin float64 printing and parsing functions for more correctness
+- faster repeated string concatenation
+- qjs: promise unhandled rejections are fatal errors by default
+- misc bug fixes
+
 2024-01-13:
 
 - top-level-await support in modules

--- a/src/couch_quickjs/quickjs/Makefile
+++ b/src/couch_quickjs/quickjs/Makefile
@@ -435,6 +435,7 @@ test: qjs
 	./qjs tests/test_bigint.js
 	./qjs tests/test_std.js
 	./qjs tests/test_worker.js
+	./qjs tests/test_cyclic_import.js
 ifdef CONFIG_SHARED_LIBS
 	./qjs tests/test_bjson.js
 	./qjs examples/test_point.js

--- a/src/couch_quickjs/quickjs/quickjs-atom.h
+++ b/src/couch_quickjs/quickjs/quickjs-atom.h
@@ -210,6 +210,8 @@ DEF(Float32Array, "Float32Array")
 DEF(Float64Array, "Float64Array")
 DEF(DataView, "DataView")
 DEF(BigInt, "BigInt")
+DEF(WeakRef, "WeakRef")
+DEF(FinalizationRegistry, "FinalizationRegistry")
 DEF(Map, "Map")
 DEF(Set, "Set") /* Map + 1 */
 DEF(WeakMap, "WeakMap") /* Map + 2 */

--- a/src/couch_quickjs/quickjs/quickjs-libc.c
+++ b/src/couch_quickjs/quickjs/quickjs-libc.c
@@ -3825,9 +3825,18 @@ static JSValue js_print(JSContext *ctx, JSValueConst this_val,
     return JS_UNDEFINED;
 }
 
+static JSValue js_console_log(JSContext *ctx, JSValueConst this_val,
+                              int argc, JSValueConst *argv)
+{
+    JSValue ret;
+    ret = js_print(ctx, this_val, argc, argv);
+    fflush(stdout);
+    return ret;
+}
+
 void js_std_add_helpers(JSContext *ctx, int argc, char **argv)
 {
-    JSValue global_obj, console, args;
+    JSValue global_obj, console, args, performance;
     int i;
 
     /* XXX: should these global definitions be enumerable? */
@@ -3835,8 +3844,13 @@ void js_std_add_helpers(JSContext *ctx, int argc, char **argv)
 
     console = JS_NewObject(ctx);
     JS_SetPropertyStr(ctx, console, "log",
-                      JS_NewCFunction(ctx, js_print, "log", 1));
+                      JS_NewCFunction(ctx, js_console_log, "log", 1));
     JS_SetPropertyStr(ctx, global_obj, "console", console);
+
+    performance = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, performance, "now",
+                      JS_NewCFunction(ctx, js_os_now, "now", 0));
+    JS_SetPropertyStr(ctx, global_obj, "performance", performance);
 
     /* same methods as the mozilla JS shell */
     if (argc >= 0) {

--- a/src/couch_quickjs/quickjs/quickjs.h
+++ b/src/couch_quickjs/quickjs/quickjs.h
@@ -322,7 +322,9 @@ static inline JSValue __JS_NewShortBigInt(JSContext *ctx, int64_t d)
 #define JS_PROP_NO_ADD           (1 << 16) /* internal use */
 #define JS_PROP_NO_EXOTIC        (1 << 17) /* internal use */
 
-#define JS_DEFAULT_STACK_SIZE (256 * 1024)
+#ifndef JS_DEFAULT_STACK_SIZE
+#define JS_DEFAULT_STACK_SIZE (1024 * 1024)
+#endif
 
 /* JS_Eval() flags */
 #define JS_EVAL_TYPE_GLOBAL   (0 << 0) /* global code (default) */
@@ -405,6 +407,7 @@ void JS_AddIntrinsicProxy(JSContext *ctx);
 void JS_AddIntrinsicMapSet(JSContext *ctx);
 void JS_AddIntrinsicTypedArrays(JSContext *ctx);
 void JS_AddIntrinsicPromise(JSContext *ctx);
+void JS_AddIntrinsicWeakRef(JSContext *ctx);
 
 JSValue js_string_codePointRange(JSContext *ctx, JSValueConst this_val,
                                  int argc, JSValueConst *argv);
@@ -829,6 +832,7 @@ int JS_DefinePropertyGetSet(JSContext *ctx, JSValueConst this_obj,
 void JS_SetOpaque(JSValue obj, void *opaque);
 void *JS_GetOpaque(JSValueConst obj, JSClassID class_id);
 void *JS_GetOpaque2(JSContext *ctx, JSValueConst obj, JSClassID class_id);
+void *JS_GetAnyOpaque(JSValueConst obj, JSClassID *class_id);
 
 /* 'buf' must be zero terminated i.e. buf[buf_len] = '\0'. */
 JSValue JS_ParseJSON(JSContext *ctx, const char *buf, size_t buf_len,

--- a/src/couch_quickjs/quickjs/test262.conf
+++ b/src/couch_quickjs/quickjs/test262.conf
@@ -107,7 +107,7 @@ Error.isError=skip
 explicit-resource-management=skip
 exponentiation
 export-star-as-namespace-from-module
-FinalizationRegistry=skip
+FinalizationRegistry
 Float16Array=skip
 Float32Array
 Float64Array
@@ -217,7 +217,7 @@ Symbol.split
 Symbol.toPrimitive
 Symbol.toStringTag
 Symbol.unscopables
-symbols-as-weakmap-keys=skip
+symbols-as-weakmap-keys
 tail-call-optimization=skip
 template
 Temporal=skip
@@ -231,7 +231,7 @@ Uint8Array
 uint8array-base64=skip
 Uint8ClampedArray
 WeakMap
-WeakRef=skip
+WeakRef
 WeakSet
 well-formed-json-stringify
 


### PR DESCRIPTION
 * break statement with labels fixes [1]
 * fix buffer overflow in bjson string + bigint reader [2]
 * bigint fixes [3] [4]
 * weak map gc fix [5]
 * segfault on large number of properties [6]
 * undefined is a valid variable name in global scope [7]

[1] https://github.com/bellard/quickjs/issues/275
[2] https://github.com/bellard/quickjs/issues/399
[3] https://github.com/bellard/quickjs/commit/083b7bab01
[4] https://github.com/bellard/quickjs/commit/fa706d5622
[5] https://github.com/bellard/quickjs/pull/393
[6] https://github.com/bellard/quickjs/issues/111
[7] https://github.com/bellard/quickjs/issues/370
