### PR TITLE
fix: Add blog.couchdb.org to frame-src CSP header to fix Fauxton News

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -444,7 +444,7 @@ authentication_db = _users
 ; CSP (Content Security Policy) Support
 [csp]
 ;utils_enable = true
-;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
+;utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src https://blog.couchdb.org;
 ;attachments_enable = true
 ;attachments_header_value = sandbox
 ;showlist_enable = true

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -101,7 +101,7 @@ handle_utils_dir_req(#httpd{method = 'GET'} = Req, DocumentRoot) ->
             CachingHeaders = [{"Cache-Control", "private, must-revalidate"}],
             DefaultValues =
                 "child-src 'self' data: blob:; default-src 'self'; img-src 'self' data:; font-src 'self'; "
-                "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
+                "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src https://blog.couchdb.org;",
             Headers = chttpd_util:maybe_add_csp_header("utils", CachingHeaders, DefaultValues),
             chttpd:serve_file(Req, RelativePath, DocumentRoot, Headers);
         {_ActionKey, "", _RelativePath} ->

--- a/src/chttpd/test/eunit/chttpd_csp_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_csp_tests.erl
@@ -125,7 +125,7 @@ should_not_return_any_csp_headers_when_disabled(_DbName) ->
 should_apply_default_policy(_DbName) ->
     ?_assertEqual(
         "child-src 'self' data: blob:; default-src 'self'; img-src 'self' data:; font-src 'self'; "
-        "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
+        "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src https://blog.couchdb.org;",
         begin
             {ok, _, Headers, _} = test_request:get(base_url() ++ "/_utils/"),
             proplists:get_value("Content-Security-Policy", Headers)
@@ -135,7 +135,7 @@ should_apply_default_policy(_DbName) ->
 should_apply_default_policy_with_legacy_config(_DbName) ->
     ?_assertEqual(
         "child-src 'self' data: blob:; default-src 'self'; img-src 'self' data:; font-src 'self'; "
-        "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';",
+        "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src https://blog.couchdb.org;",
         begin
             ok = config:set("csp", "utils_enable", "false", false),
             ok = config:set("csp", "enable", "true", false),

--- a/src/docs/src/config/misc.rst
+++ b/src/docs/src/config/misc.rst
@@ -235,7 +235,9 @@ Content-Security-Policy
         Specifies the exact header value to send. Defaults to::
 
             [csp]
-            utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';
+            utils_header_value = default-src 'self'; img-src 'self'; font-src *; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; frame-src https://blog.couchdb.org;
+
+        ``blog.couchdb.org`` exists to cover the optional Fauxton News page.
 
     .. config:option:: attachments_enable :: Enable CSP-Header (attachments)
 


### PR DESCRIPTION
## Overview

Fauxton’s News page fails with CSP error in the browser console

## Testing recommendations

Set the config yourself and see Fauxton News working again.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
