### PR TITLE
Update Fauxton to latest v1.3.3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -156,7 +156,7 @@ DepDescs = [
 
 %% %% Non-Erlang deps
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
-                   {tag, "v1.3.2"}, [raw]},
+                   {tag, "v1.3.3"}, [raw]},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-6"}},
 {jiffy,            "jiffy",            {tag, "1.1.2"}},
 {mochiweb,         "mochiweb",         {tag, "v3.2.2"}},
@@ -168,7 +168,7 @@ WithProper = lists:keyfind(with_proper, 1, CouchConfig) == {with_proper, true}.
 
 OptionalDeps = case WithProper of
     true ->
-        [{proper, {url, "https://github.com/proper-testing/proper"}, "a5ae5669f01143b0828fc21667d4f5e344aa760b"}];
+        [{proper, {url, "https://github.com/proper-testing/proper"}, "f2a44ee11a238c84403e72ee8ec68e6f65fd7e42"}];
     false ->
         []
 end.


### PR DESCRIPTION
Fauxton: https://github.com/apache/couchdb-fauxton/releases/tag/v1.3.3

Proper: https://github.com/proper-testing/proper/pull/322
