### PR TITLE
QuickJS updates

### DIFF
--- a/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
+++ b/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
@@ -1,6 +1,6 @@
---- quickjs-master/quickjs.c	2025-04-07 13:01:30
-+++ quickjs/quickjs.c	2025-04-07 18:37:55
-@@ -29256,10 +29256,24 @@
+--- quickjs-master/quickjs.c	2025-04-10 10:23:25
++++ quickjs/quickjs.c	2025-04-10 13:50:31
+@@ -29270,10 +29270,24 @@
      if (s->token.val == TOK_FUNCTION ||
          (token_is_pseudo_keyword(s, JS_ATOM_async) &&
           peek_token(s, TRUE) == TOK_FUNCTION)) {

--- a/src/couch_quickjs/quickjs/quickjs.h
+++ b/src/couch_quickjs/quickjs/quickjs.h
@@ -634,7 +634,8 @@ static inline JS_BOOL JS_IsUninitialized(JSValueConst v)
 
 static inline JS_BOOL JS_IsString(JSValueConst v)
 {
-    return JS_VALUE_GET_TAG(v) == JS_TAG_STRING;
+    return JS_VALUE_GET_TAG(v) == JS_TAG_STRING ||
+        JS_VALUE_GET_TAG(v) == JS_TAG_STRING_ROPE;
 }
 
 static inline JS_BOOL JS_IsSymbol(JSValueConst v)

--- a/src/couch_quickjs/quickjs/test262_errors.txt
+++ b/src/couch_quickjs/quickjs/test262_errors.txt
@@ -1,26 +1,6 @@
 test262/test/annexB/language/comments/single-line-html-close-first-line-1.js:1: unexpected error type: SyntaxError: unexpected token in expression: '>'
 test262/test/annexB/language/comments/single-line-html-close-first-line-2.js:1: unexpected error type: SyntaxError: unexpected token in expression: '>'
 test262/test/annexB/language/comments/single-line-html-close-first-line-3.js:1: unexpected error type: SyntaxError: unexpected token in expression: '>'
-test262/test/built-ins/Function/prototype/arguments/prop-desc.js:31: Test262Error: Function.prototype.arguments property getter/setter are the same function Expected SameValue(«function () {
-    [native code]
-}», «function () {
-    [native code]
-}») to be true
-test262/test/built-ins/Function/prototype/arguments/prop-desc.js:31: strict mode: Test262Error: Function.prototype.arguments property getter/setter are the same function Expected SameValue(«function () {
-    [native code]
-}», «function () {
-    [native code]
-}») to be true
-test262/test/built-ins/Function/prototype/caller/prop-desc.js:29: Test262Error: Caller property getter/setter are the same function Expected SameValue(«function () {
-    [native code]
-}», «function () {
-    [native code]
-}») to be true
-test262/test/built-ins/Function/prototype/caller/prop-desc.js:29: strict mode: Test262Error: Caller property getter/setter are the same function Expected SameValue(«function () {
-    [native code]
-}», «function () {
-    [native code]
-}») to be true
 test262/test/language/destructuring/binding/keyed-destructuring-property-reference-target-evaluation-order-with-bindings.js:73: Test262Error: Actual [binding::source, binding::sourceKey, sourceKey, get source, binding::defaultValue, binding::varTarget] and expected [binding::source, binding::sourceKey, sourceKey, binding::varTarget, get source, binding::defaultValue] should have the same contents. 
 test262/test/language/expressions/assignment/destructuring/iterator-destructuring-property-reference-target-evaluation-order.js:42: Test262Error: Actual [source, iterator, target, target-key, target-key-tostring, iterator-step, iterator-done, set] and expected [source, iterator, target, target-key, iterator-step, iterator-done, target-key-tostring, set] should have the same contents. 
 test262/test/language/expressions/assignment/destructuring/iterator-destructuring-property-reference-target-evaluation-order.js:42: strict mode: Test262Error: Actual [source, iterator, target, target-key, target-key-tostring, iterator-step, iterator-done, set] and expected [source, iterator, target, target-key, iterator-step, iterator-done, target-key-tostring, set] should have the same contents. 
@@ -41,12 +21,7 @@ test262/test/language/expressions/member-expression/computed-reference-null-or-u
 test262/test/language/expressions/member-expression/computed-reference-null-or-undefined.js:28: strict mode: Test262Error: Expected a TypeError but got a Test262Error
 test262/test/language/expressions/object/computed-property-name-topropertykey-before-value-evaluation.js:31: Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
 test262/test/language/expressions/object/computed-property-name-topropertykey-before-value-evaluation.js:31: strict mode: Test262Error: Expected SameValue(«"bad"», «"ok"») to be true
-test262/test/language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js:13: SyntaxError: Could not find export 'check' in module 'test262/test/language/module-code/top-level-await/async-module-sync_FIXTURE.js'
 test262/test/language/module-code/top-level-await/module-graphs-does-not-hang.js:10: TypeError: $DONE() not called
-test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js:40: SyntaxError: invalid property name
-test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-get-followed-by-generator-asi.js:40: strict mode: SyntaxError: invalid property name
-test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js:40: SyntaxError: invalid property name
-test262/test/language/statements/class/elements/syntax/valid/grammar-field-named-set-followed-by-generator-asi.js:40: strict mode: SyntaxError: invalid property name
 test262/test/language/statements/with/get-binding-value-call-with-proxy-env.js:39: Test262Error: Actual [has:Object, get:Symbol(Symbol.unscopables), get:Object] and expected [has:Object, get:Symbol(Symbol.unscopables), has:Object, get:Object] should have the same contents. 
 test262/test/language/statements/with/get-binding-value-idref-with-proxy-env.js:39: Test262Error: Actual [has:Object, get:Symbol(Symbol.unscopables), get:Object] and expected [has:Object, get:Symbol(Symbol.unscopables), has:Object, get:Object] should have the same contents. 
 test262/test/language/statements/with/get-mutable-binding-binding-deleted-in-get-unscopables-strict-mode.js:21: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all


### PR DESCRIPTION
 * Fix exporting destructured variables [1]
 * Fix class field name get or set [2]
 * TypeError compat fix [3]
 * Fixed JS_IsString() with ropes [4]
 * Fixed the handling of unicode identifiers [5]

[1] https://github.com/bellard/quickjs/commit/7adeb5c56e18858ab92337c59b393f0704538e22
[2] https://github.com/bellard/quickjs/commit/949c105aff1ff0c3edc0a1cb7c713c68509fc156
[3] https://github.com/bellard/quickjs/commit/d546fbfdb7d0f236c30a6c2a1a5641341e9d6aa7
[4] https://github.com/bellard/quickjs/commit/c505ac0f39d1b185a35c518b37db928b7b9bc2a9
[5] https://github.com/bellard/quickjs/commit/25ffdb418ea221eaab7605f24aa3087323cd501d
