### PR TITLE
Use new sets only in mango

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -287,16 +287,16 @@ extract_selector_hints(Selector) ->
     Modules = lists:flatmap(AsIndex, ?CURSOR_MODULES),
     Populate =
         fun({Module, IndexType}) ->
-            AllFields = sets:from_list(mango_selector:fields(Selector)),
+            AllFields = set_from_list(mango_selector:fields(Selector)),
             Normalize = fun(N) -> hd(string:split(N, ":")) end,
-            IndexableFields = sets:from_list(
+            IndexableFields = set_from_list(
                 lists:map(Normalize, Module:indexable_fields(Selector))
             ),
             UnindexableFields = sets:subtract(AllFields, IndexableFields),
             {[
                 {type, IndexType},
-                {indexable_fields, sets:to_list(IndexableFields)},
-                {unindexable_fields, sets:to_list(UnindexableFields)}
+                {indexable_fields, lists:sort(sets:to_list(IndexableFields))},
+                {unindexable_fields, lists:sort(sets:to_list(UnindexableFields))}
             ]}
         end,
     lists:map(Populate, Modules).
@@ -441,7 +441,9 @@ maybe_add_warning(UserFun, #cursor{index = Index, opts = Opts}, Stats, UserAcc) 
 
 % create a dummy cursor in absence of usable indexes, utilized by _explain
 create_cursor(Db, {[], Trace0}, Selector, Opts) ->
-    Blank = #{filtered_indexes => sets:new(), indexes_of_type => sets:new()},
+    Blank = #{
+        filtered_indexes => sets:new([{version, 2}]), indexes_of_type => sets:new([{version, 2}])
+    },
     Trace = maps:merge(Trace0, Blank),
     Limit = couch_util:get_value(limit, Opts, mango_opts:default_limit()),
     Skip = couch_util:get_value(skip, Opts, 0),
@@ -461,9 +463,9 @@ create_cursor(Db, {[], Trace0}, Selector, Opts) ->
         execution_stats = Stats
     }};
 create_cursor(Db, {Indexes, Trace0}, Selector, Opts) ->
-    Trace1 = maps:merge(Trace0, #{filtered_indexes => sets:from_list(Indexes)}),
+    Trace1 = maps:merge(Trace0, #{filtered_indexes => set_from_list(Indexes)}),
     [{CursorMod, CursorModIndexes} | _] = group_indexes_by_type(Indexes),
-    Trace = maps:merge(Trace1, #{indexes_of_type => sets:from_list(CursorModIndexes)}),
+    Trace = maps:merge(Trace1, #{indexes_of_type => set_from_list(CursorModIndexes)}),
     CursorMod:create(Db, {CursorModIndexes, Trace}, Selector, Opts).
 
 group_indexes_by_type(Indexes) ->
@@ -583,6 +585,9 @@ ddoc_name(<<"_design/", Name/binary>>) ->
 ddoc_name(Name) ->
     Name.
 
+set_from_list(KVs) ->
+    sets:from_list(KVs, [{version, 2}]).
+
 -ifdef(TEST).
 -include_lib("couch/include/couch_eunit.hrl").
 
@@ -613,8 +618,8 @@ t_create_regular(_) ->
     Trace1 = #{},
     Trace2 =
         #{
-            filtered_indexes => sets:from_list(FilteredIndexes),
-            indexes_of_type => sets:from_list(IndexesOfType)
+            filtered_indexes => set_from_list(FilteredIndexes),
+            indexes_of_type => set_from_list(IndexesOfType)
         },
     Options = [{use_index, []}, {allow_fallback, true}],
     meck:expect(mango_selector, normalize, [selector], meck:val(normalized_selector)),
@@ -643,8 +648,8 @@ t_create_user_specified_index(_) ->
     Trace1 = #{},
     Trace2 =
         #{
-            filtered_indexes => sets:from_list(FilteredIndexes),
-            indexes_of_type => sets:from_list(IndexesOfType)
+            filtered_indexes => set_from_list(FilteredIndexes),
+            indexes_of_type => set_from_list(IndexesOfType)
         },
     Options = [{use_index, [<<"_design/view_idx2">>]}],
     meck:expect(mango_selector, normalize, [selector], meck:val(normalized_selector)),
@@ -672,8 +677,8 @@ t_create_invalid_user_specified_index(_) ->
     Trace1 = #{},
     Trace2 =
         #{
-            filtered_indexes => sets:from_list(UsableIndexes),
-            indexes_of_type => sets:from_list(IndexesOfType)
+            filtered_indexes => set_from_list(UsableIndexes),
+            indexes_of_type => set_from_list(IndexesOfType)
         },
     Options = [{use_index, [<<"foobar">>]}, {allow_fallback, true}],
     meck:expect(mango_selector, normalize, [selector], meck:val(normalized_selector)),
@@ -701,8 +706,8 @@ t_create_invalid_user_specified_index_no_fallback(_) ->
     Trace1 = #{},
     Trace2 =
         #{
-            filtered_indexes => sets:from_list(UsableIndexes),
-            indexes_of_type => sets:from_list(IndexesOfType)
+            filtered_indexes => set_from_list(UsableIndexes),
+            indexes_of_type => set_from_list(IndexesOfType)
         },
     UseIndex = [<<"design">>, <<"foobar">>],
     Options = [{use_index, UseIndex}, {allow_fallback, false}],
@@ -729,8 +734,8 @@ t_create_no_suitable_index_no_fallback(_) ->
     Trace1 = #{},
     Trace2 =
         #{
-            filtered_indexes => sets:from_list(UsableIndexes),
-            indexes_of_type => sets:from_list(IndexesOfType)
+            filtered_indexes => set_from_list(UsableIndexes),
+            indexes_of_type => set_from_list(IndexesOfType)
         },
     Options = [{use_index, []}, {allow_fallback, false}],
     meck:expect(mango_selector, normalize, [selector], meck:val(normalized_selector)),
@@ -777,7 +782,7 @@ extract_candidate_indexes_test_() ->
     }.
 
 t_extract_candidate_indexes_empty(_) ->
-    Indexes = sets:new(),
+    Indexes = sets:new([{version, 2}]),
     UsabilityMap = [],
     Trace =
         #{
@@ -799,7 +804,7 @@ t_extract_candidate_indexes_empty(_) ->
     ?assertEqual(Candidates, extract_candidate_indexes(Cursor)).
 
 t_extract_candidate_indexes_singleton(_) ->
-    Indexes = sets:from_list([winner]),
+    Indexes = set_from_list([winner]),
     UsabilityMap = [{winner, {true, #{reason => []}}}],
     Trace =
         #{
@@ -835,15 +840,15 @@ t_extract_candidate_indexes_user_specified(_) ->
         ],
     Trace =
         #{
-            all_indexes => sets:from_list([
+            all_indexes => set_from_list([
                 winner, Partial, Partitioned, NotUsable, Filtered, Unfavored
             ]),
-            global_indexes => sets:from_list([winner, Partitioned, NotUsable, Filtered, Unfavored]),
-            partition_indexes => sets:from_list([winner, NotUsable, Filtered, Unfavored]),
-            usable_indexes => sets:from_list([winner, Filtered, Unfavored]),
+            global_indexes => set_from_list([winner, Partitioned, NotUsable, Filtered, Unfavored]),
+            partition_indexes => set_from_list([winner, NotUsable, Filtered, Unfavored]),
+            usable_indexes => set_from_list([winner, Filtered, Unfavored]),
             usability_map => UsabilityMap,
-            filtered_indexes => sets:from_list([winner, Unfavored]),
-            indexes_of_type => sets:from_list([winner])
+            filtered_indexes => set_from_list([winner, Unfavored]),
+            indexes_of_type => set_from_list([winner])
         },
     Cursor =
         #cursor{
@@ -935,7 +940,7 @@ t_extract_candidate_indexes_regular(_) ->
     ],
     Trace =
         #{
-            all_indexes => sets:from_list([
+            all_indexes => set_from_list([
                 winner,
                 Partial1,
                 Partial2,
@@ -948,7 +953,7 @@ t_extract_candidate_indexes_regular(_) ->
                 Usable2,
                 Usable3
             ]),
-            global_indexes => sets:from_list([
+            global_indexes => set_from_list([
                 winner,
                 Partitioned1,
                 Partitioned2,
@@ -959,17 +964,17 @@ t_extract_candidate_indexes_regular(_) ->
                 Usable2,
                 Usable3
             ]),
-            partition_indexes => sets:from_list([
+            partition_indexes => set_from_list([
                 winner, NotUsable, Unfavored1, Unfavored2, Usable1, Usable2, Usable3
             ]),
-            usable_indexes => sets:from_list([
+            usable_indexes => set_from_list([
                 winner, Unfavored1, Unfavored2, Usable1, Usable2, Usable3
             ]),
             usability_map => UsabilityMap,
-            filtered_indexes => sets:from_list([
+            filtered_indexes => set_from_list([
                 winner, Unfavored1, Unfavored2, Usable1, Usable2, Usable3
             ]),
-            indexes_of_type => sets:from_list([winner, Usable1, Usable2, Usable3]),
+            indexes_of_type => set_from_list([winner, Usable1, Usable2, Usable3]),
             sorted_index_ranges => SortedIndexRanges
         },
     Cursor =
@@ -1123,7 +1128,7 @@ t_extract_selector_hints_view(_) ->
             {[
                 {type, json},
                 {indexable_fields, ["field2"]},
-                {unindexable_fields, ["field3", "field1"]}
+                {unindexable_fields, ["field1", "field3"]}
             ]}
         ],
     ?assertEqual(Hints, extract_selector_hints(selector)).
@@ -1139,12 +1144,12 @@ t_extract_selector_hints_text(_) ->
             {[
                 {type, json},
                 {indexable_fields, ["field2"]},
-                {unindexable_fields, ["field3", "field1"]}
+                {unindexable_fields, ["field1", "field3"]}
             ]},
             {[
                 {type, text},
                 {indexable_fields, ["field1"]},
-                {unindexable_fields, ["field3", "field2"]}
+                {unindexable_fields, ["field2", "field3"]}
             ]}
         ],
     ?assertEqual(Hints, extract_selector_hints(selector)).
@@ -1160,12 +1165,12 @@ t_extract_selector_hints_nouveau(_) ->
             {[
                 {type, json},
                 {indexable_fields, ["field2"]},
-                {unindexable_fields, ["field3", "field1"]}
+                {unindexable_fields, ["field1", "field3"]}
             ]},
             {[
                 {type, nouveau},
                 {indexable_fields, ["field1"]},
-                {unindexable_fields, ["field3", "field2"]}
+                {unindexable_fields, ["field2", "field3"]}
             ]}
         ],
     ?assertEqual(Hints, extract_selector_hints(selector)).
@@ -1188,7 +1193,7 @@ explain_test_() ->
 
 t_explain_empty(_) ->
     Selector = {[]},
-    Indexes = sets:new(),
+    Indexes = sets:new([{version, 2}]),
     Trace =
         #{
             all_indexes => Indexes,
@@ -1236,7 +1241,7 @@ t_explain_regular(_) ->
         type = <<"special">>, name = index, def = all_docs, dbname = db, partitioned = partitioned
     },
     Selector = {[]},
-    Indexes = sets:from_list([Index]),
+    Indexes = set_from_list([Index]),
     Fields = some_fields,
     Trace =
         #{

--- a/src/mango/src/mango_idx.erl
+++ b/src/mango/src/mango_idx.erl
@@ -84,10 +84,10 @@ get_usable_indexes(Db, Selector, Opts, Kind) ->
             mango_sort_error(Db, Opts);
         {UsableIndexes, _} ->
             Trace = #{
-                all_indexes => sets:from_list(ExistingIndexes),
-                global_indexes => sets:from_list(GlobalIndexes),
-                partition_indexes => sets:from_list(PartitionIndexes),
-                usable_indexes => sets:from_list(UsableIndexes),
+                all_indexes => set_from_list(ExistingIndexes),
+                global_indexes => set_from_list(GlobalIndexes),
+                partition_indexes => set_from_list(PartitionIndexes),
+                usable_indexes => set_from_list(UsableIndexes),
                 usability_map => UsabilityMap
             },
             {UsableIndexes, Trace}
@@ -498,6 +498,9 @@ get_legacy_selector(Def) ->
         Selector -> Selector
     end.
 
+set_from_list(KVs) ->
+    sets:from_list(KVs, [{version, 2}]).
+
 -ifdef(TEST).
 -include_lib("couch/include/couch_eunit.hrl").
 
@@ -544,10 +547,10 @@ t_get_usable_indexes_empty(_) ->
     ?assertThrow(Exception2, get_usable_indexes(Database, selector, Options1, find)),
     Trace =
         #{
-            all_indexes => sets:new(),
-            global_indexes => sets:new(),
-            partition_indexes => sets:new(),
-            usable_indexes => sets:new(),
+            all_indexes => sets:new([{version, 2}]),
+            global_indexes => sets:new([{version, 2}]),
+            partition_indexes => sets:new([{version, 2}]),
+            usable_indexes => sets:new([{version, 2}]),
             usability_map => []
         },
     ?assertEqual({[], Trace}, get_usable_indexes(Database, selector, Options1, explain)),
@@ -580,10 +583,10 @@ t_get_usable_indexes_regular(_) ->
         ],
     Trace =
         #{
-            all_indexes => sets:from_list(ExistingIndexes),
-            global_indexes => sets:from_list(GlobalIndexes),
-            partition_indexes => sets:from_list(PartitionIndexes),
-            usable_indexes => sets:from_list(UsableIndexes),
+            all_indexes => set_from_list(ExistingIndexes),
+            global_indexes => set_from_list(GlobalIndexes),
+            partition_indexes => set_from_list(PartitionIndexes),
+            usable_indexes => set_from_list(UsableIndexes),
             usability_map => UsabilityMap
         },
     meck:expect(ddoc_cache, open, [Database, mango_idx], meck:val({ok, ExistingIndexes})),
@@ -636,10 +639,10 @@ t_get_usable_indexes_user_specified_index(_) ->
         ],
     Trace =
         #{
-            all_indexes => sets:from_list(ExistingIndexes),
-            global_indexes => sets:from_list(GlobalIndexes),
-            partition_indexes => sets:from_list(PartitionIndexes),
-            usable_indexes => sets:from_list(UsableIndexes),
+            all_indexes => set_from_list(ExistingIndexes),
+            global_indexes => set_from_list(GlobalIndexes),
+            partition_indexes => set_from_list(PartitionIndexes),
+            usable_indexes => set_from_list(UsableIndexes),
             usability_map => UsabilityMap
         },
     meck:expect(ddoc_cache, open, [Database, mango_idx], meck:val({ok, ExistingIndexes})),

--- a/src/mango/src/mango_idx_nouveau.erl
+++ b/src/mango/src/mango_idx_nouveau.erl
@@ -135,7 +135,7 @@ is_usable(Idx, Selector, _) ->
             {true, #{}};
         Cols ->
             Fields = indexable_fields(Selector),
-            Usable = sets:is_subset(sets:from_list(Fields), sets:from_list(Cols)),
+            Usable = sets:is_subset(set_from_list(Fields), set_from_list(Cols)),
             Reason = [field_mismatch || not Usable],
             Details = #{reason => Reason},
             {Usable, Details}
@@ -388,6 +388,9 @@ maybe_reject_index_all_req({Def}, Db) ->
 
 forbid_index_all() ->
     config:get("mango", "index_all_disabled", "false").
+
+set_from_list(KVs) ->
+    sets:from_list(KVs, [{version, 2}]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -142,7 +142,7 @@ is_usable(Idx, Selector, _) ->
             {true, #{reason => []}};
         Cols ->
             Fields = indexable_fields(Selector),
-            Usable = sets:is_subset(sets:from_list(Fields), sets:from_list(Cols)),
+            Usable = sets:is_subset(set_from_list(Fields), set_from_list(Cols)),
             Reason = [field_mismatch || not Usable],
             Details = #{reason => Reason},
             {Usable, Details}
@@ -401,6 +401,9 @@ maybe_reject_index_all_req({Def}, Db) ->
 
 forbid_index_all() ->
     config:get("mango", "index_all_disabled", "false").
+
+set_from_list(KVs) ->
+    sets:from_list(KVs, [{version, 2}]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -554,8 +554,11 @@ covers(Idx, Fields) ->
             false;
         _ ->
             Available = [<<"_id">> | columns(Idx)],
-            sets:is_subset(sets:from_list(Fields), sets:from_list(Available))
+            sets:is_subset(set_from_list(Fields), set_from_list(Available))
     end.
+
+set_from_list(KVs) ->
+    sets:from_list(KVs, [{version, 2}]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
We already use new ones everywhere else and when switching to OTP 28 we got a bunch of failure do to various order changes, so make sure to use new ones everywhere.

Moreover, do not rely on implementation order of `sets:to_list()`, but sort the result to produce deterministic results regardless of the internal representation.
