### PR TITLE
Fix QuickJS Windows build

### DIFF
--- a/src/couch_quickjs/rebar.config.script
+++ b/src/couch_quickjs/rebar.config.script
@@ -18,7 +18,7 @@ Msys = "msys2_shell.cmd -defterm -no-start -ucrt64 -here -lc ".
 PreHooks = [
     {"(linux|darwin)", compile, "make CONFIG_LTO=y -C quickjs -j8 libquickjs.lto.a qjsc"},
     {"freebsd", compile, "gmake -C quickjs -j8 libquickjs.a qjsc"},
-    {"win32", compile, Msys ++ "'make CONFIG_LTO=y -C quickjs -j8 libquickjs.lto.a qjsc'"},
+    {"win32", compile, Msys ++ "'make -C quickjs -j8 libquickjs.a qjsc.exe'"},
     {"(linux|darwin|freebsd|win32)", compile, "escript build_js.escript compile"}
 ].
 
@@ -49,8 +49,8 @@ FreeBSDEnv  = [
 ] ++ ResetFlags.
 
 WindowsEnv = [
-    {"CFLAGS", "-flto -D_GNU_SOURCE -DCONFIG_LTO=y -O2 -fwrapv -DCONFIG_VERSION=\\\"0\\\" -Iquickjs"},
-    {"LDFLAGS", "$LDFLAGS -flto -lm -Wl,-Bstatic -lpthread quickjs/libquickjs.lto.a"},
+    {"CFLAGS", "-D_GNU_SOURCE -O2 -fwrapv -DCONFIG_VERSION=\\\"0\\\" -Iquickjs"},
+    {"LDFLAGS", "$LDFLAGS -lm -Wl,-Bstatic -lpthread quickjs/libquickjs.a"},
     {"EXE_CC_TEMPLATE", "gcc.exe -g -c $CFLAGS $PORT_IN_FILES -o $PORT_OUT_FILE"},
     {"EXE_LINK_TEMPLATE", "gcc.exe -g -lm $PORT_IN_FILES $LDFLAGS -o $PORT_OUT_FILE"}
 ].
@@ -62,6 +62,7 @@ UnixCoffeeSrc = ["c_src/couchjs.c", "c_src/couchjs_coffee_bytecode.c"],
 
 WindowsBaseSrc = [
     "quickjs/quickjs.c",
+    "quickjs/dtoa.c",
     "quickjs/libregexp.c",
     "quickjs/libunicode.c",
     "quickjs/cutils.c",


### PR DESCRIPTION
This is a result of me updating the QuickJS makefile upstream

 - Skip LTO
 - Make sure to use the .exe suffix
 - Add dtoa source file to the list of source files

