### PR TITLE
Use new sets everywhere

### DIFF
--- a/src/couch/src/couch_multidb_changes.erl
+++ b/src/couch/src/couch_multidb_changes.erl
@@ -200,7 +200,7 @@ handle_info(_Msg, State) ->
 
 shards_db_fold(#row{dbname = <<"shards/", _/binary>> = DbName} = Row, {Add, Remove}) ->
     Fun = fun(Dbs) -> sets:add_element(DbName, Dbs) end,
-    Init = sets:from_list([DbName], [{version, 2}]),
+    Init = couch_util:set_from_list([DbName]),
     case Row#row.wait_shard_map of
         true ->
             {maps:update_with(mem3:dbname(DbName), Fun, Init, Add), Remove};
@@ -354,10 +354,10 @@ is_deleted(Change) ->
 local_shards(Db0) ->
     Db = mem3:dbname(Db0),
     try
-        sets:from_list([S || #shard{name = S} <- mem3:local_shards(Db)], [{version, 2}])
+        couch_util:set_from_list([S || #shard{name = S} <- mem3:local_shards(Db)])
     catch
         error:database_does_not_exist ->
-            sets:new([{version, 2}])
+            couch_util:new_set()
     end.
 
 notify_fold(DbName, {Server, DbSuffix, Count}) ->

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -47,6 +47,7 @@
 -export([get_config_hash_algorithms/0]).
 -export([remove_sensitive_data/1]).
 -export([ejson_to_map/1]).
+-export([new_set/0, set_from_list/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -862,3 +863,16 @@ ejson_to_map({Val}) when is_list(Val) ->
     maps:from_list(lists:map(fun({K, V}) -> {K, ejson_to_map(V)} end, Val));
 ejson_to_map(Val) ->
     Val.
+
+% Set types were switched to version 2 by default in OTP 28, use this helper to
+% create version 2 sets in OTP versions < 28 as well to avoid having to deal
+% with a different ordered to_list result in tests and just ensure we always
+% use version 2, which is also more performant
+%
+% Remove after OTP >= 28 and switch to plain sets:new/0 and sets:from_list/1
+
+new_set() ->
+    sets:new([{version, 2}]).
+
+set_from_list(KVs) ->
+    sets:from_list(KVs, [{version, 2}]).

--- a/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
+++ b/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
@@ -119,7 +119,7 @@ t_no_duplicate_metrics(Port) ->
     ?assertEqual(erlang:length(Diff), 0).
 
 get_duplicates(List) ->
-    List -- sets:to_list(sets:from_list(List)).
+    List -- sets:to_list(couch_util:set_from_list(List)).
 
 t_metric_updated(Port) ->
     % The passage of time should increment this metric

--- a/src/couch_replicator/src/couch_replicator_httpd_util.erl
+++ b/src/couch_replicator/src/couch_replicator_httpd_util.erl
@@ -49,8 +49,8 @@ parse_replication_state_filter(States) when is_list(States) ->
                 Msg1 = io_lib:format("States must be one or more of ~w", [AllStates]),
                 throw({query_parse_error, ?l2b(Msg1)})
         end,
-    AllSet = sets:from_list(AllStates),
-    StatesSet = sets:from_list(AtomStates),
+    AllSet = couch_util:set_from_list(AllStates),
+    StatesSet = couch_util:set_from_list(AtomStates),
     Diff = sets:to_list(sets:subtract(StatesSet, AllSet)),
     case Diff of
         [] ->

--- a/src/fabric/src/fabric_db_purged_infos.erl
+++ b/src/fabric/src/fabric_db_purged_infos.erl
@@ -29,7 +29,7 @@ go(DbName) ->
     Fun = fun handle_message/3,
     Acc0 = #pacc{
         counters = fabric_dict:init(Workers, nil),
-        replies = sets:new([{version, 2}]),
+        replies = couch_util:new_set(),
         ring_opts = [{any, Shards}]
     },
     try
@@ -66,7 +66,7 @@ handle_message({rexi_EXIT, Reason}, Shard, #pacc{} = Acc) ->
     end;
 handle_message({ok, Info}, #shard{} = Shard, #pacc{} = Acc) ->
     #pacc{counters = Counters, replies = Replies} = Acc,
-    InfoSet = sets:from_list(Info, [{version, 2}]),
+    InfoSet = couch_util:set_from_list(Info),
     Replies1 = sets:union(InfoSet, Replies),
     Counters1 = fabric_dict:erase(Shard, Counters),
     case fabric_dict:size(Counters1) =:= 0 of
@@ -92,7 +92,7 @@ make_shards() ->
 init_acc(Shards) ->
     #pacc{
         counters = fabric_dict:init(Shards, nil),
-        replies = sets:new([{version, 2}]),
+        replies = couch_util:new_set(),
         ring_opts = [{any, Shards}]
     }.
 

--- a/src/fabric/src/fabric_group_info.erl
+++ b/src/fabric/src/fabric_group_info.erl
@@ -26,7 +26,7 @@ go(DbName, #doc{id = DDocId}) ->
     Ushards = mem3:ushards(DbName),
     Workers = fabric_util:submit_jobs(Shards, group_info, [DDocId]),
     RexiMon = fabric_util:create_monitors(Shards),
-    USet = sets:from_list([{Id, N} || #shard{name = Id, node = N} <- Ushards]),
+    USet = couch_util:set_from_list([{Id, N} || #shard{name = Id, node = N} <- Ushards]),
     Acc = {fabric_dict:init(Workers, nil), [], USet},
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, Acc) of
         {timeout, {WorkersDict, _, _}} ->

--- a/src/fabric/src/fabric_streams.erl
+++ b/src/fabric/src/fabric_streams.erl
@@ -199,7 +199,7 @@ spawn_worker_cleaner(Coordinator, Workers, ClientReq) when
         undefined ->
             Pid = spawn(fun() ->
                 erlang:monitor(process, Coordinator),
-                NodeRefSet = set_from_list(shards_to_node_refs(Workers)),
+                NodeRefSet = couch_util:set_from_list(shards_to_node_refs(Workers)),
                 cleaner_loop(Coordinator, NodeRefSet, ClientReq)
             end),
             put(?WORKER_CLEANER, Pid),
@@ -227,9 +227,6 @@ add_worker_to_cleaner(CoordinatorPid, #shard{node = Node, ref = Ref}) ->
         _ ->
             ok
     end.
-
-set_from_list(List) when is_list(List) ->
-    sets:from_list(List, [{version, 2}]).
 
 shards_to_node_refs(Workers) when is_list(Workers) ->
     Fun = fun(#shard{node = Node, ref = Ref}) -> {Node, Ref} end,

--- a/src/global_changes/src/global_changes_listener.erl
+++ b/src/global_changes/src/global_changes_listener.erl
@@ -55,7 +55,7 @@ init(_) ->
     State = #state{
         update_db = UpdateDb,
         pending_update_count = 0,
-        pending_updates = sets:new([{version, 2}]),
+        pending_updates = couch_util:new_set(),
         max_event_delay = MaxEventDelay,
         dbname = global_changes_util:get_dbname()
     },
@@ -99,7 +99,7 @@ handle_cast({set_update_db, Boolean}, State0) ->
             {false, true} ->
                 State0#state{
                     update_db = Boolean,
-                    pending_updates = sets:new([{version, 2}]),
+                    pending_updates = couch_util:new_set(),
                     pending_update_count = 0,
                     last_update_time = undefined
                 };
@@ -141,7 +141,7 @@ maybe_send_updates(#state{update_db = true} = State) ->
                         0
                     ),
                     State1 = State#state{
-                        pending_updates = sets:new([{version, 2}]),
+                        pending_updates = couch_util:new_set(),
                         pending_update_count = 0,
                         last_update_time = undefined
                     },

--- a/src/global_changes/src/global_changes_server.erl
+++ b/src/global_changes/src/global_changes_server.erl
@@ -66,7 +66,7 @@ init([]) ->
     State = #state{
         update_db = UpdateDb,
         pending_update_count = 0,
-        pending_updates = sets:new([{version, 2}]),
+        pending_updates = couch_util:new_set(),
         max_write_delay = MaxWriteDelay,
         dbname = GlobalChangesDbName,
         handler_ref = erlang:monitor(process, Handler)
@@ -79,7 +79,7 @@ handle_call(_Msg, _From, State) ->
 handle_cast(_Msg, #state{update_db = false} = State) ->
     {noreply, State};
 handle_cast({update_docs, DocIds}, State) ->
-    Pending = sets:union(sets:from_list(DocIds), State#state.pending_updates),
+    Pending = sets:union(couch_util:set_from_list(DocIds), State#state.pending_updates),
     PendingCount = sets:size(Pending),
     couch_stats:update_gauge(
         [global_changes, server_pending_updates],
@@ -100,7 +100,7 @@ handle_cast({set_update_db, Boolean}, State0) ->
             {false, true} ->
                 State0#state{
                     update_db = Boolean,
-                    pending_updates = sets:new([{version, 2}]),
+                    pending_updates = couch_util:new_set(),
                     pending_update_count = 0
                 };
             _ ->
@@ -168,7 +168,7 @@ flush_updates(State) ->
         0
     ),
     {noreply, State#state{
-        pending_updates = sets:new([{version, 2}]),
+        pending_updates = couch_util:new_set(),
         pending_update_count = 0
     }}.
 

--- a/src/mango/src/mango_cursor_nouveau.erl
+++ b/src/mango/src/mango_cursor_nouveau.erl
@@ -108,7 +108,7 @@ execute(Cursor, UserFun, UserAcc) ->
         user_acc = UserAcc,
         fields = Cursor#cursor.fields,
         execution_stats = mango_execution_stats:log_start(Stats),
-        documents_seen = sets:new([{version, 2}])
+        documents_seen = couch_util:new_set()
     },
     try
         case Query of

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -113,7 +113,7 @@ execute(Cursor, UserFun, UserAcc) ->
         user_acc = UserAcc,
         fields = Cursor#cursor.fields,
         execution_stats = mango_execution_stats:log_start(Stats),
-        documents_seen = sets:new([{version, 2}])
+        documents_seen = couch_util:new_set()
     },
     try
         case Query of

--- a/src/mango/src/mango_idx.erl
+++ b/src/mango/src/mango_idx.erl
@@ -84,10 +84,10 @@ get_usable_indexes(Db, Selector, Opts, Kind) ->
             mango_sort_error(Db, Opts);
         {UsableIndexes, _} ->
             Trace = #{
-                all_indexes => set_from_list(ExistingIndexes),
-                global_indexes => set_from_list(GlobalIndexes),
-                partition_indexes => set_from_list(PartitionIndexes),
-                usable_indexes => set_from_list(UsableIndexes),
+                all_indexes => couch_util:set_from_list(ExistingIndexes),
+                global_indexes => couch_util:set_from_list(GlobalIndexes),
+                partition_indexes => couch_util:set_from_list(PartitionIndexes),
+                usable_indexes => couch_util:set_from_list(UsableIndexes),
                 usability_map => UsabilityMap
             },
             {UsableIndexes, Trace}
@@ -498,9 +498,6 @@ get_legacy_selector(Def) ->
         Selector -> Selector
     end.
 
-set_from_list(KVs) ->
-    sets:from_list(KVs, [{version, 2}]).
-
 -ifdef(TEST).
 -include_lib("couch/include/couch_eunit.hrl").
 
@@ -547,10 +544,10 @@ t_get_usable_indexes_empty(_) ->
     ?assertThrow(Exception2, get_usable_indexes(Database, selector, Options1, find)),
     Trace =
         #{
-            all_indexes => sets:new([{version, 2}]),
-            global_indexes => sets:new([{version, 2}]),
-            partition_indexes => sets:new([{version, 2}]),
-            usable_indexes => sets:new([{version, 2}]),
+            all_indexes => couch_util:new_set(),
+            global_indexes => couch_util:new_set(),
+            partition_indexes => couch_util:new_set(),
+            usable_indexes => couch_util:new_set(),
             usability_map => []
         },
     ?assertEqual({[], Trace}, get_usable_indexes(Database, selector, Options1, explain)),
@@ -583,10 +580,10 @@ t_get_usable_indexes_regular(_) ->
         ],
     Trace =
         #{
-            all_indexes => set_from_list(ExistingIndexes),
-            global_indexes => set_from_list(GlobalIndexes),
-            partition_indexes => set_from_list(PartitionIndexes),
-            usable_indexes => set_from_list(UsableIndexes),
+            all_indexes => couch_util:set_from_list(ExistingIndexes),
+            global_indexes => couch_util:set_from_list(GlobalIndexes),
+            partition_indexes => couch_util:set_from_list(PartitionIndexes),
+            usable_indexes => couch_util:set_from_list(UsableIndexes),
             usability_map => UsabilityMap
         },
     meck:expect(ddoc_cache, open, [Database, mango_idx], meck:val({ok, ExistingIndexes})),
@@ -639,10 +636,10 @@ t_get_usable_indexes_user_specified_index(_) ->
         ],
     Trace =
         #{
-            all_indexes => set_from_list(ExistingIndexes),
-            global_indexes => set_from_list(GlobalIndexes),
-            partition_indexes => set_from_list(PartitionIndexes),
-            usable_indexes => set_from_list(UsableIndexes),
+            all_indexes => couch_util:set_from_list(ExistingIndexes),
+            global_indexes => couch_util:set_from_list(GlobalIndexes),
+            partition_indexes => couch_util:set_from_list(PartitionIndexes),
+            usable_indexes => couch_util:set_from_list(UsableIndexes),
             usability_map => UsabilityMap
         },
     meck:expect(ddoc_cache, open, [Database, mango_idx], meck:val({ok, ExistingIndexes})),

--- a/src/mango/src/mango_idx_nouveau.erl
+++ b/src/mango/src/mango_idx_nouveau.erl
@@ -135,7 +135,9 @@ is_usable(Idx, Selector, _) ->
             {true, #{}};
         Cols ->
             Fields = indexable_fields(Selector),
-            Usable = sets:is_subset(set_from_list(Fields), set_from_list(Cols)),
+            Usable = sets:is_subset(
+                couch_util:set_from_list(Fields), couch_util:set_from_list(Cols)
+            ),
             Reason = [field_mismatch || not Usable],
             Details = #{reason => Reason},
             {Usable, Details}
@@ -388,9 +390,6 @@ maybe_reject_index_all_req({Def}, Db) ->
 
 forbid_index_all() ->
     config:get("mango", "index_all_disabled", "false").
-
-set_from_list(KVs) ->
-    sets:from_list(KVs, [{version, 2}]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/mango/src/mango_idx_text.erl
+++ b/src/mango/src/mango_idx_text.erl
@@ -142,7 +142,9 @@ is_usable(Idx, Selector, _) ->
             {true, #{reason => []}};
         Cols ->
             Fields = indexable_fields(Selector),
-            Usable = sets:is_subset(set_from_list(Fields), set_from_list(Cols)),
+            Usable = sets:is_subset(
+                couch_util:set_from_list(Fields), couch_util:set_from_list(Cols)
+            ),
             Reason = [field_mismatch || not Usable],
             Details = #{reason => Reason},
             {Usable, Details}
@@ -401,9 +403,6 @@ maybe_reject_index_all_req({Def}, Db) ->
 
 forbid_index_all() ->
     config:get("mango", "index_all_disabled", "false").
-
-set_from_list(KVs) ->
-    sets:from_list(KVs, [{version, 2}]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/mango/src/mango_idx_view.erl
+++ b/src/mango/src/mango_idx_view.erl
@@ -554,11 +554,8 @@ covers(Idx, Fields) ->
             false;
         _ ->
             Available = [<<"_id">> | columns(Idx)],
-            sets:is_subset(set_from_list(Fields), set_from_list(Available))
+            sets:is_subset(couch_util:set_from_list(Fields), couch_util:set_from_list(Available))
     end.
-
-set_from_list(KVs) ->
-    sets:from_list(KVs, [{version, 2}]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/mem3/src/mem3_sync_event_listener.erl
+++ b/src/mem3/src/mem3_sync_event_listener.erl
@@ -62,7 +62,7 @@ init(_) ->
     ok = subscribe_for_config(),
     Delay = config:get_integer("mem3", "sync_delay", 5000),
     Frequency = config:get_integer("mem3", "sync_frequency", 500),
-    Buckets = lists:duplicate(Delay div Frequency + 1, sets:new([{version, 2}])),
+    Buckets = lists:duplicate(Delay div Frequency + 1, couch_util:new_set()),
     St = #state{
         nodes = mem3_sync:nodes_db(),
         shards = mem3_sync:shards_db(),
@@ -162,7 +162,7 @@ rebucket_shards(Frequency, Delay, Buckets0) ->
             [sets:union([B | ToMerge]) | Buckets1];
         M ->
             %% Extend the number of buckets by M
-            lists:duplicate(M, sets:new([{version, 2}])) ++ Buckets0
+            lists:duplicate(M, couch_util:new_set()) ++ Buckets0
     end.
 
 %% To ensure that mem3_sync:push/2 is indeed called with roughly the frequency
@@ -179,7 +179,7 @@ maybe_push_shards(St) ->
     case Delta > Frequency of
         true ->
             {Buckets1, [ToPush]} = lists:split(length(Buckets0) - 1, Buckets0),
-            Buckets2 = [sets:new([{version, 2}]) | Buckets1],
+            Buckets2 = [couch_util:new_set() | Buckets1],
             %% There's no sets:map/2!
             sets:fold(
                 fun(ShardName, _) -> push_shard(ShardName) end,

--- a/src/mem3/test/eunit/mem3_ring_prop_tests.erl
+++ b/src/mem3/test/eunit/mem3_ring_prop_tests.erl
@@ -151,6 +151,6 @@ rand_range(B, E) ->
 
 endpoints(Ranges) ->
     {Begins, Ends} = lists:unzip(Ranges),
-    sets:from_list(Begins ++ Ends).
+    couch_util:set_from_list(Begins ++ Ends).
 
 -endif.


### PR DESCRIPTION
With OTP 28 sets switched to using version 2 by default. That caused various tests to fail, as Jan discovered in #5507

In the previous PR #5510 we switched few mango instances to use a helper utility, but it was repeated a few times and Gábor made a good suggestion to use utility functions instead, so that's what this PR does. But it does it for the whole code base.

Once we're post OTP 28 we can remove the utility and just use plain set functions.
