### PR TITLE
Fix query limit

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -513,8 +513,8 @@ authentication_db = _users
 ; Timeout for how long a response from a busy view group server can take.
 ; "infinity" is also a valid configuration value.
 ;group_info_timeout = 5000
-;query_limit = 268435456
-;partition_query_limit = 268435456
+;query_limit = infinity
+;partition_query_limit = infinity
 
 ; Configure what to use as the db tag when selecting design doc couchjs
 ; processes. The choices are:

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -948,14 +948,12 @@ multi_all_docs_view(Req, Db, OP, Queries) ->
 
 all_docs_view(Req, Db, Keys, OP) ->
     Args0 = couch_mrview_http:parse_body_and_query(Req, Keys),
-    Args1 = Args0#mrargs{view_type = map},
-    Args2 = fabric_util:validate_all_docs_args(Db, Args1),
-    Args3 = set_namespace(OP, Args2),
-    Args4 = set_include_sysdocs(OP, Req, Args3),
+    Args1 = set_namespace(OP, Args0),
+    Args2 = set_include_sysdocs(OP, Req, Args1),
     Options = [{user_ctx, Req#httpd.user_ctx}],
     Max = chttpd:chunked_response_buffer_size(),
     VAcc = #vacc{db = Db, req = Req, threshold = Max},
-    {ok, Resp} = fabric:all_docs(Db, Options, fun view_cb/2, VAcc, Args4),
+    {ok, Resp} = fabric:all_docs(Db, Options, fun view_cb/2, VAcc, Args2),
     {ok, Resp#vacc.resp}.
 
 view_cb({row, Row} = Msg, Acc) ->

--- a/src/couch_mrview/include/couch_mrview.hrl
+++ b/src/couch_mrview/include/couch_mrview.hrl
@@ -54,7 +54,8 @@
     view_states=nil
 }).
 
--define(MAX_VIEW_LIMIT, 16#10000000).
+% Largest 64 bit small int: 2^59-1
+-define(MAX_VIEW_LIMIT, 16#7FFFFFFFFFFFFFF).
 
 -record(mrargs, {
     view_type,

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -241,7 +241,8 @@ do_all_docs_req(Req, Db, Keys, NS) ->
         ),
         IsAdmin = is_admin(Db),
         Callback = get_view_callback(DbName, UsersDbName, IsAdmin),
-        couch_mrview:query_all_docs(Db, Args, Callback, VAcc0)
+        ValidatedArgs = couch_mrview_util:validate_all_docs_args(Db, Args),
+        couch_mrview:query_all_docs(Db, ValidatedArgs, Callback, VAcc0)
     end),
     case is_record(Resp, vacc) of
         true -> {ok, Resp#vacc.resp};

--- a/src/couch_mrview/src/couch_mrview_show.erl
+++ b/src/couch_mrview/src/couch_mrview_show.erl
@@ -224,7 +224,8 @@ handle_view_list(Req, Db, DDoc, LName, VDDoc, VName, Keys) ->
             Acc = #lacc{db = Db, req = Req, qserver = QServer, lname = LName},
             case VName of
                 <<"_all_docs">> ->
-                    couch_mrview:query_all_docs(Db, Args, fun list_cb/2, Acc);
+                    ValidatedArgs = couch_mrview_util:validate_all_docs_args(Db, Args),
+                    couch_mrview:query_all_docs(Db, ValidatedArgs, fun list_cb/2, Acc);
                 _ ->
                     couch_mrview:query_view(Db, VDDoc, VName, Args, fun list_cb/2, Acc)
             end

--- a/src/couch_mrview/src/couch_mrview_test_util.erl
+++ b/src/couch_mrview/src/couch_mrview_test_util.erl
@@ -111,6 +111,23 @@ ddoc(red) ->
                 ]}}
         ]}
     );
+ddoc(list) ->
+    couch_doc:from_json_obj(
+        map_to_proplist(#{
+            <<"_id">> => <<"_design/lists">>,
+            <<"lists">> => #{
+                <<"list">> =>
+                    <<
+                        "function(head, req){\n"
+                        "               send(\"H\");\n"
+                        "               var row;\n"
+                        "               while(row = getRow()) {send(row.key);}\n"
+                        "               return \"T\";\n"
+                        "           }"
+                    >>
+            }
+        })
+    );
 ddoc(Id) ->
     couch_doc:from_json_obj(
         {[
@@ -134,3 +151,6 @@ local_doc(Id) ->
             {<<"val">>, Id}
         ]}
     ).
+
+map_to_proplist(#{} = Map) ->
+    jiffy:decode(jiffy:encode(Map)).

--- a/src/couch_mrview/test/eunit/couch_mrview_show_list_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_show_list_tests.erl
@@ -1,0 +1,96 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_mrview_show_list_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+setup() ->
+    ok = config:set("query_server_config", "query_limit", "infinity", false),
+    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), list, 5),
+    Db.
+
+teardown(Db) ->
+    couch_db:close(Db),
+    couch_server:delete(couch_db:name(Db), [?ADMIN_CTX]),
+    config:delete("query_server_config", "query_limit", false).
+
+list_test_() ->
+    {
+        "_list tests",
+        {
+            setup,
+            fun test_util:start_couch/0,
+            fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0,
+                fun teardown/1,
+                [
+                    ?TDEF_FE(http_query),
+                    ?TDEF_FE(http_query_with_range),
+                    ?TDEF_FE(http_query_with_non_string_key),
+                    ?TDEF_FE(http_query_with_range_rev),
+                    ?TDEF_FE(http_query_with_limit_and_skip),
+                    ?TDEF_FE(http_query_with_limit_and_skip_and_query_limit),
+                    ?TDEF_FE(http_query_with_query_limit_and_over_limit)
+                ]
+            }
+        }
+    }.
+
+http_query(Db) ->
+    ?assertEqual(<<"H12345_design/listsT">>, http_query(Db, "")).
+
+http_query_with_range(Db) ->
+    ?assertEqual(<<"H345T">>, http_query(Db, "?start_key=\"3\"&end_key=\"5\"")).
+
+http_query_with_non_string_key(Db) ->
+    {Code1, Res1} = http_req(Db, "?start_key=1&end_key=1"),
+    ?assertEqual(200, Code1),
+    ?assertEqual(<<"HT">>, Res1).
+
+http_query_with_range_rev(Db) ->
+    Params = "?descending=true&start_key=\"5\"&end_key=\"3\"&include_end=true",
+    ?assertEqual(<<"H543T">>, http_query(Db, Params)).
+
+http_query_with_limit_and_skip(Db) ->
+    Params = "?start_key=\"2\"&limit=3&skip=3",
+    ?assertEqual(<<"H5_design/listsT">>, http_query(Db, Params)).
+
+http_query_with_limit_and_skip_and_query_limit(Db) ->
+    config:set("query_server_config", "query_limit", "2", false),
+    Params = "?start_key=\"1\"&skip=2",
+    ?assertEqual(<<"H34T">>, http_query(Db, Params)).
+
+http_query_with_query_limit_and_over_limit(Db) ->
+    config:set("query_server_config", "query_limit", "2", false),
+    {Code, _} = http_req(Db, "?limit=3"),
+    ?assertEqual(400, Code).
+
+db_url(Db) ->
+    DbName = couch_db:name(Db),
+    Addr = config:get("httpd", "bind_address", "127.0.0.1"),
+    Port = integer_to_list(mochiweb_socket_server:get(couch_httpd, port)),
+    "http://" ++ Addr ++ ":" ++ Port ++ "/" ++ ?b2l(DbName).
+
+http_req(DbName, Params) ->
+    Url = db_url(DbName) ++ "/_design/lists/_list/list/_all_docs",
+    {ok, Code, _Headers, Body} = test_request:get(Url ++ Params),
+    {Code, Body}.
+
+http_query(DbName, Params) ->
+    Url = db_url(DbName) ++ "/_design/lists/_list/list/_all_docs",
+    {ok, Code, _Headers, Body} = test_request:get(Url ++ Params),
+    ?assertEqual(200, Code),
+    Body.

--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -411,9 +411,10 @@ all_docs(DbName, Callback, Acc, QueryArgs) ->
 ) ->
     {ok, any()} | {error, Reason :: term()}.
 
-all_docs(DbName, Options, Callback, Acc0, #mrargs{} = QueryArgs) when
+all_docs(DbName, Options, Callback, Acc0, #mrargs{} = QueryArgs0) when
     is_function(Callback, 2)
 ->
+    QueryArgs = fabric_util:validate_all_docs_args(DbName, QueryArgs0),
     fabric_view_all_docs:go(dbname(DbName), opts(Options), QueryArgs, Callback, Acc0);
 %% @doc convenience function that takes a keylist rather than a record
 %% @equiv all_docs(DbName, Callback, Acc0, kl_to_query_args(QueryArgs))

--- a/src/fabric/src/fabric_util.erl
+++ b/src/fabric/src/fabric_util.erl
@@ -326,6 +326,8 @@ is_partitioned(DbName0) when is_binary(DbName0) ->
 is_partitioned(Db) ->
     couch_db:is_partitioned(Db).
 
+validate_all_docs_args(DbName, Args) when is_list(DbName) ->
+    validate_all_docs_args(list_to_binary(DbName), Args);
 validate_all_docs_args(DbName, Args) when is_binary(DbName) ->
     Shards = mem3:shards(fabric:dbname(DbName)),
     Db = open_cluster_db(hd(Shards)),


### PR DESCRIPTION
Previously, we set a default limit that was an effective infinity (2^28). It seems back in the 32 bit days that was the Erlang's largest small integer [1]. However, that turned out to be too low and it surprised a user when it truncated their all_docs output skipping some of the data. Fix that by increasing the limit to a larger "infinity" (highest 64 bit Erlang small integer [1]).

We did have a "query_limit" config parameter to customize the limit, however that turned out to be broken and did not take effect when the user tried it for all_docs, so fix that as well. Test to ensure the limit gets reduced appropriately. To make the setting more user friendly, allow `infinity` as the value.

Also, in the case of all_docs, we validated args and applied the limit check twice: once in the coordinator and another time on each worker, which wasted CPU resources and made things a bit confusing. To fix that, remove the validation from the common worker code in couch_mrview and validate once: either on the coordinator side, or local (port 5986) callback, right in the http callback.

[1] https://www.erlang.org/doc/system/memory.html

Fix #5176
