### PR TITLE
Enable xxhash checksums by default

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -95,10 +95,11 @@ view_index_dir = {{view_index_dir}}
 ; Sets the log level for informational compaction related entries.
 ;compaction_log_level = info
 
-; Enable writting xxHash checksums in .couch files. The current
-; default is false. When the value is false both xxHash and legacy
-; checksums can be read and verified.
-;write_xxhash_checksums = false
+; Enable writing xxHash checksums in .couch files. The current default
+; is true as of release 3.5.x. When the value is true, both xxHash and
+; legacy checksums can be read and verified but only xxhash checksums
+; will be written to the file.
+;write_xxhash_checksums = true
 
 ; Javascript engine. The choices are: spidermonkey and quickjs
 ;js_engine = spidermonkey

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -21,7 +21,7 @@
 -define(SIZE_BLOCK, 16#1000).
 -define(PREFIX_SIZE, 5).
 -define(DEFAULT_READ_COUNT, 1024).
--define(WRITE_XXHASH_CHECKSUMS_DEFAULT, false).
+-define(WRITE_XXHASH_CHECKSUMS_DEFAULT, true).
 
 -define(USE_CFILE_DEFAULT, true).
 -define(CFILE_SKIP_IOQ_DEFAULT, false).

--- a/src/docs/src/config/couchdb.rst
+++ b/src/docs/src/config/couchdb.rst
@@ -234,19 +234,18 @@ Base CouchDB Options
     .. config:option:: write_xxhash_checksums :: Enable writting xxHash checksums
 
         .. versionadded:: 3.4
+        .. versionchanged:: 3.5
 
-        The default value in version 3.4 is ``false``. The legacy checksum
-        algorithm will be used for writing couch_file blocks. During reads,
-        both xxHash and the legacy checksum algorithm will be used to verify
-        data integrity. In a future version of CouchDB the default value will
-        become ``true``. However, it would still be possible to safely
-        downgrade to version 3.4, which would be able to verify both xxHash and
-        legacy checksums. If CouchDB version downgrade is not a concern,
-        enabling xxHash checksums can result in a measuralbe document read
-        performance, especially for larger document sizes::
+        Before version 3.4 the default value was ``false``, and as of
+        version 3.5 it changed to ``true``.
+
+        During reads, both xxHash and the legacy checksum algorithm
+        can be used to verify data integrity. And it would still be
+        possible to safely downgrade to version 3.4, which would be
+        able to verify both xxHash and legacy checksums::
 
             [couchdb]
-            write_xxhash_checksums = false
+            write_xxhash_checksums = true
 
     .. config:option:: js_engine :: Set default Javascript Engine.
 


### PR DESCRIPTION
In preparation for 3.5.0
