### PR TITLE
Default upgrade_hash_on_auth to true

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -352,7 +352,7 @@ bind_address = 127.0.0.1
 ;max_iterations = 1000000000
 ;password_scheme = pbkdf2
 ;pbkdf2_prf = sha256 ; must be one of sha | sha224 | sha256 | sha384 | sha512
-;upgrade_hash_on_auth = false; whether to upgrade password hashes on successful authentication.
+;upgrade_hash_on_auth = true; whether to upgrade password hashes on successful authentication.
 
 ; List of Erlang RegExp or tuples of RegExp and an optional error message.
 ; Where a new password must match all RegExp.

--- a/src/couch/src/couch_password_hasher.erl
+++ b/src/couch/src/couch_password_hasher.erl
@@ -39,7 +39,7 @@
 %%%===================================================================
 
 maybe_upgrade_password_hash(Req, UserName, Password, UserProps, AuthModule, AuthCtx) ->
-    UpgradeEnabled = config:get_boolean("chttpd_auth", "upgrade_hash_on_auth", false),
+    UpgradeEnabled = config:get_boolean("chttpd_auth", "upgrade_hash_on_auth", true),
     IsDoc = is_doc(UserProps),
     NeedsUpgrade = needs_upgrade(UserProps),
     InProgress = in_progress(AuthModule, UserName),

--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -390,12 +390,14 @@ Authentication Configuration
     .. config:option:: upgrade_hash_on_auth :: Auto-upgrade user auth docs on next auth call
 
         .. versionadded:: 3.4
+        .. versionchanged:: 3.5
 
-        Upgrade user auth docs during the next successful
-        authentication using the current password hashing settings. ::
+        Upgrade user auth docs during the next successful authentication using
+        the current password hashing settings. The default was changed from
+        ``false`` to ``true`` in version ``3.5.0``::
 
             [chttpd_auth]
-            upgrade_hash_on_auth = false
+            upgrade_hash_on_auth = true
 
 .. config:section:: jwt_auth :: JWT Authentication
 


### PR DESCRIPTION
Initially this was set to ``true`` for ``3.4.0`` however, realizing users wouldn't be able to downgrade we defaulted it to ``false`` and quickly released ``3.4.1`` to replace ``3.4.0``. Since users now can safely downgrade to 3.4.x we can default it to ``true`` in 3.5.x releases.

See #5255 for more background
