### PR TITLE
Update and fix whatsnew for 3.5

### DIFF
--- a/src/docs/src/whatsnew/3.5.rst
+++ b/src/docs/src/whatsnew/3.5.rst
@@ -28,11 +28,11 @@ Version 3.5.0
 Highlights
 ----------
 
-* :ghissue:`5399`, :ghissue:`5441`, :ghissue:`5443`: Implement parallel
-  ``pread`` calls: lets clients issue concurrent ``pread`` calls without blocking
-  each other or having to wait for all writes and ``fsync`` calls. This is
-  enabled by default and can be disabled with ``[couchdb] use_cfile = false`` in
-  the configuration.
+* :ghissue:`5399`, :ghissue:`5441`, :ghissue:`5443`, :ghissue:`5460`,
+  :ghissue:`5461`: Implement parallel ``pread`` calls: lets clients issue
+  concurrent ``pread`` calls without blocking each other or having to wait for
+  all writes and ``fsync`` calls. This is enabled by default and can be
+  disabled with ``[couchdb] use_cfile = false`` in the configuration.
 
   CouchDB already employs a multiple-parallel-read and concurrent serial-write
   design at the database engine layer, but below that in the storage engine,
@@ -77,17 +77,48 @@ Highlights
 * :ghissue:`5347`: Fix attachment size calculation. This could lead to shards
   not being scheduled for compaction correctly.
 
+* :ghissue:`5494`: Implement ``_top_N`` and ``_bottom_N`` reducers. These
+  reducers return the top or bottom values from a map-reduce view. ``N`` is a
+  number between ``1`` and ``100``. For instance, a ``_top_5`` reducer will
+  return the top 5 highest values for a group level.
+
+* :ghissue:`5498`: Implement ``_first`` and ``_last`` reducers. These reducers
+  return the first, and respectively, the last view row for a given group
+  level. For example, ``_last`` can be used to retrieve the last timestamp
+  update for each ``device_id`` if we had a key like ``[device_id, timestamp]``
+  if we query the view with ``group_level=1``.
+
+* :ghissue:`5466`: Conflict finder plugin. Enable the
+  ``couch_scanner_plugin_conflict_finder`` plugin to find conflicting docs
+  across all the databases. It can be configured to report individual revisions
+  or aggregated statistics.
+
 Performance
 -----------
 
+* :ghissue:`5499`: QuickJS rope based string implementation.
+* :ghissue:`5451`: Optimize config system to use persistent terms.
 * :ghissue:`5437`: Fix ``atts_since`` functionality for document ``GET``
   requests. Avoids re-replicating attachment bodies on doc updates.
-* :ghissue:`5389`: Save 1 ``write`` for each committing data to disk by using
+* :ghissue:`5398`: Save 1 ``write`` for each committing data to disk by using
   ``fdatasync`` while keeping the same level of storage reliability.
 
 Features
 --------
 
+* :ghissue:`5526`: Default ``upgrade_hash_on_auth`` to ``true``. Downgrading to
+  ``3.4.1``, ``3.4.2``, or ``3.4.3`` is safe. Those versions know how to verify
+  these new password hashes.
+* :ghissue:`5517`: Enable xxHash file checksums by default. Downgrading to
+  ``3.4.x`` versions should be safe. Those versions know how to read and verify
+  xxHash checksums.
+* :ghissue:`5527`: Update Fauxton and xxHash dependencies.
+* :ghissue:`5525`: Array opcode optimization for QuickJS.
+* :ghissue:`5518`: More precise error location reporting for QuickJS.
+* :ghissue:`5507`, :ghissue:`5510`, :ghissue:`5509`: Erlang 28 compatibiliity.
+* :ghissue:`5516`: Detailed node membership info for Prometheus.
+* :ghissue:`5489`: Allow TLS client certs for Nouveau requests.
+* :ghissue:`5452`: ``BigInt`` support for QuickJS.
 * :ghissue:`5439`: Nouveau: upgrade ``dropwizard`` to 4.0.12.
 * :ghissue:`5429`: Add ``simple+pbkdf2`` migration password scheme.
 * :ghissue:`5424`: Scanner: reduce log noise, fix QuickJS plugin mocks,
@@ -97,7 +128,7 @@ Features
   ``couch_work_queue``.
 * :ghissue:`5402`: Remove unused, undocumented and detrimental idle check
   timeout feature.
-* :ghissue:`5359`: Remove unused, undocumented and unreliabele ``pread_limit``
+* :ghissue:`5395`: Remove unused, undocumented and unreliabele ``pread_limit``
   feature from ``couch_file``.
 * :ghissue:`5385`: Clean up ``fabric_doc_update`` by introducing an ``#acc``
   record.
@@ -116,6 +147,14 @@ Features
 Bugfixes
 --------
 
+* :ghissue:`5515`: Make sure ``query_limit`` config takes effect. Raise default
+  limit from ``2^28`` to ``2^59``. Allow ``infinity`` as a more ergonomic
+  config value.
+* :ghissue:`5522`: Reopen indexes closed by Lucene in Nouveau.
+* :ghissue:`5508`: Fix array ``from()`` and ``at()`` for QuickJS.
+* :ghissue:`5502`: Buffer overflow and segfault fix in QuickJS.
+* :ghissue:`5469`, :ghissue:`5471`: Retry closed connections in Nouveau.
+* :ghissue:`5463`: Fix ``badarith`` in Nouveau index query.
 * :ghissue:`5447`: Fix arithmetic mean in ``_prometheus``.
 * :ghissue:`5440`: Fix ``_purged_infos`` when exceeding ``purged_infos_limit``.
 * :ghissue:`5431`: Restore the ability to return ``Error`` objects from `map()`.
@@ -143,7 +182,7 @@ Docs
 ----
 
 * :ghissue:`5433`: Mango: document Nouveau index type.
-* :ghissue:`5433`: Nouveau: document Mango index type.
+* :ghissue:`5432`: Add conceptual docs for Mango.
 * :ghissue:`5428`: Fix wrong link in example in ``CONTRIBUTING.md``.
 * :ghissue:`5400`: Clarify RHEL9 installation caveats.
 * :ghissue:`5380`, :ghissue:`5404`: Fix various typos.
@@ -159,6 +198,8 @@ Docs
 Tests
 _____
 
+* :ghissue:`5492`: Enable Clouseau testing for FreeBSD
+* :ghissue:`5490`: Enable Clouseau testing for MacOS
 * :ghissue:`5397`: Fix negative-steps error in Elixir tests.
 
 Builds


### PR DESCRIPTION
 * Add a few more related prs to parallel preads highlights

 * Add _top_N/_bottom_N/_first/_last reducers to highlights

 * Add conflict finder to highlights

 * Mention defaults flipping and what versions it's safe to downgrade to.

 * Fix a few PR number typos
