### PR TITLE
fix(`dev/run`): complete Erlang cookie configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ EXUNIT_OPTS=$(subst $(comma),$(space),$(tests))
 
 TEST_OPTS="-c 'startup_jitter=0' -c 'default_security=admin_local' -c 'iterations=9'"
 
+ifneq ($(ERLANG_COOKIE),)
+TEST_OPTS+=" --erlang-cookie=$(ERLANG_COOKIE)"
+endif
+
 ################################################################################
 # Main commands
 ################################################################################

--- a/Makefile.win
+++ b/Makefile.win
@@ -93,6 +93,10 @@ EXUNIT_OPTS=$(subst $(comma),$(space),$(tests))
 
 TEST_OPTS="-c startup_jitter=0 -c default_security=admin_local -c iterations=9"
 
+ifneq ($(ERLANG_COOKIE),)
+TEST_OPTS+=" --erlang-cookie=$(ERLANG_COOKIE)"
+endif
+
 ################################################################################
 # Main commands
 ################################################################################

--- a/README-DEV.rst
+++ b/README-DEV.rst
@@ -311,9 +311,9 @@ follows::
 
     dev/run --with-clouseau
 
-When a specific Erlang cookie string is set in
-``rel/overlay/etc/vm.args``, the ``--erlang-cookie`` flag could be
-used to configure Clouseau to work with that::
+When a specific Erlang cookie string is needed, the
+``--erlang-cookie`` flag could be used to configure CouchDB and
+Clouseau to work with that::
 
     dev/run --with-clouseau --erlang-cookie=brumbrum
 

--- a/dev/run
+++ b/dev/run
@@ -515,7 +515,7 @@ def write_config(ctx, node, env):
             content = apply_config_overrides(ctx, content)
         elif base == "local.ini":
             content = hack_local_ini(ctx, content)
-        elif ctx["enable_tls"] and base == "vm.args":
+        elif base == "vm.args":
             content = hack_vm_args(ctx, node, content)
 
         with open(tgt, "w") as handle:
@@ -839,16 +839,23 @@ def hack_local_ini(ctx, contents):
 
 
 def hack_vm_args(ctx, node, contents):
-    contents += f"""
+    if ctx["enable_tls"]:
+        contents += f"""
 -proto_dist couch
 -couch_dist no_tls '"clouseau{node[-1]}@127.0.0.1"'
 -ssl_dist_optfile {ctx["rootdir"]}/src/couch_dist/certs/out/couch_dist.conf
-    """
-    if ctx["no_tls"]:
-        no_tls_nodes = ctx["no_tls"].split(",")
-        for node_name in no_tls_nodes:
-            node_name = node_name if "@" in node_name else f"{node_name}@127.0.0.1"
-            contents += f"""\n-couch_dist no_tls '"{node_name}"'"""
+"""
+        if ctx["no_tls"]:
+            no_tls_nodes = ctx["no_tls"].split(",")
+            for node_name in no_tls_nodes:
+                node_name = node_name if "@" in node_name else f"{node_name}@127.0.0.1"
+                contents += f"""
+-couch_dist no_tls '"{node_name}"'
+"""
+    if ctx["erlang_cookie"]:
+        contents += f"""
+-setcookie {ctx["erlang_cookie"]}
+"""
     return contents
 
 


### PR DESCRIPTION
The `--erlang-cookie` configuration flag for the `dev/run` script does not propagate the cookie value for `vm.args` so that the nodes will not have it configured on starting up.  That is why, for example, pinging the Clouseau nodes with user-provided cookie will not work, as well as Clouseau nodes will not be able to connect even though they picked up the right value already.

Add the missing parts to tweak `vm.args` accordingly and make the Erlang cookie configurable through the `Makefile` too.

## Testing recommendations

There are different ways to see if the change is working.  For example, one could launch `dev/run` directly to start the nodes with a specific Erlang cookie:

```console
% dev/run -a adm:pass -n 1 --erlang-cookie=crumbles
...
```

Then one should be able to see the cookie configured in `dev/lib/node1/etc/vm.args`:

```console
% fgrep setcookie dev/lib/node1/etc/vm.args
# -setcookie
-setcookie crumbles
```

The same could be done with involving Clouseau (assuming that it has been configured):

```console
% dev/run -a adm:pass -n 1 --with-clouseau --erlang-cookie=crumbles
...
```

Then, besides `vm.args` being adjusted (as show above), Clouseau should be run with the respective `clouseau.cookie` parameter:

```console
% ps ax | fgrep clouseau.cookie
91783 s000  S+     0:02.56 /usr/local/openjdk8/bin/java -server -Xmx2G -Dsun.net.inetaddr.ttl=30 -Dsun.net.inetaddr.negative.ttl=30 -XX:OnOutOfMemoryError="kill -9 %p" -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -cp clouseau/lucene-analyzers-kuromoji-4.6.1-cloudant1.jar:clouseau/jetlang-0.2.12.jar:clouseau/commons-logging-1.1.1.jar:clouseau/lucene-analyzers-common-4.6.1-cloudant1.jar:clouseau/metrics-scala_2.9.1-2.2.0.jar:clouseau/lucene-grouping-4.6.1-cloudant1.jar:clouseau/scala-library-2.9.1.jar:clouseau/logback-core-1.2.13.jar:clouseau/clouseau-2.25.0.jar:clouseau/slf4j-api-1.7.2.jar:clouseau/metrics-core-2.2.0.jar:clouseau/lucene-facet-4.6.1-cloudant1.jar:clouseau/lucene-sandbox-4.6.1-cloudant1.jar:clouseau/spatial4j-0.3.jar:clouseau/lucene-spatial-4.6.1-cloudant1.jar:clouseau/lucene-analyzers-stempel-4.6.1-cloudant1.jar:clouseau/lucene-analyzers-smartcn-4.6.1-cloudant1.jar:clouseau/lucene-core-4.6.1-cloudant1.jar:clouseau/lucene-queries-4.6.1-cloudant1.jar:clouseau/lucene-highlighter-4.6.1-cloudant1.jar:clouseau/commons-lang-2.6.jar:clouseau/logback-classic-1.2.13.jar:clouseau/lucene-memory-4.6.1-cloudant1.jar:clouseau/commons-configuration-1.8.jar:clouseau/jakarta-regexp-1.4.jar:clouseau -Dclouseau.name=clouseau1@127.0.0.1 -Dclouseau.dir=/Users/gaborpali/projects/github/couchdb/dev/clouseau1/data -Dclouseau.cookie=crumbles com.cloudant.clouseau.Main clouseau/clouseau.ini
93076 s001  S+     0:00.00 fgrep clouseau.cookie
```

In addition to these, tests should just work with the `ERLANG_COOKIE` parameter set when running `make`, for example, with and without Clouseau configured:

```console
% make mango-test ERLANG_COOKIE=crumbles
...
Ran 389 tests in 38.772s

OK (skipped=1)
```
