### PR TITLE
Always allow mem3_rep checkpoints

### DIFF
--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1340,8 +1340,13 @@ update_docs(Db, Docs0, Options, ?REPLICATED_CHANGES) ->
     {ok, DocErrors};
 update_docs(Db, Docs0, Options, ?INTERACTIVE_EDIT) ->
     BlockInteractiveDatabaseWrites = couch_disk_monitor:block_interactive_database_writes(),
+    InternalReplication =
+        case get(io_priority) of
+            {internal_repl, _} -> true;
+            _Else -> false
+        end,
     if
-        BlockInteractiveDatabaseWrites ->
+        not InternalReplication andalso BlockInteractiveDatabaseWrites ->
             {ok, [{insufficient_storage, <<"database_dir is too full">>} || _ <- Docs0]};
         true ->
             update_docs_interactive(Db, Docs0, Options)


### PR DESCRIPTION
## Overview

We introduced a feature in https://github.com/apache/couchdb/pull/4681 to allow couchdb to reject writes at a configurable disk usage threshold, in order to ensure couchdb does not hit end of disk. We intentionally excluded internal replication from this mechanism. Unfortunately this work was flawed and did not allow mem3 checkpoint documents to be written. This PR adds a general bypass mechanism in couch_db module and alters internal replication to use the bypass. 

Closes https://github.com/apache/couchdb/issues/5528

## Testing recommendations

Place a node (or cluster) under sustained write load (a curl loop making new empty documents is sufficient). Alter the write threshold of all nodes to 0. Observe the absence of errors of this form;

```
with exit value:#012{{nocatch,{insufficient_storage,<<"database_dir is too full">>}},[{couch_db,update_doc,4,[{file,"src/couch_db.erl"},{line,876}]},{mem3_rep,update_locals,3,[{file,"src/mem3_rep.erl"},{line,740}]},{mem3_rep,replicate_batch,4,[{file,"src/mem3_rep.erl"},{line,641}]},
```

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/4681
https://github.com/apache/couchdb/issues/5528

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
