### PR TITLE
Fix mem3_util overlapping shards

### DIFF
--- a/src/mem3/src/mem3_util.erl
+++ b/src/mem3/src/mem3_util.erl
@@ -469,13 +469,15 @@ range_overlap([A, B], [X, Y]) when
 ->
     A =< Y andalso X =< B.
 
-non_overlapping_shards(Shards) ->
+non_overlapping_shards([]) ->
+    [];
+non_overlapping_shards([_ | _] = Shards) ->
     {Start, End} = lists:foldl(
         fun(Shard, {Min, Max}) ->
             [B, E] = mem3:range(Shard),
             {min(B, Min), max(E, Max)}
         end,
-        {0, ?RING_END},
+        {?RING_END, 0},
         Shards
     ),
     non_overlapping_shards(Shards, Start, End).
@@ -705,10 +707,11 @@ range_overlap_test_() ->
         ]
     ].
 
-non_overlapping_shards_test() ->
+non_overlapping_shards_test_() ->
     [
         ?_assertEqual(Res, non_overlapping_shards(Shards))
      || {Shards, Res} <- [
+            {[], []},
             {
                 [shard(0, ?RING_END)],
                 [shard(0, ?RING_END)]
@@ -719,7 +722,7 @@ non_overlapping_shards_test() ->
             },
             {
                 [shard(0, 1), shard(0, 1)],
-                [shard(0, 1)]
+                [shard(0, 1), shard(0, 1)]
             },
             {
                 [shard(0, 1), shard(3, 4)],
@@ -731,15 +734,15 @@ non_overlapping_shards_test() ->
             },
             {
                 [shard(1, 2), shard(0, 1)],
-                [shard(0, 1), shard(1, 2)]
+                []
             },
             {
                 [shard(0, 1), shard(0, 2), shard(2, 5), shard(3, 5)],
-                [shard(0, 2), shard(2, 5)]
+                [shard(0, 2), shard(3, 5)]
             },
             {
-                [shard(0, 2), shard(4, 5), shard(1, 3)],
-                []
+                [shard(1, 2), shard(3, 4), shard(1, 4), shard(5, 6)],
+                [shard(1, 4), shard(5, 6)]
             }
         ]
     ].


### PR DESCRIPTION
Previously we started the `{min, max}` accumulator as `{0, ?RANGE_END}` while it should have been `{?RANGE_END, 0}` so during the fold they'd be reduced to the actual min/max seen in the list of shards.

Another bug was that the unit test was never run as it didn't end in `_` and it emitted test generators `?_assertEqual(...)` so make sure the test runs and add a few cases: empty list of shards and when range doesn't start or end at `0` or `?RANGE_END`.

Thanks to @rnewson for finding the bug!
 