### PR TITLE
Add retries to native full CI stage

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -170,7 +170,7 @@ def generateNativeStage(platform) {
   return {
     stage(platform) {
       node(platform) {
-        timeout(time: 90, unit: "MINUTES") {
+        timeout(time: 180, unit: "MINUTES") {
           // Steps to configure and build CouchDB on *nix platforms
           if (isUnix()) {
             try {
@@ -190,12 +190,12 @@ def generateNativeStage(platform) {
                 dir( "${platform}/build" ) {
                   sh "${configure(meta[platform])}"
                   sh '$MAKE'
-                  sh '$MAKE eunit'
-                  sh '$MAKE elixir'
-                  sh '$MAKE elixir-search'
-                  sh '$MAKE mango-test'
-                  sh '$MAKE weatherreport-test'
-                  sh '$MAKE nouveau-test'
+                  retry (3) {sh '$MAKE eunit'}
+                  retry (3) {sh '$MAKE elixir'}
+                  retry (3) {sh '$MAKE elixir-search'}
+                  retry (3) {sh '$MAKE mango-test'}
+                  retry (3) {sh '$MAKE weatherreport-test'}
+                  retry (3) {sh '$MAKE nouveau-test'}
                 }
               }
             }
@@ -295,7 +295,7 @@ def generateContainerStage(platform) {
       node(meta[platform].get('node_label', 'docker')) {
         docker.withRegistry('https://docker.io/', 'dockerhub_creds') {
           docker.image(meta[platform].image).inside("${DOCKER_ARGS}") {
-            timeout(time: 90, unit: "MINUTES") {
+            timeout(time: 180, unit: "MINUTES") {
               stage("${meta[platform].name} - build & test") {
                 try {
                   sh( script: "rm -rf ${platform} apache-couchdb-*", label: 'Clean workspace' )
@@ -383,7 +383,7 @@ pipeline {
   options {
     buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10'))
     preserveStashes(buildCount: 10)
-    timeout(time: 3, unit: 'HOURS')
+    timeout(time: 4, unit: 'HOURS')
     timestamps()
   }
 
@@ -399,7 +399,7 @@ pipeline {
         }
       }
       steps {
-        timeout(time: 15, unit: "MINUTES") {
+        timeout(time: 30, unit: "MINUTES") {
           sh (script: 'rm -rf apache-couchdb-*', label: 'Clean workspace of any previous release artifacts' )
           sh "./configure --spidermonkey-version 78 --with-nouveau"
           sh 'make dist'
@@ -454,7 +454,7 @@ pipeline {
       }
       options {
         skipDefaultCheckout()
-        timeout(time: 90, unit: "MINUTES")
+        timeout(time: 120, unit: "MINUTES")
       }
 
       steps {


### PR DESCRIPTION
Noticed a few flaky failures in FreeBSD ARM worker. We see those in the docker workers but there we have retries, so they don't stop the build.

Also, noticed on the s390x worker, we had two flaky failures with eunit crashing towards the end of the runs and there was not enough time to re-run a 3rd time as the job died due a timeout, so expand all the timeouts a bit. They are clearly not enough for all 3 timeouts.
