### PR TITLE
Extend `remsh` to read cookie from various sources

### DIFF
--- a/dev/remsh
+++ b/dev/remsh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
@@ -11,18 +11,48 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-if [ -z $NODE ]; then
-    if [ -z $1 ]; then
-        NODE=1
-    else
-        NODE=$1
-    fi
+# Cookies can be set in 3 different ways:
+# - Use `dev/run` script to pass cookies:
+#     `dev/run --erlang-cookie=crumbles`
+# - Use `vm.args` config file in rel/overlay/etc to set cookies:
+#     `-setcookie crumbles`
+# - Use cookies from the `.erlang.cookie` file in the user's home directory.
+
+# NOTE: If more than 2 cookies are passed to node, node will ignore them
+#       and use the default cookies from `~/.erlang.cookie`.
+
+if [ -z "$NODE" ]; then
+  if [ -z "$1" ]; then
+    NODE=1
+  else
+    NODE=$1
+  fi
 fi
 
-if [ -z $HOST ]; then
-    HOST="127.0.0.1"
+if [ -z "$HOST" ]; then
+  HOST="127.0.0.1"
 fi
 
 NAME="remsh$$@$HOST"
 NODE="node$NODE@$HOST"
-erl -name $NAME -remsh $NODE -hidden
+
+COOKIE_PY=$(ps ax |
+  grep -E "dev/run .* --erlang-cookie=" |
+  sed -n "s/.*--erlang-cookie=\([a-zA-Z0-9!@%^&*()_+-=(){}<>,;.:?/|]*\).*/\1/p")
+
+DIR="$(
+  cd "${0%/*}" 2>/dev/null || exit
+  echo "$PWD"/../rel/overlay/etc/
+)"
+COOKIE_VM=$(grep "^-setcookie" "$DIR"/vm.args |
+  sed -n "s/-setcookie *\([a-zA-Z0-9!@%^&*()_+-=(){}<>,;.:?/|]*\).*/\1/p")
+
+if [[ -n "$COOKIE_PY" && -z "$COOKIE_VM" ]]; then
+  erl -name "$NAME" -remsh "$NODE" -hidden -setcookie "$COOKIE_PY"
+elif [[ -z "$COOKIE_PY" && $(echo "$COOKIE_VM" | wc -l) -eq 1 ]]; then
+  erl -name "$NAME" -remsh "$NODE" -hidden -setcookie "$COOKIE_VM"
+else
+  erl -name "$NAME" -remsh "$NODE" -hidden
+fi
+
+erl -name "$NAME" -remsh "$NODE" -hidden


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

We can set cookies using `./dev/run --erlang-cookie=crumbles` or `vm.args`: `-setcookie crumbles`.

If neither of them is set or we set the cookie in both places, then the Erlang node will read the cookie from `~/.erlang.cookie`.

Add this mechanism to the `remsh` script to extend flexibility.

Related PR: https://github.com/apache/couchdb/pull/5531

## Testing recommendations

```bash
# After the change it should pass
./dev/run --admin=adm:pass -n 1 --erlang-cookie=crumbles --no-eval 'dev/remsh'
```

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
