### PR TITLE
chore(`ci`): enable Clouseau for Windows

### DIFF
--- a/build-aux/Jenkinsfile.full
+++ b/build-aux/Jenkinsfile.full
@@ -134,6 +134,7 @@ meta = [
   'win2022': [
     name: 'Windows 2022',
     spidermonkey_vsn: '128',
+    with_clouseau: true,
     node_label: 'win'
   ]
 ]
@@ -229,9 +230,11 @@ def generateNativeStage(platform) {
                 powershell( script: "New-Item -ItemType Directory -Path '${platform}/build' -Force", label: 'Create build directories' )
                 powershell( script: "tar -xf (Get-Item apache-couchdb-*.tar.gz) -C '${platform}/build' --strip-components=1", label: 'Unpack release' )
                 dir( "${platform}/build" ) {
+                  withClouseau = meta[platform].with_clouseau ? '-WithClouseau' : ''
+
                   powershell( script: """
                     .\\..\\..\\couchdb-glazier\\bin\\shell.ps1
-                    .\\configure.ps1 -SkipDeps -WithNouveau -SpiderMonkeyVersion ${meta[platform].spidermonkey_vsn}
+                    .\\configure.ps1 -SkipDeps -WithNouveau ${withClouseau} -SpiderMonkeyVersion ${meta[platform].spidermonkey_vsn}
                     Set-Item -Path env:GRADLE_OPTS -Value '-Dorg.gradle.daemon=false'
                     make -f Makefile.win release
                   """, label: 'Configure and Build')
@@ -239,13 +242,17 @@ def generateNativeStage(platform) {
                   //powershell( script: ".\\..\\..\\couchdb-glazier\\bin\\shell.ps1; make -f Makefile.win eunit", label: 'EUnit tests')
                   //powershell( script: ".\\..\\..\\couchdb-glazier\\bin\\shell.ps1; make -f Makefile.win elixir", label: 'Elixir tests')
 
-                  powershell( script: '& .\\..\\..\\couchdb-glazier\\bin\\shell.ps1; Write-Host "NOT AVAILABLE: make -f Makefile.win elixir-search"', label: 'N/A Clouseau tests')
-
                   powershell( script: """
                     .\\..\\..\\couchdb-glazier\\bin\\shell.ps1
                     Set-Item -Path env:GRADLE_OPTS -Value '-Dorg.gradle.daemon=false'
-                    make -f Makefile.win mango-test
-                  """, label: 'Mango tests')
+                    make -f Makefile.win elixir-search ERLANG_COOKIE=crumbles
+                  """, label: 'Clouseau tests')
+
+                  powershell( script: """
+                      .\\..\\..\\couchdb-glazier\\bin\\shell.ps1
+                      Set-Item -Path env:GRADLE_OPTS -Value '-Dorg.gradle.daemon=false'
+                      make -f Makefile.win mango-test ERLANG_COOKIE=crumbles
+                    """, label: 'Mango tests')
 
                   powershell( script: '.\\..\\..\\couchdb-glazier\\bin\\shell.ps1; Write-Host "NOT AVAILABLE: make -f Makefile.win weatherreport-test"', label: 'N/A Weatherreport tests')
 


### PR DESCRIPTION
Implement the `with_clouseau` flag for the Windows worker.  The `elixir-search` target could be safely run unconditionally, the `Makefile` is going to skip the tests when Clouseau is not present.

At the moment, sharing the Erlang cookie between the CouchDB and Clouseau nodes for orchestrating the tests does not work in the current setup.  By default, we rely on the `.erlang.cookie` file in the user's home directory, but this file could only be opened exclusively.  Work this around by setting the cookie string through the command line.

For the full CI run (as a verification), please see [`jenkins-clouseau-windows` #16](https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/jenkins-clouseau-windows/16/pipeline-console/).