### PR TITLE
Bump process limit to 1M

### DIFF
--- a/rel/overlay/etc/vm.args
+++ b/rel/overlay/etc/vm.args
@@ -57,6 +57,17 @@
 #
 -kernel prevent_overlapping_partitions false
 
+# Set Erlang process limit. If not set in Erlang 27 and greater versions it
+# defaults to 1048576. In Erlang versions less than 27 it defaulted to 262144.
+# When a cluster reaches this limit it will emit "Too many processes" error in
+# the log. That could be a time to bump it up. The actual value set will be a
+# larger power of 2 number. To check the actual limit call
+# `erlang:system_info(process_limit).` in remsh.
+#
+# For additional info see
+#   https://www.erlang.org/doc/apps/erts/erl_cmd.html#emulator-flags
++P 1048576
+
 # Increase the pool of dirty IO schedulers from 10 to 16
 # Dirty IO schedulers are used for file IO.
 +SDio 16


### PR DESCRIPTION
In Erlang < 27, it defaulted to `262144` and that's too easy to hit with medium and larger clusters these days. In Erlang >= 27 the deafult was bumped to 1M so set it at that default in vm.args with a note to help users configure it, and know when it may need to be increased.

Issue: https://github.com/apache/couchdb/issues/5544
