### PR TITLE
Fix config key typo in mem3_reshard_dbdoc

### DIFF
--- a/src/docs/src/config/resharding.rst
+++ b/src/docs/src/config/resharding.rst
@@ -21,7 +21,7 @@ Resharding
 Resharding Configuration
 ========================
 
-.. config:section:: resharding :: Resharding Configuration
+.. config:section:: reshard :: Resharding Configuration
 
     .. config:option:: max_jobs :: Maximum resharding jobs per node
 

--- a/src/mem3/src/mem3_reshard_dbdoc.erl
+++ b/src/mem3/src/mem3_reshard_dbdoc.erl
@@ -210,7 +210,7 @@ range_key(#shard{range = [B, E]}) ->
     list_to_binary([BHex, "-", EHex]).
 
 shard_update_timeout_msec() ->
-    config:get_integer("reshard", "shard_upate_timeout_msec", 300000).
+    config:get_integer("reshard", "shard_update_timeout_msec", 300000).
 
 wait_source_removed(#shard{name = Name} = Source, SleepSec, UntilSec) ->
     case check_source_removed(Source) of


### PR DESCRIPTION
Thanks to Robert Newson for finding the error
