### PR TITLE
Fix init delete dir

### DIFF
--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -410,9 +410,7 @@ delete_dir(RootDelDir, Dir) ->
 
 init_delete_dir(RootDir) ->
     Dir = filename:join(RootDir, ".delete"),
-    % note: ensure_dir requires an actual filename companent, which is the
-    % reason for "foo".
-    filelib:ensure_dir(filename:join(Dir, "foo")),
+    filelib:ensure_path(Dir),
     spawn(fun() ->
         filelib:fold_files(
             Dir,

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -303,7 +303,12 @@ init([N]) ->
         "couchdb", "update_lru_on_read", false
     ),
     ok = config:listen_for_changes(?MODULE, N),
-    ok = couch_file:init_delete_dir(RootDir),
+    % Spawn async .deleted files recursive cleaner, but only
+    % for the first sharded couch_server instance
+    case N of
+        1 -> ok = couch_file:init_delete_dir(RootDir);
+        _ -> ok
+    end,
     ets:new(couch_dbs(N), [
         set,
         protected,


### PR DESCRIPTION
Two improvements for `init_delete_dir`:

 * Avoid spawning more than one `init_delete_dir/1` instances from `couch_server`
 * Use `filelib:ensure_path/1` since it's now available as of OTP 25