### PR TITLE
Improve mem3

### DIFF
--- a/src/mem3/src/mem3_sup.erl
+++ b/src/mem3/src/mem3_sup.erl
@@ -18,19 +18,39 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init(_Args) ->
+    % Some startup order constraints based on call dependencies:
+    %
+    % * mem3_events gen_event should be started before all the others
+    %
+    % * mem3_nodes gen_server is needed so everyone can call mem3:nodes()
+    %
+    % * mem3_sync_nodes needs to run before mem3_sync and
+    %   mem3_sync_event_listener, so they can both can call
+    %   mem3_sync_nodes:add/1
+    %
+    % * mem3_distribution force connects nodes from mem3:nodes(), so start it
+    %   before mem3_sync since mem3_sync:initial_sync/0 expects the connected
+    %   nodes to be there when calling mem3_sync_nodes:add(nodes())
+    %
+    % * mem3_sync_event_listener has to start after mem3_sync, so it can call
+    %   mem3_sync:push/2
+    %
+    % * mem3_seeds and mem3_reshard_sup can wait till the end, as they will
+    %   spawn background work that can go on for a while: seeding system dbs
+    %   from other nodes running resharding jobs
+    %
     Children = [
         child(mem3_events),
         child(mem3_nodes),
-        child(mem3_distribution),
-        child(mem3_seeds),
-        % Order important?
-        child(mem3_sync_nodes),
-        child(mem3_sync),
         child(mem3_shards),
+        child(mem3_sync_nodes),
+        child(mem3_distribution),
+        child(mem3_sync),
         child(mem3_sync_event_listener),
+        child(mem3_seeds),
         child(mem3_reshard_sup)
     ],
-    {ok, {{one_for_one, 10, 1}, couch_epi:register_service(mem3_epi, Children)}}.
+    {ok, {{rest_for_one, 10, 1}, couch_epi:register_service(mem3_epi, Children)}}.
 
 child(mem3_events) ->
     MFA = {gen_event, start_link, [{local, mem3_events}]},

--- a/src/rexi/src/rexi_server_mon.erl
+++ b/src/rexi/src/rexi_server_mon.erl
@@ -57,7 +57,6 @@ aggregate_queue_len(ChildMod) ->
 % Mem3 cluster callbacks
 
 cluster_unstable(Server) ->
-    couch_log:notice("~s : cluster unstable", [?MODULE]),
     gen_server:cast(Server, cluster_unstable),
     Server.
 
@@ -75,7 +74,7 @@ init(ChildMod) ->
         ?CLUSTER_STABILITY_PERIOD_SEC
     ),
     start_servers(ChildMod),
-    couch_log:notice("~s : started servers", [ChildMod]),
+    couch_log:info("~s : started servers", [ChildMod]),
     {ok, ChildMod}.
 
 handle_call(status, _From, ChildMod) ->
@@ -93,13 +92,13 @@ handle_call(Msg, _From, St) ->
 % can be started, but do not immediately stop nodes, defer that till cluster
 % stabilized.
 handle_cast(cluster_unstable, ChildMod) ->
-    couch_log:notice("~s : cluster unstable", [ChildMod]),
+    couch_log:info("~s : cluster unstable", [ChildMod]),
     start_servers(ChildMod),
     {noreply, ChildMod};
 % When cluster is stable, start any servers for new nodes and stop servers for
 % the ones that disconnected.
 handle_cast(cluster_stable, ChildMod) ->
-    couch_log:notice("~s : cluster stable", [ChildMod]),
+    couch_log:info("~s : cluster stable", [ChildMod]),
     start_servers(ChildMod),
     stop_servers(ChildMod),
     {noreply, ChildMod};


### PR DESCRIPTION
Improve cluster startup behavior as three separate commits:

* Sometimes if `mem3` is not initialized yet but `rexi` could start calling us, and so we have to handle `mem3_shards` ets tables not being created yet. Previously, we handled the case of missing ets tables by catching `error:badarg` in places like `for_db/2`, but then forgot to handle it the lower level `maybe_spawn_shard_writer/3` function, so call was still crashing and making a mess in the logs. This is more apparent on startup with nodes being upgraded in a busy cluster.

 * Improve mem3 supervisor. There was a question there left from years back if order is important, it turns out it is. So fix the order. See the reasoning in the commit message. Also since order is important we want to use a [rest_for_one]( https://www.erlang.org/doc/system/sup_princ.html#rest_for_one) supervisor not a `one_for_one`.
 
 * Cleanup node startup logging a bit. We were emitting duplicate logs and also at level that's a bit higher than needed.
 