### PR TITLE
Add guards to `fabric:design_docs/1` to prevent function_clause error

### DIFF
--- a/src/dreyfus/src/dreyfus_fabric_cleanup.erl
+++ b/src/dreyfus/src/dreyfus_fabric_cleanup.erl
@@ -21,7 +21,14 @@
 -export([go/1]).
 
 go(DbName) ->
-    {ok, DesignDocs} = fabric:design_docs(DbName),
+    DesignDocs =
+        case fabric:design_docs(DbName) of
+            {ok, DDocs} when is_list(DDocs) ->
+                DDocs;
+            Else ->
+                couch_log:debug("Invalid design docs: ~p~n", [Else]),
+                []
+        end,
     ActiveSigs = lists:usort(
         lists:flatmap(
             fun active_sigs/1,

--- a/src/nouveau/src/nouveau_fabric_cleanup.erl
+++ b/src/nouveau/src/nouveau_fabric_cleanup.erl
@@ -22,7 +22,14 @@
 -export([go/1]).
 
 go(DbName) ->
-    {ok, DesignDocs} = fabric:design_docs(DbName),
+    DesignDocs =
+        case fabric:design_docs(DbName) of
+            {ok, DDocs} when is_list(DDocs) ->
+                DDocs;
+            Else ->
+                couch_log:debug("Invalid design docs: ~p~n", [Else]),
+                []
+        end,
     ActiveSigs =
         lists:usort(
             lists:flatmap(

--- a/src/smoosh/src/smoosh.erl
+++ b/src/smoosh/src/smoosh.erl
@@ -64,7 +64,14 @@ fold_local_shards(Fun, Acc0) ->
 
 enqueue_views(ShardName) ->
     DbName = mem3:dbname(ShardName),
-    {ok, DDocs} = fabric:design_docs(DbName),
+    DDocs =
+        case fabric:design_docs(DbName) of
+            {ok, Resp} when is_list(Resp) ->
+                Resp;
+            Else ->
+                couch_log:debug("Invalid design docs: ~p~n", [Else]),
+                []
+        end,
     [sync_enqueue({ShardName, id(DDoc)}) || DDoc <- DDocs].
 
 id(#doc{id = Id}) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

When a node is down, `fabric:design_docs/1` will return
`{ok, {nodedown, <<"progress not possible">>}}` instead
of a list of design docs. So added some guards for this
function.

In `ddoc_cache_entry_validation_funs.erl`, we cannot use
an empty list because we need to use the VDU function to
validate the document before updating it, so we raise an
error here.


Error log:
```
exit value:#012{
  {function_clause, [
    {
      lists, flatmap_1,
      [#Fun<ddoc_cache_entry_validation_funs.0.82671214>, {nodedown, <<"progress not possible">>}],
      [{file, "lists.erl"}, {line, 1578}]
    },
    {
      ddoc_cache_entry_validation_funs, recover, 1,
      [{file, "src/ddoc_cache_entry_validation_funs.erl"}, {line, 30}]
    },
    {
      couch_db, '-load_validation_funs/1-fun-0-', 1,
      [{file, "src/couch_db.erl"}, {line, 972}]
    }
  ]}
}#012
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
