### PR TITLE
Update reverse-proxies.rst

### DIFF
--- a/src/docs/src/best-practices/reverse-proxies.rst
+++ b/src/docs/src/best-practices/reverse-proxies.rst
@@ -224,7 +224,7 @@ as ``http(s)://domain.com/couchdb/db1/doc1`` are proxied to
 To proxy the URL ``http(s)://domain.com/couchdb`` to
 ``http://localhost:5984`` so that requests appended to the subdirectory, such
 as ``http(s)://domain.com/couchdb/db1/doc1`` are proxied to
-``http://localhost:5984/db1/doc1``, you have to configure a route in Caddy:
+``http://localhost:5984/db1/doc1``, you have to configure a route in Caddy and strip the subdirectory from the target URI with ``uri strip_prefix``:
 
 .. code-block:: text
 
@@ -236,8 +236,6 @@ as ``http(s)://domain.com/couchdb/db1/doc1`` are proxied to
         }
 
     }
-
-
 
 Reverse proxying + load balancing for CouchDB clusters
 ------------------------------------------------------


### PR DESCRIPTION
Corrected reverse proxying subdirectories with Caddy. Former description would not strip the subdirectory from the reverse proxy target. Changed documentation accordingly. Added an additional paragraph how stripping the subdirectory should be configured in Caddys configuration file. Source: Spent an afternoon figuring this out after unsuccesful application of this doc to a CouchDB+Caddy setup.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Corrected documentation regarding reverse proxying subdirectories with Caddy. Former description would not strip the subdirectory from the reverse proxy target as described. Changed documentation accordingly. Added an additional paragraph how stripping the subdirectory should be configured in Caddys configuration file. Source: Spent an afternoon figuring this out after unsuccesful application of this doc to a CouchDB+Caddy setup.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ X] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
