### PR TITLE
Bump requests to 2.32.4

### DIFF
--- a/src/mango/requirements.txt
+++ b/src/mango/requirements.txt
@@ -1,5 +1,5 @@
 # nose2 0.13.0, requests, hypothesis version are driven
 # by the minimum version for python on centos 8 currently
 nose2==0.13.0
-requests==2.27.1
+requests==2.32.4
 hypothesis==6.31.6

--- a/src/mango/test/mango.py
+++ b/src/mango/test/mango.py
@@ -43,9 +43,17 @@ def random_string(n_max):
     return "".join(random.choice(string.ascii_letters) for _ in range(n))
 
 
+def requests_session():
+    # use trust_env=False to disable possible .netrc usage
+    sess = requests.session()
+    sess.trust_env = False
+    return sess
+
+
 def has_text_service():
-    features = requests.get(COUCH_HOST).json()["features"]
-    return "search" in features
+    with requests_session() as sess:
+        features = sess.get(COUCH_HOST).json()["features"]
+        return "search" in features
 
 
 def clean_up_dbs():
@@ -82,7 +90,7 @@ class Concurrently(object):
 class Database(object):
     def __init__(self, dbname):
         self.dbname = dbname
-        self.sess = requests.session()
+        self.sess = requests_session()
         self.sess.auth = (COUCH_USER, COUCH_PASS)
         self.sess.headers["Content-Type"] = "application/json"
 


### PR DESCRIPTION
Bump requests to the latest version 2.32.4. This is predicated that we also update our Almalinux(CentOS) 8 image to install a later Python.

But as a belt and suspenders, or in case the python update fails also set `trust_env=False` in mango tests. The only place we use requests.
