### PR TITLE
Upgrade Snappy to 1.2.2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -152,7 +152,8 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{snappy,           "snappy",           {tag, "CouchDB-1.0.9"}},
+%%{snappy,           "snappy",           {tag, "CouchDB-1.0.9"}},
+{snappy,           "snappy",           {branch, "upgrade-snappy-1.2.2"}},
 
 %% %% Non-Erlang deps
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},


### PR DESCRIPTION
Upgrading Snappy to version 1.2.2.