### PR TITLE
Update QuickJS

### DIFF
--- a/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
+++ b/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
@@ -1,6 +1,6 @@
---- quickjs-master/quickjs.c	2025-05-24 09:43:14
-+++ quickjs/quickjs.c	2025-05-28 21:55:36
-@@ -30590,10 +30590,24 @@
+--- quickjs-master/quickjs.c	2025-06-14 05:51:48
++++ quickjs/quickjs.c	2025-06-20 13:56:52
+@@ -30599,10 +30599,24 @@
      if (s->token.val == TOK_FUNCTION ||
          (token_is_pseudo_keyword(s, JS_ATOM_async) &&
           peek_token(s, TRUE) == TOK_FUNCTION)) {

--- a/src/couch_quickjs/quickjs/Changelog
+++ b/src/couch_quickjs/quickjs/Changelog
@@ -1,3 +1,18 @@
+- added JSON modules and import attributes
+- added JS_PrintValue() API
+- qjs: pretty print objects in print() and console.log()
+- qjs: better promise rejection tracker heuristics
+- added RegExp v flag
+- added RegExp modifiers
+- added RegExp.escape
+- added Float16Array
+- added Promise.try
+- improved JSON parser spec conformance
+- qjs: improved compatibility of std.parseExtJSON() with JSON5 and
+  accept JSON5 modules
+- added JS_FreePropertyEnum() and JS_AtomToCStringLen() API
+- added Error.isError()
+
 2025-04-26:
 
 - removed the bignum extensions and qjscalc

--- a/src/couch_quickjs/quickjs/test262.conf
+++ b/src/couch_quickjs/quickjs/test262.conf
@@ -103,7 +103,7 @@ destructuring-assignment
 destructuring-binding
 dynamic-import
 error-cause
-Error.isError=skip
+Error.isError
 explicit-resource-management=skip
 exponentiation
 export-star-as-namespace-from-module

--- a/src/couch_quickjs/quickjs/test262_errors.txt
+++ b/src/couch_quickjs/quickjs/test262_errors.txt
@@ -23,7 +23,6 @@ test262/test/staging/sm/TypedArray/prototype-constructor-identity.js:17: Test262
 test262/test/staging/sm/TypedArray/set-detached-bigint.js:27: Error: Assertion failed: expected exception SyntaxError, got RangeError: invalid array length
 test262/test/staging/sm/TypedArray/set-detached.js:112: RangeError: invalid array length
 test262/test/staging/sm/TypedArray/sort_modifications.js:12: Test262Error: Int8Array at index 0 for size 4 Expected SameValue(«0», «1») to be true
-test262/test/staging/sm/TypedArray/subarray.js:15: Test262Error: Expected SameValue(«0», «1») to be true
 test262/test/staging/sm/async-functions/async-contains-unicode-escape.js:45: Error: Assertion failed: expected exception SyntaxError, no exception thrown
 test262/test/staging/sm/async-functions/await-error.js:12: Test262Error: Expected SameValue(«false», «true») to be true
 test262/test/staging/sm/async-functions/await-in-arrow-parameters.js:33: Error: Assertion failed: expected exception SyntaxError, no exception thrown - AsyncFunction:(a = (b = await/r/g) => {}) => {}

--- a/src/couch_quickjs/update_and_apply_patches.sh
+++ b/src/couch_quickjs/update_and_apply_patches.sh
@@ -7,9 +7,6 @@ set -e
 # This is the main branch of the github mirror
 URL=https://github.com/bellard/quickjs/archive/refs/heads/master.zip
 #
-# The other alternatives:
-#   https://github.com/quickjs-ng/quickjs/commits/master/
-
 
 echo
 echo " * backup quickjs to quickjs.bak"
@@ -50,6 +47,9 @@ echo " * removing quickjs.bak"
 rm -rf quickjs.bak
 echo
 
-# Example how to generate patches:
+# Example how to update patches themselves:
 #
+# Run
+#  ./update_patches.sh
+# OR manually run after cloning and unzipping master.zip from quickjs:
 #  diff -u quickjs-master/quickjs.c quickjs/quickjs.c > patches/01-spidermonkey-185-mode.patch

--- a/src/couch_quickjs/update_patches.sh
+++ b/src/couch_quickjs/update_patches.sh
@@ -1,0 +1,22 @@
+# Update patches
+#
+# Call this script after using update_and_apply_patches.sh to adjust
+# the patches themselves. Sometimes line offsets drift and so this takes
+# a new diff from the master QuickJS vs current source tree and regenerates
+# the patch.
+
+set -e
+
+URL=https://github.com/bellard/quickjs/archive/refs/heads/master.zip
+
+echo " * wget ${URL}"
+rm -rf master.zip quickjs-master
+wget -q ${URL}
+echo " * unzip master.zip to quickjs-master"
+unzip -q -o master.zip
+echo " * updating 01-spidermonkey-185-mode.patch"
+set +e
+diff -u quickjs-master/quickjs.c quickjs/quickjs.c > patches/01-spidermonkey-185-mode.patch
+set -e
+echo " * cleaning up"
+rm -rf master.zip quickjs-master


### PR DESCRIPTION
 * Read byteOffset for detached buffers https://github.com/bellard/quickjs/commit/00b1d8d0b2d06e540444245b54a8fd86ccf7260b

 * Add `Error.isError()` https://github.com/bellard/quickjs/commit/098f221cf3124a4a423d089bae83b81ccf108d20

Some tests were updated (more tests pass now) and the upstream changelog was updated, but already have most of those changes anyway.

Also, update our maintenance scripts -- add a script used to adjust the patches themselves. Normally we just have to run `./update_and_apply_patches.sh` that clones QuickJS and applies our patch. But after some time the line numbers in our patch may start to drift vs the upstream `quickjs.c` file, so it helps to regenerate the patch itself periodically. Assuming the local working directory is patched, call the `./update_patches.sh` script and it will clone a fresh QuickJS master and run a diff from that master to our working directory and make that a new patch.
