### PR TITLE
Introduce couch_file:commit_header/2

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -562,7 +562,9 @@ commit_data(St) ->
 
     case NewHeader /= OldHeader orelse NeedsCommit of
         true ->
-            ok = couch_file:commit_header(Fd, NewHeader),
+            couch_file:sync(Fd),
+            ok = couch_file:write_header(Fd, NewHeader),
+            couch_file:sync(Fd),
             couch_stats:increment_counter([couchdb, commits]),
             {ok, St#st{
                 header = NewHeader,

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -562,9 +562,7 @@ commit_data(St) ->
 
     case NewHeader /= OldHeader orelse NeedsCommit of
         true ->
-            couch_file:sync(Fd),
-            ok = couch_file:write_header(Fd, NewHeader),
-            couch_file:sync(Fd),
+            ok = couch_file:commit_header(Fd, NewHeader),
             couch_stats:increment_counter([couchdb, commits]),
             {ok, St#st{
                 header = NewHeader,

--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -660,7 +660,8 @@ commit_compaction_data(#st{header = OldHeader} = St0, Fd) ->
         db_header = Header,
         meta_st = MetaState
     },
-    ok = couch_file:commit_header(Fd, CompHeader),
+    ok = couch_file:sync(Fd),
+    ok = couch_file:write_header(Fd, CompHeader),
     St2 = St1#st{
         header = Header
     },

--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -660,8 +660,7 @@ commit_compaction_data(#st{header = OldHeader} = St0, Fd) ->
         db_header = Header,
         meta_st = MetaState
     },
-    ok = couch_file:sync(Fd),
-    ok = couch_file:write_header(Fd, CompHeader),
+    ok = couch_file:commit_header(Fd, CompHeader),
     St2 = St1#st{
         header = Header
     },

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -598,19 +598,19 @@ handle_call(find_header, _From, #file{fd = Fd, eof = Pos} = File) ->
     {reply, find_header(Fd, Pos div ?SIZE_BLOCK), File};
 handle_call({commit_header, Bin}, _From, #file{fd = Fd} = File) ->
     maybe
-      ok ?= fsync(Fd),
-      {ok, NewFile} ?= do_write_header(Bin, File),
-      ok ?= fsync(Fd),
-      {reply, ok, NewFile}
+        ok ?= fsync(Fd),
+        {ok, NewFile} ?= do_write_header(Bin, File),
+        ok ?= fsync(Fd),
+        {reply, ok, NewFile}
     else
-      {{error, _} = Error, State} ->
-        {reply, Error, State};
-      {error, _} = Error ->
-        % We're intentionally dropping all knowledge
-        % of this Fd so that we don't accidentally
-        % recover in some whacky edge case that I
-        % can't fathom.
-        {stop, Error, Error, #file{fd = nil}}
+        {{error, _} = Error, State} ->
+            {reply, Error, State};
+        {error, _} = Error ->
+            % We're intentionally dropping all knowledge
+            % of this Fd so that we don't accidentally
+            % recover in some whacky edge case that I
+            % can't fathom.
+            {stop, Error, Error, #file{fd = nil}}
     end.
 
 handle_cast(Msg, #file{} = File) ->

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -773,7 +773,7 @@ find_newest_header(Fd, [{Location, Size} | LocationSizes]) ->
     end.
 
 -spec do_write_header(_, _) ->
-    {ok, #file{}} | {{error, Reason :: any()},  #file{}}.
+    {ok, #file{}} | {{error, Reason :: any()}, #file{}}.
 do_write_header(Bin, #file{fd = Fd, eof = Pos} = File) ->
     BinSize = byte_size(Bin),
     case Pos rem ?SIZE_BLOCK of

--- a/src/couch/src/couch_file.erl
+++ b/src/couch/src/couch_file.erl
@@ -47,7 +47,7 @@
 -export([append_term/2, append_term/3]).
 -export([pread_terms/2]).
 -export([append_terms/2, append_terms/3]).
--export([write_header/2, read_header/1]).
+-export([write_header/2, read_header/1, commit_header/2]).
 -export([delete/2, delete/3, nuke_dir/2, init_delete_dir/1]).
 
 % gen_server callbacks
@@ -439,6 +439,14 @@ write_header(Fd, Data) ->
     FinalBin = <<Checksum/binary, Bin/binary>>,
     ioq:call(Fd, {write_header, FinalBin}, erlang:get(io_priority)).
 
+% Same as write_header/2, but ensure durable write.
+commit_header(Fd, Data) ->
+    Bin = ?term_to_bin(Data),
+    Checksum = generate_checksum(Bin),
+    % now we assemble the final header binary and write to disk
+    FinalBin = <<Checksum/binary, Bin/binary>>,
+    ioq:call(Fd, {commit_header, FinalBin}, erlang:get(io_priority)).
+
 init_status_error(ReturnPid, Ref, Error) ->
     ReturnPid ! {Ref, self(), Error},
     ignore.
@@ -596,7 +604,28 @@ handle_call({write_header, Bin}, _From, #file{fd = Fd, eof = Pos} = File) ->
             {reply, Error, reset_eof(File)}
     end;
 handle_call(find_header, _From, #file{fd = Fd, eof = Pos} = File) ->
-    {reply, find_header(Fd, Pos div ?SIZE_BLOCK), File}.
+    {reply, find_header(Fd, Pos div ?SIZE_BLOCK), File};
+handle_call({commit_header, Bin}, From, #file{fd = Fd} = File) ->
+    case fsync(Fd) of
+        ok ->
+            Result = handle_call({write_header, Bin}, From, File),
+            case fsync(Fd) of
+                ok ->
+                    Result;
+                {error, _} = Error ->
+                    % We're intentionally dropping all knowledge
+                    % of this Fd so that we don't accidentally
+                    % recover in some whacky edge case that I
+                    % can't fathom.
+                    {stop, Error, Error, #file{fd = nil}}
+            end;
+        {error, _} = Error ->
+            % We're intentionally dropping all knowledge
+            % of this Fd so that we don't accidentally
+            % recover in some whacky edge case that I
+            % can't fathom.
+            {stop, Error, Error, #file{fd = nil}}
+    end.
 
 handle_cast(Msg, #file{} = File) ->
     {stop, {invalid_cast, Msg}, File}.


### PR DESCRIPTION
## Overview

This PR is an optimization to reduce number of messages to couch_file proccess, in casses when we need to call sync. The couch_file:commit_header/2 is more efficient equivalent of:

```
couch_file:sync(Fd),
ok = couch_file:write_header(Fd, NewHeader),
couch_file:sync(Fd),
```

## Testing recommendations

Existing testing suite should suffice. 

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
