### PR TITLE
Populate zone attribute from COUCHDB_ZONE environment variable

### DIFF
--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -228,8 +228,14 @@ get_value(Key, List, Default) ->
             Default
     end.
 
-set_value(Key, List, Value) ->
-    lists:keyreplace(Key, 1, List, {Key, Value}).
+% insert or update a {Key, Value} tuple in a list of tuples
+-spec set_value(Key, TupleList1, Value) -> TupleList2 when
+    Key :: term(),
+    TupleList1 :: [tuple()],
+    Value :: term(),
+    TupleList2 :: [tuple()].
+set_value(Key, TupleList1, Value) ->
+    lists:keystore(Key, 1, TupleList1, {Key, Value}).
 
 get_nested_json_value({Props}, [Key | Keys]) ->
     case couch_util:get_value(Key, Props, nil) of

--- a/src/docs/src/cluster/databases.rst
+++ b/src/docs/src/cluster/databases.rst
@@ -66,6 +66,9 @@ Add a key value pair of the form:
 
     "zone": "metro-dc-a"
 
+Alternatively, you can set the ``COUCHDB_ZONE`` environment variable
+on each node and CouchDB will configure this document for you on startup.
+
 Do this for all of the nodes in your cluster.
 
 In your config file (``local.ini`` or ``default.ini``) on each node, define a

--- a/src/docs/src/cluster/sharding.rst
+++ b/src/docs/src/cluster/sharding.rst
@@ -650,6 +650,9 @@ Do this for all of the nodes in your cluster. For example:
             "zone": "{zone-name}"
             }'
 
+Alternatively, you can set the ``COUCHDB_ZONE`` environment variable
+on each node and CouchDB will configure this document for you on startup.
+
 In the local config file (``local.ini``) of each node, define a
 consistent cluster-wide setting like:
 
@@ -669,7 +672,7 @@ when the database is created, using the same syntax as the ini file:
 
 .. code-block:: bash
 
-    curl -X PUT $COUCH_URL:5984/{db}?zone={zone}
+    curl -X PUT $COUCH_URL:5984/{db}?placement={zone}
 
 The ``placement`` argument may also be specified. Note that this *will*
 override the logic that determines the number of created replicas!

--- a/src/mem3/test/eunit/mem3_zone_test.erl
+++ b/src/mem3/test/eunit/mem3_zone_test.erl
@@ -1,0 +1,77 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mem3_zone_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+mem3_zone_test_() ->
+    {
+        foreach,
+        fun setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(t_empty_zone),
+            ?TDEF_FE(t_set_zone_from_env),
+            ?TDEF_FE(t_set_zone_when_node_in_seedlist),
+            ?TDEF_FE(t_zone_already_set)
+        ]
+    }.
+
+assertZoneEqual(Expected) ->
+    [Node | _] = mem3:nodes(),
+    Actual = mem3:node_info(Node, <<"zone">>),
+    ?assertEqual(Expected, Actual).
+
+t_empty_zone(_) ->
+    ok = application:start(mem3),
+    assertZoneEqual(undefined).
+
+t_set_zone_from_env(_) ->
+    Zone = "zone1",
+    os:putenv("COUCHDB_ZONE", Zone),
+    ok = application:start(mem3),
+    assertZoneEqual(iolist_to_binary(Zone)).
+
+t_set_zone_when_node_in_seedlist(_) ->
+    CfgSeeds = "nonode@nohost",
+    config:set("cluster", "seedlist", CfgSeeds, false),
+    Zone = "zone1",
+    os:putenv("COUCHDB_ZONE", Zone),
+    ok = application:start(mem3),
+    assertZoneEqual(iolist_to_binary(Zone)).
+
+t_zone_already_set(_) ->
+    Zone = "zone1",
+    os:putenv("COUCHDB_ZONE", Zone),
+    ok = application:start(mem3),
+    application:stop(mem3),
+    ok = application:start(mem3),
+    assertZoneEqual(iolist_to_binary(Zone)).
+
+setup() ->
+    meck:new(mem3_seeds, [passthrough]),
+    meck:new(mem3_rpc, [passthrough]),
+    test_util:start_couch([rexi]).
+
+teardown(Ctx) ->
+    catch application:stop(mem3),
+    os:unsetenv("COUCHDB_ZONE"),
+    Filename = config:get("mem3", "nodes_db", "_nodes") ++ ".couch",
+    file:delete(filename:join([?BUILDDIR(), "tmp", "data", Filename])),
+    case config:get("couch_httpd_auth", "authentication_db") of
+        undefined -> ok;
+        DbName -> couch_server:delete(list_to_binary(DbName), [])
+    end,
+    meck:unload(),
+    test_util:stop_couch(Ctx).


### PR DESCRIPTION
## Overview

This adds a feature to populate the zone field in the `nodes` database by setting the
`COUCHDB_ZONE` environment variable. Setting the zone for a node was previously an awkward piece of cluster setup orchestration because it required editing the a document on each of the local "nodes" after CouchDB has started but before creating any other system databases.

This implementation reads the `COUCHDB_ZONE` environment variable when mem3 starts and, if present, updates the local node document with that zone string.

One nuance is that multiple nodes in the cluster might create the same first revision of a node document due to the seedlist feature, which pre-emptively adds the seeds to the nodes database. To prevent conflicts when the nodes database is replicated between peers, the zone is set using an additional update to the node document for the local node only.

Other things to note:
 * We generally don't expect `COUCHDB_ZONE` to change in the lifetime of a node, but the code does allow this.
 * If `COUCHDB_ZONE` is not set, no modifications to the node document are made.

## Testing recommendations

Eunit tests are added to verify the node document is as expected. You can also test using:

```
COUCHDB_ZONE="zone1" ./dev/run

...

curl http://127.0.0.1:15984/_node/_local/_nodes/_all_docs?include_docs=true  
```

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
