### PR TITLE
Fix query args parsing during cluster upgrades

### DIFF
--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -287,12 +287,22 @@ query_all_docs(Db, Args0, Callback, Acc) ->
         couch_index_util:hexsig(couch_hash:md5_hash(?term_to_bin(Info)))
     end),
     Args1 = Args0#mrargs{view_type = map},
+
+    % TODO: Compatibility clause. Remove after upgrading to next minor release
+    % after 3.5.0.
+    %
+    % As of commit 7aa8a4, args are validated in fabric. However, during online
+    % cluster upgrades, old nodes will still expect args to be validated on
+    % workers, so keep the clause around until the next minor version then
+    % remove.
+    %
+    Args2 = couch_mrview_util:validate_all_docs_args(Db, Args1),
     {ok, Acc1} =
-        case Args1#mrargs.preflight_fun of
+        case Args2#mrargs.preflight_fun of
             PFFun when is_function(PFFun, 2) -> PFFun(Sig, Acc);
             _ -> {ok, Acc}
         end,
-    all_docs_fold(Db, Args1, Callback, Acc1).
+    all_docs_fold(Db, Args2, Callback, Acc1).
 
 query_view(Db, DDoc, VName) ->
     Args = #mrargs{extra = [{view_row_map, true}]},

--- a/src/fabric/test/eunit/fabric_tests.erl
+++ b/src/fabric/test/eunit/fabric_tests.erl
@@ -298,7 +298,7 @@ t_query_view_configuration({_Ctx, DbName}) ->
             view_type = map,
             start_key_docid = <<>>,
             end_key_docid = <<255>>,
-            extra = [{view_row_map, true}]
+            extra = [{validated, true}, {view_row_map, true}]
         },
     Options = [],
     Accumulator = [],


### PR DESCRIPTION
In commit caa4f9b3557e0bc6253b3099fef51903c0b5707c we optimized query args validation so it happens on the coordinator side only. However, during online cluster upgrades some requests like _all_docs from old nodes executed on newly upgrades nodes will fail as the args won't be validated.

To bridge the online upgrade gap add a `validated` optional flag to args. If the flag is not set, the workers will validate the args; if the flag is already set by the coordinator, they won't be revalidated, so we don't lose the minor performance gain from having to validate them twice.
