### PR TITLE
Print the name of the failed property test

### DIFF
--- a/src/couch/include/couch_eunit_proper.hrl
+++ b/src/couch/include/couch_eunit_proper.hrl
@@ -18,12 +18,12 @@
         {
             atom_to_list(F),
             {timeout, QuickcheckTimeout,
-                ?_assert(proper:quickcheck(?MODULE:F(), [
+                ?_test(?assertMatch(true, proper:quickcheck(?MODULE:F(), [
                     {to_file, user},
                     {start_size, 2},
                     {numtests, NumTests},
                     long_result
-                 ]))}
+                ]), "Failed property test '" ++ atom_to_list(F) ++ "'"))}
             }
         || {F, 0} <- ?MODULE:module_info(exports), F > 'prop_', F < 'prop`'
     ]).


### PR DESCRIPTION
## Overview

When the eunit test has many property tests in it the developer have a hard time figuring out which of the tests fail. Because the output look like:

```
**error:{assertMatch,[{module,mem3_ring_prop_tests},
              {line,20},
              {expression,"proper : quickcheck ( ? MODULE : F ( ) , [ { to_file , user } , { start_size , 2 } , { numtests , 100 } , long_result ] )"},
              {pattern,"true"},
              {value, ...}]}
```

The line number in there is not usable either since it points to the place where we are calling proper:quickcheck.

This PR adds a `comment` tuple to the error, so it would look like the following:

```
**error:{assertMatch,[{module,mem3_ring_prop_tests},
              {line,20},
              {comment,"Failed property test 'prop_get_ring_with_connected_intervals'"},
              {expression,"proper : quickcheck ( ? MODULE : F ( ) , [ { to_file , user } , { start_size , 2 } , { numtests , 100 } , long_result ] )"},
              {pattern,"true"},
              {value, ... }]}
```


## Testing recommendations

Update https://github.com/apache/couchdb/blob/a7f0abf43c68b6641f05e4fb669463b3ff04c5b7/src/mem3/test/eunit/mem3_ring_prop_tests.erl#L24 to make it fail.

```diff
diff --git i/src/mem3/test/eunit/mem3_ring_prop_tests.erl w/src/mem3/test/eunit/mem3_ring_prop_tests.erl
index 150bdbd4a..ec4e2dee1 100644
--- i/src/mem3/test/eunit/mem3_ring_prop_tests.erl
+++ w/src/mem3/test/eunit/mem3_ring_prop_tests.erl
@@ -28,7 +28,7 @@ prop_get_ring_with_connected_intervals() ->
         ?FORALL(
             Intervals,
             g_connected_intervals(Start, End),
-            mem3_util:get_ring(Intervals, Start, End) =:= lists:sort(Intervals)
+            mem3_util:get_ring(Intervals, Start, End) =/= lists:sort(Intervals)
         )
     ).
```

Then run `make && make eunit apps=mem3 tests=property_test_` to see the error message.

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
