### PR TITLE
use ASF fork of gun for cowlib dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ clean:
 	@rm -rf .rebar/
 	@rm -f bin/couchjs
 	@rm -f bin/weatherreport
-	@rm -rf src/*/ebin
+	@find src/*/ebin -not -path 'src/cowlib/ebin/cowlib.app' -not -path 'src/gun/ebin/gun.app' -delete
 	@rm -rf src/*/.rebar
 	@rm -rf src/*/priv/*.so
 	@rm -rf share/server/main.js share/server/main-ast-bypass.js share/server/main-coffee.js

--- a/configure
+++ b/configure
@@ -34,10 +34,6 @@ ERLANG_MD5="false"
 SKIP_DEPS="false"
 WITH_SPIDERMONKEY="true"
 
-export GIT_CONFIG_COUNT=1
-export GIT_CONFIG_KEY_0="url.https://github.com/apache/couchdb-.insteadOf"
-export GIT_CONFIG_VALUE_0="https://github.com/ninenines/"
-
 run_erlang() {
     erl -noshell -eval "$1" -eval "halt()."
 }

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -158,7 +158,7 @@ DepDescs = [
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
                    {tag, "v1.3.4"}, [raw]},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-6"}},
-{gun,              "gun",              {tag, "2.2.0"}},
+{gun,              "gun",              {tag, "2.2.0-couchdb"}},
 {jiffy,            "jiffy",            {tag, "1.1.2"}},
 {mochiweb,         "mochiweb",         {tag, "v3.2.2"}},
 {meck,             "meck",             {tag, "1.0.0"}},


### PR DESCRIPTION
I made a branch called `couchdb` in the apache/couchdb-gun repo based on the `2.2.0` tag. I added a commit that changes where the `cowlib` dep comes from and tagged that as `2.2.0-couchdb`. This PR switches couchdb to point to that tag.
