### PR TITLE
Increase some test timeouts to hopefully fix a flaky PPC64LE test

### DIFF
--- a/src/couch_replicator/src/couch_replicator_fabric_rpc.erl
+++ b/src/couch_replicator/src/couch_replicator_fabric_rpc.erl
@@ -106,7 +106,7 @@ docs_test_() ->
         fun() -> ok end,
         fun(_) -> ok end,
         [
-            ?TDEF_FE(t_docs)
+            ?TDEF_FE(t_docs, 15)
         ]
     }.
 
@@ -140,10 +140,10 @@ docs_cb_test_() ->
         end,
         fun(_) -> meck:unload() end,
         [
-            ?TDEF_FE(t_docs_cb_meta),
-            ?TDEF_FE(t_docs_cb_row_skip),
-            ?TDEF_FE(t_docs_cb_row),
-            ?TDEF_FE(t_docs_cb_complete)
+            ?TDEF_FE(t_docs_cb_meta, 15),
+            ?TDEF_FE(t_docs_cb_row_skip, 15),
+            ?TDEF_FE(t_docs_cb_row, 15),
+            ?TDEF_FE(t_docs_cb_complete, 15)
         ]
     }.
 


### PR DESCRIPTION
Noticed three failures in there on PPC64LE worker. I think it's something to do with those nodes being slow or oversubscribed or something like that. Before taking out PPC64LE out of the CI rotation give it another chance and see if just increasing the timeouts on these tests would help.
