### PR TITLE
Improve scanner performance

### DIFF
--- a/src/couch_scanner/src/couch_scanner_plugin_conflict_finder.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin_conflict_finder.erl
@@ -19,7 +19,7 @@
     complete/1,
     checkpoint/1,
     db/2,
-    doc_id/3
+    doc_fdi/3
 ]).
 
 -include_lib("couch_scanner/include/couch_scanner_plugin.hrl").
@@ -76,12 +76,10 @@ checkpoint(#st{sid = SId, opts = Opts}) ->
 db(#st{} = St, _DbName) ->
     {ok, St}.
 
-doc_id(#st{} = St, <<?DESIGN_DOC_PREFIX, _/binary>>, _Db) ->
-    {skip, St};
-doc_id(#st{} = St, DocId, Db) ->
-    {ok, #doc_info{revs = Revs}} = couch_db:get_doc_info(Db, DocId),
+doc_fdi(#st{} = St, #full_doc_info{} = FDI, Db) ->
+    #doc_info{revs = Revs} = couch_doc:to_doc_info(FDI),
     DbName = mem3:dbname(couch_db:name(Db)),
-    {ok, check(St, DbName, DocId, Revs)}.
+    {ok, check(St, DbName, FDI#full_doc_info.id, Revs)}.
 
 % Private
 

--- a/src/couch_scanner/src/couch_scanner_plugin_find.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin_find.erl
@@ -23,7 +23,6 @@
     complete/1,
     checkpoint/1,
     db/2,
-    ddoc/3,
     shards/2,
     db_opened/2,
     doc_id/3,
@@ -76,11 +75,6 @@ db(#st{} = St, DbName) ->
     Meta = #{sid => SId, db => DbName},
     report_match(DbName, Pats, Meta),
     {ok, St}.
-
-ddoc(#st{} = St, _DbName, #doc{} = _DDoc) ->
-    % We'll check doc bodies during the shard scan
-    % so no need to keep inspecting ddocs
-    {stop, St}.
 
 shards(#st{sid = SId} = St, Shards) ->
     case debug() of


### PR DESCRIPTION
 * If the plugin doesn't need to inspect ddocs at the cluster level, avoid the expensive `fabric:all_docs()` call, both the finder and the conflict checker benefit from this one.

 * Let the plugins examine the `#full_doc_info{}` structure directly in the new optional `doc_fdi` callback. Previously, the conflict checker had to re-read the FDI just to look for conflict even though the plugin already read the FDI.
