### PR TITLE
In the scanner, traverse docs by sequence instead of by ID.

### DIFF
--- a/src/couch_scanner/src/couch_scanner_plugin_find.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin_find.erl
@@ -88,7 +88,9 @@ db_opened(#st{sid = SId} = St, Db) ->
         true -> ?DEBUG("", [], #{sid => SId, db => Db});
         false -> ok
     end,
-    {ok, St}.
+    % Search backwards with the idea that we may be looking for some recent
+    % changes we just made to the database.
+    {couch_db:get_update_seq(Db), [{dir, rev}], St}.
 
 doc_id(#st{} = St, DocId, Db) ->
     #st{sid = SId, compiled_regexes = Pats} = St,


### PR DESCRIPTION
Previously, the scanner traversed docs by id, skipping deleted documents. However, some plugins like the conflict checker, may want to inspect deleted docs. To fix this, switch to using by-seq order during scanning. This will also let us add more precise checkpoints in the future; we could, for example, checkpoint during the db traversal not just per-db.

To let plugins customize the traversal, modify the db_opened/2 callback so it can return start changes sequence and changes folding options. Use this new feature in the finder since there it makes sense to scan backwards to find the most recently added data first (i.e. someone just added something they shouldn't have to the db and we'd like to find it).

Since we now consider deleted documents, adjust the QuickJS scanner to discard deleted FDIs before even opening the doc bodies.

For the conflict checker, add a test to ensure we do catch deleted conflicts when all of them are deleted.

As minor tweak, improved the scanner tests by using `#doc{}` records instead of plain tuples.
