### PR TITLE
Nouveau search optimization

### DIFF
--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -30,6 +30,7 @@
     "purge with conflicts",
     "index same field with different field types",
     "index not found",
-    "meta"
+    "meta",
+    "stale search"
   ]
 }


### PR DESCRIPTION
## Overview

optimize searches when index is fresh

Send the search request first and use the 409 Conflict response to trigger index update (as long as query param 'update' is not set to false). This eliminates a round-trip on every search request when the index is up to date at the cost of an additional search request when it isn't (though the additional search request is rejected with a 409 based on the index state, no additional Lucene query is executed).

I also fixed a bug for the update=false case. If the index never becomes fresh (via `ken` background) the search request loops until we hit a timeout. What now happens is we'll return whatever the out-of-date search indexes return.

## Testing recommendations

Test added for the update=false bug, existing tests cover the rest.

## Related Issues or Pull Requests

N/A
## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
