### PR TITLE
Use copy_props in the compactor instead of set_props

### DIFF
--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -381,7 +381,7 @@ copy_compact(#comp_st{} = CompSt) ->
 
     % Copy general properties over
     Props = couch_bt_engine:get_props(St),
-    {ok, NewSt5} = couch_bt_engine:set_props(NewSt4, Props),
+    {ok, NewSt5} = couch_bt_engine:copy_props(NewSt4, Props),
 
     FinalUpdateSeq = couch_bt_engine:get_update_seq(St),
     {ok, NewSt6} = couch_bt_engine:set_update_seq(NewSt5, FinalUpdateSeq),


### PR DESCRIPTION
Previously, compactor used set_props/2 instead of copy_props/2. The difference is set_props/2 also advances the update sequence, while copy_props/2 doesn't. However, we should not do that when we copy security and props in the compactor. In this case it turned to be a benign issue since immediately after the update sequence is reset anyway to the one from the old state the following snippet:

```
    FinalUpdateSeq = couch_bt_engine:get_update_seq(St)
    {ok, NewSt6} = couch_bt_engine:set_update_seq(NewSt5, FinalUpdateSeq)
```
