### PR TITLE
Minor couch_btree refactoring

### DIFF
--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -182,16 +182,6 @@
     db_open_options = []
 }).
 
--record(btree, {
-    fd,
-    root,
-    extract_kv,
-    assemble_kv,
-    less,
-    reduce = nil,
-    compression = ?DEFAULT_COMPRESSION
-}).
-
 -record(proc, {
     pid,
     lang,

--- a/src/couch/src/couch_btree.erl
+++ b/src/couch/src/couch_btree.erl
@@ -14,10 +14,21 @@
 
 -export([open/2, open/3, query_modify/4, add/2, add_remove/3]).
 -export([fold/4, full_reduce/1, final_reduce/2, size/1, foldl/3, foldl/4]).
--export([fold_reduce/4, lookup/2, get_state/1, set_options/2]).
+-export([fold_reduce/4, lookup/2, set_options/2]).
+-export([is_btree/1, get_state/1, get_fd/1, get_reduce_fun/1]).
 -export([extract/2, assemble/3, less/3]).
 
 -include_lib("couch/include/couch_db.hrl").
+
+-record(btree, {
+    fd,
+    root,
+    extract_kv,
+    assemble_kv,
+    less,
+    reduce = nil,
+    compression = ?DEFAULT_COMPRESSION
+}).
 
 -define(FILL_RATIO, 0.5).
 
@@ -56,8 +67,19 @@ set_options(Bt, [{compression, Comp} | Rest]) ->
 open(State, Fd, Options) ->
     {ok, set_options(#btree{root = State, fd = Fd}, Options)}.
 
+is_btree(#btree{}) ->
+    true;
+is_btree(_) ->
+    false.
+
 get_state(#btree{root = Root}) ->
     Root.
+
+get_fd(#btree{fd = Fd}) ->
+    Fd.
+
+get_reduce_fun(#btree{reduce = Reduce}) ->
+    Reduce.
 
 final_reduce(#btree{reduce = Reduce}, Val) ->
     final_reduce(Reduce, Val);

--- a/src/couch/test/eunit/couch_btree_tests.erl
+++ b/src/couch/test/eunit/couch_btree_tests.erl
@@ -13,7 +13,6 @@
 -module(couch_btree_tests).
 
 -include_lib("couch/include/couch_eunit.hrl").
--include_lib("couch/include/couch_db.hrl").
 
 -define(ROWS, 1000).
 % seconds
@@ -81,7 +80,7 @@ btree_open_test_() ->
     {ok, Btree} = couch_btree:open(nil, Fd, [{compression, none}]),
     {
         "Ensure that created btree is really a btree record",
-        ?_assert(is_record(Btree, btree))
+        ?_assert(couch_btree:is_btree(Btree))
     }.
 
 sorted_kvs_test_() ->
@@ -189,10 +188,10 @@ reductions_test_() ->
     }.
 
 should_set_fd_correctly(_, {Fd, Btree}) ->
-    ?_assertMatch(Fd, Btree#btree.fd).
+    ?_assertMatch(Fd, couch_btree:get_fd(Btree)).
 
 should_set_root_correctly(_, {_, Btree}) ->
-    ?_assertMatch(nil, Btree#btree.root).
+    ?_assertMatch(nil, couch_btree:get_state(Btree)).
 
 should_create_zero_sized_btree(_, {_, Btree}) ->
     ?_assertMatch(0, couch_btree:size(Btree)).
@@ -200,7 +199,7 @@ should_create_zero_sized_btree(_, {_, Btree}) ->
 should_set_reduce_option(_, {_, Btree}) ->
     ReduceFun = fun reduce_fun/2,
     Btree1 = couch_btree:set_options(Btree, [{reduce, ReduceFun}]),
-    ?_assertMatch(ReduceFun, Btree1#btree.reduce).
+    ?_assertMatch(ReduceFun, couch_btree:get_reduce_fun(Btree1)).
 
 should_fold_over_empty_btree(_, {_, Btree}) ->
     {ok, _, EmptyRes} = couch_btree:foldl(Btree, fun(_, X) -> {ok, X + 1} end, 0),
@@ -228,7 +227,7 @@ should_have_lesser_size_than_file(Fd, Btree) ->
 should_keep_root_pointer_to_kp_node(Fd, Btree) ->
     ?_assertMatch(
         {ok, {kp_node, _}},
-        couch_file:pread_term(Fd, element(1, Btree#btree.root))
+        couch_file:pread_term(Fd, element(1, couch_btree:get_state(Btree)))
     ).
 
 should_remove_all_keys(KeyValues, Btree) ->

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -1317,7 +1317,8 @@ make_user_reds_reduce_fun(Lang, ReduceFuns, NthRed) ->
 
 get_btree_state(nil) ->
     nil;
-get_btree_state(#btree{} = Btree) ->
+get_btree_state(Btree) ->
+    true = couch_btree:is_btree(Btree),
     couch_btree:get_state(Btree).
 
 extract_view_reduce({red, {N, _Lang, #mrview{reduce_funs = Reds}}, _Ref}) ->


### PR DESCRIPTION
Make the #btree{} record private. There is no reason for the record to be in the public include file.
