### PR TITLE
BTree engine term cache

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -130,6 +130,26 @@ view_index_dir = {{view_index_dir}}
 ; downgrade or even open the databases in question.
 ;prohibit_downgrade = true
 
+[bt_engine_cache]
+; Memory used for btree engine cache. This is a cache for top levels of
+; database btrees (id tree, seq tree) and a few terms from the db header. Value
+; is in bytes.
+;max_size = 67108864
+;
+; Items not accessed in a while are eventually evicted. However, if the memory
+; used is below this percentage, then even the unused items are left in the
+; cache. The trade-off here is when a new workload starts, it may find the
+; cache with some stale items during the first few seconds and not be able to
+; insert its entries in.
+;leave_percent = 30
+;
+; Cache database btree nodes up to this depth only. Depth starts at 1 at root,
+; then at 2 the next level down, and so on. Only intermediate (pointer) nodes
+; will be cached, those are the nodes which point to other nodes, as opposed to
+; leaf key-value nodes, which hold revision trees. To disable db btree node
+; caching set the value to 0
+;db_btree_cache_depth = 3
+
 [purge]
 ; Allowed maximum number of documents in one purge request
 ;max_document_id_number = 100

--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -286,6 +286,7 @@ get_stats() ->
         {run_queue, SQ},
         {run_queue_dirty_cpu, DCQ},
         {ets_table_count, length(ets:all())},
+        {bt_engine_cache, couch_bt_engine_cache:info()},
         {context_switches, element(1, statistics(context_switches))},
         {reductions, element(1, statistics(reductions))},
         {garbage_collection_count, NumberOfGCs},

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -474,3 +474,15 @@
     {type, counter},
     {desc, <<"number of mango selector evaluations">>}
 ]}.
+{[couchdb, bt_engine_cache, hits], [
+    {type, counter},
+    {desc, <<"number of bt_engine cache hits">>}
+]}.
+{[couchdb, bt_engine_cache, misses], [
+    {type, counter},
+    {desc, <<"number of bt_engine cache misses">>}
+]}.
+{[couchdb, bt_engine_cache, full], [
+    {type, counter},
+    {desc, <<"number of times bt_engine cache was full">>}
+]}.

--- a/src/couch/src/couch_bt_engine_cache.erl
+++ b/src/couch/src/couch_bt_engine_cache.erl
@@ -1,0 +1,292 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_bt_engine_cache).
+
+-include_lib("stdlib/include/ms_transform.hrl").
+
+% Main API
+%
+-export([
+    insert/2,
+    insert/3,
+    reset/1,
+    lookup/1,
+    info/0,
+    tables/0
+]).
+
+% Supervision and start API
+%
+-export([
+    create_tables/0,
+    sup_children/0,
+    start_link/1,
+    init/1
+]).
+
+-define(DEFAULT_SIZE, 67108864).
+-define(DEFAULT_LEAVE_PERCENT, 30).
+-define(INTERVAL_MSEC, 3000).
+% How often cleaners check if the ets size increases. This is used in cases
+% when initially, at the start the cleaning interval, ets table size is below
+% "leave percent". Then we skip cleaning all the 0 usage entries. However, if a
+% new set of requests come in soon after, but before the next clean-up interval
+% they'll fail since the cache would be full. To be able to react quicker and
+% make room, cleaners poll table sizes a bit more often.
+-define(CLEANUP_INTERVAL_MSEC, 100).
+% 1 bsl 58, power of 2 that's still an immediate integer
+-define(MAX_PRIORITY, 288230376151711744).
+-define(PTERM_KEY, {?MODULE, caches}).
+% Metrics
+-define(HITS, hits).
+-define(MISSES, misses).
+-define(FULL, full).
+
+-record(cache, {tid, max_size}).
+
+% Main API
+
+insert(Key, Term) ->
+    insert(Key, Term, 1).
+
+insert(Key, Term, Priority) when is_integer(Priority) ->
+    Priority1 = min(?MAX_PRIORITY, max(0, Priority)),
+    case get_cache(Key) of
+        #cache{tid = Tid, max_size = Max} ->
+            case ets:info(Tid, memory) < Max of
+                true ->
+                    case ets:insert_new(Tid, {Key, Priority1, Term}) of
+                        true ->
+                            true;
+                        false ->
+                            bump_usage(Tid, Key),
+                            false
+                    end;
+                false ->
+                    bump_metric(?FULL),
+                    false
+            end;
+        undefined ->
+            false
+    end.
+
+reset(Key) ->
+    case get_cache(Key) of
+        #cache{tid = Tid} -> reset_usage(Tid, Key);
+        undefined -> true
+    end.
+
+lookup(Key) ->
+    case get_cache(Key) of
+        #cache{tid = Tid} ->
+            case ets:lookup_element(Tid, Key, 3, undefined) of
+                undefined ->
+                    bump_metric(?MISSES),
+                    undefined;
+                Term ->
+                    bump_usage(Tid, Key),
+                    bump_metric(?HITS),
+                    Term
+            end;
+        undefined ->
+            undefined
+    end.
+
+info() ->
+    case persistent_term:get(?PTERM_KEY, undefined) of
+        Caches when is_tuple(Caches) ->
+            SizeMem = [info(C) || C <- tuple_to_list(Caches)],
+            MaxMem = [Max || #cache{max_size = Max} <- tuple_to_list(Caches)],
+            {Sizes, Mem} = lists:unzip(SizeMem),
+            #{
+                size => lists:sum(Sizes),
+                memory => lists:sum(Mem),
+                max_memory => lists:sum(MaxMem) * wordsize(),
+                full => sample_metric(?FULL),
+                hits => sample_metric(?HITS),
+                misses => sample_metric(?MISSES),
+                shard_count => shard_count()
+            };
+        undefined ->
+            #{}
+    end.
+
+tables() ->
+    case persistent_term:get(?PTERM_KEY, undefined) of
+        Caches when is_tuple(Caches) ->
+            [Tid || #cache{tid = Tid} <- tuple_to_list(Caches)];
+        undefined ->
+            []
+    end.
+
+% Supervisor helper functions
+
+create_tables() ->
+    BtCaches = [new() || _ <- lists:seq(1, shard_count())],
+    persistent_term:put(?PTERM_KEY, list_to_tuple(BtCaches)).
+
+sup_children() ->
+    [sup_child(I) || I <- lists:seq(1, shard_count())].
+
+sup_child(N) ->
+    Name = list_to_atom("couch_bt_engine_cache_" ++ integer_to_list(N)),
+    #{id => Name, start => {?MODULE, start_link, [N]}, shutdown => brutal_kill}.
+
+% Process start and main loop
+
+start_link(N) when is_integer(N) ->
+    {ok, proc_lib:spawn_link(?MODULE, init, [N])}.
+
+init(N) ->
+    Caches = persistent_term:get(?PTERM_KEY),
+    Cache = #cache{tid = Tid} = element(N, Caches),
+    ets:delete_all_objects(Tid),
+    loop(Cache).
+
+loop(#cache{tid = Tid} = Cache) ->
+    decay(Tid),
+    Next = now_msec() + wait_interval(?INTERVAL_MSEC),
+    clean(Cache, Next - ?CLEANUP_INTERVAL_MSEC),
+    remove_dead(Cache),
+    WaitLeft = max(10, Next - now_msec()),
+    timer:sleep(WaitLeft),
+    loop(Cache).
+
+% Clean unused procs. If we haven't cleaned any keep polling at a higher
+% rate so we react quicker if a new set of entries are added.
+%
+clean(#cache{tid = Tid} = Cache, Until) ->
+    case now_msec() < Until of
+        true ->
+            case should_clean(Cache) of
+                true ->
+                    ets:match_delete(Tid, {'_', 0, '_'});
+                false ->
+                    timer:sleep(wait_interval(?CLEANUP_INTERVAL_MSEC)),
+                    clean(Cache, Until)
+            end;
+        false ->
+            false
+    end.
+
+should_clean(#cache{tid = Tid, max_size = Max}) ->
+    ets:info(Tid, memory) >= Max * leave_percent() / 100.
+
+remove_dead(#cache{tid = Tid}) ->
+    All = pids(Tid),
+    Alive = sets:filter(fun is_process_alive/1, All),
+    Dead = sets:subtract(All, Alive),
+    % In OTP 27+ use sets:map/2
+    Fun = fun(Pid, _) -> ets:match_delete(Tid, {{Pid, '_'}, '_', '_'}) end,
+    sets:fold(Fun, true, Dead).
+
+pids(Tid) ->
+    Acc = couch_util:new_set(),
+    try
+        ets:foldl(fun pids_fold/2, Acc, Tid)
+    catch
+        error:badarg -> Acc
+    end.
+
+pids_fold({{Pid, _}, _, _}, Acc) when is_pid(Pid) ->
+    sets:add_element(Pid, Acc);
+pids_fold({_, _, _}, Acc) ->
+    Acc.
+
+new() ->
+    Opts = [public, {write_concurrency, true}, {read_concurrency, true}],
+    Max0 = round(max_size() / wordsize() / shard_count()),
+    % Some per-table overhead for the table metadata
+    Max = Max0 + round(250 * 1024 / wordsize()),
+    #cache{tid = ets:new(?MODULE, Opts), max_size = Max}.
+
+get_cache(Term) ->
+    case persistent_term:get(?PTERM_KEY, undefined) of
+        Caches when is_tuple(Caches) ->
+            Index = erlang:phash2(Term, tuple_size(Caches)),
+            #cache{} = element(1 + Index, Caches);
+        undefined ->
+            undefined
+    end.
+
+bump_usage(Tid, Key) ->
+    % We're updating the second field incrementing it by 1 and clamping it
+    % at ?MAX_PRIORITY. We don't set the default for the update_counter
+    % specifically to avoid creating bogus entries just from updating the
+    % counter, so expect the error:badarg here sometimes.
+    UpdateOp = {2, 1, ?MAX_PRIORITY, ?MAX_PRIORITY},
+    try
+        ets:update_counter(Tid, Key, UpdateOp)
+    catch
+        error:badarg -> ok
+    end.
+
+reset_usage(Tid, Key) ->
+    % Reset the value of the usage to 0. Since max value is ?MAX_PRIORITY,
+    % subtract that and clamp it at 0. Do not provide a default since if an
+    % entry is missing we don't want to create a bogus one from this operation.
+    UpdateOp = {2, -?MAX_PRIORITY, 0, 0},
+    try
+        ets:update_counter(Tid, Key, UpdateOp)
+    catch
+        error:badarg -> ok
+    end.
+
+info(#cache{tid = Tid}) ->
+    Memory = ets:info(Tid, memory) * wordsize(),
+    Size = ets:info(Tid, size),
+    {Size, Memory}.
+
+decay(Tid) ->
+    MatchSpec = ets:fun2ms(
+        fun({Key, Usage, Term}) when Usage > 0 ->
+            {Key, Usage bsr 1, Term}
+        end
+    ),
+    ets:select_replace(Tid, MatchSpec).
+
+shard_count() ->
+    % Use a minimum size of 16 even for there are less than 16 schedulers
+    % to keep the total tables size a bit smaller
+    max(16, erlang:system_info(schedulers)).
+
+wait_interval(Interval) ->
+    Jitter = rand:uniform(max(1, Interval bsr 1)),
+    Interval + Jitter.
+
+max_size() ->
+    config:get_integer("bt_engine_cache", "max_size", ?DEFAULT_SIZE).
+
+leave_percent() ->
+    Val = config:get_integer("bt_engine_cache", "leave_percent", ?DEFAULT_LEAVE_PERCENT),
+    max(0, min(90, Val)).
+
+now_msec() ->
+    erlang:monotonic_time(millisecond).
+
+bump_metric(Metric) when is_atom(Metric) ->
+    couch_stats:increment_counter([couchdb, bt_engine_cache, Metric]).
+
+sample_metric(Metric) when is_atom(Metric) ->
+    try
+        couch_stats:sample([couchdb, bt_engine_cache, Metric])
+    catch
+        throw:unknown_metric ->
+            0
+    end.
+
+% ETS sizes are expressed in "words". To get the byte size need to multiply
+% memory sizes by the wordsize. On 64 bit systems this should be 8
+%
+wordsize() ->
+    erlang:system_info(wordsize).

--- a/src/couch/src/couch_primary_sup.erl
+++ b/src/couch/src/couch_primary_sup.erl
@@ -18,6 +18,7 @@ start_link() ->
     supervisor:start_link({local, couch_primary_services}, ?MODULE, []).
 
 init([]) ->
+    ok = couch_bt_engine_cache:create_tables(),
     Children =
         [
             {couch_task_status, {couch_task_status, start_link, []}, permanent, brutal_kill, worker,
@@ -45,7 +46,7 @@ init([]) ->
                     ]
                 ]},
                 permanent, 5000, worker, [ets_lru]}
-        ] ++ couch_servers(),
+        ] ++ couch_bt_engine_cache:sup_children() ++ couch_servers(),
     {ok, {{one_for_one, 10, 3600}, Children}}.
 
 couch_servers() ->

--- a/src/couch/test/eunit/couch_bt_engine_cache_test.erl
+++ b/src/couch/test/eunit/couch_bt_engine_cache_test.erl
@@ -1,0 +1,102 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_bt_engine_cache_test).
+
+-include_lib("couch/include/couch_eunit.hrl").
+
+couch_bt_engine_cache_test_() ->
+    {
+        foreach,
+        fun setup/0,
+        fun teardown/1,
+        [
+            ?TDEF_FE(t_created),
+            ?TDEF_FE(t_insert_and_lookup),
+            ?TDEF_FE(t_decay_and_removal_works, 10),
+            ?TDEF_FE(t_pid_cleanup_works, 10)
+        ]
+    }.
+
+setup() ->
+    Ctx = test_util:start_applications([config]),
+    couch_bt_engine_cache:create_tables(),
+    #{shard_count := N} = couch_bt_engine_cache:info(),
+    Pids = lists:map(
+        fun(I) ->
+            {ok, Pid} = couch_bt_engine_cache:start_link(I),
+            Pid
+        end,
+        lists:seq(1, N)
+    ),
+    {Ctx, Pids}.
+
+teardown({Ctx, [_ | _] = Pids}) ->
+    lists:foreach(
+        fun(Pid) ->
+            catch unlink(Pid),
+            exit(Pid, kill)
+        end,
+        Pids
+    ),
+    clear_tables(),
+    config:delete("bt_engine_cache", "max_size", false),
+    config:delete("bt_engine_cache", "leave_percent", false),
+    test_util:stop_applications(Ctx).
+
+clear_tables() ->
+    lists:foreach(fun ets:delete/1, couch_bt_engine_cache:tables()).
+
+t_created(_) ->
+    Info = couch_bt_engine_cache:info(),
+    #{size := Size, memory := Mem, shard_count := N} = Info,
+    ?assert(N >= 16, "shard count is greater or equal to 16"),
+    ?assertEqual(0, Size),
+    ?assert(is_integer(Mem)),
+    ?assert(Mem >= 0).
+
+t_insert_and_lookup(_) ->
+    ?assertError(function_clause, couch_bt_engine_cache:insert(not_a_pid, 1, foo)),
+    ?assertError(function_clause, couch_bt_engine_cache:insert(self(), xyz, foo)),
+    ?assertMatch(#{size := 0}, couch_bt_engine_cache:info()),
+    ?assert(couch_bt_engine_cache:insert({pid, 42}, term)),
+    ?assertMatch(#{size := 1}, couch_bt_engine_cache:info()),
+    ?assertNot(couch_bt_engine_cache:insert({pid, 42}, term)),
+    ?assertEqual(term, couch_bt_engine_cache:lookup({pid, 42})),
+    ?assertEqual(undefined, couch_bt_engine_cache:lookup({pid, 43})).
+
+t_decay_and_removal_works(_) ->
+    config:set("bt_engine_cache", "leave_percent", "0", false),
+    Term = [foo, bar, baz, lists:seq(1, 100)],
+    [couch_bt_engine_cache:insert({pid, I}, Term) || I <- lists:seq(1, 10000)],
+    WaitFun = fun() ->
+        #{size := Size} = couch_bt_engine_cache:info(),
+        case Size > 0 of
+            true -> wait;
+            false -> ok
+        end
+    end,
+    test_util:wait(WaitFun, 7500),
+    ?assertMatch(#{size := 0}, couch_bt_engine_cache:info()).
+
+t_pid_cleanup_works(_) ->
+    Pid = spawn(fun() -> timer:sleep(2000) end),
+    [couch_bt_engine_cache:insert({Pid, I}, baz) || I <- lists:seq(1, 1000)],
+    WaitFun = fun() ->
+        #{size := Size} = couch_bt_engine_cache:info(),
+        case Size > 0 of
+            true -> wait;
+            false -> ok
+        end
+    end,
+    test_util:wait(WaitFun, 7500),
+    ?assertMatch(#{size := 0}, couch_bt_engine_cache:info()).

--- a/src/couch_prometheus/src/couch_prometheus.erl
+++ b/src/couch_prometheus/src/couch_prometheus.erl
@@ -68,7 +68,8 @@ get_system_stats() ->
         get_internal_replication_jobs_stat(),
         get_membership_stat(),
         get_membership_nodes(),
-        get_distribution_stats()
+        get_distribution_stats(),
+        get_bt_engine_cache_stats()
     ]).
 
 get_uptime_stat() ->
@@ -374,3 +375,12 @@ get_distribution_stats() ->
 get_ets_stats() ->
     NumTabs = length(ets:all()),
     to_prom(erlang_ets_table, gauge, "number of ETS tables", NumTabs).
+
+get_bt_engine_cache_stats() ->
+    Stats = couch_bt_engine_cache:info(),
+    Size = maps:get(size, Stats, 0),
+    Mem = maps:get(memory, Stats, 0),
+    [
+        to_prom(couchdb_bt_engine_cache_memory, gauge, "memory used by the btree cache", Mem),
+        to_prom(couchdb_bt_engine_cache_size, gauge, "number of entries in the btree cache", Size)
+    ].


### PR DESCRIPTION
Cache the top b-tree nodes and header terms. In order to get or update any kv leaf nodes in the b-trees, we always have to read the top few kp nodes closer to the root. Even with parallel preads and data being in the page cache the cost of system calls, marshaling the term, going through the erlang IO system can add up.

The cache is limited in size. The size defaults to 64MB and is configurable by the user. If the cache is full, no more entries will be added until more space frees up.

Since multiple processes are accessing the data concurrently, ets tables are sharded by the number of schedulers, not unlike how we shard our couch_server processes. Each ets table has an associated cleaner process which evicts unused entries. Cleaners traverse table entries and "decay" the usage counters exponentially, by repeatedly shifting the value to the right with the `bsr` operator. Entries with a usage counter equal 0 are then removed.

In order to only insert the top nodes in the cache the `couch_btree` module's lookup and streaming functions were updated with a `depth` parameter. In that way we avoid thrashing nodes which are less likely to be reused through the cache: if the depth > 3 or the node is a kv_node it skips the cache altogether.

Those are the metrics after running `fabric_bench:go(#{q=>8, doc_size=>small, docs=>100000})`.

A quick and dirty comparison with main:

```
> fabric_bench:go(#{q=>8, doc_size=>small, docs=>100000}).
 *** Parameters
 * batch_size       : 1000
 * doc_size         : small
 * docs             : 100000
 * individual_docs  : 1000
 * n                : default
 * q                : 8

 *** Environment
 * Nodes        : 1
 * Bench ver.   : 1
 * N            : 1
 * Q            : 8
 * OS           : unix/darwin
 * Couch ver.   : 3.5.0-d16fc1f
 * Couch git sha: d16fc1f
 * VM details   : Erlang/OTP 26 [erts-14.2.5.11] [source] [64-bit] [smp:12:12] [ds:12:12:16] [async-threads:1]

 *** Inserting 100000 docs
 * Add 100000 docs, ok:100/accepted:0     (Hz):   22000
 * Get random doc 100000X                 (Hz):    3800
 * All docs                               (Hz):  130000
 * All docs w/ include_docs               (Hz):   48000
 * Changes                                (Hz):   16000
 * Single doc updates 1000X               (Hz):     530
 * Time to run all benchmarks            (sec):      40
```

With the btree cache:

```
fabric_bench:go(#{q=>8, doc_size=>small, docs=>100000}).
 *** Parameters
 * batch_size       : 1000
 * doc_size         : small
 * docs             : 100000
 * individual_docs  : 1000
 * n                : default
 * q                : 8

 *** Environment
 * Nodes        : 1
 * Bench ver.   : 1
 * N            : 1
 * Q            : 8
 * OS           : unix/darwin
 * Couch ver.   : 3.5.0-d16fc1f
 * Couch git sha: d16fc1f
 * VM details   : Erlang/OTP 26 [erts-14.2.5.11] [source] [64-bit] [smp:12:12] [ds:12:12:16] [async-threads:1]

 *** Inserting 100000 docs
 * Add 100000 docs, ok:100/accepted:0     (Hz):   24000
 * Get random doc 100000X                 (Hz):    4400
 * All docs                               (Hz):  140000
 * All docs w/ include_docs               (Hz):   49000
 * Changes                                (Hz):   29000
 * Single doc updates 1000X               (Hz):     680
 * Time to run all benchmarks            (sec):      33
```

The idea to use a depth parameter and an ets table came from Paul J. Davis (@davisp).