### PR TITLE
Scanner improvements

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1011,6 +1011,11 @@ url = {{nouveau_url}}
 ; is shared across all running plugins.
 ;doc_rate_limit = 1000
 
+; Batch size to use when fetching design documents. For lots of small design
+; documents this value could be increased to 500 or 1000. If design documents
+; are large (100KB+) it could make sense to decrease it a bit to 25 or 10.
+;ddoc_batch_size = 100
+
 [couch_scanner_plugins]
 ;couch_scanner_plugin_ddoc_features = false
 ;couch_scanner_plugin_find = false

--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -680,8 +680,10 @@ fold_ddocs(Fun, #st{dbname = DbName, mod = Mod} = Acc) ->
 % We just got these docs from the cluster, they are already saved on disk.
 ejson_to_doc({[_ | _] = Props}) ->
     {value, {_, DocId}, Props1} = lists:keytake(<<"_id">>, 1, Props),
-    Props2 = [{K, V} || {K, V} <- Props1, K =:= <<>> orelse binary:first(K) =/= $_],
-    #doc{id = DocId, body = {Props2}}.
+    {value, {_, Rev}, Props2} = lists:keytake(<<"_rev">>, 1, Props1),
+    {Pos, RevId} = couch_doc:parse_rev(Rev),
+    Props3 = [{K, V} || {K, V} <- Props2, K =:= <<>> orelse binary:first(K) =/= $_],
+    #doc{id = DocId, revs = {Pos, [RevId]}, body = {Props3}}.
 
 % Skip patterns
 

--- a/src/couch_scanner/test/eunit/couch_scanner_test.erl
+++ b/src/couch_scanner/test/eunit/couch_scanner_test.erl
@@ -53,6 +53,9 @@ setup() ->
     meck:new(couch_scanner_server, [passthrough]),
     meck:new(couch_scanner_util, [passthrough]),
     Ctx = test_util:start_couch([fabric, couch_scanner]),
+    % Run with the smallest batch size to exercise the batched
+    % ddoc iteration
+    config:set("couch_scanner", "ddoc_batch_size", "2", false),
     DbName1 = <<"dbname1", (?tempdb())/binary>>,
     DbName2 = <<"dbname2", (?tempdb())/binary>>,
     DbName3 = <<"dbname3", (?tempdb())/binary>>,

--- a/src/docs/src/config/scanner.rst
+++ b/src/docs/src/config/scanner.rst
@@ -85,6 +85,16 @@ Scanner Options
             [couch_scanner]
             doc_rate_limit = 1000
 
+    .. config:option:: ddoc_batch_size
+
+        Batch size to use when fetching design documents. For lots of small
+        design documents this value could be increased to 500 or 1000. If
+        design documents are large (100KB+) it could make sense to decrease it
+        a bit to 25 or 10. ::
+
+            [couch_scanner]
+            ddoc_batch_size = 100
+
 .. config:section:: couch_scanner_plugins :: Enable Scanner Plugins
 
     .. config:option:: {plugin}


### PR DESCRIPTION
Two improvements to the scanner as separate commits:

  * Include the revision in the parsed design document (patch by Robert Newson)

  * Avoid timeouts in the ddoc plugin callback. This can help with longer running operations inside the ddoc callback (idea for the patch also by Robert Newson, thanks!)