### PR TITLE
Reduce btree prop test count a bit

### DIFF
--- a/src/couch/test/eunit/couch_btree_prop_tests.erl
+++ b/src/couch/test/eunit/couch_btree_prop_tests.erl
@@ -32,7 +32,7 @@
 -include_lib("couch/include/couch_eunit.hrl").
 
 btree_property_test_() ->
-    ?EUNIT_QUICKCHECK(90, 5000).
+    ?EUNIT_QUICKCHECK(90, 3000).
 
 %
 % Properties


### PR DESCRIPTION
The PPC64LE managed to time out after running 4600 tests so use 3000 as the test count.
