### PR TITLE
Remove redundant *_to_list / list_to_* conversion

### DIFF
--- a/src/chttpd/src/chttpd_external.erl
+++ b/src/chttpd/src/chttpd_external.erl
@@ -139,7 +139,7 @@ to_json_terms(Data) ->
 to_json_terms([], Acc) ->
     {lists:reverse(Acc)};
 to_json_terms([{Key, Value} | Rest], Acc) when is_atom(Key) ->
-    to_json_terms(Rest, [{list_to_binary(atom_to_list(Key)), list_to_binary(Value)} | Acc]);
+    to_json_terms(Rest, [{atom_to_binary(Key), list_to_binary(Value)} | Acc]);
 to_json_terms([{Key, Value} | Rest], Acc) ->
     to_json_terms(Rest, [{list_to_binary(Key), list_to_binary(Value)} | Acc]).
 

--- a/src/chttpd/test/eunit/chttpd_purge_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_purge_tests.erl
@@ -316,7 +316,7 @@ create_docs(Url, Docs) ->
 docs(Counter) ->
     lists:foldl(
         fun(I, Acc) ->
-            Id = ?l2b(integer_to_list(I)),
+            Id = integer_to_binary(I),
             Doc = #{<<"_id">> => Id, <<"val">> => I},
             [Doc | Acc]
         end,

--- a/src/config/src/config.erl
+++ b/src/config/src/config.erl
@@ -100,7 +100,7 @@ to_integer(Int) when is_integer(Int) ->
 to_integer(List) when is_list(List) ->
     list_to_integer(List);
 to_integer(Bin) when is_binary(Bin) ->
-    list_to_integer(binary_to_list(Bin)).
+    binary_to_integer(Bin).
 
 get_float(Section, Key, Default) when is_float(Default) ->
     try
@@ -125,7 +125,7 @@ to_float(List) when is_list(List) ->
 to_float(Int) when is_integer(Int) ->
     list_to_float(integer_to_list(Int) ++ ".0");
 to_float(Bin) when is_binary(Bin) ->
-    list_to_float(binary_to_list(Bin)).
+    binary_to_float(Bin).
 
 get_boolean(Section, Key, Default) when is_boolean(Default) ->
     try

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -491,7 +491,7 @@ encoded_lengths_from_json(Props) ->
             EncodedLen = Len;
         EncodingValue ->
             EncodedLen = couch_util:get_value(<<"encoded_length">>, Props, Len),
-            Encoding = list_to_existing_atom(binary_to_list(EncodingValue))
+            Encoding = binary_to_existing_atom(EncodingValue)
     end,
     {Len, EncodedLen, Encoding}.
 

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -1279,7 +1279,7 @@ new_revid(#doc{body = Body, revs = {OldStart, OldRevs}, atts = Atts, deleted = D
     case DigestedAtts of
         Atts2 when length(Atts) =/= length(Atts2) ->
             % We must have old style non-md5 attachments
-            ?l2b(integer_to_list(couch_util:rand32()));
+            integer_to_binary(couch_util:rand32());
         Atts2 ->
             OldRev =
                 case OldRevs of

--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -43,7 +43,7 @@ to_branch(Doc, [RevId | Rest]) ->
 to_json_rev(0, []) ->
     [];
 to_json_rev(Start, [FirstRevId | _]) ->
-    [{<<"_rev">>, ?l2b([integer_to_list(Start), "-", revid_to_str(FirstRevId)])}].
+    [{<<"_rev">>, rev_to_str({Start, FirstRevId})}].
 
 to_json_body(true, {Body}) ->
     Body ++ [{<<"_deleted">>, true}];
@@ -75,11 +75,13 @@ to_json_revisions(Options, Start, RevIds0) ->
 
 revid_to_str(RevId) when size(RevId) =:= 16 ->
     couch_util:to_hex_bin(RevId);
-revid_to_str(RevId) ->
-    RevId.
+revid_to_str(RevId) when is_binary(RevId) ->
+    RevId;
+revid_to_str(RevId) when is_list(RevId) ->
+    list_to_binary(RevId).
 
 rev_to_str({Pos, RevId}) ->
-    ?l2b([integer_to_list(Pos), "-", revid_to_str(RevId)]).
+    <<(integer_to_binary(Pos))/binary, $-, (revid_to_str(RevId))/binary>>.
 
 revs_to_strs([]) ->
     [];
@@ -95,7 +97,7 @@ to_json_meta(Meta) ->
                         JsonObj =
                             {[
                                 {<<"rev">>, rev_to_str({PosAcc, RevId})},
-                                {<<"status">>, ?l2b(atom_to_list(Status))}
+                                {<<"status">>, atom_to_binary(Status)}
                             ]},
                         {JsonObj, PosAcc - 1}
                     end,
@@ -186,11 +188,11 @@ from_json_obj({Props}, DbName) ->
 from_json_obj(_Other, _) ->
     throw({bad_request, "Document must be a JSON object"}).
 
-parse_revid(RevId) when size(RevId) =:= 32 ->
-    RevInt = erlang:list_to_integer(?b2l(RevId), 16),
+parse_revid(RevId) when is_binary(RevId), size(RevId) =:= 32 ->
+    RevInt = binary_to_integer(RevId, 16),
     <<RevInt:128>>;
-parse_revid(RevId) when length(RevId) =:= 32 ->
-    RevInt = erlang:list_to_integer(RevId, 16),
+parse_revid(RevId) when is_list(RevId), length(RevId) =:= 32 ->
+    RevInt = list_to_integer(RevId, 16),
     <<RevInt:128>>;
 parse_revid(RevId) when is_binary(RevId) ->
     RevId;

--- a/src/couch/src/couch_httpd_multipart.erl
+++ b/src/couch/src/couch_httpd_multipart.erl
@@ -274,7 +274,7 @@ atts_to_mp(
     WriteFun,
     AttFun
 ) ->
-    LengthBin = list_to_binary(integer_to_list(Len)),
+    LengthBin = integer_to_binary(Len),
     % write headers
     WriteFun(<<"\r\nContent-Disposition: attachment; filename=\"", Name/binary, "\"">>),
     WriteFun(<<"\r\nContent-Type: ", Type/binary>>),

--- a/src/couch/src/couch_native_process.erl
+++ b/src/couch/src/couch_native_process.erl
@@ -478,6 +478,6 @@ to_binary(true) ->
 to_binary(false) ->
     false;
 to_binary(Data) when is_atom(Data) ->
-    list_to_binary(atom_to_list(Data));
+    atom_to_binary(Data);
 to_binary(Data) ->
     Data.

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -137,7 +137,7 @@ to_existing_atom(V) when is_list(V) ->
     end;
 to_existing_atom(V) when is_binary(V) ->
     try
-        list_to_existing_atom(?b2l(V))
+        binary_to_existing_atom(V)
     catch
         _:_ -> V
     end;
@@ -429,16 +429,16 @@ to_binary(V) when is_list(V) ->
             list_to_binary(io_lib:format("~p", [V]))
     end;
 to_binary(V) when is_atom(V) ->
-    list_to_binary(atom_to_list(V));
+    atom_to_binary(V);
 to_binary(V) ->
     list_to_binary(io_lib:format("~p", [V])).
 
 to_integer(V) when is_integer(V) ->
     V;
 to_integer(V) when is_list(V) ->
-    erlang:list_to_integer(V);
+    list_to_integer(V);
 to_integer(V) when is_binary(V) ->
-    erlang:list_to_integer(binary_to_list(V)).
+    binary_to_integer(V).
 
 to_list(V) when is_list(V) ->
     V;

--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -183,7 +183,7 @@ map_function_type({Props}) ->
     end.
 
 format_type(Type) when is_atom(Type) ->
-    ?l2b(atom_to_list(Type));
+    atom_to_binary(Type);
 format_type(Types) when is_list(Types) ->
     iolist_to_binary(join(lists:map(fun atom_to_list/1, Types), <<" or ">>)).
 

--- a/src/couch_mrview/src/couch_mrview_test_util.erl
+++ b/src/couch_mrview/src/couch_mrview_test_util.erl
@@ -139,7 +139,7 @@ ddoc(Id) ->
 doc(Id) ->
     couch_doc:from_json_obj(
         {[
-            {<<"_id">>, list_to_binary(integer_to_list(Id))},
+            {<<"_id">>, integer_to_binary(Id)},
             {<<"val">>, Id}
         ]}
     ).

--- a/src/couch_mrview/test/eunit/couch_mrview_collation_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_collation_tests.erl
@@ -137,7 +137,7 @@ find_matching_rows(Index, Value) ->
     ),
     lists:map(
         fun({Id, V}) ->
-            {row, [{id, list_to_binary(integer_to_list(Id))}, {key, V}, {value, 0}]}
+            {row, [{id, integer_to_binary(Id)}, {key, V}, {value, 0}]}
         end,
         Matches
     ).
@@ -206,7 +206,7 @@ make_docs() ->
         fun(V, {Docs0, Count}) ->
             Doc = couch_doc:from_json_obj(
                 {[
-                    {<<"_id">>, list_to_binary(integer_to_list(Count))},
+                    {<<"_id">>, integer_to_binary(Count)},
                     {<<"foo">>, V}
                 ]}
             ),
@@ -220,7 +220,7 @@ make_docs() ->
 rows() ->
     {Rows, _} = lists:foldl(
         fun(V, {Rows0, Count}) ->
-            Id = list_to_binary(integer_to_list(Count)),
+            Id = integer_to_binary(Count),
             Row = {row, [{id, Id}, {key, V}, {value, 0}]},
             {[Row | Rows0], Count + 1}
         end,

--- a/src/couch_mrview/test/eunit/couch_mrview_purge_docs_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_purge_docs_tests.erl
@@ -299,7 +299,7 @@ test_purge_index_reset(Db) ->
 
         PurgeInfos = lists:map(
             fun(I) ->
-                DocId = list_to_binary(integer_to_list(I)),
+                DocId = integer_to_binary(I),
                 FDI = couch_db:get_full_doc_info(Db, DocId),
                 Rev = get_rev(FDI),
                 {couch_uuids:random(), DocId, [Rev]}
@@ -600,7 +600,7 @@ fold_fun({_PSeq, _UUID, Id, Revs}, Acc) ->
     {ok, [{Id, Revs} | Acc]}.
 
 docid(I) ->
-    list_to_binary(integer_to_list(I)).
+    integer_to_binary(I).
 
 uuid(I) ->
     Str = io_lib:format("UUID~4..0b", [I]),

--- a/src/couch_pse_tests/src/cpse_util.erl
+++ b/src/couch_pse_tests/src/cpse_util.erl
@@ -309,7 +309,7 @@ gen_write(Db, {Action, {<<"_local/", _/binary>> = DocId, Body}}) ->
         end,
     {local, #doc{
         id = DocId,
-        revs = {0, [list_to_binary(integer_to_list(RevId))]},
+        revs = {0, [integer_to_binary(RevId)]},
         body = Body,
         deleted = Deleted
     }};

--- a/src/couch_replicator/src/couch_replicator_utils.erl
+++ b/src/couch_replicator/src/couch_replicator_utils.erl
@@ -81,7 +81,7 @@ get_json_value(Key, Props, Default) when is_atom(Key) ->
     Ref = make_ref(),
     case get_value(Key, Props, Ref) of
         Ref ->
-            get_value(?l2b(atom_to_list(Key)), Props, Default);
+            get_value(atom_to_binary(Key), Props, Default);
         Else ->
             Else
     end;
@@ -89,7 +89,7 @@ get_json_value(Key, Props, Default) when is_binary(Key) ->
     Ref = make_ref(),
     case get_value(Key, Props, Ref) of
         Ref ->
-            get_value(list_to_atom(?b2l(Key)), Props, Default);
+            get_value(binary_to_atom(Key), Props, Default);
         Else ->
             Else
     end.

--- a/src/couch_replicator/test/eunit/couch_replicator_compact_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_compact_tests.erl
@@ -409,7 +409,7 @@ writer_loop(Db0, Parent, Counter) ->
         fun(I) ->
             couch_doc:from_json_obj(
                 {[
-                    {<<"_id">>, ?l2b(integer_to_list(Counter + I))},
+                    {<<"_id">>, integer_to_binary(Counter + I)},
                     {<<"value">>, Counter + I},
                     {<<"_attachments">>,
                         {[

--- a/src/couch_replicator/test/eunit/couch_replicator_small_max_request_size_target.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_small_max_request_size_target.erl
@@ -63,7 +63,7 @@ binary_chunk(Size) when is_integer(Size), Size > 0 ->
 add_docs(DbName, DocCount, DocSize, AttSize) ->
     [
         begin
-            DocId = iolist_to_binary(["doc", integer_to_list(Id)]),
+            DocId = <<"doc", (integer_to_binary(Id))/binary>>,
             add_doc(DbName, DocId, DocSize, AttSize)
         end
      || Id <- lists:seq(1, DocCount)

--- a/src/couch_stats/src/couch_stats_httpd.erl
+++ b/src/couch_stats/src/couch_stats_httpd.erl
@@ -99,8 +99,8 @@ extract_path([_ | _], _NotAnObject) ->
 maybe_format_key(Key) when is_list(Key) ->
     list_to_binary(Key);
 maybe_format_key(Key) when is_atom(Key) ->
-    list_to_binary(atom_to_list(Key));
+    atom_to_binary(Key);
 maybe_format_key(Key) when is_integer(Key) ->
-    list_to_binary(integer_to_list(Key));
+    integer_to_binary(Key);
 maybe_format_key(Key) when is_binary(Key) ->
     Key.

--- a/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
@@ -162,7 +162,7 @@ check_capped_size(_) ->
     meck:reset(ddoc_cache_ev),
     lists:foreach(
         fun(I) ->
-            DbName = list_to_binary("big_" ++ integer_to_list(I)),
+            DbName = <<"bin_", (integer_to_binary(I))/binary>>,
             ddoc_cache:open_custom(DbName, ?MODULE),
             meck:wait(I, ddoc_cache_ev, event, [started, '_'], ?EVENT_TIMEOUT),
             ?assert(cache_size() < MaxSize * 2)
@@ -171,7 +171,7 @@ check_capped_size(_) ->
     ),
     lists:foreach(
         fun(I) ->
-            DbName = list_to_binary("big_" ++ integer_to_list(I)),
+            DbName = <<"bin_", (integer_to_binary(I))/binary>>,
             ddoc_cache:open_custom(DbName, ?MODULE),
             meck:wait(I, ddoc_cache_ev, event, [started, '_'], ?EVENT_TIMEOUT),
             ?assert(cache_size() < MaxSize * 2)
@@ -184,7 +184,7 @@ check_cache_refill({DbName, _}) ->
     meck:reset(ddoc_cache_ev),
 
     InitDDoc = fun(I) ->
-        NumBin = list_to_binary(integer_to_list(I)),
+        NumBin = integer_to_binary(I),
         DDocId = <<"_design/", NumBin/binary>>,
         Doc = #doc{id = DDocId, body = {[]}},
         {ok, _} = fabric:update_doc(DbName, Doc, [?ADMIN_CTX]),

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -489,10 +489,10 @@ get_node_seqs(Db, Nodes) ->
                 {stop, Acc}
         end
     end,
-    InitAcc = [{list_to_binary(atom_to_list(Node)), 0} || Node <- Nodes],
+    InitAcc = [{atom_to_binary(Node), 0} || Node <- Nodes],
     Opts = [{start_key, <<?LOCAL_DOC_PREFIX, "purge-mem3-">>}],
     {ok, NodeBinSeqs} = couch_db:fold_local_docs(Db, FoldFun, InitAcc, Opts),
-    [{list_to_existing_atom(binary_to_list(N)), S} || {N, S} <- NodeBinSeqs].
+    [{binary_to_existing_atom(N), S} || {N, S} <- NodeBinSeqs].
 
 get_or_create_db(DbName, Options) ->
     mem3_util:get_or_create_db_int(DbName, Options).

--- a/src/fabric/src/fabric_view_changes.erl
+++ b/src/fabric/src/fabric_view_changes.erl
@@ -395,7 +395,7 @@ pack_seqs(Workers) ->
     SeqList = [{N, R, S} || {#shard{node = N, range = R}, S} <- Workers],
     SeqSum = lists:sum([fake_packed_seq(S) || {_, _, S} <- SeqList]),
     Opaque = couch_util:encodeBase64Url(?term_to_bin(SeqList, [compressed])),
-    ?l2b([integer_to_list(SeqSum), $-, Opaque]).
+    <<(integer_to_binary(SeqSum))/binary, $-, Opaque/binary>>.
 
 % Generate the sequence number used to build the emitted N-... prefix.
 %

--- a/src/fabric/test/eunit/fabric_rpc_purge_tests.erl
+++ b/src/fabric/test/eunit/fabric_rpc_purge_tests.erl
@@ -152,7 +152,7 @@ t_no_filter_different_node({DbName, DocId, OldDoc, PSeq}) ->
     create_purge_checkpoint(DbName, PSeq),
 
     % Create a valid purge for a different node
-    TgtNode = list_to_binary(atom_to_list('notfoo@127.0.0.1')),
+    TgtNode = atom_to_binary('notfoo@127.0.0.1'),
     create_purge_checkpoint(DbName, 0, TgtNode),
 
     rpc_update_doc(DbName, OldDoc),
@@ -164,7 +164,7 @@ t_filter_local_node({DbName, DocId, OldDoc, PSeq}) ->
     create_purge_checkpoint(DbName, PSeq),
 
     % Create a valid purge for a different node
-    TgtNode = list_to_binary(atom_to_list('notfoo@127.0.0.1')),
+    TgtNode = atom_to_binary('notfoo@127.0.0.1'),
     create_purge_checkpoint(DbName, 0, TgtNode),
 
     % Add a local node rev to the list of node revs. It should
@@ -274,4 +274,4 @@ tgt_node() ->
     'foo@127.0.0.1'.
 
 tgt_node_bin() ->
-    iolist_to_binary(atom_to_list(tgt_node())).
+    atom_to_binary(tgt_node()).

--- a/src/mango/src/mango_doc.erl
+++ b/src/mango/src/mango_doc.erl
@@ -399,7 +399,7 @@ get_field({Props}, [Name | Rest], Validator) ->
 get_field(Values, [Name | Rest], Validator) when is_list(Values) ->
     % Name might be an integer index into an array
     try
-        Pos = list_to_integer(binary_to_list(Name)),
+        Pos = binary_to_integer(Name),
         case Pos >= 0 andalso Pos < length(Values) of
             true ->
                 % +1 because Erlang uses 1 based list indices
@@ -441,7 +441,7 @@ rem_field({Props}, [Name | Rest]) ->
 rem_field(Values, [Name]) when is_list(Values) ->
     % Name might be an integer index into an array
     try
-        Pos = list_to_integer(binary_to_list(Name)),
+        Pos = binary_to_integer(Name),
         case Pos >= 0 andalso Pos < length(Values) of
             true ->
                 % +1 because Erlang uses 1 based list indices
@@ -456,7 +456,7 @@ rem_field(Values, [Name]) when is_list(Values) ->
 rem_field(Values, [Name | Rest]) when is_list(Values) ->
     % Name might be an integer index into an array
     try
-        Pos = list_to_integer(binary_to_list(Name)),
+        Pos = binary_to_integer(Name),
         case Pos >= 0 andalso Pos < length(Values) of
             true ->
                 % +1 because Erlang uses 1 based list indices
@@ -494,7 +494,7 @@ set_field({Props}, [Name | Rest], Value) ->
 set_field(Values, [Name], Value) when is_list(Values) ->
     % Name might be an integer index into an array
     try
-        Pos = list_to_integer(binary_to_list(Name)),
+        Pos = binary_to_integer(Name),
         case Pos >= 0 andalso Pos < length(Values) of
             true ->
                 % +1 because Erlang uses 1 based list indices
@@ -509,7 +509,7 @@ set_field(Values, [Name], Value) when is_list(Values) ->
 set_field(Values, [Name | Rest], Value) when is_list(Values) ->
     % Name might be an integer index into an array
     try
-        Pos = list_to_integer(binary_to_list(Name)),
+        Pos = binary_to_integer(Name),
         case Pos >= 0 andalso Pos < length(Values) of
             true ->
                 % +1 because Erlang uses 1 based list indices

--- a/src/mango/src/mango_json.erl
+++ b/src/mango/src/mango_json.erl
@@ -105,7 +105,7 @@ to_binary(true) ->
 to_binary(false) ->
     false;
 to_binary(Data) when is_atom(Data) ->
-    list_to_binary(atom_to_list(Data));
+    atom_to_binary(Data);
 to_binary(Data) when is_number(Data) ->
     Data;
 to_binary(Data) when is_binary(Data) ->

--- a/src/mango/src/mango_selector_text.erl
+++ b/src/mango/src/mango_selector_text.erl
@@ -369,9 +369,9 @@ value_str(Value) when is_binary(Value) ->
             <<"\"", Escaped/binary, "\"">>
     end;
 value_str(Value) when is_integer(Value) ->
-    list_to_binary(integer_to_list(Value));
+    integer_to_binary(Value);
 value_str(Value) when is_float(Value) ->
-    list_to_binary(float_to_list(Value));
+    float_to_binary(Value);
 value_str(true) ->
     <<"true">>;
 value_str(false) ->
@@ -427,7 +427,7 @@ replace_array_indexes([], NewPartsAcc, HasIntAcc) ->
 replace_array_indexes([Part | Rest], NewPartsAcc, HasIntAcc) ->
     {NewPart, HasInt} =
         try
-            _ = list_to_integer(binary_to_list(Part)),
+            _ = binary_to_integer(Part),
             {<<"[]">>, true}
         catch
             _:_ ->

--- a/src/mem3/src/mem3_util.erl
+++ b/src/mem3/src/mem3_util.erl
@@ -270,14 +270,14 @@ build_shards_by_range(DbName, DocProps) ->
     ).
 
 to_atom(Node) when is_binary(Node) ->
-    list_to_atom(binary_to_list(Node));
+    binary_to_atom(Node);
 to_atom(Node) when is_atom(Node) ->
     Node.
 
 to_integer(N) when is_integer(N) ->
     N;
 to_integer(N) when is_binary(N) ->
-    list_to_integer(binary_to_list(N));
+    binary_to_integer(N);
 to_integer(N) when is_list(N) ->
     list_to_integer(N).
 

--- a/src/setup/src/setup.erl
+++ b/src/setup/src/setup.erl
@@ -376,7 +376,7 @@ add_node_int(Options, true) ->
     end.
 
 get_port(Port) when is_integer(Port) ->
-    list_to_binary(integer_to_list(Port));
+    integer_to_binary(Port);
 get_port(Port) when is_list(Port) ->
     list_to_binary(Port);
 get_port(Port) when is_binary(Port) ->


### PR DESCRIPTION
At some point Erlang/OTP didn't have direct *_to_binary, binary_to_* and similar functions, and we had to go through lists. Since now we have direct functions simplify some of the code to avoid redunant list conversions.

It's mostly for readability, but in microbenchmarks it's also a bit faster:

```
1> timer:tc(fun() -> lists:foreach(fun(_) -> list_to_binary(integer_to_list(123456789)) end, lists:seq(1, 1000000)) end).
{1609116,ok}
2> timer:tc(fun() -> lists:foreach(fun(_) -> list_to_binary(integer_to_list(123456789)) end, lists:seq(1, 1000000)) end).
{1593957,ok}
3> timer:tc(fun() -> lists:foreach(fun(_) -> list_to_binary(integer_to_list(123456789)) end, lists:seq(1, 1000000)) end).
{1595424,ok}
```

```
4> timer:tc(fun() -> lists:foreach(fun(_) -> integer_to_binary(123456789) end, lists:seq(1, 1000000)) end).
{1014511,ok}
5> timer:tc(fun() -> lists:foreach(fun(_) -> integer_to_binary(123456789) end, lists:seq(1, 1000000)) end).
{961102,ok}
6> timer:tc(fun() -> lists:foreach(fun(_) -> integer_to_binary(123456789) end, lists:seq(1, 1000000)) end).
{971104,ok}
```
