### PR TITLE
Add write limiting to the scanner

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1047,6 +1047,12 @@ url = {{nouveau_url}}
 ; is shared across all running plugins.
 ;doc_rate_limit = 1000
 
+; Limit the rate per second at which plugins write/update documents. The rate
+; is shared across all running plugins. Unlike other rate limit which are
+; applied automatically by the plugin backend this rate assume the plugins will
+; explicitly use the couch_scanner_rate_limiter API when performing writes.
+;doc_write_rate_limit = 500
+
 ; Batch size to use when fetching design documents. For lots of small design
 ; documents this value could be increased to 500 or 1000. If design documents
 ; are large (100KB+) it could make sense to decrease it a bit to 25 or 10.

--- a/src/docs/src/config/scanner.rst
+++ b/src/docs/src/config/scanner.rst
@@ -85,6 +85,15 @@ Scanner Options
             [couch_scanner]
             doc_rate_limit = 1000
 
+    .. config:option:: doc_write_rate_limit
+
+        Limit the rate at which plugins update documents. This rate limit
+        applies to plugins which explicitly use the
+        ``couch_scanner_rate_limiter`` module for rate limiting ::
+
+            [couch_scanner]
+            doc_write_rate_limit = 500
+
     .. config:option:: ddoc_batch_size
 
         Batch size to use when fetching design documents. For lots of small


### PR DESCRIPTION
Previously, scanner applied db, shard and doc open rate limits. However, plugins may want to also perform updates and still ensure they always stay in the background and only consume a limited amount of resources in a cluster. For that add a `doc_write` rate limit option.

Plugins which perform write can use the ``couch_scanner_rate_limiter`` explicitly: initialize, then consume tokens from it during every update (possibly indicated they used more than one token in a single operation) and then sleep the recommended amount of time provided the rate limiter.

Added a simple example of how it could work in the couch_scanner_rate_limiter module in the comments at the top.
