### PR TITLE
Upgrade erlfmt and rebar3

### DIFF
--- a/configure
+++ b/configure
@@ -21,8 +21,8 @@ basename=`basename $0`
 
 PACKAGE_AUTHOR_NAME="The Apache Software Foundation"
 
-REBAR3_BRANCH="3.23.0"
-ERLFMT_VERSION="v1.3.0"
+REBAR3_BRANCH="3.25.1"
+ERLFMT_VERSION="v1.7.0"
 
 # TEST=0
 WITH_PROPER="true"


### PR DESCRIPTION
For erlfmt it's mainly the ability to format newer syntax constructs in OTP 28.

For rebar3 it's mainly staying current with it

Changelogs:

 * erlfmt v1.3.0 -> v1.7.0 : https://github.com/WhatsApp/erlfmt/compare/v1.3.0...v1.7.0

 * rebar3 3.23.0 -> 3.25.1 : https://github.com/erlang/rebar3/compare/3.23.0...3.25.1
