### PR TITLE
Implement prop updates for shards

### DIFF
--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -25,6 +25,8 @@
     get_db_info/1,
     get_doc_count/1, get_doc_count/2,
     set_revs_limit/3,
+    update_props/3,
+    update_props/4,
     set_security/2, set_security/3,
     get_revs_limit/1,
     get_security/1, get_security/2,
@@ -185,6 +187,16 @@ get_revs_limit(DbName) ->
     after
         catch couch_db:close(Db)
     end.
+
+%% @doc update shard property. Some properties like `partitioned` or `hash` are
+%% static and cannot be updated. They will return an error.
+-spec update_props(dbname(), atom() | binary(), any()) -> ok.
+update_props(DbName, K, V) ->
+    update_props(DbName, K, V, [?ADMIN_CTX]).
+
+-spec update_props(dbname(), atom() | binary(), any(), [option()]) -> ok.
+update_props(DbName, K, V, Options) when is_atom(K) orelse is_binary(K) ->
+    fabric_db_meta:update_props(dbname(DbName), K, V, opts(Options)).
 
 %% @doc sets the readers/writers/admin permissions for a database
 -spec set_security(dbname(), SecObj :: json_obj()) -> ok.

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -33,6 +33,7 @@
     reset_validation_funs/1,
     set_security/3,
     set_revs_limit/3,
+    update_props/4,
     create_shard_db_doc/2,
     delete_shard_db_doc/2,
     get_partition_info/2
@@ -268,6 +269,9 @@ set_revs_limit(DbName, Limit, Options) ->
 
 set_purge_infos_limit(DbName, Limit, Options) ->
     with_db(DbName, Options, {couch_db, set_purge_infos_limit, [Limit]}).
+
+update_props(DbName, K, V, Options) ->
+    with_db(DbName, Options, {couch_db, update_props, [K, V]}).
 
 open_doc(DbName, DocId, Options) ->
     with_db(DbName, Options, {couch_db, open_doc, [DocId, Options]}).


### PR DESCRIPTION
When we implemented partitioned dbs we added a generic `props` features to the db shards and the shard docs. The `props` is a generic prop (KV) list which can store database metadata properties. Currently it only stores the `partitioned` and the `hash` db properties.

Recently we discussed possibly storing a new TTL flag or moving some other metadata bits like security or revs limits and such to props and we'd want to them both for the clustered and local shards (for local _dbs, _nodes etc).

In order to use props like that we'd want to allow dynamically updating props after the initial db creations so that's what this PR does.

We still want to ensure ``partitioned`` and hash ``properties`` are "static" and we don't allow modifying them later so there an way in couch_db.erl to flag a set of properties as "static".

A part of the dynamic API to set props on shards was already implemented in the form of `couch_db_engine:set_props/2` so in the PR we just build the rest of the bits in couch_db and fabric.

This is also a first part which update properties for shards files, we'll follow up with another commit to allow update the props in the shard map document as well.
