### PR TITLE
Document that _all_dbs endpoint supports inclusive_end query param

### DIFF
--- a/src/docs/src/api/server/common.rst
+++ b/src/docs/src/api/server/common.rst
@@ -200,6 +200,8 @@
     :query json endkey: Stop returning databases when the specified key is
       reached.
     :query json end_key: Alias for ``endkey`` param
+    :query boolean inclusive_end: Specifies whether the specified end key
+      should be included in the result. Default is ``true``.
     :query number limit: Limit the number of the returned databases to the
       specified number.
     :query number skip: Skip this number of databases before starting to return


### PR DESCRIPTION
## Overview

While experimenting with _all_dbs, I noticed  that inclusive_end works with this endpoint, same as it does for views and other similar endpoints, but is undocumented. This fixes that oversight.

## Testing recommendations

n/a

## Related Issues or Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
