### PR TITLE
Revert "dev: support multiarch names (Debian based systems) (#5626)"

### DIFF
--- a/configure
+++ b/configure
@@ -46,7 +46,6 @@ CLOUSEAU_URI=${CLOUSEAU_URI:-"https://github.com/cloudant-labs/clouseau/releases
 CLOUSEAU_VSN=${CLOUSEAU_VSN:-"2.25.0"}
 CLOUSEAU_DIR="$(pwd)"/clouseau
 ARCH="$(uname -m)"
-MULTIARCH_NAME="$(dpkg-architecture -q DEB_HOST_MULTIARCH || true)"
 ERLANG_VER="$(run_erlang 'io:put_chars(erlang:system_info(otp_release)).')"
 ERLANG_OS="$(run_erlang 'case os:type() of {OS, _} -> io:format("~s~n", [OS]) end.')"
 
@@ -328,7 +327,6 @@ if [ "${WITH_SPIDERMONKEY}" = "true" ] && [ "${ERLANG_OS}" = "unix" ]; then
 
     # This list is taken from src/couch/rebar.config.script, please keep them in sync.
     if [ ! -d "/usr/include/${SM_HEADERS}" ] && \
-        [ ! -d "/usr/include/${MULTIARCH_NAME}/${SM_HEADERS}" ] && \
         [ ! -d "/usr/local/include/${SM_HEADERS}" ] && \
         [ ! -d "/opt/homebrew/include/${SM_HEADERS}" ]; then
         echo "ERROR: SpiderMonkey ${SM_VSN} is not found. Please specify with --spidermonkey-version."

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -36,16 +36,16 @@ end.
 CouchJSPath = filename:join(["priv", CouchJSName]).
 Version = case os:getenv("COUCHDB_VERSION") of
     false ->
-        string:trim(os:cmd("git describe --always"));
+        string:strip(os:cmd("git describe --always"), right, $\n);
     Version0 ->
-        string:trim(Version0)
+        string:strip(Version0, right)
 end.
 
 GitSha = case os:getenv("COUCHDB_GIT_SHA") of
     false ->
         ""; % release builds won\'t get a fallback
     GitSha0 ->
-        string:trim(GitSha0)
+        string:strip(GitSha0, right)
 end.
 
 CouchConfig = case filelib:is_file(os:getenv("COUCHDB_CONFIG")) of
@@ -151,25 +151,6 @@ ProperConfig = case code:lib_dir(proper) of
     _ -> [{d, 'WITH_PROPER'}]
 end.
 
-DpkgArchitectureCmd = "dpkg-architecture -q DEB_HOST_MULTIARCH".
-GenericMozJSIncludePaths = "-I/usr/include/mozjs-" ++ SMVsn ++ " -I/usr/local/include/mozjs-" ++ SMVsn.
-GenericMozJSLibPaths = "-L/usr/local/lib -L/opt/homebrew/lib".
-
-WithDpkgArchitecture = case os:find_executable("dpkg-architecture") of
-    false -> false;
-    _ -> true
-end.
-
-MozJSIncludePath = case WithDpkgArchitecture of
-    false -> GenericMozJSIncludePaths;
-    true -> GenericMozJSIncludePaths ++ " -I/usr/include/" ++ string:trim(os:cmd(DpkgArchitectureCmd)) ++ "/mozjs-" ++ SMVsn
-end.
-
-MozJSLibPath = case WithDpkgArchitecture of
-    false -> GenericMozJSLibPaths;
-    true -> GenericMozJSLibPaths ++ " -L/usr/lib/" ++ string:trim(os:cmd(DpkgArchitectureCmd))
-end.
-
 % The include directories (parameters for the `-I` C compiler flag) are
 % considered in the `configure` script as a pre-check for their existence.
 % Please keep them in sync.
@@ -214,20 +195,45 @@ end.
             "-DXP_UNIX -I/usr/include/mozjs-86 -I/usr/local/include/mozjs-86 -I/opt/homebrew/include/mozjs-86/ -std=c++17 -Wno-invalid-offsetof",
             "-L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-86 -lm"
         };
-    {unix, _} when SMVsn == "91"; SMVsn == "102"; SMVsn == "115"; SMVsn == "128" ->
+    {unix, _} when SMVsn == "91" ->
         {
-            "$CFLAGS -DXP_UNIX " ++ MozJSIncludePath ++ " -std=c++17 -Wno-invalid-offsetof",
-            "$LDFLAGS " ++ MozJSLibPath ++ " -std=c++17 -lm -lmozjs-" ++ SMVsn
+            "$CFLAGS -DXP_UNIX -I/usr/include/mozjs-91 -I/usr/local/include/mozjs-91 -I/opt/homebrew/include/mozjs-91/ -std=c++17 -Wno-invalid-offsetof",
+            "$LDFLAGS -L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-91 -lm"
+        };
+    {unix, _} when SMVsn == "102" ->
+        {
+            "$CFLAGS -DXP_UNIX -I/usr/include/mozjs-102 -I/usr/local/include/mozjs-102 -I/opt/homebrew/include/mozjs-102/ -std=c++17 -Wno-invalid-offsetof",
+            "$LDFLAGS -L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-102 -lm"
+        };
+    {unix, _} when SMVsn == "115" ->
+        {
+            "$CFLAGS -DXP_UNIX -I/usr/include/mozjs-115 -I/usr/local/include/mozjs-115 -I/opt/homebrew/include/mozjs-115/ -std=c++17 -Wno-invalid-offsetof",
+            "$LDFLAGS -L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-115 -lm"
+        };
+    {unix, _} when SMVsn == "128" ->
+        {
+            "$CFLAGS -DXP_UNIX -I/usr/include/mozjs-128 -I/usr/local/include/mozjs-128 -I/opt/homebrew/include/mozjs-128/ -std=c++17 -Wno-invalid-offsetof",
+            "$LDFLAGS -L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-128 -lm"
         };
     {win32, _} when SMVsn == "91" ->
         {
             "/std:c++17 /DXP_WIN",
             "$LDFLAGS mozjs-91.lib"
         };
-    {win32, _} when SMVsn == "102"; SMVsn == "115"; SMVsn == "128" ->
+    {win32, _} when SMVsn == "102" ->
         {
             "/std:c++17 /DXP_WIN /Zc:preprocessor /utf-8",
-            "$LDFLAGS mozjs-" ++ SMVsn ++ ".lib"
+            "$LDFLAGS mozjs-102.lib"
+         };
+    {win32, _} when SMVsn == "115" ->
+        {
+            "/std:c++17 /DXP_WIN /Zc:preprocessor /utf-8",
+            "$LDFLAGS mozjs-115.lib"
+        };
+    {win32, _} when SMVsn == "128" ->
+        {
+            "/std:c++17 /DXP_WIN /Zc:preprocessor /utf-8",
+            "$LDFLAGS mozjs-128.lib"
         }
 end.
 
@@ -267,12 +273,12 @@ end.
 
 IcuIncludePath = case WithBrew of
     false -> GenericIcuIncludePaths;
-    true -> "-I" ++ string:trim(os:cmd(BrewIcuPrefixCmd)) ++ "/include"
+    true -> "-I" ++ string:strip(os:cmd(BrewIcuPrefixCmd), right, $\n) ++ "/include"
 end.
 
 IcuLibPath = case WithBrew of
     false -> GenericIcuLibPaths;
-    true -> "-L" ++ string:trim(os:cmd(BrewIcuPrefixCmd)) ++ "/lib"
+    true -> "-L" ++ string:strip(os:cmd(BrewIcuPrefixCmd), right, $\n) ++ "/lib"
 end.
 
 IcuEnv = [{"DRV_CFLAGS",  "$DRV_CFLAGS -DPIC -O2 -fno-common"},


### PR DESCRIPTION
This reverts commit c1162fa758cdbdee00423f74582ac5003a5f04f8.

this code breaks builds on macOS by removing all the version-specific include paths like `-I/opt/homebrew/include/mozjs-128/`