### PR TITLE
Update mochiweb to v3.3.0

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -160,7 +160,7 @@ DepDescs = [
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-6"}},
 {gun,              "gun",              {tag, "2.2.0-couchdb"}},
 {jiffy,            "jiffy",            {tag, "1.1.2"}},
-{mochiweb,         "mochiweb",         {tag, "v3.2.2"}},
+{mochiweb,         "mochiweb",         {tag, "v3.3.0"}},
 {meck,             "meck",             {tag, "1.0.0"}},
 {recon,            "recon",            {tag, "2.5.6"}}
 ].


### PR DESCRIPTION
It fixed a few deprecation warnings in tests and removes support for OTP 18 and 19 [v.3.3.0](https://github.com/mochi/mochiweb/releases/tag/v3.3.0)
