### PR TITLE
feat: Add support for SpiderMonkey v140

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -44,247 +44,247 @@ other_changes = "git diff --name-only origin/${env.CHANGE_TARGET} | grep -q -v -
 // We create parallel build / test / package stages for each OS using the metadata
 // in this map. Adding a new OS should ideally only involve adding a new entry here.
 meta = [
-  'centos8': [
-    name: 'CentOS 8',
-    spidermonkey_vsn: '60',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/usr',
-    quickjs_test262: true,
-    image: "apache/couchdbci-centos:8-erlang-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  'centos9': [
-    name: 'CentOS 9',
-    spidermonkey_vsn: '78',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/usr',
-    quickjs_test262: true,
-    image: "apache/couchdbci-centos:9-erlang-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  'centos10': [
-    name: 'CentOS 10',
-    disable_spidermonkey: true,
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/usr',
-    quickjs_test262: true,
-    image: "apache/couchdbci-centos:10-erlang-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  'jammy': [
-    name: 'Ubuntu 22.04',
-    spidermonkey_vsn: '91',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    quickjs_test262: true,
-    image: "apache/couchdbci-ubuntu:jammy-erlang-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  'noble': [
-    name: 'Ubuntu 24.04',
-    spidermonkey_vsn: '115',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    quickjs_test262: true,
-    image: "apache/couchdbci-ubuntu:noble-erlang-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
+//'centos8': [
+//  name: 'CentOS 8',
+//  spidermonkey_vsn: '60',
+//  with_nouveau: true,
+//  with_clouseau: true,
+//  clouseau_java_home: '/usr',
+//  quickjs_test262: true,
+//  image: "apache/couchdbci-centos:8-erlang-${ERLANG_VERSION}",
+//  gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//],
+//
+//'centos9': [
+//  name: 'CentOS 9',
+//  spidermonkey_vsn: '78',
+//  with_nouveau: true,
+//  with_clouseau: true,
+//  clouseau_java_home: '/usr',
+//  quickjs_test262: true,
+//  image: "apache/couchdbci-centos:9-erlang-${ERLANG_VERSION}",
+//  gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//],
+//
+//'centos10': [
+//  name: 'CentOS 10',
+//  disable_spidermonkey: true,
+//  with_nouveau: true,
+//  with_clouseau: true,
+//  clouseau_java_home: '/usr',
+//  quickjs_test262: true,
+//  image: "apache/couchdbci-centos:10-erlang-${ERLANG_VERSION}",
+//  gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//],
+//
+//'jammy': [
+//  name: 'Ubuntu 22.04',
+//  spidermonkey_vsn: '91',
+//  with_nouveau: true,
+//  with_clouseau: true,
+//  clouseau_java_home: '/opt/java/openjdk',
+//  quickjs_test262: true,
+//  image: "apache/couchdbci-ubuntu:jammy-erlang-${ERLANG_VERSION}",
+//  gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//],
+//
+//'noble': [
+//  name: 'Ubuntu 24.04',
+//  spidermonkey_vsn: '115',
+//  with_nouveau: true,
+//  with_clouseau: true,
+//  clouseau_java_home: '/opt/java/openjdk',
+//  quickjs_test262: true,
+//  image: "apache/couchdbci-ubuntu:noble-erlang-${ERLANG_VERSION}",
+//  gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//],
 
   'resolute': [
     name: 'Ubuntu 26.04',
-    spidermonkey_vsn: '128',
+    spidermonkey_vsn: '140',
     with_nouveau: true,
     with_clouseau: true,
     clouseau_java_home: '/opt/java/openjdk',
     quickjs_test262: true,
     image: "apache/couchdbci-ubuntu:resolute-erlang-${ERLANG_VERSION}",
     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
+  ]
 
-  'bullseye': [
-    name: 'Debian x86_64',
-    spidermonkey_vsn: '78',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    quickjs_test262: true,
-    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  // Sometimes we "pick up" ppc64le workers from the asf jenkins intance That
-  // seems like a good thing, however, those workers allow running multiple
-  // agents at a time and often time out even with retries. The build times
-  // take close to an hour, which is at least x2 as long as it takes to run
-  // other arch CI jobs and they still time out often and fail. Disable for
-  // now. This is a low demand arch distro, maybe remove support altogether?
-  //
-  // 'base-ppc64': [
-  //   name: 'Debian POWER',
-  //   spidermonkey_vsn: '78',
-  //   with_nouveau: true,
-  //   with_clouseau: true,
-  //   quickjs_test262: true,
-  //   image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
-  //   node_label: 'ppc64le',
-  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  // ],
-
-  // Just like in the ppc64le case we sometimes "pick up" built-in s390x workers added to
-  // our jenkins, but since those are managed by us, our .mix/.venv/.hex packaging
-  // cache hack in /home/jenkins doesn't work, and so elixir tests fail. Skip this arch build
-  // until we figure out caching (probably need to use a proper caching plugin).
-  //
-  // 'base-s390x': [
-  //   name: 'Debian s390x',
-  //   spidermonkey_vsn: '78',
-  //   with_nouveau: true,
-  //   // QuickJS test262 shows a discrepancy typedarray-arg-set-values-same-buffer-other-type.js
-  //   // Test262Error: 51539607552,42,0,4,5,6,7,8
-  //   quickjs_test262: false,
-  //   image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
-  //   node_label: 's390x',
-  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  // ],
-
-  'base': [
-    name: 'Debian x86_64',
-    spidermonkey_vsn: '78',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    // Test this in in the bookworm-quickjs variant
-    quickjs_test262: false,
-    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  'base-max-erlang': [
-    name: 'Debian x86_64',
-    spidermonkey_vsn: '78',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    quickjs_test262: false,
-    image: "${DOCKER_IMAGE_BASE}-${MAXIMUM_ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  // Skip this temporarily. We have too many CI jobs for the workers available
-  // which forces a CI job to wait for some of the worker to full run the CI
-  // before continuing effectively making the runs take about 2x the time. When
-  // we remove bullseye we can uncomment this perhaps
-  // 'base-intermediate-erlang': [
-  //   name: 'Debian x86_64',
-  //   spidermonkey_vsn: '78',
-  //   with_nouveau: true,
-  //   with_clouseau: true,
-  //   clouseau_java_home: '/opt/java/openjdk',
-  //   quickjs_test262: false,
-  //   image: "${DOCKER_IMAGE_BASE}-${INTERMEDIATE_ERLANG_VERSION}",
-  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  // ],
-
-  'base-quickjs': [
-    name: 'Debian 12 with QuickJS',
-    disable_spidermonkey: true,
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    quickjs_test262: true,
-    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  // This runs on a docker ARM64 host. Normally we should be able to run all
-  // ubuntu and centos containers on top any docker host, however spidermonkey
-  // 60 from CentOS cannot build on ARM64 so we're forced to separate it as a
-  // separate build usable for ubuntu/debian only and isolated it from other
-  // builds. At some point when we remove CentOS 8 or switch to QuickJS only,
-  // remove the docker-arm64 label on ubuntu-nc-arm64-12 node in Jenkins and
-  // remove this flavor
-  //
-  'base-arm64': [
-    name: 'Debian ARM64',
-    spidermonkey_vsn: '78',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    // Test this in in the bookworm-quickjs variant
-    quickjs_test262: false,
-    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
-    node_label: 'docker-arm64',
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  'trixie': [
-    name: 'Debian x86_64',
-    spidermonkey_vsn: '128',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    quickjs_test262: true,
-    image: "apache/couchdbci-debian:trixie-erlang-${ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
-
-  // Disable temporarily to not block PR merging. Worker unexpectedly went
-  // offline.
-  // 'freebsd-x86_64': [
-  //     name: 'FreeBSD x86_64',
-  //     spidermonkey_vsn: '91',
-  //     with_nouveau: false,
-  //     with_clouseau: true,
-  //     clouseau_java_home: '/usr/local/openjdk21',
-  //     quickjs_test262: false,
-  //     gnu_make: 'gmake',
-  //     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  // ],
-
-  // Spidermonkey 91 has issues on ARM64 FreeBSD
-  // use QuickJS for now
-  // Temporarily disabled because on too slow a host
-  // 'freebsd-arm64': [
-  //    name: 'FreeBSD ARM64 QuickJS',
-  //    disable_spidermonkey: true,
-  //    with_clouseau: true,
-  //    clouseau_java_home: '/usr/local/openjdk21',
-  //    quickjs_test262: false,
-  //    gnu_make: 'gmake',
-  //    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  // ],
-
-  // Disable temporarily as it is running out of space and Jenkins
-  // keeps auto-disabling it which blocks CI jobs
-  // 'macos': [
-  //    name: 'macOS',
-  //    disable_spidermonkey: true,
-  //    with_nouveau: true,
-  //    with_clouseau: true,
-  //    clouseau_java_home: '/opt/homebrew/opt/openjdk@21',
-  //    gnu_make: 'gmake',
-  //    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  //  ],
-
-   'win2022': [
-     name: 'Windows 2022',
-     spidermonkey_vsn: '128',
-     with_nouveau: true,
-     with_clouseau: true,
-     clouseau_java_home: /C:\tools\zulu21.46.19-ca-jdk21.0.9-win_x64/,
-     quickjs_test262: false,
-     node_label: 'win',
-     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-   ]
+//  'bullseye': [
+//    name: 'Debian x86_64',
+//    spidermonkey_vsn: '78',
+//    with_nouveau: true,
+//    with_clouseau: true,
+//    clouseau_java_home: '/opt/java/openjdk',
+//    quickjs_test262: true,
+//    image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}",
+//    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  ],
+//
+//  // Sometimes we "pick up" ppc64le workers from the asf jenkins intance That
+//  // seems like a good thing, however, those workers allow running multiple
+//  // agents at a time and often time out even with retries. The build times
+//  // take close to an hour, which is at least x2 as long as it takes to run
+//  // other arch CI jobs and they still time out often and fail. Disable for
+//  // now. This is a low demand arch distro, maybe remove support altogether?
+//  //
+//  // 'base-ppc64': [
+//  //   name: 'Debian POWER',
+//  //   spidermonkey_vsn: '78',
+//  //   with_nouveau: true,
+//  //   with_clouseau: true,
+//  //   quickjs_test262: true,
+//  //   image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
+//  //   node_label: 'ppc64le',
+//  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  // ],
+//
+//  // Just like in the ppc64le case we sometimes "pick up" built-in s390x workers added to
+//  // our jenkins, but since those are managed by us, our .mix/.venv/.hex packaging
+//  // cache hack in /home/jenkins doesn't work, and so elixir tests fail. Skip this arch build
+//  // until we figure out caching (probably need to use a proper caching plugin).
+//  //
+//  // 'base-s390x': [
+//  //   name: 'Debian s390x',
+//  //   spidermonkey_vsn: '78',
+//  //   with_nouveau: true,
+//  //   // QuickJS test262 shows a discrepancy typedarray-arg-set-values-same-buffer-other-type.js
+//  //   // Test262Error: 51539607552,42,0,4,5,6,7,8
+//  //   quickjs_test262: false,
+//  //   image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
+//  //   node_label: 's390x',
+//  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  // ],
+//
+//  'base': [
+//    name: 'Debian x86_64',
+//    spidermonkey_vsn: '78',
+//    with_nouveau: true,
+//    with_clouseau: true,
+//    clouseau_java_home: '/opt/java/openjdk',
+//    // Test this in in the bookworm-quickjs variant
+//    quickjs_test262: false,
+//    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
+//    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  ],
+//
+//  'base-max-erlang': [
+//    name: 'Debian x86_64',
+//    spidermonkey_vsn: '78',
+//    with_nouveau: true,
+//    with_clouseau: true,
+//    clouseau_java_home: '/opt/java/openjdk',
+//    quickjs_test262: false,
+//    image: "${DOCKER_IMAGE_BASE}-${MAXIMUM_ERLANG_VERSION}",
+//    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  ],
+//
+//  // Skip this temporarily. We have too many CI jobs for the workers available
+//  // which forces a CI job to wait for some of the worker to full run the CI
+//  // before continuing effectively making the runs take about 2x the time. When
+//  // we remove bullseye we can uncomment this perhaps
+//  // 'base-intermediate-erlang': [
+//  //   name: 'Debian x86_64',
+//  //   spidermonkey_vsn: '78',
+//  //   with_nouveau: true,
+//  //   with_clouseau: true,
+//  //   clouseau_java_home: '/opt/java/openjdk',
+//  //   quickjs_test262: false,
+//  //   image: "${DOCKER_IMAGE_BASE}-${INTERMEDIATE_ERLANG_VERSION}",
+//  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  // ],
+//
+//  'base-quickjs': [
+//    name: 'Debian 12 with QuickJS',
+//    disable_spidermonkey: true,
+//    with_nouveau: true,
+//    with_clouseau: true,
+//    clouseau_java_home: '/opt/java/openjdk',
+//    quickjs_test262: true,
+//    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
+//    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  ],
+//
+//  // This runs on a docker ARM64 host. Normally we should be able to run all
+//  // ubuntu and centos containers on top any docker host, however spidermonkey
+//  // 60 from CentOS cannot build on ARM64 so we're forced to separate it as a
+//  // separate build usable for ubuntu/debian only and isolated it from other
+//  // builds. At some point when we remove CentOS 8 or switch to QuickJS only,
+//  // remove the docker-arm64 label on ubuntu-nc-arm64-12 node in Jenkins and
+//  // remove this flavor
+//  //
+//  'base-arm64': [
+//    name: 'Debian ARM64',
+//    spidermonkey_vsn: '78',
+//    with_nouveau: true,
+//    with_clouseau: true,
+//    clouseau_java_home: '/opt/java/openjdk',
+//    // Test this in in the bookworm-quickjs variant
+//    quickjs_test262: false,
+//    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
+//    node_label: 'docker-arm64',
+//    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  ],
+//
+//  'trixie': [
+//    name: 'Debian x86_64',
+//    spidermonkey_vsn: '128',
+//    with_nouveau: true,
+//    with_clouseau: true,
+//    clouseau_java_home: '/opt/java/openjdk',
+//    quickjs_test262: true,
+//    image: "apache/couchdbci-debian:trixie-erlang-${ERLANG_VERSION}",
+//    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  ],
+//
+//  // Disable temporarily to not block PR merging. Worker unexpectedly went
+//  // offline.
+//  // 'freebsd-x86_64': [
+//  //     name: 'FreeBSD x86_64',
+//  //     spidermonkey_vsn: '91',
+//  //     with_nouveau: false,
+//  //     with_clouseau: true,
+//  //     clouseau_java_home: '/usr/local/openjdk21',
+//  //     quickjs_test262: false,
+//  //     gnu_make: 'gmake',
+//  //     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  // ],
+//
+//  // Spidermonkey 91 has issues on ARM64 FreeBSD
+//  // use QuickJS for now
+//  // Temporarily disabled because on too slow a host
+//  // 'freebsd-arm64': [
+//  //    name: 'FreeBSD ARM64 QuickJS',
+//  //    disable_spidermonkey: true,
+//  //    with_clouseau: true,
+//  //    clouseau_java_home: '/usr/local/openjdk21',
+//  //    quickjs_test262: false,
+//  //    gnu_make: 'gmake',
+//  //    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  // ],
+//
+//  // Disable temporarily as it is running out of space and Jenkins
+//  // keeps auto-disabling it which blocks CI jobs
+//  // 'macos': [
+//  //    name: 'macOS',
+//  //    disable_spidermonkey: true,
+//  //    with_nouveau: true,
+//  //    with_clouseau: true,
+//  //    clouseau_java_home: '/opt/homebrew/opt/openjdk@21',
+//  //    gnu_make: 'gmake',
+//  //    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//  //  ],
+//
+//   'win2022': [
+//     name: 'Windows 2022',
+//     spidermonkey_vsn: '128',
+//     with_nouveau: true,
+//     with_clouseau: true,
+//     clouseau_java_home: /C:\tools\zulu21.46.19-ca-jdk21.0.9-win_x64/,
+//     quickjs_test262: false,
+//     node_label: 'win',
+//     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+//   ]
 ]
 
 containerClouseauConfig = '''logger: {

--- a/src/couch/priv/couch_js/140/help.h
+++ b/src/couch/priv/couch_js/140/help.h
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#ifndef COUCHJS_HELP_H
+#define COUCHJS_HELP_H
+
+#include "config.h"
+
+static const char VERSION_TEMPLATE[] =
+    "%s - %s (SpiderMonkey %s)\n"
+    "\n"
+    "Licensed under the Apache License, Version 2.0 (the \"License\"); you may "
+        "not use\n"
+    "this file except in compliance with the License. You may obtain a copy of"
+        "the\n"
+    "License at\n"
+    "\n"
+    "  http://www.apache.org/licenses/LICENSE-2.0\n"
+    "\n"
+    "Unless required by applicable law or agreed to in writing, software "
+        "distributed\n"
+    "under the License is distributed on an \"AS IS\" BASIS, WITHOUT "
+        "WARRANTIES OR\n"
+    "CONDITIONS OF ANY KIND, either express or implied. See the License "
+        "for the\n"
+    "specific language governing permissions and limitations under the "
+        "License.\n";
+
+static const char USAGE_TEMPLATE[] =
+    "Usage: %s [FILE]\n"
+    "\n"
+    "The %s command runs the %s JavaScript interpreter.\n"
+    "\n"
+    "The exit status is 0 for success or 1 for failure.\n"
+    "\n"
+    "Options:\n"
+    "\n"
+    "  -h          display a short help message and exit\n"
+    "  -V          display version information and exit\n"
+    "  -S SIZE     specify that the runtime should allow at\n"
+    "              most SIZE bytes of memory to be allocated\n"
+    "              default is 64 MiB\n"
+    "  --eval      Enable runtime code evaluation (dangerous!)\n"
+    "\n"
+    "Report bugs at <%s>.\n";
+
+#define BASENAME COUCHJS_NAME
+
+#define couch_version(basename)  \
+    fprintf(                     \
+            stdout,              \
+            VERSION_TEMPLATE,    \
+            basename,            \
+            PACKAGE_STRING,      \
+            get_spidermonkey_version())
+
+#define DISPLAY_VERSION couch_version(BASENAME)
+
+
+#define couch_usage(basename) \
+    fprintf(                                    \
+            stdout,                             \
+            USAGE_TEMPLATE,                     \
+            basename,                           \
+            basename,                           \
+            PACKAGE_NAME,                       \
+            PACKAGE_BUGREPORT)
+
+#define DISPLAY_USAGE couch_usage(BASENAME)
+
+#endif // Included help.h

--- a/src/couch/priv/couch_js/140/main.cpp
+++ b/src/couch/priv/couch_js/140/main.cpp
@@ -1,0 +1,337 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef XP_WIN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#include <jsapi.h>
+#include <js/CompilationAndEvaluation.h>
+#include <js/Conversions.h>
+#include <js/Initialization.h>
+#include <js/SourceText.h>
+#include <js/StableStringChars.h>
+#include <js/Warnings.h>
+#include <js/Wrapper.h>
+
+#include "config.h"
+#include "util.h"
+
+static bool enableSharedMemory = true;
+static bool enableToSource = true;
+
+/* The class of the global object. */
+static JSClass global_class = {
+    "global",
+    JSCLASS_GLOBAL_FLAGS,
+    &JS::DefaultGlobalClassOps
+};
+
+static JSObject*
+NewSandbox(JSContext* cx, bool lazy)
+{
+    JS::RealmOptions options;
+    options.creationOptions().setSharedMemoryAndAtomicsEnabled(enableSharedMemory);
+    options.creationOptions().setNewCompartmentAndZone();
+    // we need this in the query server error handling
+    options.creationOptions().setToSourceEnabled(enableToSource);
+    JS::RootedObject obj(cx, JS_NewGlobalObject(cx, &global_class, nullptr,
+                                            JS::DontFireOnNewGlobalHook, options));
+    if (!obj)
+        return nullptr;
+
+    {
+        JSAutoRealm ac(cx, obj);
+        if (!lazy && !JS::InitRealmStandardClasses(cx))
+            return nullptr;
+
+        JS::RootedValue value(cx, JS::BooleanValue(lazy));
+        if (!JS_DefineProperty(cx, obj, "lazy", value, JSPROP_PERMANENT | JSPROP_READONLY))
+            return nullptr;
+
+        JS_FireOnNewGlobalObject(cx, obj);
+    }
+
+    if (!JS_WrapObject(cx, &obj))
+        return nullptr;
+    return obj;
+}
+
+static bool
+evalcx(JSContext *cx, unsigned int argc, JS::Value* vp)
+{
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    bool ret = false;
+
+    JS::RootedString str(cx, args[0].toString());
+    if (!str)
+        return false;
+
+    JS::RootedObject sandbox(cx);
+    if (args.hasDefined(1)) {
+        sandbox = JS::ToObject(cx, args[1]);
+        if (!sandbox)
+            return false;
+    }
+
+    if (!sandbox) {
+        sandbox = NewSandbox(cx, false);
+        if (!sandbox)
+            return false;
+    }
+
+    JS::AutoStableStringChars strChars(cx);
+    if (!strChars.initTwoByte(cx, str))
+        return false;
+
+    mozilla::Range<const char16_t> chars = strChars.twoByteRange();
+    JS::SourceText<char16_t> srcBuf;
+    if (!srcBuf.init(cx, chars.begin().get(), chars.length(),
+                     JS::SourceOwnership::Borrowed)) {
+        return false;
+    }
+
+    if(srcBuf.length() == 0) {
+        args.rval().setObject(*sandbox);
+    } else {
+        mozilla::Maybe<JSAutoRealm> ar;
+        unsigned flags;
+        JSObject* unwrapped = UncheckedUnwrap(sandbox, true, &flags);
+        if (flags & js::Wrapper::CROSS_COMPARTMENT) {
+            sandbox = unwrapped;
+            ar.emplace(cx, sandbox);
+        }
+
+        JS::CompileOptions opts(cx);
+        JS::RootedValue rval(cx);
+        opts.setFileAndLine("<unknown>", 1);
+
+        if (!JS::Evaluate(cx, opts, srcBuf, args.rval())) {
+             return false;
+         }
+    }
+    ret = true;
+    if (!JS_WrapValue(cx, args.rval()))
+        return false;
+
+    return ret;
+}
+
+
+static bool
+gc(JSContext* cx, unsigned int argc, JS::Value* vp)
+{
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    JS_GC(cx);
+    args.rval().setUndefined();
+    return true;
+}
+
+
+static bool
+print(JSContext* cx, unsigned int argc, JS::Value* vp)
+{
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+
+    bool use_stderr = false;
+    if(argc > 1 && args[1].isTrue()) {
+        use_stderr = true;
+    }
+
+    if(!args[0].isString()) {
+        JS_ReportErrorUTF8(cx, "Unable to print non-string value.");
+        return false;
+    }
+
+    couch_print(cx, args[0], use_stderr);
+
+    args.rval().setUndefined();
+    return true;
+}
+
+
+static bool
+quit(JSContext* cx, unsigned int argc, JS::Value* vp)
+{
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+
+    int exit_code = args[0].toInt32();;
+    JS_DestroyContext(cx);
+    JS_ShutDown();
+    exit(exit_code);
+}
+
+
+static bool
+readline(JSContext* cx, unsigned int argc, JS::Value* vp)
+{
+    JSString* line;
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+
+    /* GC Occasionally */
+    JS_MaybeGC(cx);
+
+    line = couch_readline(cx, stdin);
+    if(line == NULL) return false;
+
+    // return with JSString* instead of JSValue in the past
+    args.rval().setString(line);
+    return true;
+}
+
+
+static bool
+seal(JSContext* cx, unsigned int argc, JS::Value* vp)
+{
+    JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+    JS::RootedObject target(cx);
+    target = JS::ToObject(cx, args[0]);
+    if (!target) {
+        args.rval().setUndefined();
+        return true;
+    }
+    bool deep = false;
+    deep = args[1].toBoolean();
+    bool ret = deep ? JS_DeepFreezeObject(cx, target) : JS_FreezeObject(cx, target);
+    args.rval().setUndefined();
+    return ret;
+}
+
+
+static JSFunctionSpec global_functions[] = {
+    JS_FN("evalcx", evalcx, 0, 0),
+    JS_FN("gc", gc, 0, 0),
+    JS_FN("print", print, 0, 0),
+    JS_FN("quit", quit, 0, 0),
+    JS_FN("readline", readline, 0, 0),
+    JS_FN("seal", seal, 0, 0),
+    JS_FS_END
+};
+
+
+static bool
+csp_allows(JSContext* cx,
+    JS::RuntimeCode kind, JS::Handle<JSString*> codeString,
+    JS::CompilationType compilationType,
+    JS::Handle<JS::StackGCVector<JSString*>> parameterStrings,
+    JS::Handle<JSString*> bodyString,
+    JS::Handle<JS::StackGCVector<JS::Value>> parameterArgs,
+    JS::Handle<JS::Value> bodyArg, bool* outCanCompileStrings)
+{
+    couch_args* args = static_cast<couch_args*>(JS_GetContextPrivate(cx));
+    if(args->eval) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+
+static JSSecurityCallbacks security_callbacks = {
+    csp_allows,     //JSCSPEvalChecker contentSecurityPolicyAllows;
+    nullptr,        //JSCodeForEvalOp codeForEvalGets;
+    nullptr         //JSSubsumesOp subsumes;
+};
+
+int runWithContext(JSContext* cx, couch_args* args) {
+    JS_SetGlobalJitCompilerOption(cx, JSJITCOMPILER_BASELINE_ENABLE, 0);
+    JS_SetGlobalJitCompilerOption(cx, JSJITCOMPILER_ION_ENABLE, 0);
+
+    if (!JS::InitSelfHostedCode(cx))
+        return 1;
+
+    JS::SetWarningReporter(cx, couch_error);
+    JS::SetOutOfMemoryCallback(cx, couch_oom, NULL);
+    JS_SetContextPrivate(cx, args);
+    JS_SetSecurityCallbacks(cx, &security_callbacks);
+
+    JS::RealmOptions options;
+    // we need this in the query server error handling
+    options.creationOptions().setToSourceEnabled(enableToSource);
+    JS::RootedObject global(cx, JS_NewGlobalObject(cx, &global_class, nullptr,
+                                                   JS::FireOnNewGlobalHook, options));
+    if (!global)
+        return 1;
+
+    JSAutoRealm ar(cx, global);
+
+    if(!JS::InitRealmStandardClasses(cx))
+        return 1;
+
+    if(couch_load_funcs(cx, global, global_functions) != true)
+        return 1;
+
+    for(int i = 0 ; args->scripts[i] ; i++) {
+        const char* filename = args->scripts[i];
+
+        // Compile and run
+        JS::CompileOptions options(cx);
+        JS::RootedScript script(cx);
+
+        script = JS::CompileUtf8Path(cx, options, filename);
+        if (!script) {
+            JS::RootedValue exc(cx);
+            if(!JS_GetPendingException(cx, &exc)) {
+                fprintf(stderr, "Failed to compile file: %s\n", filename);
+            } else {
+                JS::RootedObject exc_obj(cx, &exc.toObject());
+                JSErrorReport* report = JS_ErrorFromException(cx, exc_obj);
+                couch_error(cx, report);
+            }
+            return 1;
+        }
+
+        JS::RootedValue result(cx);
+        if(JS_ExecuteScript(cx, script, &result) != true) {
+            JS::RootedValue exc(cx);
+            if(!JS_GetPendingException(cx, &exc)) {
+                fprintf(stderr, "Failed to execute script.\n");
+            } else {
+                JS::RootedObject exc_obj(cx, &exc.toObject());
+                JSErrorReport* report = JS_ErrorFromException(cx, exc_obj);
+                couch_error(cx, report);
+            }
+        }
+
+        // Give the GC a chance to run.
+        JS_MaybeGC(cx);
+    }
+    return 0;
+}
+
+int
+main(int argc, const char* argv[])
+{
+    JSContext* cx = NULL;
+    int ret;
+
+    couch_args* args = couch_parse_args(argc, argv);
+
+    JS_Init();
+    cx = JS_NewContext(args->stack_size);
+    if(cx == NULL) {
+        JS_ShutDown();
+        return 1;
+    }
+    ret = runWithContext(cx, args);
+    JS_DestroyContext(cx);
+    JS_ShutDown();
+
+    return ret;
+}

--- a/src/couch/priv/couch_js/140/util.cpp
+++ b/src/couch/priv/couch_js/140/util.cpp
@@ -1,0 +1,380 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <sstream>
+
+#include <jsapi.h>
+#include <jsfriendapi.h>
+#include <js/CharacterEncoding.h>
+#include <js/Conversions.h>
+#include <js/Initialization.h>
+#include <js/MemoryFunctions.h>
+#include <js/RegExp.h>
+
+#include "help.h"
+#include "util.h"
+
+const char*
+get_spidermonkey_version() {
+    const char *JAVASCRIPT = "JavaScript-C";
+    int js_len = strlen(JAVASCRIPT);
+
+    // JS_GetImplementationVersion()
+    // returns "JavaScript-CMAJOR.MINOR.PATCH"
+    const char *FULLVERSION = JS_GetImplementationVersion();
+    int fv_len = strlen(FULLVERSION);
+
+    const char* foundJSString = strstr(FULLVERSION,JAVASCRIPT);
+    if (foundJSString != NULL) {
+        //trim off "JavaScript-C",
+        char *buf = (char*) malloc((fv_len - js_len + 1) * sizeof(char));
+        strncpy(buf, &FULLVERSION[js_len], fv_len - js_len);
+        buf[fv_len - js_len] = '\0';
+        return buf;
+    } else {
+        //something changed in JS_GetImplementationVersion(), return original
+        return FULLVERSION;
+    }
+}
+
+std::string
+js_to_string(JSContext* cx, JS::HandleValue val)
+{
+    JS::AutoSaveExceptionState exc_state(cx);
+    JS::RootedString sval(cx);
+    sval = val.toString();
+
+    JS::UniqueChars chars(JS_EncodeStringToUTF8(cx, sval));
+    if(!chars) {
+        JS_ClearPendingException(cx);
+        return std::string();
+    }
+
+    return chars.get();
+}
+
+bool
+js_to_string(JSContext* cx, JS::HandleValue val, std::string& str)
+{
+    if(!val.isString()) {
+        return false;
+    }
+
+    if(JS_GetStringLength(val.toString()) == 0) {
+        str = "";
+        return true;
+    }
+
+    std::string conv = js_to_string(cx, val);
+    if(!conv.size()) {
+        return false;
+    }
+
+    str = conv;
+    return true;
+}
+
+JSString*
+string_to_js(JSContext* cx, const std::string& raw)
+{
+    JS::UTF8Chars utf8(raw.c_str(), raw.size());
+    JS::UniqueTwoByteChars utf16;
+    size_t len;
+
+    utf16.reset(JS::UTF8CharsToNewTwoByteCharsZ(cx, utf8, &len, js::MallocArena).get());
+    if(!utf16) {
+        return nullptr;
+    }
+
+    return JS_NewUCString(cx, std::move(utf16), len);
+}
+
+size_t
+couch_readfile(const char* file, char** outbuf_p)
+{
+    FILE* fp;
+    char fbuf[16384];
+    char *buf = NULL;
+    char* tmp;
+    size_t nread = 0;
+    size_t buflen = 0;
+
+    if(strcmp(file, "-") == 0) {
+        fp = stdin;
+    } else {
+        fp = fopen(file, "r");
+        if(fp == NULL) {
+            fprintf(stderr, "Failed to read file: %s\n", file);
+            exit(3);
+        }
+    }
+
+    while((nread = fread(fbuf, 1, 16384, fp)) > 0) {
+        if(buf == NULL) {
+            buf = new char[nread + 1];
+            if(buf == NULL) {
+                fprintf(stderr, "Out of memory.\n");
+                exit(3);
+            }
+            memcpy(buf, fbuf, nread);
+        } else {
+            tmp = new char[buflen + nread + 1];
+            if(tmp == NULL) {
+                fprintf(stderr, "Out of memory.\n");
+                exit(3);
+            }
+            memcpy(tmp, buf, buflen);
+            memcpy(tmp+buflen, fbuf, nread);
+            delete buf;
+            buf = tmp;
+        }
+        buflen += nread;
+        buf[buflen] = '\0';
+    }
+    *outbuf_p = buf;
+    return buflen ;
+}
+
+couch_args*
+couch_parse_args(int argc, const char* argv[])
+{
+    couch_args* args;
+    int i = 1;
+
+    args = new couch_args();
+    if(args == NULL)
+        return NULL;
+
+    args->eval = 0;
+    args->stack_size = 64L * 1024L * 1024L;
+    args->scripts = nullptr;
+
+    while(i < argc) {
+        if(strcmp("-h", argv[i]) == 0) {
+            DISPLAY_USAGE;
+            exit(0);
+        } else if(strcmp("-V", argv[i]) == 0) {
+            DISPLAY_VERSION;
+            exit(0);
+        } else if(strcmp("-S", argv[i]) == 0) {
+            args->stack_size = atoi(argv[++i]);
+            if(args->stack_size <= 0) {
+                fprintf(stderr, "Invalid stack size.\n");
+                exit(2);
+            }
+        } else if(strcmp("--eval", argv[i]) == 0) {
+            args->eval = 1;
+        } else if(strcmp("--", argv[i]) == 0) {
+            i++;
+            break;
+        } else {
+            break;
+        }
+        i++;
+    }
+
+    if(i >= argc) {
+        DISPLAY_USAGE;
+        exit(3);
+    }
+    args->scripts = argv + i;
+
+    return args;
+}
+
+
+int
+couch_fgets(char* buf, int size, FILE* fp)
+{
+    int n, i, c;
+
+    if(size <= 0) return -1;
+    n = size - 1;
+
+    for(i = 0; i < n && (c = getc(fp)) != EOF; i++) {
+        buf[i] = c;
+        if(c == '\n') {
+            i++;
+            break;
+        }
+    }
+
+    buf[i] = '\0';
+    return i;
+}
+
+
+JSString*
+couch_readline(JSContext* cx, FILE* fp)
+{
+    JSString* str;
+    char* bytes = NULL;
+    char* tmp = NULL;
+    size_t used = 0;
+    size_t byteslen = 256;
+    size_t oldbyteslen = 256;
+    size_t readlen = 0;
+
+    bytes = static_cast<char*>(JS_malloc(cx, byteslen));
+    if(bytes == NULL) return NULL;
+
+    while((readlen = couch_fgets(bytes+used, byteslen-used, fp)) > 0) {
+        used += readlen;
+
+        if(bytes[used-1] == '\n') {
+            bytes[used-1] = '\0';
+            break;
+        }
+
+        // Double our buffer and read more.
+        oldbyteslen = byteslen;
+        byteslen *= 2;
+        tmp = static_cast<char*>(JS_realloc(cx, bytes, oldbyteslen, byteslen));
+        if(!tmp) {
+            JS_free(cx, bytes);
+            return NULL;
+        }
+
+        bytes = tmp;
+    }
+
+    // Treat empty strings specially
+    if(used == 0) {
+        JS_free(cx, bytes);
+        return JS_NewStringCopyZ(cx, nullptr);
+    }
+
+    // Shrink the buffer to the actual data size
+    tmp = static_cast<char*>(JS_realloc(cx, bytes, byteslen, used));
+    if(!tmp) {
+        JS_free(cx, bytes);
+        return NULL;
+    }
+    bytes = tmp;
+    byteslen = used;
+
+    str = string_to_js(cx, std::string(tmp));
+    JS_free(cx, bytes);
+    return str;
+}
+
+
+void
+couch_print(JSContext* cx, JS::HandleValue obj, bool use_stderr)
+{
+    FILE *stream = stdout;
+
+    if (use_stderr) {
+        stream = stderr;
+    }
+    std::string val = js_to_string(cx, obj);
+    fprintf(stream, "%s\n", val.c_str());
+    fflush(stream);
+}
+
+
+void
+couch_error(JSContext* cx, JSErrorReport* report)
+{
+    if(!report) {
+        return;
+    }
+
+    if(report->isWarning()) {
+        return;
+    }
+
+    std::ostringstream msg;
+    msg << "error: " << report->message().c_str();
+
+    mozilla::Maybe<JSAutoRealm> ar;
+    JS::RootedValue exc(cx);
+    JS::RootedObject exc_obj(cx);
+    JS::RootedObject stack_obj(cx);
+    JS::RootedString stack_str(cx);
+    JS::RootedValue stack_val(cx);
+    JSPrincipals* principals = GetRealmPrincipals(js::GetContextRealm(cx));
+
+    if(!JS_GetPendingException(cx, &exc)) {
+        goto done;
+    }
+
+    // Clear the exception before an JS method calls or the result is
+    // infinite, recursive error report generation.
+    JS_ClearPendingException(cx);
+
+    exc_obj.set(exc.toObjectOrNull());
+    stack_obj.set(JS::ExceptionStackOrNull(exc_obj));
+
+    if(!stack_obj) {
+        // Compilation errors don't have a stack
+
+        msg << " at ";
+
+        if(report->filename) {
+#if MOZJS_MAJOR_VERSION < 128
+            msg << report->filename;
+#else  // MOZJS_MAJOR_VERSION >= 128
+            msg << report->filename.c_str();
+#endif
+        } else {
+            msg << "<unknown>";
+        }
+
+        if(report->lineno) {
+#if MOZJS_MAJOR_VERSION < 128
+            msg << ':' << report->lineno << ':' << report->column;
+#else  // MOZJS_MAJOR_VERSION >= 128
+            msg << ':' << report->lineno << ':' <<
+                report->column.oneOriginValue();
+#endif
+        }
+
+        goto done;
+    }
+
+    if(!JS::BuildStackString(cx, principals, stack_obj, &stack_str, 2)) {
+        goto done;
+    }
+
+    stack_val.set(JS::StringValue(stack_str));
+    msg << std::endl << std::endl << js_to_string(cx, stack_val).c_str();
+
+done:
+    msg << std::endl;
+    fprintf(stderr, "%s", msg.str().c_str());
+}
+
+
+void
+couch_oom(JSContext* cx, void* data)
+{
+    fprintf(stderr, "out of memory\n");
+    _Exit(1);
+}
+
+
+bool
+couch_load_funcs(JSContext* cx, JS::HandleObject obj, JSFunctionSpec* funcs)
+{
+    JSFunctionSpec* f;
+    for(f = funcs; f->name; f++) {
+        if(!JS_DefineFunction(cx, obj, f->name.string(), f->call.op, f->nargs, f->flags)) {
+            fprintf(stderr, "Failed to create function: %s\n", f->name.string());
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/couch/priv/couch_js/140/util.h
+++ b/src/couch/priv/couch_js/140/util.h
@@ -1,0 +1,43 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#ifndef COUCHJS_UTIL_H
+#define COUCHJS_UTIL_H
+
+#include <jsapi.h>
+
+typedef struct {
+    int          eval;
+    int          use_http;
+    int          use_test_funs;
+    int          stack_size;
+    const char** scripts;
+    const char*  uri_file;
+    JSString*    uri;
+} couch_args;
+
+const char* get_spidermonkey_version();
+
+std::string js_to_string(JSContext* cx, JS::HandleValue val);
+bool js_to_string(JSContext* cx, JS::HandleValue val, std::string& str);
+JSString* string_to_js(JSContext* cx, const std::string& s);
+
+couch_args* couch_parse_args(int argc, const char* argv[]);
+int couch_fgets(char* buf, int size, FILE* fp);
+JSString* couch_readline(JSContext* cx, FILE* fp);
+size_t couch_readfile(const char* file, char** outbuf_p);
+void couch_print(JSContext* cx, JS::HandleValue str, bool use_stderr);
+void couch_error(JSContext* cx, JSErrorReport* report);
+void couch_oom(JSContext* cx, void* data);
+bool couch_load_funcs(JSContext* cx, JS::HandleObject obj, JSFunctionSpec* funcs);
+
+#endif // Included util.h

--- a/src/couch/rebar.config.script
+++ b/src/couch/rebar.config.script
@@ -97,13 +97,15 @@ SMVsn = case lists:keyfind(spidermonkey_version, 1, CouchConfig) of
         "115";
     {_, "128"} ->
         "128";
+    {_, "140"} ->
+        "140";
     undefined ->
-        "128";
+        "140";
     {_, Unsupported} ->
         io:format(standard_error, "Unsupported SpiderMonkey version: ~s~n", [Unsupported]),
         erlang:halt(1);
     false ->
-        "128"
+        "140"
 end.
 
 ConfigH = [
@@ -129,6 +131,8 @@ CouchJSConfig = case SMVsn of
         "priv/couch_js/102/config.h";
     "128" ->
         "priv/couch_js/102/config.h";
+    "140" ->
+    "priv/couch_js/140/config.h";
     _ ->
         "priv/couch_js/" ++ SMVsn ++ "/config.h"
 end.
@@ -214,7 +218,7 @@ end.
             "-DXP_UNIX -I/usr/include/mozjs-86 -I/usr/local/include/mozjs-86 -I/opt/homebrew/include/mozjs-86/ -std=c++17 -Wno-invalid-offsetof",
             "-L/usr/local/lib -L /opt/homebrew/lib/ -std=c++17 -lmozjs-86 -lm"
         };
-    {unix, _} when SMVsn == "91"; SMVsn == "102"; SMVsn == "115"; SMVsn == "128" ->
+    {unix, _} when SMVsn == "91"; SMVsn == "102"; SMVsn == "115"; SMVsn == "128"; SMVsn == "140" ->
         {
             "$CFLAGS -DXP_UNIX " ++ MozJSIncludePath ++ " -std=c++17 -Wno-invalid-offsetof",
             "$LDFLAGS " ++ MozJSLibPath ++ " -std=c++17 -lm -lmozjs-" ++ SMVsn
@@ -224,7 +228,7 @@ end.
             "/std:c++17 /DXP_WIN",
             "$LDFLAGS mozjs-91.lib"
         };
-    {win32, _} when SMVsn == "102"; SMVsn == "115"; SMVsn == "128" ->
+    {win32, _} when SMVsn == "102"; SMVsn == "115"; SMVsn == "128"; SMVsn == "140" ->
         {
             "/std:c++17 /DXP_WIN /Zc:preprocessor /utf-8",
             "$LDFLAGS mozjs-" ++ SMVsn ++ ".lib"
@@ -240,7 +244,8 @@ CouchJSSrc = case SMVsn of
     "91" -> ["priv/couch_js/86/*.cpp"];
     "102" -> ["priv/couch_js/102/*.cpp"];
     "115" -> ["priv/couch_js/102/*.cpp"];
-    "128" -> ["priv/couch_js/102/*.cpp"]
+    "128" -> ["priv/couch_js/102/*.cpp"];
+    "140" -> ["priv/couch_js/140/*.cpp"]
 end.
 
 CouchJSEnv = case SMVsn of


### PR DESCRIPTION
Tried to add SM v140. There are again some internal SpiderMonkey API changes.

Tried to compile against SpiderMonkey v140 and got following errors:

```
==> couch (compile)
Compiling /Users/big-r/Documents/Developer/CouchDB/couchdb/src/couch/priv/couch_js/140/main.cpp
In file included from /Users/big-r/Documents/Developer/CouchDB/couchdb/src/couch/priv/couch_js/140/main.cpp:24:
In file included from /usr/local/include/mozjs-140/jsapi.h:30:
In file included from /usr/local/include/mozjs-140/js/CallAndConstruct.h:15:
/usr/local/include/mozjs-140/js/RootingAPI.h:1169:34: warning: unknown warning group '-Wdangling-pointer', ignored [-Wunknown-warning-option]
 1169 | #  pragma GCC diagnostic ignored "-Wdangling-pointer"
      |                                  ^
/Users/big-r/Documents/Developer/CouchDB/couchdb/src/couch/priv/couch_js/140/main.cpp:241:5: error: cannot initialize a member subobject of type 'JSCSPEvalChecker' (aka 'bool (*)(JSContext *, JS::RuntimeCode, JS::Handle<JSString *>, JS::CompilationType, JS::Handle<JS::StackGCVector<JSString *>>, JS::Handle<JSString *>, JS::Handle<JS::StackGCVector<JS::Value>>, JS::Handle<JS::Value>, bool *)') with an lvalue of type 'bool (JSContext *, JS::RuntimeCode, JS::HandleString)' (aka 'bool (JSContext *, JS::RuntimeCode, Handle<JSString *>)'): different number of parameters (9 vs 3)
  241 |     csp_allows,
      |     ^~~~~~~~~~
1 warning and 1 error generated.
ERROR: compile failed while processing /Users/big-r/Documents/Developer/CouchDB/couchdb/src/couch: rebar_abort
make: *** [couch] Error 1
```

I changed the csp_allow method signature to fit the `typedef` in `js/public/Principals.h`. I don't know if there is a better solution. 

Before:
```cpp
static bool
csp_allows(JSContext* cx, JS::RuntimeCode kind, JS::HandleString code)
{
    couch_args* args = static_cast<couch_args*>(JS_GetContextPrivate(cx));
    if(args->eval) {
        return true;
    } else {
        return false;
    }
}


static JSSecurityCallbacks security_callbacks = {
    csp_allows,
    nullptr
};
```

After:
```cpp
static bool
csp_allows(JSContext* cx,
    JS::RuntimeCode kind, JS::Handle<JSString*> codeString,
    JS::CompilationType compilationType,
    JS::Handle<JS::StackGCVector<JSString*>> parameterStrings,
    JS::Handle<JSString*> bodyString,
    JS::Handle<JS::StackGCVector<JS::Value>> parameterArgs,
    JS::Handle<JS::Value> bodyArg, bool* outCanCompileStrings)
{
    couch_args* args = static_cast<couch_args*>(JS_GetContextPrivate(cx));
    if(args->eval) {
        return true;
    } else {
        return false;
    }
}


static JSSecurityCallbacks security_callbacks = {
    csp_allows,     //JSCSPEvalChecker contentSecurityPolicyAllows;
    nullptr,        //JSCodeForEvalOp codeForEvalGets;
    nullptr         //JSSubsumesOp subsumes;
};
```

Here are some additional [infos](https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples/blob/esr140/docs/Migration%20Guide.md#esr-128-to-esr-140) what changed in SpiderMonkey from 128 -> 140.