### PR TITLE
Fix run_on_first_node scanner features

### DIFF
--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -315,9 +315,7 @@ scan_dbs_fold(#full_doc_info{} = FDI, #st{shards_db = Db} = Acc) ->
             {ok, Acc2}
     end.
 
-scan_db([], #st{} = St) ->
-    {ok, St};
-scan_db([_ | _] = Shards, #st{} = St) ->
+scan_db(Shards, #st{} = St) ->
     #st{dbname = DbName, callbacks = Cbks, pst = PSt, skip_dbs = Skip} = St,
     #{db := DbCbk} = Cbks,
     case match_skip_pat(DbName, Skip) of


### PR DESCRIPTION
`run_on_first_node` feature is a running mode for plugins which are only interested in design documents, and may want to avoid fetching clustered design docs on all nodes.

However that feature didn't work since it clashed with a premature optimization in plugin's `scan_db/2` function, which avoided scanning the db if no shards were scheduled to be scanned on the first node. For example, with a 3 node cluster and a q=2 db, it was possible to have both of its shards scheduled to be scanned on db2 and db3, respectively, while the plugin was running on db1 only. In that case the plugin would have skipped calling the main part of `scan_db` which does ddoc processing.

The fix is to remove the premature optimization and load the ddoc even if no shards are scheduled to be scanned on that node since we may be dealing with a plugin which is only interested in design documents.
