### PR TITLE
Handle timeout in `dreyfus_fabric_search:go`

### DIFF
--- a/src/dreyfus/src/dreyfus_fabric_search.erl
+++ b/src/dreyfus/src/dreyfus_fabric_search.erl
@@ -142,7 +142,9 @@ go(DbName, DDoc, IndexName, QueryArgs, Counters, Bookmark, RingOpts) ->
                     {ok, Bookmark1, TotalHits, Hits1, Counts, Ranges}
             end;
         {error, Reason} ->
-            {error, Reason}
+            {error, Reason};
+        {timeout, _State} ->
+            {error, timeout}
     after
         rexi_monitor:stop(RexiMon),
         fabric_streams:cleanup(Workers)


### PR DESCRIPTION
## Overview

Currently, receiving a timeout from `rexi_util:recv` exposes internal state in the error message, and obscures the timeout:
```

❯ curl -u adm:pass $D1/db-e3/_find -d '{"use_index": "_design/af381e41784d465bb1349f8378f90bba9c6d252e", "selector": {"x": {"$regex": "^(((a+)+)+)+$"}}, "execution_stats": true}' | jq .
{
  "error": "try_clause",
  "reason": "{timeout,{state,200,relevance,\n                {top_docs,undefined,0,[],undefined,undefined},\n                [{{shard,<<\"shards/00000000-7fffffff/db-e3.1757182851\">>,\n                         'node1@127.0.0.1',<<\"db-e3\">>,\n                         [0,2147483647],\n                         #Ref<0.4061688246.3678666753.76196>,\n                         [{props,[]}]},\n                  nil},\n                 {{shard,<<\"shards/00000000-7fffffff/db-e3.1757182851\">>,\n                         'node2@127.0.0.1',<<\"db-e3\">>,\n                         [0,2147483647],\n                         #Ref<0.4061688246.3678666753.76197>,\n                         [{props,[]}]},\n                  nil},\n                 {{shard,<<\"shards/00000000-7fffffff/db-e3.1757182851\">>,\n                         'node3@127.0.0.1',<<\"db-e3\">>,\n                         [0,2147483647],\n                         #Ref<0.4061688246.3678666753.76198>,\n                         [{props,[]}]},\n                  nil},\n                 {{shard,<<\"shards/80000000-ffffffff/db-e3.1757182851\">>,\n                         'node1@127.0.0.1',<<\"db-e3\">>,\n                         [2147483648,4294967295],\n                         #Ref<0.4061688246.3678666753.76199>,\n                         [{props,[]}]},\n                  nil},\n                 {{shard,<<\"shards/80000000-ffffffff/db-e3.1757182851\">>,\n                         'node2@127.0.0.1',<<\"db-e3\">>,\n                         [2147483648,4294967295],\n                         #Ref<0.4061688246.3678666753.76200>,\n                         [{props,[]}]},\n                  nil},\n                 {{shard,<<\"shards/80000000-ffffffff/db-e3.1757182851\">>,\n                         'node3@127.0.0.1',<<\"db-e3\">>,\n                         [2147483648,4294967295],\n                         #Ref<0.4061688246.3678666753.76201>,\n                         [{props,[]}]},\n                  nil}],\n                [{doc,<<\"_design/af381e41784d465bb1349f8378f90bba9c6d252e\">>,\n                      {1,[<<\"-\\\"�3ICQ\\es��\\n�7�\">>]},\n                      {[{<<\"language\">>,<<\"query\">>},\n                        {<<\"indexes\">>,\n                         {[{<<\"af381e41784d465bb1349f8378f90bba9c6d252e\">>,\n                            {[{<<\"index\">>,\n                               {[{<<\"default_analyzer\">>,<<\"keyword\">>},\n                                 {<<\"default_field\">>,{[]}},\n                                 {<<\"partial_filter_selector\">>,{[]}},\n                                 {<<\"selector\">>,{[]}},\n                                 {<<\"fields\">>,\n                                  [{[{<<\"name\">>,<<\"x\">>},\n                                     {<<\"type\">>,<<\"string\">>}]}]},\n                                 {<<\"index_array_lengths\">>,true}]}},\n                              {<<\"analyzer\">>,\n                               {[{<<\"name\">>,<<\"perfield\">>},\n                                 {<<\"default\">>,<<\"keyword\">>},\n                                 {<<\"fields\">>,\n                                  {[{<<\"$default\">>,\n                                     <<\"standard\">>}]}}]}}]}}]}}]},\n                      [],false,[]},\n                 <<\"af381e41784d465bb1349f8378f90bba9c6d252e\">>,\n                 {index_query_args,<<\"($fieldnames:x_3astring)\">>,nil,200,\n                                   false,false,nil,relevance,\n                                   {grouping,nil,[],0,10,relevance,true},\n                                   false,nil,nil,[],nil,nil,<<\"<em>\">>,\n                                   <<\"</em>\">>,1,0,true}],\n                [],[]}}",
  "ref": 2182595996
}
```

With this patch, a timeout is handled more elegantly:
```
❯ curl -u adm:pass $D1/db-e3/_find -d '{"use_index": "_design/af381e41784d465bb1349f8378f90bba9c6d252e", "selector": {"x": {"$regex": "^(((a+)+)+)+$"}}, "execution_stats": true}' | jq .
{
  "error": "text_search_error",
  "reason": "timeout",
  "ref": 68970337
}
```


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

```
make elixir-search
```
<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
