### PR TITLE
Add assert comments to search related elixir tests

### DIFF
--- a/test/elixir/lib/asserts.ex
+++ b/test/elixir/lib/asserts.ex
@@ -1,0 +1,20 @@
+defmodule Couch.Test.Asserts do
+  @moduledoc """
+  Custom asserts.
+  """
+  defmacro assert_on_status(resp, expected, failure_message) do
+    expected_list = List.wrap(expected)
+
+    expected_msg = case expected_list do
+      [single] -> "Expected #{single}"
+      multiple -> "Expected one of #{inspect(multiple)}"
+    end
+
+    quote do
+      status_code = unquote(resp).status_code
+      body = unquote(resp).body
+      message = "#{unquote(failure_message)} #{unquote(expected_msg)}, got: #{status_code}, body: #{inspect(body)}"
+      ExUnit.Assertions.assert(status_code in unquote(expected_list), "#{message}")
+    end
+  end
+end

--- a/test/elixir/test/search_test.exs
+++ b/test/elixir/test/search_test.exs
@@ -1,5 +1,6 @@
 defmodule SearchTest do
   use CouchTestCase
+  import Couch.Test.Asserts
 
   @moduletag :search
 
@@ -43,10 +44,7 @@ defmodule SearchTest do
     ddoc = Enum.into(opts, default_ddoc)
 
     resp = Couch.put("/#{db_name}/_design/inventory", body: ddoc)
-    assert resp.status_code in [201, 202],
-      "Cannot create design doc. " <>
-      "Expected one of [201, 202], got: #{resp.status_code}, body: #{inspect resp.body}"
-
+    assert_on_status(resp, [201, 202], "Cannot create design doc.")
     assert Map.has_key?(resp.body, "ok") == true
   end
 
@@ -60,10 +58,7 @@ defmodule SearchTest do
     ddoc = Enum.into(opts, invalid_ddoc)
 
     resp = Couch.put("/#{db_name}/_design/search", body: ddoc)
-    assert resp.status_code in [201, 202],
-      "Cannot create design doc. " <>
-      "Expected one of [201, 202], got: #{resp.status_code}, body: #{inspect resp.body}"
-
+    assert_on_status(resp, [201, 202], "Cannot create design doc.")
     assert Map.has_key?(resp.body, "ok") == true
   end
 
@@ -80,10 +75,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.get(url, query: %{q: "*:*", include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
-
+    assert_on_status(resp, 200, "Fail to do search.")
     ids = get_items(resp)
     assert Enum.sort(ids) == Enum.sort(["apple", "banana", "carrot", "date"])
   end
@@ -96,9 +88,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.get(url, query: %{q: "*:*", drilldown: :jiffy.encode(["place", "kitchen"]), include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == Enum.sort(["apple", "banana", "carrot"])
@@ -112,9 +102,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.get(url, query: %{q: "*:*", drilldown: :jiffy.encode(["state", "new", "unknown"]), include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == Enum.sort(["apple", "banana", "date"])
@@ -128,9 +116,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.get(url, query: %{q: "*:*", drilldown: :jiffy.encode([["state", "old"], ["item", "apple"]]), include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == []
@@ -144,9 +130,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits?q=*:*&drilldown=[\"state\",\"old\"]&drilldown=[\"item\",\"apple\"]&include_docs=true"
     resp = Couch.get(url)
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == []
@@ -161,9 +145,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.post(url, body: %{q: "*:*", include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == Enum.sort(["apple", "banana", "carrot", "date"])
@@ -177,9 +159,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.post(url, body: %{query: "*:*", drilldown: ["place", "kitchen"], include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == Enum.sort(["apple", "banana", "carrot"])
@@ -193,9 +173,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.post(url, body: %{query: "*:*", drilldown: ["state", "new", "unknown"], include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == Enum.sort(["apple", "banana", "date"])
@@ -209,9 +187,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.post(url, body: %{q: "*:*", drilldown: [["state", "old"], ["item", "apple"]], include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == []
@@ -225,9 +201,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.post(url, body: %{q: "*:*", drilldown: [["place", "kitchen"], ["state", "new"], ["item", "apple"]], include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == ["apple"]
@@ -241,9 +215,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.post(url, body: %{q: "*:*", drilldown: [["state", "old", "new"], ["item", "apple"]], include_docs: true})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == ["apple"]
@@ -257,9 +229,7 @@ defmodule SearchTest do
 
     url = "/#{db_name}/_design/inventory/_search/fruits"
     resp = Couch.post(url, body: "{\"include_docs\": true, \"q\": \"*:*\", \"drilldown\": [\"state\", \"old\"], \"drilldown\": [\"item\", \"apple\"]}")
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     ids = get_items(resp)
     assert Enum.sort(ids) == ["apple"]
@@ -273,10 +243,7 @@ defmodule SearchTest do
     create_invalid_ddoc(db_name)
 
     resp = Couch.post("/#{db_name}/_search_cleanup")
-    assert resp.status_code in [201, 202],
-      "Fail to do a _search_cleanup. " <>
-      "Expected one of [201, 202], got: #{resp.status_code}, body: #{inspect resp.body}"
-
+    assert_on_status(resp, [201, 202], "Fail to do a _search_cleanup.")
   end
 
   @tag :with_db
@@ -288,10 +255,7 @@ defmodule SearchTest do
     url = "/#{db_name}/_design/inventory/_search/fruits"
     counts = ["place"]
     resp = Couch.get(url, query: %{q: "*:*", limit: 0, counts: :jiffy.encode(counts)})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
-
+    assert_on_status(resp, 200, "Fail to do search.")
 
     %{:body => %{"counts" => counts}} = resp
     assert counts == %{"place" => %{"kitchen" => 3, "lobby" => 1}}
@@ -306,9 +270,7 @@ defmodule SearchTest do
     url = "/#{db_name}/_design/inventory/_search/fruits"
     counts = ["place"]
     resp = Couch.get(url, query: %{q: "item:tomato", limit: 0, counts: :jiffy.encode(counts)})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     %{:body => %{"counts" => counts}} = resp
     assert counts == %{"place" => %{}}
@@ -323,9 +285,7 @@ defmodule SearchTest do
     url = "/#{db_name}/_design/inventory/_search/fruits"
     ranges = %{"price" => %{"cheap" => "[0 TO 0.99]", "expensive" => "[1.00 TO Infinity]"}}
     resp = Couch.get(url, query: %{q: "*:*", limit: 0, ranges: :jiffy.encode(ranges)})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     %{:body => %{"ranges" => ranges}} = resp
     assert ranges == %{"price" => %{"cheap" => 2, "expensive" => 2}}
@@ -340,9 +300,7 @@ defmodule SearchTest do
     url = "/#{db_name}/_design/inventory/_search/fruits"
     ranges = %{"price" => %{}}
     resp = Couch.get(url, query: %{q: "*:*", limit: 0, ranges: :jiffy.encode(ranges)})
-    assert resp.status_code == 200,
-      "Fail to do search. " <>
-      "Expected 200, got: #{resp.status_code}, body: #{inspect resp.body}"
+    assert_on_status(resp, 200, "Fail to do search.")
 
     %{:body => %{"ranges" => ranges}} = resp
     assert ranges == %{"price" => %{}}


### PR DESCRIPTION
## Overview

It is quite hard to debug the failing test cases when the response causing assertion to fail is not printed out. This PR add assert messages to search test suite (Elixir tests). 

```

PartitionSearchTest [test/elixir/test/partition_search_test.exs]
  * test Simple query returns partitioned search results (31593.1ms) [L#53]

  1) test Simple query returns partitioned search results (PartitionSearchTest)
     test/elixir/test/partition_search_test.exs:53
     Fail to do partitioned search. Expected 200, got: 500, body: %{"error" => "ou_est_clouseau", "reason" => "Could not connect to the Clouseau Java service at clouseau1@127.0.0.1"}
     code: assert_on_status(resp, 200, "Fail to do partitioned search.")
     stacktrace:
       test/elixir/test/partition_search_test.exs:60: (test)
```

## Testing recommendations

1. Stop clouseau
2. Modify following files
```diff
diff --git i/Makefile w/Makefile
index 6847037df..725750f95 100644
--- i/Makefile
+++ w/Makefile
@@ -279,15 +279,10 @@ endif
 # target: elixir-search - Run search tests, requires a configured Clouseau instance
 elixir-search: export MIX_ENV=integration
 elixir-search: elixir-init devclean
-ifneq ($(_WITH_CLOUSEAU), )
 	@dev/run -n 1 -q -a adm:pass \
-		"$(_WITH_CLOUSEAU)" \
 		"$(TEST_OPTS)" \
 		--locald-config test/config/test-config.ini \
 		--no-eval 'mix test --trace --include test/elixir/test/config/search.elixir'
-else
-	@echo "Warning: Clouseau is not enabled, \`elixir-search\` cannot be run."
-endif
 
 .PHONY: elixir-source-checks
 # target: elixir-source-checks - Check source code formatting of Elixir test files
diff --git i/src/dreyfus/src/dreyfus.erl w/src/dreyfus/src/dreyfus.erl
index 0fed3e60e..915d4b364 100644
--- i/src/dreyfus/src/dreyfus.erl
+++ w/src/dreyfus/src/dreyfus.erl
@@ -17,15 +17,16 @@
 -export([available/0]).
 
 available() ->
-    case application:get_env(dreyfus, available) of
-        {ok, Val} ->
-            Val;
-        undefined ->
-            case clouseau_rpc:connected() of
-                true ->
-                    ok = application:set_env(dreyfus, available, true),
-                    true;
-                false ->
-                    false
-            end
-    end.
+    true.
```
3. Build the project `make`
4. Run elixir tests `make elixir-search`
5. Check the messages on the console to make sure the response body is present

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
