### PR TITLE
Remove explicit erlang module prefix for auto-imported functions

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -1473,7 +1473,7 @@ receive_request_data(Req, Len) when Len == chunked ->
         GetChunk
     };
 receive_request_data(Req, LenLeft) when LenLeft > 0 ->
-    Len = erlang:min(4096, LenLeft),
+    Len = min(4096, LenLeft),
     Data = chttpd:recv(Req, Len),
     {Data, fun() -> receive_request_data(Req, LenLeft - iolist_size(Data)) end};
 receive_request_data(_Req, _) ->
@@ -1514,13 +1514,13 @@ purge_results_to_json([{DocId, _Revs} | RIn], [{accepted, PRevs} | ROut]) ->
     {Code, Results} = purge_results_to_json(RIn, ROut),
     couch_stats:increment_counter([couchdb, document_purges, success]),
     NewResults = [{DocId, couch_doc:revs_to_strs(PRevs)} | Results],
-    {erlang:max(Code, 202), NewResults};
+    {max(Code, 202), NewResults};
 purge_results_to_json([{DocId, _Revs} | RIn], [Error | ROut]) ->
     {Code, Results} = purge_results_to_json(RIn, ROut),
     {NewCode, ErrorStr, Reason} = chttpd:error_info(Error),
     couch_stats:increment_counter([couchdb, document_purges, failure]),
     NewResults = [{DocId, {[{error, ErrorStr}, {reason, Reason}]}} | Results],
-    {erlang:max(NewCode, Code), NewResults}.
+    {max(NewCode, Code), NewResults}.
 
 send_updated_doc(Req, Db, DocId, Json) ->
     send_updated_doc(Req, Db, DocId, Json, []).
@@ -1582,7 +1582,7 @@ update_doc(Db, DocId, #doc{deleted = Deleted, body = DocBody} = Doc, Options) ->
             {'DOWN', Ref, _, _, {exit_error, Reason}} ->
                 error(Reason);
             {'DOWN', Ref, _, _, {exit_exit, Reason}} ->
-                erlang:exit(Reason)
+                exit(Reason)
         end,
 
     case Result of

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -281,7 +281,7 @@ cancel_replication(PostBody, Ctx) ->
 
 choose_node(Key) when is_binary(Key) ->
     Checksum = erlang:crc32(Key),
-    Nodes = lists:sort([node() | erlang:nodes()]),
+    Nodes = lists:sort([node() | nodes()]),
     lists:nth(1 + Checksum rem length(Nodes), Nodes);
 choose_node(Key) ->
     choose_node(?term_to_bin(Key)).

--- a/src/chttpd/src/chttpd_node.erl
+++ b/src/chttpd/src/chttpd_node.erl
@@ -191,7 +191,7 @@ handle_node_req(#httpd{
         "max_http_request_size", 4294967296
     ),
     NewOpts = [{body, MochiReq0:recv_body(MaxSize)} | MochiReq0:get(opts)],
-    Ref = erlang:make_ref(),
+    Ref = make_ref(),
     MochiReq = mochiweb_request:new(
         {remote, self(), Ref},
         NewOpts,

--- a/src/chttpd/test/eunit/chttpd_auth_hash_algorithms_tests.erl
+++ b/src/chttpd/test/eunit/chttpd_auth_hash_algorithms_tests.erl
@@ -64,7 +64,7 @@ base_url() ->
     "http://" ++ Addr ++ ":" ++ Port.
 
 make_auth_session_string(HashAlgorithm, User, Secret, TimeStamp) ->
-    SessionData = User ++ ":" ++ erlang:integer_to_list(TimeStamp, 16),
+    SessionData = User ++ ":" ++ integer_to_list(TimeStamp, 16),
     Hash = couch_util:hmac(HashAlgorithm, Secret, SessionData),
     "AuthSession=" ++ couch_util:encodeBase64Url(SessionData ++ ":" ++ ?b2l(Hash)).
 

--- a/src/config/src/config_listener_mon.erl
+++ b/src/config/src/config_listener_mon.erl
@@ -40,7 +40,7 @@ subscribe(Module, InitSt) ->
     end.
 
 init({Pid, Mod, InitSt}) ->
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     case config_listener:start(Mod, {Mod, Pid}, {Pid, InitSt}) of
         ok ->
             proc_lib:init_ack({ok, self()}),

--- a/src/config/test/config_tests.erl
+++ b/src/config/test/config_tests.erl
@@ -700,10 +700,10 @@ should_remove_handler_when_pid_exits({_Apps, Pid}) ->
 
         % Monitor the config_listener_mon process
         {monitored_by, [Mon]} = process_info(Pid, monitored_by),
-        MonRef = erlang:monitor(process, Mon),
+        MonRef = monitor(process, Mon),
 
         % Kill the process synchronously
-        PidRef = erlang:monitor(process, Pid),
+        PidRef = monitor(process, Pid),
         exit(Pid, kill),
         receive
             {'DOWN', PidRef, _, _, _} -> ok
@@ -728,7 +728,7 @@ should_stop_monitor_on_error({_Apps, Pid}) ->
 
         % Monitor the config_listener_mon process
         {monitored_by, [Mon]} = process_info(Pid, monitored_by),
-        MonRef = erlang:monitor(process, Mon),
+        MonRef = monitor(process, Mon),
 
         % Have the process throw an error
         ?assertEqual(ok, config:set("throw_error", "foo", "bar", false)),
@@ -784,7 +784,7 @@ should_unsubscribe_when_subscriber_gone(_Subscription, {_Apps, Pid}) ->
         ?assert(is_process_alive(Pid)),
 
         % Monitor subscriber process
-        MonRef = erlang:monitor(process, Pid),
+        MonRef = monitor(process, Pid),
 
         exit(Pid, kill),
 
@@ -1015,7 +1015,7 @@ wait_config_get(Sec, Key, Val) ->
 
 spawn_config_listener() ->
     Self = self(),
-    Pid = erlang:spawn(fun() ->
+    Pid = spawn(fun() ->
         ok = config:listen_for_changes(?MODULE, {self(), undefined}),
         Self ! registered,
         loop(undefined)
@@ -1029,7 +1029,7 @@ spawn_config_listener() ->
 
 spawn_config_notifier(Subscription) ->
     Self = self(),
-    Pid = erlang:spawn(fun() ->
+    Pid = spawn(fun() ->
         ok = config:subscribe_for_changes(Subscription),
         Self ! registered,
         loop(undefined)
@@ -1072,7 +1072,7 @@ loop({config_msg, _} = Msg) ->
     loop(undefined).
 
 getmsg(Pid) ->
-    Ref = erlang:make_ref(),
+    Ref = make_ref(),
     Pid ! {get_msg, self(), Ref},
     receive
         {Ref, {config_msg, Msg}} -> Msg
@@ -1112,7 +1112,7 @@ wait_process_restart(Name, Timeout, Delay, Started, _Prev) ->
     end.
 
 stop_sync(Pid, Timeout) when is_pid(Pid) ->
-    MRef = erlang:monitor(process, Pid),
+    MRef = monitor(process, Pid),
     try
         begin
             catch unlink(Pid),
@@ -1125,7 +1125,7 @@ stop_sync(Pid, Timeout) when is_pid(Pid) ->
             end
         end
     after
-        erlang:demonitor(MRef, [flush])
+        demonitor(MRef, [flush])
     end;
 stop_sync(_, _) ->
     error(badarg).

--- a/src/couch/src/couch_att.erl
+++ b/src/couch/src/couch_att.erl
@@ -585,7 +585,7 @@ flush_data(Db, Fun, Att) when is_function(Fun) ->
             end)
     end;
 flush_data(Db, {follows, Parser, Ref}, Att) ->
-    ParserRef = erlang:monitor(process, Parser),
+    ParserRef = monitor(process, Parser),
     Fun = fun() ->
         Parser ! {get_bytes, Ref, self()},
         receive
@@ -600,7 +600,7 @@ flush_data(Db, {follows, Parser, Ref}, Att) ->
     try
         flush_data(Db, Fun, store(data, Fun, Att))
     after
-        erlang:demonitor(ParserRef, [flush])
+        demonitor(ParserRef, [flush])
     end;
 flush_data(Db, {stream, StreamEngine}, Att) ->
     case couch_db:is_active_stream(Db, StreamEngine) of
@@ -645,7 +645,7 @@ foldl(DataFun, Att, Fun, Acc) when is_function(DataFun) ->
     Len = fetch(att_len, Att),
     fold_streamed_data(DataFun, Len, Fun, Acc);
 foldl({follows, Parser, Ref}, Att, Fun, Acc) ->
-    ParserRef = erlang:monitor(process, Parser),
+    ParserRef = monitor(process, Parser),
     DataFun = fun() ->
         Parser ! {get_bytes, Ref, self()},
         receive
@@ -660,7 +660,7 @@ foldl({follows, Parser, Ref}, Att, Fun, Acc) ->
     try
         foldl(DataFun, store(data, DataFun, Att), Fun, Acc)
     after
-        erlang:demonitor(ParserRef, [flush])
+        demonitor(ParserRef, [flush])
     end.
 
 range_foldl(Att, From, To, Fun, Acc) ->

--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -213,14 +213,14 @@ handle_db_updater_info({'DOWN', Ref, _, _, _}, #st{fd_monitor = Ref} = St) ->
     {stop, normal, St#st{fd = undefined, fd_monitor = closed}}.
 
 incref(St) ->
-    {ok, St#st{fd_monitor = erlang:monitor(process, St#st.fd)}}.
+    {ok, St#st{fd_monitor = monitor(process, St#st.fd)}}.
 
 decref(St) ->
-    true = erlang:demonitor(St#st.fd_monitor, [flush]),
+    true = demonitor(St#st.fd_monitor, [flush]),
     ok.
 
 monitored_by(St) ->
-    case erlang:process_info(St#st.fd, monitored_by) of
+    case process_info(St#st.fd, monitored_by) of
         {monitored_by, Pids} ->
             lists:filter(fun is_pid/1, Pids);
         _ ->
@@ -483,7 +483,7 @@ write_doc_infos(#st{} = St, Pairs, LocalDocs) ->
 
     NewUpdateSeq = lists:foldl(
         fun(#full_doc_info{update_seq = Seq}, Acc) ->
-            erlang:max(Seq, Acc)
+            max(Seq, Acc)
         end,
         get_update_seq(St),
         Add
@@ -893,7 +893,7 @@ init_state(FilePath, Fd, Header0, Options) ->
     St = #st{
         filepath = FilePath,
         fd = Fd,
-        fd_monitor = erlang:monitor(process, Fd),
+        fd_monitor = monitor(process, Fd),
         header = Header,
         needs_commit = false,
         id_tree = IdTree,

--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -147,7 +147,7 @@ open_compaction_files(DbName, OldSt, Options) ->
                 }
         end,
     unlink(DataFd),
-    erlang:monitor(process, MetaFd),
+    monitor(process, MetaFd),
     {ok, CompSt}.
 
 copy_purge_info(#comp_st{} = CompSt) ->

--- a/src/couch/src/couch_db.erl
+++ b/src/couch/src/couch_db.erl
@@ -267,7 +267,7 @@ monitored_by(Db) ->
     end.
 
 monitor(#db{main_pid = MainPid}) ->
-    erlang:monitor(process, MainPid).
+    monitor(process, MainPid).
 
 start_compact(#db{} = Db) ->
     gen_server:call(Db#db.main_pid, start_compact).
@@ -282,7 +282,7 @@ wait_for_compaction(#db{main_pid = Pid} = Db, Timeout) ->
     Start = os:timestamp(),
     case gen_server:call(Pid, compactor_pid) of
         CPid when is_pid(CPid) ->
-            Ref = erlang:monitor(process, CPid),
+            Ref = monitor(process, CPid),
             receive
                 {'DOWN', Ref, _, _, normal} when Timeout == infinity ->
                     wait_for_compaction(Db, Timeout);
@@ -292,7 +292,7 @@ wait_for_compaction(#db{main_pid = Pid} = Db, Timeout) ->
                 {'DOWN', Ref, _, _, Reason} ->
                     {error, Reason}
             after Timeout ->
-                erlang:demonitor(Ref, [flush]),
+                demonitor(Ref, [flush]),
                 {error, Timeout}
             end;
         _ ->
@@ -491,7 +491,7 @@ get_minimum_purge_seq(#db{} = Db) ->
                     CS when is_integer(CS) ->
                         case purge_client_exists(DbName, DocId, Props) of
                             true ->
-                                {ok, erlang:min(CS, SeqAcc)};
+                                {ok, min(CS, SeqAcc)};
                             false ->
                                 Fmt1 =
                                     "Missing or stale purge doc '~s' on ~p "
@@ -502,7 +502,7 @@ get_minimum_purge_seq(#db{} = Db) ->
                     _ ->
                         Fmt2 = "Invalid purge doc '~s' on ~p with purge_seq '~w'",
                         couch_log:error(Fmt2, [DocId, DbName, ClientSeq]),
-                        {ok, erlang:min(OldestPurgeSeq, SeqAcc)}
+                        {ok, min(OldestPurgeSeq, SeqAcc)}
                 end;
             _ ->
                 {stop, SeqAcc}
@@ -516,7 +516,7 @@ get_minimum_purge_seq(#db{} = Db) ->
     FinalSeq =
         case MinIdxSeq < PurgeSeq - PurgeInfosLimit of
             true -> MinIdxSeq;
-            false -> erlang:max(0, PurgeSeq - PurgeInfosLimit)
+            false -> max(0, PurgeSeq - PurgeInfosLimit)
         end,
     % Log a warning if we've got a purge sequence exceeding the
     % configured threshold.
@@ -1517,7 +1517,7 @@ write_and_commit(
 ) ->
     DocBuckets = prepare_doc_summaries(Db, DocBuckets1),
     ReplicatedChanges = lists:member(?REPLICATED_CHANGES, Options),
-    MRef = erlang:monitor(process, Pid),
+    MRef = monitor(process, Pid),
     try
         Pid ! {update_docs, self(), DocBuckets, LocalDocs, ReplicatedChanges},
         case collect_results_with_metrics(Pid, MRef, []) of
@@ -1541,7 +1541,7 @@ write_and_commit(
                 end
         end
     after
-        erlang:demonitor(MRef, [flush])
+        demonitor(MRef, [flush])
     end.
 
 prepare_doc_summaries(Db, BucketList) ->

--- a/src/couch/src/couch_debug.erl
+++ b/src/couch/src/couch_debug.erl
@@ -239,7 +239,7 @@ help(link_tree) ->
     The function doesn't recurse to pids older than initial one.
     The Pids which are lesser than initial Pid are still shown in the output.
     The info argument is a list of process_info_item() as documented in
-    erlang:process_info/2. We don't do any attempts to prevent dangerous items.
+    process_info/2. We don't do any attempts to prevent dangerous items.
     Be warn that passing some of them such as `messages` for example
     can be dangerous in a very busy system.
     ---
@@ -297,7 +297,7 @@ help(linked_processes_info) ->
         use of link_tree.
           - Pid: initial Pid to start from
           - Info: a list of process_info_item() as documented
-            in erlang:process_info/2.
+            in process_info/2.
 
         ---
     ", []);
@@ -1147,8 +1147,8 @@ random_processes(Acc, Depth) ->
                 end);
             open_port ->
                 spawn_link(fun() ->
-                    Port = erlang:open_port({spawn, "sleep 10"}, [hide]),
-                    true = erlang:link(Port),
+                    Port = open_port({spawn, "sleep 10"}, [hide]),
+                    true = link(Port),
                     Caller ! {Ref, random_processes(Depth - 1)},
                     receive
                         looper -> ok

--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -390,13 +390,13 @@ max_seq(Tree, UpdateSeq) ->
         case Value of
             {_Deleted, _DiskPos, OldTreeSeq} ->
                 % Older versions didn't track data sizes.
-                erlang:max(MaxOldSeq, OldTreeSeq);
+                max(MaxOldSeq, OldTreeSeq);
             % necessary clause?
             {_Deleted, _DiskPos, OldTreeSeq, _Size} ->
                 % Older versions didn't store #leaf records.
-                erlang:max(MaxOldSeq, OldTreeSeq);
+                max(MaxOldSeq, OldTreeSeq);
             #leaf{seq = OldTreeSeq} ->
-                erlang:max(MaxOldSeq, OldTreeSeq);
+                max(MaxOldSeq, OldTreeSeq);
             _ ->
                 MaxOldSeq
         end

--- a/src/couch/src/couch_flags_config.erl
+++ b/src/couch/src/couch_flags_config.erl
@@ -134,7 +134,7 @@ parse_flags(_Tokens, _) ->
 
 parse_flags_term(FlagsBin) ->
     {Flags, Errors} = lists:splitwith(
-        fun erlang:is_atom/1,
+        fun is_atom/1,
         [parse_flag(F) || F <- split_by_comma(FlagsBin)]
     ),
     case Errors of

--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -381,7 +381,7 @@ cookie_authentication_handler(#httpd{mochi_req = MochiReq} = Req, AuthModule) ->
                                 "timeout", 600
                             ),
                             couch_log:debug("timeout ~p", [Timeout]),
-                            case (catch erlang:list_to_integer(TimeStr, 16)) of
+                            case (catch list_to_integer(TimeStr, 16)) of
                                 TimeStamp when CurrentTime < TimeStamp + Timeout ->
                                     case lists:any(VerifyHash, HashAlgorithms) of
                                         true ->
@@ -438,7 +438,7 @@ cookie_auth_header(_Req, _Headers) ->
     [].
 
 cookie_auth_cookie(Req, User, Secret, TimeStamp) ->
-    SessionItems = [User, erlang:integer_to_list(TimeStamp, 16)],
+    SessionItems = [User, integer_to_list(TimeStamp, 16)],
     cookie_auth_cookie(Req, Secret, SessionItems).
 
 cookie_auth_cookie(Req, Secret, SessionItems) when is_list(SessionItems) ->

--- a/src/couch/src/couch_httpd_db.erl
+++ b/src/couch/src/couch_httpd_db.erl
@@ -817,7 +817,7 @@ receive_request_data(Req) ->
     receive_request_data(Req, couch_httpd:body_length(Req)).
 
 receive_request_data(Req, LenLeft) when LenLeft > 0 ->
-    Len = erlang:min(4096, LenLeft),
+    Len = min(4096, LenLeft),
     Data = couch_httpd:recv(Req, Len),
     {Data, fun() -> receive_request_data(Req, LenLeft - iolist_size(Data)) end};
 receive_request_data(_Req, _) ->

--- a/src/couch/src/couch_httpd_multipart.erl
+++ b/src/couch/src/couch_httpd_multipart.erl
@@ -27,7 +27,7 @@ decode_multipart_stream(ContentType, DataFun, Ref) ->
     Parent = self(),
     NumMpWriters = num_mp_writers(),
     {Parser, ParserRef} = spawn_monitor(fun() ->
-        ParentRef = erlang:monitor(process, Parent),
+        ParentRef = monitor(process, Parent),
         put(mp_parent_ref, ParentRef),
         num_mp_writers(NumMpWriters),
         {<<"--", _/binary>>, _, _} = couch_httpd:parse_multipart_request(
@@ -214,7 +214,7 @@ maybe_send_data({Ref, Chunks, Offset, Counters, Waiting}) ->
     end.
 
 handle_hello(WriterPid, Counters) ->
-    WriterRef = erlang:monitor(process, WriterPid),
+    WriterRef = monitor(process, WriterPid),
     orddict:store(WriterPid, {WriterRef, 0}, Counters).
 
 update_writer(WriterPid, Counters) ->
@@ -222,7 +222,7 @@ update_writer(WriterPid, Counters) ->
         {ok, {WriterRef, Count}} ->
             orddict:store(WriterPid, {WriterRef, Count + 1}, Counters);
         error ->
-            WriterRef = erlang:monitor(process, WriterPid),
+            WriterRef = monitor(process, WriterPid),
             orddict:store(WriterPid, {WriterRef, 1}, Counters)
     end.
 
@@ -344,7 +344,7 @@ length_multipart_stream(Boundary, JsonBytes, Atts) ->
     end.
 
 abort_multipart_stream(Parser) ->
-    MonRef = erlang:monitor(process, Parser),
+    MonRef = monitor(process, Parser),
     Parser ! abort_parsing,
     receive
         {'DOWN', MonRef, _, _, _} -> ok

--- a/src/couch/src/couch_httpd_vhost.erl
+++ b/src/couch/src/couch_httpd_vhost.erl
@@ -329,7 +329,7 @@ split_host_port(HostAsString) ->
         N ->
             HostPart = string:substr(HostAsString, 1, N - 1),
             case
-                (catch erlang:list_to_integer(
+                (catch list_to_integer(
                     string:substr(
                         HostAsString,
                         N + 1,

--- a/src/couch/src/couch_key_tree.erl
+++ b/src/couch/src/couch_key_tree.erl
@@ -113,7 +113,7 @@ merge_tree([{Depth, Nodes} | Rest], {IDepth, INodes} = Tree, MergeAcc) ->
     % value that's used throughout this module.
     case merge_at([Nodes], Depth - IDepth, [INodes]) of
         {[Merged], Result} ->
-            NewDepth = erlang:min(Depth, IDepth),
+            NewDepth = min(Depth, IDepth),
             {Rest ++ [{NewDepth, Merged} | MergeAcc], Result};
         fail ->
             merge_tree(Rest, Tree, [{Depth, Nodes} | MergeAcc])
@@ -507,12 +507,12 @@ stem_tree(Depth, {Key, Val, Children}, Limit, Seen0) ->
             {SeenAcc, LimitPosAcc, ChildAcc, BranchAcc} = Acc,
             case stem_tree(Depth + 1, Child, Limit, SeenAcc) of
                 {NewSeenAcc, LimitPos, NewChild, NewBranches} ->
-                    NewLimitPosAcc = erlang:max(LimitPos, LimitPosAcc),
+                    NewLimitPosAcc = max(LimitPos, LimitPosAcc),
                     NewChildAcc = [NewChild | ChildAcc],
                     NewBranchAcc = NewBranches ++ BranchAcc,
                     {NewSeenAcc, NewLimitPosAcc, NewChildAcc, NewBranchAcc};
                 {NewSeenAcc, LimitPos, NewBranches} ->
-                    NewLimitPosAcc = erlang:max(LimitPos, LimitPosAcc),
+                    NewLimitPosAcc = max(LimitPos, LimitPosAcc),
                     NewBranchAcc = NewBranches ++ BranchAcc,
                     {NewSeenAcc, NewLimitPosAcc, ChildAcc, NewBranchAcc}
             end

--- a/src/couch/src/couch_multidb_changes.erl
+++ b/src/couch/src/couch_multidb_changes.erl
@@ -241,7 +241,7 @@ should_wait_for_shard_map(<<_/binary>>) ->
 
 -spec register_with_event_server(pid()) -> reference().
 register_with_event_server(Server) ->
-    Ref = erlang:monitor(process, couch_event_server),
+    Ref = monitor(process, couch_event_server),
     couch_event:register_all(Server),
     Ref.
 
@@ -475,7 +475,7 @@ setup_all() ->
     meck:expect(couch_db, close, 1, ok),
     mock_changes_reader(),
     % create process to stand in for couch_event_server
-    % mocking erlang:monitor doesn't work, so give it real process to monitor
+    % mocking monitor doesn't work, so give it real process to monitor
     EvtPid = spawn_link(fun() ->
         receive
             looper -> ok
@@ -709,7 +709,7 @@ t_handle_info_change_feed_exited_and_need_rescan(_) ->
 
 t_spawn_changes_reader(_) ->
     Pid = start_changes_reader(?DBNAME, 3),
-    ?assert(erlang:is_process_alive(Pid)),
+    ?assert(is_process_alive(Pid)),
     ChArgs = kill_mock_changes_reader_and_get_its_args(Pid),
     ?assertEqual({self(), ?DBNAME}, ChArgs),
     ?assert(meck:validate(couch_db)),

--- a/src/couch/src/couch_native_process.erl
+++ b/src/couch/src/couch_native_process.erl
@@ -111,7 +111,7 @@ handle_call({prompt, Data}, _From, State) ->
     end.
 
 handle_cast(garbage_collect, State) ->
-    erlang:garbage_collect(),
+    garbage_collect(),
     {noreply, State, State#evstate.idle};
 handle_cast(stop, State) ->
     {stop, normal, State};
@@ -120,7 +120,7 @@ handle_cast(_Msg, State) ->
 
 handle_info(timeout, State) ->
     couch_proc_manager:os_proc_idle(self()),
-    erlang:garbage_collect(),
+    garbage_collect(),
     {noreply, State, State#evstate.idle};
 handle_info({'EXIT', _, normal}, State) ->
     {noreply, State, State#evstate.idle};

--- a/src/couch/src/couch_os_process.erl
+++ b/src/couch/src/couch_os_process.erl
@@ -152,7 +152,7 @@ init([Command]) ->
     couch_stats:increment_counter([couchdb, query_server, process_starts]),
     spawn(fun() ->
         % this ensure the real os process is killed when this process dies.
-        erlang:monitor(process, Pid),
+        monitor(process, Pid),
         killer(OsPid)
     end),
     {ok, OsProc, IdleLimit}.
@@ -191,7 +191,7 @@ handle_call({prompt, Data}, _From, #os_proc{idle = Idle} = OsProc) ->
     end.
 
 handle_cast(garbage_collect, #os_proc{idle = Idle} = OsProc) ->
-    erlang:garbage_collect(),
+    garbage_collect(),
     {noreply, OsProc, Idle};
 handle_cast(stop, OsProc) ->
     {stop, normal, OsProc};
@@ -201,7 +201,7 @@ handle_cast(Msg, #os_proc{idle = Idle} = OsProc) ->
 
 handle_info(timeout, #os_proc{idle = Idle} = OsProc) ->
     couch_proc_manager:os_proc_idle(self()),
-    erlang:garbage_collect(),
+    garbage_collect(),
     {noreply, OsProc, Idle};
 handle_info({Port, {exit_status, 0}}, #os_proc{port = Port} = OsProc) ->
     couch_log:info("OS Process terminated normally", []),

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -162,7 +162,7 @@ handle_call({get_proc, #client{} = Client}, From, State) ->
     {noreply, State};
 handle_call({ret_proc, #proc{} = Proc}, From, State) ->
     #proc{client = Ref, pid = Pid} = Proc,
-    erlang:demonitor(Ref, [flush]),
+    demonitor(Ref, [flush]),
     gen_server:reply(From, true),
     case ets:lookup(?PROCS, Pid) of
         [#proc{} = ProcInt] ->
@@ -615,7 +615,7 @@ make_proc(Pid, Lang, Mod) when is_binary(Lang) ->
     {ok, Proc}.
 
 assign_proc(Pid, #proc{client = undefined} = Proc0) when is_pid(Pid) ->
-    Proc = Proc0#proc{client = erlang:monitor(process, Pid)},
+    Proc = Proc0#proc{client = monitor(process, Pid)},
     % It's important to insert the proc here instead of doing an update_element
     % as we might have updated the db_key or ddoc_keys in teach_ddoc/4
     ets:insert(?PROCS, Proc),

--- a/src/couch/src/couch_query_servers.erl
+++ b/src/couch/src/couch_query_servers.erl
@@ -327,8 +327,8 @@ stat_values(Value, Acc) when is_tuple(Value), is_tuple(Acc) ->
     {
         Sum0 + Sum1,
         Cnt0 + Cnt1,
-        erlang:min(Min0, Min1),
-        erlang:max(Max0, Max1),
+        min(Min0, Min1),
+        max(Max0, Max1),
         Sqr0 + Sqr1
     };
 stat_values(Else, _Acc) ->

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -405,7 +405,7 @@ handle_config_terminate(_Server, _Reason, N) ->
     erlang:send_after(?RELISTEN_DELAY, whereis(?MODULE), {restart_config_listener, N}).
 
 per_couch_server(X) ->
-    erlang:max(1, X div num_servers()).
+    max(1, X div num_servers()).
 
 all_databases() ->
     {ok, DbList} = all_databases(

--- a/src/couch/src/couch_stream.erl
+++ b/src/couch/src/couch_stream.erl
@@ -185,7 +185,7 @@ init({Engine, OpenerPid, OpenerPriority, Options}) ->
         end,
     {ok, #stream{
         engine = Engine,
-        opener_monitor = erlang:monitor(process, OpenerPid),
+        opener_monitor = monitor(process, OpenerPid),
         md5 = couch_hash:md5_hash_init(),
         identity_md5 = couch_hash:md5_hash_init(),
         encoding_fun = EncodingFun,
@@ -269,7 +269,7 @@ handle_call(close, _From, Stream) ->
                 StreamLen = WrittenLen + iolist_size(WriteBin2),
                 {do_finalize(NewEngine), StreamLen, IdenLen, Md5Final, IdenMd5Final}
         end,
-    erlang:demonitor(MonRef),
+    demonitor(MonRef),
     {stop, normal, Result, Stream}.
 
 handle_cast(_Msg, State) ->

--- a/src/couch/src/couch_task_status.erl
+++ b/src/couch/src/couch_task_status.erl
@@ -107,7 +107,7 @@ handle_call({add_task, TaskProps}, {From, _}, Server) ->
     case ets:lookup(?MODULE, From) of
         [] ->
             true = ets:insert(?MODULE, {From, TaskProps}),
-            erlang:monitor(process, From),
+            monitor(process, From),
             {reply, ok, Server};
         [_] ->
             {reply, {add_task_error, already_registered}, Server}
@@ -130,7 +130,7 @@ handle_cast({update_status, Pid, NewProps}, Server) ->
     {noreply, Server}.
 
 handle_info({'DOWN', _MonitorRef, _Type, Pid, _Info}, Server) ->
-    %% should we also erlang:demonitor(_MonitorRef), ?
+    %% should we also demonitor(_MonitorRef), ?
     ets:delete(?MODULE, Pid),
     {noreply, Server}.
 

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -147,7 +147,7 @@ to_existing_atom(V) when is_atom(V) ->
 shutdown_sync(Pid) when not is_pid(Pid) ->
     ok;
 shutdown_sync(Pid) ->
-    MRef = erlang:monitor(process, Pid),
+    MRef = monitor(process, Pid),
     try
         catch unlink(Pid),
         catch exit(Pid, shutdown),
@@ -156,7 +156,7 @@ shutdown_sync(Pid) ->
                 ok
         end
     after
-        erlang:demonitor(MRef, [flush])
+        demonitor(MRef, [flush])
     end.
 
 validate_utf8(Data) when is_list(Data) ->
@@ -630,7 +630,7 @@ find_in_binary(_B, <<>>) ->
 find_in_binary(B, Data) ->
     case binary:match(Data, [B], []) of
         nomatch ->
-            MatchLength = erlang:min(byte_size(B), byte_size(Data)),
+            MatchLength = min(byte_size(B), byte_size(Data)),
             match_prefix_at_end(
                 binary:part(B, {0, MatchLength}),
                 binary:part(Data, {byte_size(Data), -MatchLength}),
@@ -724,7 +724,7 @@ ensure_loaded(_Module) ->
 %% a function that does a receive as it would hijack incoming messages.
 with_proc(M, F, A, Timeout) ->
     {Pid, Ref} = spawn_monitor(fun() ->
-        exit({reply, erlang:apply(M, F, A)})
+        exit({reply, apply(M, F, A)})
     end),
     receive
         {'DOWN', Ref, process, Pid, {reply, Resp}} ->
@@ -732,7 +732,7 @@ with_proc(M, F, A, Timeout) ->
         {'DOWN', Ref, process, Pid, Error} ->
             {error, Error}
     after Timeout ->
-        erlang:demonitor(Ref, [flush]),
+        demonitor(Ref, [flush]),
         {error, timeout}
     end.
 
@@ -772,7 +772,7 @@ version_to_binary(Ver) when is_tuple(Ver) ->
 version_to_binary(Ver) when is_list(Ver) ->
     IsZero = fun(N) -> N == 0 end,
     Ver1 = lists:reverse(lists:dropwhile(IsZero, lists:reverse(Ver))),
-    Ver2 = [erlang:integer_to_list(N) || N <- Ver1],
+    Ver2 = [integer_to_list(N) || N <- Ver1],
     ?l2b(lists:join(".", Ver2)).
 
 verify_hash_names(HashAlgorithms, SupportedHashes) ->

--- a/src/couch/src/test_util.erl
+++ b/src/couch/src/test_util.erl
@@ -155,7 +155,7 @@ stop_sync(Name, Reason, Timeout) when is_atom(Name) ->
 stop_sync(Pid, Reason, Timeout) when is_atom(Reason) and is_pid(Pid) ->
     stop_sync(Pid, fun() -> exit(Pid, Reason) end, Timeout);
 stop_sync(Pid, Fun, Timeout) when is_function(Fun) and is_pid(Pid) ->
-    MRef = erlang:monitor(process, Pid),
+    MRef = monitor(process, Pid),
     try
         begin
             catch unlink(Pid),
@@ -168,7 +168,7 @@ stop_sync(Pid, Fun, Timeout) when is_function(Fun) and is_pid(Pid) ->
             end
         end
     after
-        erlang:demonitor(MRef, [flush])
+        demonitor(MRef, [flush])
     end;
 stop_sync(_, _, _) ->
     error(badarg).
@@ -380,7 +380,7 @@ load_applications_with_stats() ->
 
 stats_file_to_app(File) ->
     [_Desc, _Priv, App | _] = lists:reverse(filename:split(File)),
-    erlang:list_to_atom(App).
+    list_to_atom(App).
 
 calculate_start_order(Apps) ->
     AllApps = calculate_start_order(sort_apps(Apps), []),

--- a/src/couch/test/eunit/couch_bt_engine_compactor_ev_tests.erl
+++ b/src/couch/test/eunit/couch_bt_engine_compactor_ev_tests.erl
@@ -270,7 +270,7 @@ run_successful_compaction(DbName) ->
     {ok, ContinueFun} = ?EV_MOD:set_wait(init),
     {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX]),
     {ok, CPid} = couch_db:start_compact(Db),
-    Ref = erlang:monitor(process, CPid),
+    Ref = monitor(process, CPid),
     ContinueFun(CPid),
     receive
         {'DOWN', Ref, _, _, normal} -> ok
@@ -313,7 +313,7 @@ add_bogus_time_seq(Db) ->
 populate_db(_Db, NumDocs) when NumDocs =< 0 ->
     ok;
 populate_db(Db, NumDocs) ->
-    String = [$a || _ <- lists:seq(1, erlang:min(NumDocs, 500))],
+    String = [$a || _ <- lists:seq(1, min(NumDocs, 500))],
     Docs = lists:map(
         fun(_) ->
             couch_doc:from_json_obj(

--- a/src/couch/test/eunit/couch_server_tests.erl
+++ b/src/couch/test/eunit/couch_server_tests.erl
@@ -224,7 +224,7 @@ t_interleaved_create_delete_open(DbName) ->
 
     % Now monitor and resume the couch_server and assert that
     % couch_server does not crash while processing OpenResultMsg
-    CSRef = erlang:monitor(process, CouchServer),
+    CSRef = monitor(process, CouchServer),
     erlang:resume_process(CouchServer),
     check_monitor_not_triggered(CSRef),
 
@@ -253,7 +253,7 @@ get_opener_pid(DbName) ->
 
 wait_for_open_async_result(CouchServer, Opener) ->
     WaitFun = fun() ->
-        {_, Messages} = erlang:process_info(CouchServer, messages),
+        {_, Messages} = process_info(CouchServer, messages),
         Found = lists:foldl(
             fun(Msg, Acc) ->
                 case Msg of

--- a/src/couch/test/eunit/couch_stream_tests.erl
+++ b/src/couch/test/eunit/couch_stream_tests.erl
@@ -124,7 +124,7 @@ should_stop_on_normal_exit_of_stream_opener({Fd, _}) ->
     end,
     ?assertNot(is_process_alive(OpenerPid)),
     % Verify the stream itself has also died
-    StreamRef = erlang:monitor(process, StreamPid),
+    StreamRef = monitor(process, StreamPid),
     receive
         {'DOWN', StreamRef, _, _, _} -> ok
     end,

--- a/src/couch/test/eunit/couch_task_status_tests.erl
+++ b/src/couch/test/eunit/couch_task_status_tests.erl
@@ -181,7 +181,7 @@ loop() ->
     end.
 
 call(Pid, done) ->
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     Pid ! {done, self()},
     Res = wait(Pid),
     receive

--- a/src/couch/test/eunit/couchdb_os_proc_pool.erl
+++ b/src/couch/test/eunit/couchdb_os_proc_pool.erl
@@ -574,7 +574,7 @@ get_client_proc({Pid, Ref}, ClientName) ->
     end.
 
 stop_client({Pid, Ref}) ->
-    MRef = erlang:monitor(process, Pid),
+    MRef = monitor(process, Pid),
     Pid ! stop,
     receive
         {stop, Ref} ->
@@ -583,12 +583,12 @@ stop_client({Pid, Ref}) ->
             end,
             ok
     after ?TIMEOUT ->
-        erlang:demonitor(MRef, [flush]),
+        demonitor(MRef, [flush]),
         timeout
     end.
 
 kill_client({Pid, Ref}) ->
-    MRef = erlang:monitor(process, Pid),
+    MRef = monitor(process, Pid),
     Pid ! die,
     receive
         {die, Ref} ->
@@ -597,7 +597,7 @@ kill_client({Pid, Ref}) ->
             end,
             ok
     after ?TIMEOUT ->
-        erlang:demonitor(MRef, [flush]),
+        demonitor(MRef, [flush]),
         timeout
     end.
 

--- a/src/couch/test/eunit/couchdb_update_conflicts_tests.erl
+++ b/src/couch/test/eunit/couchdb_update_conflicts_tests.erl
@@ -120,7 +120,7 @@ concurrent_doc_update(NumClients, DbName, InitRev) ->
                 ]}
             ),
             Pid = spawn_client(DbName, ClientDoc),
-            {Value, Pid, erlang:monitor(process, Pid)}
+            {Value, Pid, monitor(process, Pid)}
         end,
         lists:seq(1, NumClients)
     ),

--- a/src/couch/test/eunit/couchdb_views_tests.erl
+++ b/src/couch/test/eunit/couchdb_views_tests.erl
@@ -728,7 +728,7 @@ couchdb_1283() ->
         ),
 
         % Start and pause compacton
-        WaitRef = erlang:make_ref(),
+        WaitRef = make_ref(),
         meck:expect(couch_mrview_index, compact, fun(Db, State, Opts) ->
             receive
                 {WaitRef, From, init} -> ok
@@ -741,7 +741,7 @@ couchdb_1283() ->
         end),
 
         {ok, CPid} = gen_server:call(Pid, compact),
-        CRef = erlang:monitor(process, CPid),
+        CRef = monitor(process, CPid),
         ?assert(is_process_alive(CPid)),
 
         % Make sure that our compactor is waiting for us

--- a/src/couch_event/src/couch_event_listener.erl
+++ b/src/couch_event/src/couch_event_listener.erl
@@ -47,7 +47,7 @@
     term().
 
 start(Mod, Arg, Options) ->
-    Pid = erlang:spawn(?MODULE, do_init, [Mod, Arg, Options]),
+    Pid = spawn(?MODULE, do_init, [Mod, Arg, Options]),
     {ok, Pid}.
 
 start(Name, Mod, Arg, Options) ->
@@ -59,7 +59,7 @@ start(Name, Mod, Arg, Options) ->
     end.
 
 start_link(Mod, Arg, Options) ->
-    Pid = erlang:spawn_link(?MODULE, do_init, [Mod, Arg, Options]),
+    Pid = spawn_link(?MODULE, do_init, [Mod, Arg, Options]),
     {ok, Pid}.
 
 start_link(Name, Mod, Arg, Options) ->
@@ -87,7 +87,7 @@ do_init(Module, Arg, Options) ->
         {ok, State, Timeout} when is_integer(Timeout), Timeout >= 0 ->
             ?MODULE:loop(#st{module = Module, state = State}, Timeout);
         Else ->
-            erlang:exit(Else)
+            exit(Else)
     end.
 
 loop(St, Timeout) ->
@@ -173,7 +173,7 @@ do_terminate(Reason, #st{module = Module, state = State}) ->
             ignore -> normal;
             Else -> Else
         end,
-    erlang:exit(Status).
+    exit(Status).
 
 where({local, Name}) -> whereis(Name).
 

--- a/src/couch_event/src/couch_event_listener_mfa.erl
+++ b/src/couch_event/src/couch_event_listener_mfa.erl
@@ -47,7 +47,7 @@ enter_loop(Mod, Func, State, Options) ->
     Parent =
         case proplists:get_value(parent, Options) of
             P when is_pid(P) ->
-                erlang:monitor(process, P),
+                monitor(process, P),
                 P;
             _ ->
                 undefined
@@ -64,7 +64,7 @@ stop(Pid) ->
     couch_event_listener:cast(Pid, shutdown).
 
 init({Parent, Mod, Func, State}) ->
-    erlang:monitor(process, Parent),
+    monitor(process, Parent),
     {ok, #st{
         mod = Mod,
         func = Func,

--- a/src/couch_event/src/couch_event_server.erl
+++ b/src/couch_event/src/couch_event_server.erl
@@ -42,7 +42,7 @@ init(_) ->
 handle_call({register, Pid, NewDbNames}, _From, St) ->
     case maps:get(Pid, St#st.by_pid, undefined) of
         undefined ->
-            NewRef = erlang:monitor(process, Pid),
+            NewRef = monitor(process, Pid),
             {reply, ok, register(St, NewRef, Pid, NewDbNames)};
         {ReuseRef, OldDbNames} ->
             unregister(St, Pid, OldDbNames),
@@ -53,7 +53,7 @@ handle_call({unregister, Pid}, _From, #st{by_pid = ByPid} = St) ->
         undefined ->
             {reply, not_registered, St};
         {Ref, OldDbNames} ->
-            erlang:demonitor(Ref, [flush]),
+            demonitor(Ref, [flush]),
             {reply, ok, unregister(St, Pid, OldDbNames)}
     end;
 handle_call(Msg, From, St) ->
@@ -229,7 +229,7 @@ t_invalid_gen_server_messages(_) ->
 
 kill_sync(Pid) ->
     unlink(Pid),
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     exit(Pid, kill),
     receive
         {'DOWN', Ref, _, _, _} -> ok

--- a/src/couch_index/src/couch_index.erl
+++ b/src/couch_index/src/couch_index.erl
@@ -61,7 +61,7 @@ compact(Pid) ->
 compact(Pid, Options) ->
     {ok, CPid} = gen_server:call(Pid, compact),
     case lists:member(monitor, Options) of
-        true -> {ok, erlang:monitor(process, CPid)};
+        true -> {ok, monitor(process, CPid)};
         false -> ok
     end.
 

--- a/src/couch_index/src/couch_index_server.erl
+++ b/src/couch_index/src/couch_index_server.erl
@@ -78,7 +78,7 @@ get_index(Module, <<"shards/", _/binary>> = DbName, DDoc) ->
         {'DOWN', Ref, process, Pid, Error} ->
             Error
     after 61000 ->
-        erlang:demonitor(Ref, [flush]),
+        demonitor(Ref, [flush]),
         {error, timeout}
     end;
 get_index(Module, DbName, DDoc) when is_binary(DbName) ->

--- a/src/couch_index/test/eunit/couch_index_ddoc_updated_tests.erl
+++ b/src/couch_index/test/eunit/couch_index_ddoc_updated_tests.erl
@@ -88,7 +88,7 @@ check_all_indexers_exit_on_ddoc_change({_Ctx, DbName}) ->
         IndexesBefore = get_indexes_by_ddoc(DDocID, N),
         ?assertEqual(N, length(IndexesBefore)),
 
-        AliveBefore = lists:filter(fun erlang:is_process_alive/1, IndexesBefore),
+        AliveBefore = lists:filter(fun is_process_alive/1, IndexesBefore),
         ?assertEqual(N, length(AliveBefore)),
 
         % update ddoc
@@ -121,7 +121,7 @@ check_all_indexers_exit_on_ddoc_change({_Ctx, DbName}) ->
         ?assertEqual(0, length(IndexesAfter)),
 
         %% assert that previously running indexes are gone
-        AliveAfter = lists:filter(fun erlang:is_process_alive/1, IndexesBefore),
+        AliveAfter = lists:filter(fun is_process_alive/1, IndexesBefore),
         ?assertEqual(0, length(AliveAfter)),
         ok
     end).

--- a/src/couch_log/src/couch_log_config.erl
+++ b/src/couch_log/src/couch_log_config.erl
@@ -108,7 +108,7 @@ transform(filter_fields, FieldsStr) ->
     Default = [pid, registered_name, error_info, messages],
     case parse_term(FieldsStr) of
         {ok, List} when is_list(List) ->
-            case lists:all(fun erlang:is_atom/1, List) of
+            case lists:all(fun is_atom/1, List) of
                 true ->
                     List;
                 false ->

--- a/src/couch_log/src/couch_log_trunc_io.erl
+++ b/src/couch_log/src/couch_log_trunc_io.erl
@@ -249,7 +249,7 @@ print(Fun, Max, _Options) when is_function(Fun) ->
     L = erlang:fun_to_list(Fun),
     case length(L) > Max of
         true ->
-            S = erlang:max(5, Max),
+            S = max(5, Max),
             Res = string:substr(L, 1, S) ++ "..>",
             {Res, length(Res)};
         _ ->
@@ -347,7 +347,7 @@ list_bodyc(X, Max, Options, _Tuple) ->
     {[$|, List], Len + 1}.
 
 map_body(Map, Max, #print_options{depth = Depth}) when Max < 4; Depth =:= 0 ->
-    case erlang:map_size(Map) of
+    case map_size(Map) of
         0 -> {[], 0};
         _ -> {"...", 3}
     end;

--- a/src/couch_log/src/couch_log_trunc_io_fmt.erl
+++ b/src/couch_log/src/couch_log_trunc_io_fmt.erl
@@ -324,7 +324,7 @@ term(T, F, Adj, P0, Pad) ->
     L = lists:flatlength(T),
     P =
         case P0 of
-            none -> erlang:min(L, F);
+            none -> min(L, F);
             _ -> P0
         end,
     if
@@ -501,10 +501,10 @@ unprefixed_integer(Int, F, Adj, Base, Pad, Lowercase) when
 ->
     if
         Int < 0 ->
-            S = cond_lowercase(erlang:integer_to_list(-Int, Base), Lowercase),
+            S = cond_lowercase(integer_to_list(-Int, Base), Lowercase),
             term([$- | S], F, Adj, none, Pad);
         true ->
-            S = cond_lowercase(erlang:integer_to_list(Int, Base), Lowercase),
+            S = cond_lowercase(integer_to_list(Int, Base), Lowercase),
             term(S, F, Adj, none, Pad)
     end.
 
@@ -516,10 +516,10 @@ prefixed_integer(Int, F, Adj, Base, Pad, Prefix, Lowercase) when
 ->
     if
         Int < 0 ->
-            S = cond_lowercase(erlang:integer_to_list(-Int, Base), Lowercase),
+            S = cond_lowercase(integer_to_list(-Int, Base), Lowercase),
             term([$-, Prefix | S], F, Adj, none, Pad);
         true ->
-            S = cond_lowercase(erlang:integer_to_list(Int, Base), Lowercase),
+            S = cond_lowercase(integer_to_list(Int, Base), Lowercase),
             term([Prefix | S], F, Adj, none, Pad)
     end.
 

--- a/src/couch_log/test/eunit/couch_log_config_listener_test.erl
+++ b/src/couch_log/test/eunit/couch_log_config_listener_test.erl
@@ -29,7 +29,7 @@ check_restart_listener() ->
 
     Handler1 = get_handler(),
     ?assertNotEqual(not_found, Handler1),
-    Ref = erlang:monitor(process, Listener1),
+    Ref = monitor(process, Listener1),
     ok = gen_event:delete_handler(config_event, get_handler(), testing),
 
     receive

--- a/src/couch_log/test/eunit/couch_log_formatter_test.erl
+++ b/src/couch_log/test/eunit/couch_log_formatter_test.erl
@@ -53,7 +53,7 @@ crashing_formatting_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** Generic server and some stuff",
@@ -76,7 +76,7 @@ gen_server_error_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** Generic server and some stuff",
@@ -102,7 +102,7 @@ gen_server_error_with_extra_args_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** Generic server and some stuff",
@@ -128,7 +128,7 @@ gen_fsm_error_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** State machine did a thing",
@@ -154,7 +154,7 @@ gen_fsm_error_with_extra_args_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** State machine did a thing",
@@ -180,7 +180,7 @@ gen_event_error_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** gen_event handler did a thing",
@@ -210,7 +210,7 @@ gen_event_error_test() ->
 emulator_error_test() ->
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             emulator,
             "~s~n",
@@ -230,7 +230,7 @@ normal_error_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "format thing: ~w ~w",
@@ -253,7 +253,7 @@ error_report_std_error_test() ->
     Pid = self(),
     Event = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             std_error,
@@ -274,7 +274,7 @@ supervisor_report_test() ->
     % A standard supervisor report
     Event1 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             supervisor_report,
@@ -307,7 +307,7 @@ supervisor_report_test() ->
     % in the offender blob.
     Event2 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             supervisor_report,
@@ -339,7 +339,7 @@ supervisor_report_test() ->
     % A supervisor_bridge
     Event3 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             supervisor_report,
@@ -370,7 +370,7 @@ supervisor_report_test() ->
     % Any other supervisor report
     Event4 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             supervisor_report,
@@ -391,7 +391,7 @@ crash_report_test() ->
     % A standard crash report
     Event1 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             crash_report,
@@ -425,7 +425,7 @@ crash_report_test() ->
     % A registered process crash report
     Event2 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             crash_report,
@@ -450,7 +450,7 @@ crash_report_test() ->
     % A non-exit crash report
     Event3 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             crash_report,
@@ -475,7 +475,7 @@ crash_report_test() ->
     % A extra report info
     Event4 = {
         error_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             crash_report,
@@ -504,7 +504,7 @@ warning_report_test() ->
     % A warning message
     Event1 = {
         warning_msg,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "a ~s string ~w",
@@ -522,7 +522,7 @@ warning_report_test() ->
     % A warning report
     Event2 = {
         warning_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             std_warning,
@@ -543,7 +543,7 @@ info_report_test() ->
     % An info message
     Event1 = {
         info_msg,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "an info ~s string ~w",
@@ -561,7 +561,7 @@ info_report_test() ->
     % Application exit info
     Event2 = {
         info_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             std_info,
@@ -583,7 +583,7 @@ info_report_test() ->
     % Any other std_info message
     Event3 = {
         info_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             std_info,
@@ -604,7 +604,7 @@ info_report_test() ->
     % Non-list other report
     Event4 = {
         info_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             std_info,
@@ -625,7 +625,7 @@ progress_report_test() ->
     % Application started
     Event1 = {
         info_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             progress,
@@ -643,7 +643,7 @@ progress_report_test() ->
     % Supervisor started child
     Event2 = {
         info_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             progress,
@@ -669,7 +669,7 @@ progress_report_test() ->
     %  Other progress report
     Event3 = {
         info_report,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             progress,
@@ -787,7 +787,7 @@ format_reason_test_() ->
             "bad argument in call to j:k(a, 2) at y:x/1"
         },
         {
-            {{badarity, {fun erlang:spawn/1, [a, b]}}, [{y, x, 1}]},
+            {{badarity, {fun spawn/1, [a, b]}}, [{y, x, 1}]},
             "function called with wrong arity of 2 instead of 1 at y:x/1"
         },
         {
@@ -837,7 +837,7 @@ coverage_test() ->
         do_format(
             {
                 error_report,
-                erlang:group_leader(),
+                group_leader(),
                 {self(), std_error, "foobar"}
             }
         )
@@ -852,7 +852,7 @@ coverage_test() ->
         do_format(
             {
                 error_report,
-                erlang:group_leader(),
+                group_leader(),
                 {self(), std_error, dang}
             }
         )
@@ -862,7 +862,7 @@ gen_server_error_with_last_msg_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** Generic server and some stuff",
@@ -890,7 +890,7 @@ gen_event_error_with_last_msg_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** gen_event handler did a thing",
@@ -923,7 +923,7 @@ gen_fsm_error_with_last_msg_test() ->
     Pid = self(),
     Event = {
         error,
-        erlang:group_leader(),
+        group_leader(),
         {
             Pid,
             "** State machine did a thing",

--- a/src/couch_log/test/eunit/couch_log_server_test.erl
+++ b/src/couch_log/test/eunit/couch_log_server_test.erl
@@ -39,7 +39,7 @@ check_can_reconfigure() ->
 
 check_can_restart() ->
     Pid1 = whereis(couch_log_server),
-    Ref = erlang:monitor(process, Pid1),
+    Ref = monitor(process, Pid1),
     ?assert(is_process_alive(Pid1)),
 
     supervisor:terminate_child(couch_log_sup, couch_log_server),

--- a/src/couch_mrview/src/couch_mrview.erl
+++ b/src/couch_mrview/src/couch_mrview.erl
@@ -338,7 +338,7 @@ query_view(Db, {Type, View, Ref}, Args, Callback, Acc) ->
             red -> red_fold(Db, View, Args, Callback, Acc)
         end
     after
-        erlang:demonitor(Ref, [flush])
+        demonitor(Ref, [flush])
     end.
 
 get_info(Db, DDoc) ->

--- a/src/couch_mrview/src/couch_mrview_compactor.erl
+++ b/src/couch_mrview/src/couch_mrview_compactor.erl
@@ -140,7 +140,7 @@ recompact(#mrst{db_name = DbName, idx_name = IdxName}, 0) ->
 recompact(State, RetryCount) ->
     Self = self(),
     link(State#mrst.fd),
-    {Pid, Ref} = erlang:spawn_monitor(fun() ->
+    {Pid, Ref} = spawn_monitor(fun() ->
         couch_index_updater:update(Self, couch_mrview_index, State)
     end),
     recompact_loop(Pid, Ref, State, RetryCount).
@@ -240,7 +240,7 @@ swap_compacted(OldState, NewState) ->
     } = NewState,
 
     link(NewState#mrst.fd),
-    Ref = erlang:monitor(process, NewState#mrst.fd),
+    Ref = monitor(process, NewState#mrst.fd),
 
     RootDir = couch_index_util:root_dir(),
     IndexFName = couch_mrview_util:index_file(DbName, Sig),
@@ -257,7 +257,7 @@ swap_compacted(OldState, NewState) ->
     ok = file:rename(CompactFName, IndexFName),
 
     unlink(OldState#mrst.fd),
-    erlang:demonitor(OldState#mrst.fd_monitor, [flush]),
+    demonitor(OldState#mrst.fd_monitor, [flush]),
 
     {ok, NewState#mrst{fd_monitor = Ref}}.
 

--- a/src/couch_mrview/src/couch_mrview_index.erl
+++ b/src/couch_mrview/src/couch_mrview_index.erl
@@ -167,7 +167,7 @@ open(Db, State0) ->
     end.
 
 close(State) ->
-    erlang:demonitor(State#mrst.fd_monitor, [flush]),
+    demonitor(State#mrst.fd_monitor, [flush]),
     couch_file:close(State#mrst.fd).
 
 % This called after ddoc_updated event occurrs, and
@@ -178,7 +178,7 @@ close(State) ->
 % couch_file will be closed automatically after all
 % outstanding queries are done.
 shutdown(State) ->
-    erlang:demonitor(State#mrst.fd_monitor, [flush]),
+    demonitor(State#mrst.fd_monitor, [flush]),
     unlink(State#mrst.fd).
 
 delete(#mrst{db_name = DbName, sig = Sig} = State) ->

--- a/src/couch_mrview/src/couch_mrview_updater.erl
+++ b/src/couch_mrview/src/couch_mrview_updater.erl
@@ -166,13 +166,13 @@ map_docs(Parent, #mrst{db_name = DbName, idx_name = IdxName} = State0) ->
             QServer = State1#mrst.qserver,
             DocFun = fun
                 ({nil, Seq, _}, {SeqAcc, Results}) ->
-                    {erlang:max(Seq, SeqAcc), Results};
+                    {max(Seq, SeqAcc), Results};
                 ({Id, Seq, deleted}, {SeqAcc, Results}) ->
-                    {erlang:max(Seq, SeqAcc), [{Id, []} | Results]};
+                    {max(Seq, SeqAcc), [{Id, []} | Results]};
                 ({Id, Seq, Doc}, {SeqAcc, Results}) ->
                     couch_stats:increment_counter([couchdb, mrview, map_doc]),
                     {ok, Res} = couch_query_servers:map_doc_raw(QServer, Doc),
-                    {erlang:max(Seq, SeqAcc), [{Id, Res} | Results]}
+                    {max(Seq, SeqAcc), [{Id, Res} | Results]}
             end,
             FoldFun = fun(Docs, Acc) ->
                 update_task(length(Docs)),
@@ -242,7 +242,7 @@ merge_results([{Seq, Results} | Rest], SeqAcc, ViewKVs, DocIdKeys) ->
         merge_results(RawResults, VKV, DIK)
     end,
     {ViewKVs1, DocIdKeys1} = lists:foldl(Fun, {ViewKVs, DocIdKeys}, Results),
-    merge_results(Rest, erlang:max(Seq, SeqAcc), ViewKVs1, DocIdKeys1).
+    merge_results(Rest, max(Seq, SeqAcc), ViewKVs1, DocIdKeys1).
 
 merge_results({DocId, []}, ViewKVs, DocIdKeys) ->
     {ViewKVs, [{DocId, []} | DocIdKeys]};

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -152,7 +152,7 @@ get_index_files(Db) ->
 get_view(Db, DDoc, ViewName, Args0) ->
     case get_view_index_state(Db, DDoc, ViewName, Args0) of
         {ok, State, Args2} ->
-            Ref = erlang:monitor(process, State#mrst.fd),
+            Ref = monitor(process, State#mrst.fd),
             #mrst{language = Lang, views = Views} = State,
             {Type, View, Args3} = extract_view(Lang, Args2, ViewName, Views),
             check_range(Args3, view_cmp(View)),
@@ -382,7 +382,7 @@ init_state(Db, Fd, State, Header) ->
 
     {ShouldCommit, State#mrst{
         fd = Fd,
-        fd_monitor = erlang:monitor(process, Fd),
+        fd_monitor = monitor(process, Fd),
         update_seq = Seq,
         purge_seq = PurgeSeq,
         id_btree = IdBtree,

--- a/src/couch_mrview/test/eunit/couch_mrview_compact_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_compact_tests.erl
@@ -86,7 +86,7 @@ should_remove(Db) ->
         ok = couch_index:compact(IndexPid, []),
         {ok, CompactorPid} = couch_index:get_compactor_pid(IndexPid),
         {ok, CompactingPid} = couch_index_compactor:get_compacting_pid(CompactorPid),
-        MonRef = erlang:monitor(process, CompactingPid),
+        MonRef = monitor(process, CompactingPid),
         exit(CompactingPid, crash),
         receive
             {'DOWN', MonRef, process, _, crash} ->

--- a/src/couch_mrview/test/eunit/couch_mrview_ddoc_updated_tests.erl
+++ b/src/couch_mrview/test/eunit/couch_mrview_ddoc_updated_tests.erl
@@ -90,7 +90,7 @@ check_indexing_stops_on_ddoc_change(Db) ->
 
         IndexesBefore = get_indexes_by_ddoc(couch_db:name(Db), DDocID, 1),
         ?assertEqual(1, length(IndexesBefore)),
-        AliveBefore = lists:filter(fun erlang:is_process_alive/1, IndexesBefore),
+        AliveBefore = lists:filter(fun is_process_alive/1, IndexesBefore),
         ?assertEqual(1, length(AliveBefore)),
 
         {ok, DDoc} = couch_db:open_doc(Db, DDocID, [ejson_body, ?ADMIN_CTX]),
@@ -129,7 +129,7 @@ check_indexing_stops_on_ddoc_change(Db) ->
         %% assert that previously running indexes are gone
         IndexesAfter = get_indexes_by_ddoc(couch_db:name(Db), DDocID, 0),
         ?assertEqual(0, length(IndexesAfter)),
-        AliveAfter = lists:filter(fun erlang:is_process_alive/1, IndexesBefore),
+        AliveAfter = lists:filter(fun is_process_alive/1, IndexesBefore),
         ?assertEqual(0, length(AliveAfter))
     end).
 

--- a/src/couch_peruser/src/couch_peruser.erl
+++ b/src/couch_peruser/src/couch_peruser.erl
@@ -269,7 +269,7 @@ should_handle_doc(ShardName, DocId) ->
 ) -> boolean().
 should_handle_doc_int(ShardName, DocId) ->
     DbName = mem3:dbname(ShardName),
-    Live = [erlang:node() | erlang:nodes()],
+    Live = [erlang:node() | nodes()],
     Shards = mem3:shards(DbName, DocId),
     Nodes = [N || #shard{node = N} <- Shards, lists:member(N, Live)],
     case mem3:owner(DbName, DocId, Nodes) of

--- a/src/couch_prometheus/src/couch_prometheus.erl
+++ b/src/couch_prometheus/src/couch_prometheus.erl
@@ -120,9 +120,9 @@ get_vm_stats() ->
         end,
         erlang:memory()
     ),
-    {NumGCs, WordsReclaimed, _} = erlang:statistics(garbage_collection),
-    CtxSwitches = element(1, erlang:statistics(context_switches)),
-    Reds = element(1, erlang:statistics(reductions)),
+    {NumGCs, WordsReclaimed, _} = statistics(garbage_collection),
+    CtxSwitches = element(1, statistics(context_switches)),
+    Reds = element(1, statistics(reductions)),
     ProcCount = erlang:system_info(process_count),
     ProcLimit = erlang:system_info(process_limit),
     [
@@ -158,7 +158,7 @@ get_vm_stats() ->
     ].
 
 get_io_stats() ->
-    {{input, In}, {output, Out}} = erlang:statistics(io),
+    {{input, In}, {output, Out}} = statistics(io),
     [
         to_prom(
             erlang_io_recv_bytes_total,

--- a/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
+++ b/src/couch_prometheus/test/eunit/couch_prometheus_e2e_tests.erl
@@ -114,9 +114,9 @@ t_no_duplicate_metrics(Port) ->
     % definition, not the values. These lines always start with
     % a # character.
     MetricDefs = lists:filter(fun(S) -> string:find(S, "#") =:= S end, Lines),
-    ?assertNotEqual(erlang:length(MetricDefs), 0),
+    ?assertNotEqual(length(MetricDefs), 0),
     Diff = get_duplicates(MetricDefs),
-    ?assertEqual(erlang:length(Diff), 0).
+    ?assertEqual(length(Diff), 0).
 
 get_duplicates(List) ->
     List -- sets:to_list(couch_util:set_from_list(List)).

--- a/src/couch_pse_tests/src/cpse_util.erl
+++ b/src/couch_pse_tests/src/cpse_util.erl
@@ -95,7 +95,7 @@ open_db(DbName) ->
 
 shutdown_db(Db) ->
     Pid = couch_db:get_pid(Db),
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     exit(Pid, kill),
     receive
         {'DOWN', Ref, _, _, _} ->
@@ -617,7 +617,7 @@ list_diff([T1 | R1], [T2 | R2]) ->
 
 compact(Db) ->
     {ok, Pid} = couch_db:start_compact(Db),
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
 
     % Ideally I'd assert that Pid is linked to us
     % at this point but its technically possible

--- a/src/couch_replicator/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator/src/couch_replicator_api_wrap.erl
@@ -118,7 +118,7 @@ db_open(#httpdb{} = Db1, Create, CreateParams) ->
             error(Error);
         exit:Error ->
             db_close(Db),
-            erlang:exit(Error)
+            exit(Error)
     end.
 
 db_close(#httpdb{httpc_pool = Pool} = HttpDb) ->
@@ -300,7 +300,7 @@ open_doc_revs(#httpdb{} = HttpDb, Id, Revs, Options, Fun, Acc) ->
         % hammer approach to making sure it releases
         % that connection back to the pool.
         spawn(fun() ->
-            Ref = erlang:monitor(process, Self),
+            Ref = monitor(process, Self),
             receive
                 {'DOWN', Ref, process, Self, normal} ->
                     exit(Streamer, {streamer_parent_died, Self});
@@ -352,7 +352,7 @@ open_doc_revs(#httpdb{} = HttpDb, Id, Revs, Options, Fun, Acc) ->
             NewRetries = Retries - 1,
             case NewRetries > 0 of
                 true ->
-                    Wait = 2 * erlang:min(Wait0 * 2, ?MAX_WAIT),
+                    Wait = 2 * min(Wait0 * 2, ?MAX_WAIT),
                     LogRetryMsg = "Retrying GET to ~s in ~p seconds due to error ~w",
                     couch_log:notice(LogRetryMsg, [Url, Wait / 1000, error_reason(Else)]),
                     ok = timer:sleep(Wait),
@@ -532,7 +532,7 @@ changes_since(
     UserFun,
     Options
 ) ->
-    Timeout = erlang:max(1000, InactiveTimeout div 3),
+    Timeout = max(1000, InactiveTimeout div 3),
     EncodedSeq = couch_replicator_utils:seq_encode(StartSeq),
     BaseQArgs =
         case get_value(continuous, Options, false) of
@@ -820,7 +820,7 @@ run_user_fun(UserFun, Arg, UserAcc, OldRef) ->
     end),
     receive
         {started_open_doc_revs, NewRef} ->
-            erlang:demonitor(Ref, [flush]),
+            demonitor(Ref, [flush]),
             exit(Pid, kill),
             restart_remote_open_doc_revs(OldRef, NewRef);
         {'DOWN', Ref, process, Pid, {exit_ok, Ret}} ->
@@ -830,7 +830,7 @@ run_user_fun(UserFun, Arg, UserAcc, OldRef) ->
         {'DOWN', Ref, process, Pid, {exit_error, Reason}} ->
             error(Reason);
         {'DOWN', Ref, process, Pid, {exit_exit, Reason}} ->
-            erlang:exit(Reason)
+            exit(Reason)
     end.
 
 restart_remote_open_doc_revs(Ref, NewRef) ->

--- a/src/couch_replicator/src/couch_replicator_auth_session.erl
+++ b/src/couch_replicator/src/couch_replicator_auth_session.erl
@@ -344,7 +344,7 @@ stop_worker_if_server_requested(ResultHeaders0, Worker) ->
     ResultHeaders = mochiweb_headers:make(ResultHeaders0),
     case mochiweb_headers:get_value("Connection", ResultHeaders) of
         "close" ->
-            Ref = erlang:monitor(process, Worker),
+            Ref = monitor(process, Worker),
             ibrowse_http_client:stop(Worker),
             receive
                 {'DOWN', Ref, _, _, _} ->

--- a/src/couch_replicator/src/couch_replicator_doc_processor_worker.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor_worker.erl
@@ -66,7 +66,7 @@ worker_fun(Id, Rep, WaitSec, WRef) ->
         {'DOWN', Ref, _, Pid, Result} ->
             exit(#doc_worker_result{id = Id, wref = WRef, result = Result})
     after ?WORKER_TIMEOUT_MSEC ->
-        erlang:demonitor(Ref, [flush]),
+        demonitor(Ref, [flush]),
         exit(Pid, kill),
         {DbName, DocId} = Id,
         TimeoutSec = round(?WORKER_TIMEOUT_MSEC / 1000),

--- a/src/couch_replicator/src/couch_replicator_docs.erl
+++ b/src/couch_replicator/src/couch_replicator_docs.erl
@@ -159,7 +159,7 @@ update_rep_doc(RepDbName, RepDocId, KVs, Wait) when is_binary(RepDocId) ->
         throw:conflict ->
             Msg = "Conflict when updating replication doc `~s`. Retrying.",
             couch_log:error(Msg, [RepDocId]),
-            ok = timer:sleep(rand:uniform(erlang:min(128, Wait)) * 100),
+            ok = timer:sleep(rand:uniform(min(128, Wait)) * 100),
             update_rep_doc(RepDbName, RepDocId, KVs, Wait * 2)
     end;
 update_rep_doc(RepDbName, #doc{body = {RepDocBody}} = RepDoc, KVs, _Try) ->

--- a/src/couch_replicator/src/couch_replicator_fabric.erl
+++ b/src/couch_replicator/src/couch_replicator_fabric.erl
@@ -121,7 +121,7 @@ handle_message({meta, Meta0}, {Worker, From}, State) ->
                 offset = Offset
             }};
         false ->
-            FinalOffset = erlang:min(Total, Offset + State#collector.skip),
+            FinalOffset = min(Total, Offset + State#collector.skip),
             Meta = [{total, Total}, {offset, FinalOffset}],
             {Go, Acc} = Callback({meta, Meta}, AccIn),
             {Go, State#collector{

--- a/src/couch_replicator/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc.erl
@@ -154,7 +154,7 @@ send_ibrowse_req(#httpdb{headers = BaseHeaders} = HttpDb0, Params) ->
 %% {error, req_timedout} error. While in reality is not really a timeout, just
 %% a race condition.
 stop_and_release_worker(Pool, Worker) ->
-    Ref = erlang:monitor(process, Worker),
+    Ref = monitor(process, Worker),
     ibrowse_http_client:stop(Worker),
     receive
         {'DOWN', Ref, _, _, _} ->
@@ -355,7 +355,7 @@ maybe_retry(
         false ->
             ok = timer:sleep(Wait),
             log_retry_error(Params, HttpDb, Wait, Error),
-            Wait2 = erlang:min(Wait * 2, ?MAX_WAIT),
+            Wait2 = min(Wait * 2, ?MAX_WAIT),
             HttpDb1 = HttpDb#httpdb{retries = Retries - 1, wait = Wait2},
             HttpDb2 = update_first_error_timestamp(HttpDb1),
             throw({retry, HttpDb2, Params})

--- a/src/couch_replicator/src/couch_replicator_httpc_pool.erl
+++ b/src/couch_replicator/src/couch_replicator_httpc_pool.erl
@@ -154,12 +154,12 @@ format_status(Status) ->
     ).
 
 monitor_client(Callers, Worker, {ClientPid, _}) ->
-    [{Worker, erlang:monitor(process, ClientPid)} | Callers].
+    [{Worker, monitor(process, ClientPid)} | Callers].
 
 demonitor_client(Callers, Worker) ->
     case lists:keysearch(Worker, 1, Callers) of
         {value, {Worker, MonRef}} ->
-            erlang:demonitor(MonRef, [flush]),
+            demonitor(MonRef, [flush]),
             lists:keydelete(Worker, 1, Callers);
         false ->
             Callers

--- a/src/couch_replicator/src/couch_replicator_rate_limiter.erl
+++ b/src/couch_replicator/src/couch_replicator_rate_limiter.erl
@@ -170,9 +170,9 @@ update_failure(_Key, Interval, Timestamp, Now) when
     % Ignore too frequent updates.
     Interval;
 update_failure(Key, Interval, _Timestamp, Now) ->
-    Interval1 = erlang:max(Interval, ?BASE_INTERVAL),
+    Interval1 = max(Interval, ?BASE_INTERVAL),
     Interval2 = round(Interval1 * ?BACKOFF_FACTOR),
-    Interval3 = erlang:min(Interval2, ?MAX_INTERVAL),
+    Interval3 = min(Interval2, ?MAX_INTERVAL),
     insert(Key, Interval3, Now).
 
 -spec insert(any(), interval(), msec()) -> interval().
@@ -195,7 +195,7 @@ interval_and_timestamp(Key) ->
 -spec time_decay(msec(), interval()) -> interval().
 time_decay(Dt, Interval) when Dt > ?TIME_DECAY_THRESHOLD ->
     DecayedInterval = Interval - ?TIME_DECAY_FACTOR * Dt,
-    erlang:max(round(DecayedInterval), 0);
+    max(round(DecayedInterval), 0);
 time_decay(_Dt, Interval) ->
     Interval.
 

--- a/src/couch_replicator/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler.erl
@@ -408,7 +408,7 @@ handle_config_terminate(_, _, _) ->
 stop_clear_all_jobs(TimeLeftMSec) ->
     ShutdownFun = fun(#job{pid = Pid}) ->
         Pid ! shutdown,
-        erlang:monitor(process, Pid)
+        monitor(process, Pid)
     end,
     Refs = lists:map(ShutdownFun, running_jobs()),
     ets:delete_all_objects(?MODULE),
@@ -637,7 +637,7 @@ backoff_micros(CrashCount) ->
     % exponent in Base * 2 ^ CrashCount to achieve an exponential backoff
     % doubling every consecutive failure, starting with the base value of
     % ?BACKOFF_INTERVAL_MICROS.
-    BackoffExp = erlang:min(CrashCount - 1, ?MAX_BACKOFF_EXPONENT),
+    BackoffExp = min(CrashCount - 1, ?MAX_BACKOFF_EXPONENT),
     (1 bsl BackoffExp) * ?BACKOFF_INTERVAL_MICROS.
 
 -spec add_job_int(#job{}) -> boolean().
@@ -938,7 +938,7 @@ update_running_jobs_stats(StatsPid) when is_pid(StatsPid) ->
     ok.
 
 start_stats_updater() ->
-    erlang:spawn_link(?MODULE, stats_updater_loop, [undefined]).
+    spawn_link(?MODULE, stats_updater_loop, [undefined]).
 
 stats_updater_loop(Timer) ->
     receive
@@ -951,7 +951,7 @@ stats_updater_loop(Timer) ->
             ok = stats_updater_refresh(),
             ?MODULE:stats_updater_loop(undefined);
         Else ->
-            erlang:exit({stats_updater_bad_msg, Else})
+            exit({stats_updater_bad_msg, Else})
     end.
 
 -spec stats_updater_refresh() -> ok.

--- a/src/couch_replicator/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator/src/couch_replicator_scheduler_job.erl
@@ -105,7 +105,7 @@ start_link(#rep{id = Id = {BaseId, Ext}, source = Src, target = Tgt} = Rep) ->
     end.
 
 stop(Pid) when is_pid(Pid) ->
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     unlink(Pid),
     % In the rare case the job is already stopping as we try to stop it, it
     % won't return ok but exit the calling process, usually the scheduler, so
@@ -530,7 +530,7 @@ startup_jitter() ->
         "startup_jitter",
         ?STARTUP_JITTER_DEFAULT
     ),
-    rand:uniform(erlang:max(1, Jitter)).
+    rand:uniform(max(1, Jitter)).
 
 headers_strip_creds([], Acc) ->
     lists:reverse(Acc);

--- a/src/couch_replicator/src/json_stream_parse.erl
+++ b/src/couch_replicator/src/json_stream_parse.erl
@@ -300,7 +300,7 @@ toke_string(DF, <<$\\, $t, Rest/binary>>, Acc) ->
     toke_string(DF, Rest, [$\t | Acc]);
 toke_string(DF, <<$\\, $u, Rest/binary>>, Acc) ->
     {<<A, B, C, D, Data/binary>>, DF2} = must_df(DF, 4, Rest, missing_hex),
-    UTFChar = erlang:list_to_integer([A, B, C, D], 16),
+    UTFChar = list_to_integer([A, B, C, D], 16),
     if
         UTFChar == 16#FFFF orelse UTFChar == 16#FFFE ->
             err(invalid_utf_char);

--- a/src/couch_replicator/test/eunit/couch_replicator_compact_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_compact_tests.erl
@@ -235,7 +235,7 @@ compact_db(Type, Db0) ->
     Name = couch_db:name(Db0),
     {ok, Db} = couch_db:open_int(Name, []),
     {ok, CompactPid} = couch_db:start_compact(Db),
-    MonRef = erlang:monitor(process, CompactPid),
+    MonRef = monitor(process, CompactPid),
     receive
         {'DOWN', MonRef, process, CompactPid, normal} ->
             ok;
@@ -378,7 +378,7 @@ stop_writer(Pid) ->
     Pid ! {stop, Ref},
     receive
         {stopped, Ref, DocsWritten} ->
-            MonRef = erlang:monitor(process, Pid),
+            MonRef = monitor(process, Pid),
             receive
                 {'DOWN', MonRef, process, Pid, _Reason} ->
                     DocsWritten

--- a/src/couch_replicator/test/eunit/couch_replicator_connection_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_connection_tests.erl
@@ -187,7 +187,7 @@ user_pass() ->
     {User, Pass, B64Auth}.
 
 worker_internals(Pid) ->
-    Dict = io_lib:format("~p", [erlang:process_info(Pid, dictionary)]),
+    Dict = io_lib:format("~p", [process_info(Pid, dictionary)]),
     State = io_lib:format("~p", [sys:get_state(Pid)]),
     lists:flatten([Dict, State]).
 

--- a/src/couch_replicator/test/eunit/couch_replicator_rate_limiter_tests.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_rate_limiter_tests.erl
@@ -57,7 +57,7 @@ setup() ->
     Pid.
 
 teardown(Pid) ->
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     unlink(Pid),
     exit(Pid, kill),
     receive

--- a/src/couch_replicator/test/eunit/couch_replicator_retain_stats_between_job_runs.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_retain_stats_between_job_runs.erl
@@ -80,7 +80,7 @@ t_stats_retained_on_job_removal({_Ctx, {Source, Target}}) ->
     couch_replicator_scheduler:remove_job(RepId).
 
 stop_job(RepPid) ->
-    Ref = erlang:monitor(process, RepPid),
+    Ref = monitor(process, RepPid),
     gen_server:cast(couch_replicator_scheduler, {set_max_jobs, 0}),
     couch_replicator_scheduler:reschedule(),
     receive

--- a/src/couch_replicator/test/eunit/couch_replicator_test_helper.erl
+++ b/src/couch_replicator/test/eunit/couch_replicator_test_helper.erl
@@ -181,7 +181,7 @@ replicate({[_ | _]} = RepObject) ->
     ok = couch_replicator_scheduler:add_job(Rep),
     couch_replicator_scheduler:reschedule(),
     Pid = get_pid(Rep#rep.id),
-    MonRef = erlang:monitor(process, Pid),
+    MonRef = monitor(process, Pid),
     receive
         {'DOWN', MonRef, process, Pid, _} ->
             ok

--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -198,7 +198,7 @@ spawn_link(Id) ->
 
 stop(Pid) when is_pid(Pid) ->
     unlink(Pid),
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     Pid ! stop,
     receive
         {'DOWN', Ref, _, _, _} -> ok
@@ -369,7 +369,7 @@ scan_docs(#st{} = St, #shard{name = ShardDbName}) ->
                 #st{changes_seq = Seq, changes_opts = Opts} = St3,
                 {ok, St4} = couch_db:fold_changes(Db, Seq, fun scan_docs_fold/2, St3, Opts),
                 St5 = db_closing_callback(St4),
-                erlang:garbage_collect(),
+                garbage_collect(),
                 St5#st{db = undefined}
             after
                 couch_db:close(Db)
@@ -424,7 +424,7 @@ maybe_checkpoint(#st{checkpoint_sec = LastCheckpointTSec} = St) ->
         stop -> exit({shutdown, stop})
     after 0 -> ok
     end,
-    erlang:garbage_collect(),
+    garbage_collect(),
     case tsec() - LastCheckpointTSec > ?CHECKPOINT_INTERVAL_SEC of
         true -> checkpoint(St);
         false -> St

--- a/src/couch_stats/src/couch_stats_process_tracker.erl
+++ b/src/couch_stats/src/couch_stats_process_tracker.erl
@@ -49,7 +49,7 @@ handle_call(Msg, _From, State) ->
 
 handle_cast({track, Pid, Name}, State) ->
     couch_stats:increment_counter(Name),
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     ets:insert(?MODULE, {Ref, Name}),
     {noreply, State};
 handle_cast(Msg, State) ->

--- a/src/ddoc_cache/src/ddoc_cache_entry.erl
+++ b/src/ddoc_cache/src/ddoc_cache_entry.erl
@@ -75,16 +75,16 @@ start_link(Key, Default) ->
     {ok, Pid}.
 
 shutdown(Pid) ->
-    Ref = erlang:monitor(process, Pid),
+    Ref = monitor(process, Pid),
     ok = gen_server:cast(Pid, shutdown),
     receive
         {'DOWN', Ref, process, Pid, normal} ->
             ok;
         {'DOWN', Ref, process, Pid, Reason} ->
-            erlang:exit(Reason)
+            exit(Reason)
     after ?ENTRY_SHUTDOWN_TIMEOUT ->
-        erlang:demonitor(Ref, [flush]),
-        erlang:exit({timeout, {entry_shutdown, Pid}})
+        demonitor(Ref, [flush]),
+        exit({timeout, {entry_shutdown, Pid}})
     end.
 
 open(Pid, Key) ->
@@ -257,7 +257,7 @@ handle_info(Msg, St) ->
     {stop, {bad_info, Msg}, St}.
 
 spawn_opener(Key) ->
-    {Pid, _} = erlang:spawn_monitor(?MODULE, do_open, [Key]),
+    {Pid, _} = spawn_monitor(?MODULE, do_open, [Key]),
     Pid.
 
 start_timer() ->
@@ -269,10 +269,10 @@ start_timer() ->
 do_open(Key) ->
     try recover(Key) of
         Resp ->
-            erlang:exit({open_ok, Key, Resp})
+            exit({open_ok, Key, Resp})
     catch
         T:R:S ->
-            erlang:exit({open_error, Key, {T, R, S}})
+            exit({open_error, Key, {T, R, S}})
     end.
 
 update_lru(#st{key = Key, ts = Ts} = St) ->

--- a/src/ddoc_cache/src/ddoc_cache_lru.erl
+++ b/src/ddoc_cache/src/ddoc_cache_lru.erl
@@ -273,7 +273,7 @@ remove_key(#{} = Dbs, Key) ->
     end.
 
 unlink_and_flush(Pid) ->
-    erlang:unlink(Pid),
+    unlink(Pid),
     % Its possible that the entry process has already exited before
     % we unlink it so we have to flush out a possible 'EXIT'
     % message sitting in our message queue. Notice that we're

--- a/src/ddoc_cache/test/eunit/ddoc_cache_coverage_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_coverage_test.erl
@@ -37,7 +37,7 @@ stop_on_evictor_death() ->
         Lru = whereis(ddoc_cache_lru),
         State = sys:get_state(Lru),
         Evictor = element(4, State),
-        Ref = erlang:monitor(process, Lru),
+        Ref = monitor(process, Lru),
         exit(Evictor, shutdown),
         receive
             {'DOWN', Ref, _, _, Reason} ->
@@ -61,7 +61,7 @@ send_bad_messages(Name) ->
     end).
 
 wait_for_restart(Server, Fun) ->
-    Ref = erlang:monitor(process, whereis(Server)),
+    Ref = monitor(process, whereis(Server)),
     Fun(),
     receive
         {'DOWN', Ref, _, _, _} ->

--- a/src/ddoc_cache/test/eunit/ddoc_cache_entry_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_entry_test.erl
@@ -53,7 +53,7 @@ cancel_and_replace_opener(_) ->
     true = ets:insert_new(?CACHE, #entry{key = Key}),
     {ok, Entry} = ddoc_cache_entry:start_link(Key, undefined),
     Opener1 = element(4, sys:get_state(Entry)),
-    Ref1 = erlang:monitor(process, Opener1),
+    Ref1 = monitor(process, Opener1),
     gen_server:cast(Entry, force_refresh),
     receive
         {'DOWN', Ref1, _, _, _} -> ok
@@ -102,7 +102,7 @@ evict_when_not_accessed(_) ->
     Key = {ddoc_cache_entry_custom, {<<"bar">>, ?MODULE}},
     true = ets:insert_new(?CACHE, #entry{key = Key}),
     {ok, Entry} = ddoc_cache_entry:start_link(Key, undefined),
-    Ref = erlang:monitor(process, Entry),
+    Ref = monitor(process, Entry),
     AccessCount1 = element(7, sys:get_state(Entry)),
     ?assertEqual(1, AccessCount1),
     ok = gen_server:cast(Entry, refresh),

--- a/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_lru_test.erl
@@ -91,7 +91,7 @@ check_multi_start(_) ->
     ),
     [#entry{pid = Pid}] = ets:tab2list(?CACHE),
     Opener = element(4, sys:get_state(Pid)),
-    OpenerRef = erlang:monitor(process, Opener),
+    OpenerRef = monitor(process, Opener),
     ?assert(is_process_alive(Opener)),
     Opener ! go,
     receive
@@ -135,7 +135,7 @@ check_multi_open(_) ->
     ),
     [#entry{pid = Pid}] = ets:tab2list(?CACHE),
     Opener = element(4, sys:get_state(Pid)),
-    OpenerRef = erlang:monitor(process, Opener),
+    OpenerRef = monitor(process, Opener),
     ?assert(is_process_alive(Opener)),
     Opener ! go,
     receive
@@ -242,7 +242,7 @@ check_evict_and_exit(_) ->
     ?assertEqual({ok, <<"dbname">>}, ddoc_cache_lru:open(Key)),
     [#entry{key = Key, pid = Pid}] = ets:tab2list(?CACHE),
 
-    erlang:monitor(process, whereis(ddoc_cache_lru)),
+    monitor(process, whereis(ddoc_cache_lru)),
 
     % Pause the LRU so we can queue multiple messages
     erlang:suspend_process(whereis(ddoc_cache_lru)),

--- a/src/ddoc_cache/test/eunit/ddoc_cache_remove_test.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_remove_test.erl
@@ -193,7 +193,7 @@ do_compact(ShardName) ->
     {ok, Db} = couch_db:open_int(ShardName, []),
     try
         {ok, Pid} = couch_db:start_compact(Db),
-        Ref = erlang:monitor(process, Pid),
+        Ref = monitor(process, Pid),
         receive
             {'DOWN', Ref, _, _, _} ->
                 ok

--- a/src/ddoc_cache/test/eunit/ddoc_cache_tutil.erl
+++ b/src/ddoc_cache/test/eunit/ddoc_cache_tutil.erl
@@ -50,7 +50,7 @@ clear() ->
     application:start(ddoc_cache).
 
 get_rev(DbName, DDocId) ->
-    {_, Ref} = erlang:spawn_monitor(fun() ->
+    {_, Ref} = spawn_monitor(fun() ->
         {ok, #doc{revs = Revs}} = fabric:open_doc(DbName, DDocId, [?ADMIN_CTX]),
         {Depth, [RevId | _]} = Revs,
         exit({Depth, RevId})

--- a/src/docs/src/cluster/troubleshooting.rst
+++ b/src/docs/src/cluster/troubleshooting.rst
@@ -97,7 +97,7 @@ the ``--level`` option:
     %MEM    RSS
     0.3  25116
 
-    [debug] Local RPC: erlang:nodes([]) [5000]
+    [debug] Local RPC: nodes([]) [5000]
     [debug] Local RPC: mem3:nodes([]) [5000]
     [warning] Cluster member node3@127.0.0.1 is not connected to this node. Please check whether it is down.
     [info] Process is using 0.3% of available RAM, totalling 25116 KB of real memory.

--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -307,7 +307,7 @@ clouseau_major_vsn() ->
 -spec connected() -> boolean().
 
 connected() ->
-    HiddenNodes = erlang:nodes(hidden),
+    HiddenNodes = nodes(hidden),
     case lists:member(clouseau(), HiddenNodes) of
         true ->
             true;

--- a/src/dreyfus/src/dreyfus_util.erl
+++ b/src/dreyfus/src/dreyfus_util.erl
@@ -241,7 +241,7 @@ export(QueryArgs) ->
 time(Metric, {M, F, A}) when is_list(Metric) ->
     Start = os:timestamp(),
     try
-        erlang:apply(M, F, A)
+        apply(M, F, A)
     after
         Length = timer:now_diff(os:timestamp(), Start) / 1000,
         couch_stats:update_histogram([dreyfus | Metric], Length)

--- a/src/dreyfus/test/eunit/dreyfus_purge_test.erl
+++ b/src/dreyfus/test/eunit/dreyfus_purge_test.erl
@@ -1085,7 +1085,7 @@ wait_for_replicate(DbName, DocIds, ExpectRevCount, TimeOut) when
 wait_for_replicate(DbName, DocId, ExpectRevCount, TimeOut) ->
     FDI = fabric:get_full_doc_info(DbName, DocId, []),
     #doc_info{revs = Revs} = couch_doc:to_doc_info(FDI),
-    case erlang:length(Revs) of
+    case length(Revs) of
         ExpectRevCount ->
             couch_log:notice(
                 "[~p] wait end by expect, time used:~p, DocId:~p",

--- a/src/ets_lru/src/ets_lru.erl
+++ b/src/ets_lru/src/ets_lru.erl
@@ -349,7 +349,7 @@ next_timeout(Tab, Now, Max) ->
             infinity;
         {Time, _} ->
             TimeDiff = Now - Time,
-            erlang:max(Max - TimeDiff, 0)
+            max(Max - TimeDiff, 0)
     end.
 
 set_options(St, []) ->

--- a/src/ets_lru/test/ets_lru_test.erl
+++ b/src/ets_lru/test/ets_lru_test.erl
@@ -355,7 +355,7 @@ insert_kvs(Info, LRU, Count, Limit) ->
     insert_kvs(Info, LRU, Count - 1, Limit).
 
 stop_lru({ok, LRU}) ->
-    Ref = erlang:monitor(process, LRU),
+    Ref = monitor(process, LRU),
     ets_lru:stop(LRU),
     receive
         {'DOWN', Ref, process, LRU, Reason} -> Reason

--- a/src/fabric/src/fabric_db_update_listener.erl
+++ b/src/fabric/src/fabric_db_update_listener.erl
@@ -99,7 +99,7 @@ handle_db_event(_DbName, _Event, St) ->
 
 start_cleanup_monitor(Parent, Notifiers, ClientReq) ->
     spawn(fun() ->
-        Ref = erlang:monitor(process, Parent),
+        Ref = monitor(process, Parent),
         cleanup_monitor(Parent, Ref, Notifiers, ClientReq)
     end).
 
@@ -129,11 +129,11 @@ stop({Pid, Ref}) ->
     erlang:send(Pid, {Ref, done}).
 
 wait_db_updated({Pid, Ref}) ->
-    MonRef = erlang:monitor(process, Pid),
+    MonRef = monitor(process, Pid),
     erlang:send(Pid, {Ref, get_state}),
     receive
         {state, Pid, State} ->
-            erlang:demonitor(MonRef, [flush]),
+            demonitor(MonRef, [flush]),
             State;
         {'DOWN', MonRef, process, Pid, _Reason} ->
             changes_feed_died

--- a/src/fabric/src/fabric_doc_open.erl
+++ b/src/fabric/src/fabric_doc_open.erl
@@ -45,7 +45,7 @@ go(DbName, Id, Options) ->
     Acc0 = #acc{
         dbname = DbName,
         workers = Workers,
-        r = erlang:min(N, list_to_integer(R)),
+        r = min(N, list_to_integer(R)),
         state = r_not_met,
         replies = []
     },
@@ -317,8 +317,8 @@ t_handle_message_down(_) ->
 
 t_handle_message_exit(_) ->
     Exit = {rexi_EXIT, nil},
-    Worker0 = #shard{ref = erlang:make_ref()},
-    Worker1 = #shard{ref = erlang:make_ref()},
+    Worker0 = #shard{ref = make_ref()},
+    Worker1 = #shard{ref = make_ref()},
 
     % Only removes the specified worker
     ?assertEqual(
@@ -338,9 +338,9 @@ t_handle_message_exit(_) ->
     ).
 
 t_handle_message_reply(_) ->
-    Worker0 = #shard{ref = erlang:make_ref()},
-    Worker1 = #shard{ref = erlang:make_ref()},
-    Worker2 = #shard{ref = erlang:make_ref()},
+    Worker0 = #shard{ref = make_ref()},
+    Worker1 = #shard{ref = make_ref()},
+    Worker2 = #shard{ref = make_ref()},
     Workers = [Worker0, Worker1, Worker2],
     Acc0 = #acc{workers = Workers, r = 2, replies = []},
 
@@ -426,9 +426,9 @@ t_handle_message_reply(_) ->
     ).
 
 t_store_node_revs(_) ->
-    W1 = #shard{node = w1, ref = erlang:make_ref()},
-    W2 = #shard{node = w2, ref = erlang:make_ref()},
-    W3 = #shard{node = w3, ref = erlang:make_ref()},
+    W1 = #shard{node = w1, ref = make_ref()},
+    W2 = #shard{node = w2, ref = make_ref()},
+    W3 = #shard{node = w3, ref = make_ref()},
     Foo1 = {ok, #doc{id = <<"bar">>, revs = {1, [<<"foo">>]}}},
     Foo2 = {ok, #doc{id = <<"bar">>, revs = {2, [<<"foo2">>, <<"foo">>]}}},
     NFM = {not_found, missing},

--- a/src/fabric/src/fabric_doc_open_revs.erl
+++ b/src/fabric/src/fabric_doc_open_revs.erl
@@ -213,7 +213,7 @@ maybe_read_repair(Db, IsTree, Replies, NodeRevs, ReplyCount, DoRepair) ->
         [] ->
             ok;
         _ ->
-            erlang:spawn(fun() -> read_repair(Db, Docs, NodeRevs) end)
+            spawn(fun() -> read_repair(Db, Docs, NodeRevs) end)
     end.
 
 tree_repair_docs(_Replies, false) ->

--- a/src/fabric/src/fabric_doc_purge.erl
+++ b/src/fabric/src/fabric_doc_purge.erl
@@ -558,7 +558,7 @@ create_init_acc(W) ->
     % about any hashing here.
     WorkerUUIDs = lists:map(
         fun(Shard) ->
-            {Shard#shard{ref = erlang:make_ref()}, [UUID1, UUID2]}
+            {Shard#shard{ref = make_ref()}, [UUID1, UUID2]}
         end,
         Shards
     ),

--- a/src/fabric/src/fabric_rpc.erl
+++ b/src/fabric/src/fabric_rpc.erl
@@ -364,7 +364,7 @@ compact(ShardName, DesignName) ->
     {ok, Pid} = couch_index_server:get_index(
         couch_mrview_index, ShardName, <<"_design/", DesignName/binary>>
     ),
-    Ref = erlang:make_ref(),
+    Ref = make_ref(),
     Pid ! {'$gen_call', {self(), Ref}, compact}.
 
 get_uuid(DbName) ->
@@ -493,7 +493,7 @@ get_node_seqs(Db, Nodes) ->
                 PurgeSeq = couch_util:get_value(<<"purge_seq">>, Props),
                 case lists:keyfind(TgtNode, 1, Acc) of
                     {_, OldSeq} ->
-                        NewSeq = erlang:max(OldSeq, PurgeSeq),
+                        NewSeq = max(OldSeq, PurgeSeq),
                         NewEntry = {TgtNode, NewSeq},
                         NewAcc = lists:keyreplace(TgtNode, 1, Acc, NewEntry),
                         {ok, NewAcc};
@@ -661,7 +661,7 @@ make_att_reader({follows, Parser, Ref}) when is_pid(Parser) ->
                 % First time encountering a particular parser pid. Monitor it,
                 % in case it dies, and notify it about us, so it could monitor
                 % us in case we die.
-                PRef = erlang:monitor(process, Parser),
+                PRef = monitor(process, Parser),
                 put({mp_parser_ref, Parser}, PRef),
                 Parser ! {hello_from_writer, Ref, WriterPid},
                 PRef;

--- a/src/fabric/src/fabric_streams.erl
+++ b/src/fabric/src/fabric_streams.erl
@@ -198,7 +198,7 @@ spawn_worker_cleaner(Coordinator, Workers, ClientReq) when
     case get(?WORKER_CLEANER) of
         undefined ->
             Pid = spawn(fun() ->
-                erlang:monitor(process, Coordinator),
+                monitor(process, Coordinator),
                 NodeRefSet = couch_util:set_from_list(shards_to_node_refs(Workers)),
                 cleaner_loop(Coordinator, NodeRefSet, ClientReq)
             end),
@@ -269,7 +269,7 @@ should_clean_workers(_) ->
         end
     end),
     Cleaner = spawn_worker_cleaner(Coord, Workers, undefined),
-    Ref = erlang:monitor(process, Cleaner),
+    Ref = monitor(process, Cleaner),
     Coord ! die,
     receive
         {'DOWN', Ref, _, Cleaner, _} -> ok
@@ -289,7 +289,7 @@ does_not_fire_if_cleanup_called(_) ->
         end
     end),
     Cleaner = spawn_worker_cleaner(Coord, Workers, undefined),
-    Ref = erlang:monitor(process, Cleaner),
+    Ref = monitor(process, Cleaner),
     cleanup(Workers),
     Coord ! die,
     receive
@@ -312,7 +312,7 @@ should_clean_additional_worker_too(_) ->
     end),
     Cleaner = spawn_worker_cleaner(Coord, Workers, undefined),
     add_worker_to_cleaner(Coord, #shard{node = 'n2', ref = make_ref()}),
-    Ref = erlang:monitor(process, Cleaner),
+    Ref = monitor(process, Cleaner),
     Coord ! die,
     receive
         {'DOWN', Ref, _, Cleaner, _} -> ok
@@ -337,7 +337,7 @@ coordinator_is_killed_if_client_disconnects(_) ->
     % Close the socket and then expect coordinator to be killed
     ok = gen_tcp:close(Sock),
     Cleaner = spawn_worker_cleaner(Coord, Workers, ClientReq),
-    CleanerRef = erlang:monitor(process, Cleaner),
+    CleanerRef = monitor(process, Cleaner),
     % Assert the correct behavior on the support platforms (all except Windows so far)
     case os:type() of
         {unix, Type} when
@@ -378,7 +378,7 @@ coordinator_is_not_killed_if_client_is_connected(_) ->
     {ok, Sock} = gen_tcp:listen(0, [{active, false}]),
     ClientReq = mochiweb_request:new(Sock, 'GET', "/foo", {1, 1}, Headers),
     Cleaner = spawn_worker_cleaner(Coord, Workers, ClientReq),
-    CleanerRef = erlang:monitor(process, Cleaner),
+    CleanerRef = monitor(process, Cleaner),
     % Coordinator should stay up
     receive
         {'DOWN', CoordRef, _, Coord, _} ->
@@ -430,7 +430,7 @@ submit_jobs_sets_up_cleaner(_) ->
     meck:wait(2, rexi, cast_ref, '_', 1000),
     % If we kill the coordinator, the cleaner should kill the workers
     meck:reset(rexi),
-    CleanupMon = erlang:monitor(process, Cleaner),
+    CleanupMon = monitor(process, Cleaner),
     exit(Coord, kill),
     receive
         {'DOWN', CoordRef, _, _, WorkerReason} ->

--- a/src/fabric/src/fabric_view_all_docs.erl
+++ b/src/fabric/src/fabric_view_all_docs.erl
@@ -239,7 +239,7 @@ handle_message({meta, Meta0}, {Worker, From}, State) ->
             FinalOffset =
                 case Offset of
                     null -> null;
-                    _ -> erlang:min(Total, Offset + State#collector.skip)
+                    _ -> min(Total, Offset + State#collector.skip)
                 end,
             Meta =
                 [{total, Total}, {offset, FinalOffset}] ++
@@ -373,7 +373,7 @@ cancel_read_pids(Pids) ->
     case queue:out(Pids) of
         {{value, {Pid, Ref}}, RestPids} ->
             exit(Pid, kill),
-            erlang:demonitor(Ref, [flush]),
+            demonitor(Ref, [flush]),
             cancel_read_pids(RestPids);
         {empty, _} ->
             ok

--- a/src/fabric/src/fabric_view_map.erl
+++ b/src/fabric/src/fabric_view_map.erl
@@ -181,7 +181,7 @@ handle_message({meta, Meta0}, {Worker, From}, State) ->
                 offset = Offset
             }};
         false ->
-            FinalOffset = erlang:min(Total, Offset + State#collector.skip),
+            FinalOffset = min(Total, Offset + State#collector.skip),
             Meta =
                 [{total, Total}, {offset, FinalOffset}] ++
                     case UpdateSeq of

--- a/src/fabric/test/eunit/fabric_moved_shards_seq_tests.erl
+++ b/src/fabric/test/eunit/fabric_moved_shards_seq_tests.erl
@@ -39,7 +39,7 @@ t_shard_moves_avoid_sequence_rewinds(_) ->
     ok = fabric:create_db(DbName, [{q, 1}, {n, 1}]),
     lists:foreach(
         fun(I) ->
-            update_doc(DbName, #doc{id = erlang:integer_to_binary(I)})
+            update_doc(DbName, #doc{id = integer_to_binary(I)})
         end,
         lists:seq(1, DocCnt)
     ),

--- a/src/fabric/test/eunit/fabric_rpc_purge_tests.erl
+++ b/src/fabric/test/eunit/fabric_rpc_purge_tests.erl
@@ -257,7 +257,7 @@ rpc_update_doc(DbName, Doc) ->
     rpc_update_doc(DbName, Doc, [RROpt]).
 
 rpc_update_doc(DbName, Doc, Opts) ->
-    Ref = erlang:make_ref(),
+    Ref = make_ref(),
     put(rexi_from, {self(), Ref}),
     fabric_rpc:update_docs(DbName, [Doc], Opts),
     Reply = test_util:wait(fun() ->

--- a/src/global_changes/src/global_changes_server.erl
+++ b/src/global_changes/src/global_changes_server.erl
@@ -69,7 +69,7 @@ init([]) ->
         pending_updates = couch_util:new_set(),
         max_write_delay = MaxWriteDelay,
         dbname = GlobalChangesDbName,
-        handler_ref = erlang:monitor(process, Handler)
+        handler_ref = monitor(process, Handler)
     },
     {ok, State}.
 
@@ -122,7 +122,7 @@ handle_info(flush_updates, State) ->
 handle_info(start_listener, State) ->
     {ok, Handler} = global_changes_listener:start(),
     NewState = State#state{
-        handler_ref = erlang:monitor(process, Handler)
+        handler_ref = monitor(process, Handler)
     },
     {noreply, NewState};
 handle_info({'DOWN', Ref, _, _, Reason}, #state{handler_ref = Ref} = State) ->

--- a/src/ioq/src/ioq.erl
+++ b/src/ioq/src/ioq.erl
@@ -146,7 +146,7 @@ handle_cast(_Msg, State) ->
 handle_info({Ref, Reply}, State) ->
     case lists:keytake(Ref, #request.ref, State#state.running) of
         {value, Request, Remaining} ->
-            erlang:demonitor(Ref, [flush]),
+            demonitor(Ref, [flush]),
             gen_server:reply(Request#request.from, Reply),
             {noreply, State#state{running = Remaining}, 0};
         false ->
@@ -225,6 +225,6 @@ choose_next_request(Index, State) ->
     end.
 
 submit_request(#request{} = Request, #state{} = State) ->
-    Ref = erlang:monitor(process, Request#request.fd),
+    Ref = monitor(process, Request#request.fd),
     Request#request.fd ! {'$gen_call', {self(), Ref}, Request#request.msg},
     State#state{running = [Request#request{ref = Ref} | State#state.running]}.

--- a/src/ken/src/ken_server.erl
+++ b/src/ken/src/ken_server.erl
@@ -148,7 +148,7 @@ handle_cast({resubmit, DbName}, State) ->
 % st index job names have 3 elements, 3rd being 'hastings'. See job record definition.
 handle_cast({trigger_update, #job{name = {_, _, hastings}, server = GPid, seq = Seq} = Job}, State) ->
     % hastings_index:await will trigger a hastings index update
-    {Pid, _} = erlang:spawn_monitor(
+    {Pid, _} = spawn_monitor(
         hastings_index,
         await,
         [GPid, Seq]
@@ -158,7 +158,7 @@ handle_cast({trigger_update, #job{name = {_, _, hastings}, server = GPid, seq = 
     {noreply, State, 0};
 handle_cast({trigger_update, #job{name = {_, Index, nouveau}} = Job}, State) ->
     % nouveau_index_manager:update_index will trigger a search index update.
-    {Pid, _} = erlang:spawn_monitor(
+    {Pid, _} = spawn_monitor(
         nouveau_index_manager,
         update_index,
         [Index]
@@ -169,7 +169,7 @@ handle_cast({trigger_update, #job{name = {_, Index, nouveau}} = Job}, State) ->
 % search index job names have 3 elements. See job record definition.
 handle_cast({trigger_update, #job{name = {_, _, _}, server = GPid, seq = Seq} = Job}, State) ->
     % dreyfus_index:await will trigger a search index update.
-    {Pid, _} = erlang:spawn_monitor(
+    {Pid, _} = spawn_monitor(
         dreyfus_index,
         await,
         [GPid, Seq]
@@ -179,7 +179,7 @@ handle_cast({trigger_update, #job{name = {_, _, _}, server = GPid, seq = Seq} = 
     {noreply, State, 0};
 handle_cast({trigger_update, #job{name = {_, _}, server = SrvPid, seq = Seq} = Job}, State) ->
     % couch_index:get_state/2 will trigger a view group index update.
-    {Pid, _} = erlang:spawn_monitor(couch_index, get_state, [SrvPid, Seq]),
+    {Pid, _} = spawn_monitor(couch_index, get_state, [SrvPid, Seq]),
     Now = erlang:monotonic_time(),
     ets:insert(ken_workers, Job#job{worker_pid = Pid, lru = Now}),
     {noreply, State, 0};

--- a/src/ken/test/ken_server_test.erl
+++ b/src/ken/test/ken_server_test.erl
@@ -79,7 +79,7 @@ start_server(Module, Config) ->
 
 stop_server(Key, Cfg) ->
     {Key, Pid} = lists:keyfind(Key, 1, Cfg),
-    MRef = erlang:monitor(process, Pid),
+    MRef = monitor(process, Pid),
     true = exit(Pid, kill),
     receive
         {'DOWN', MRef, _, _, _} -> ok

--- a/src/mango/src/mango_cursor_nouveau.erl
+++ b/src/mango/src/mango_cursor_nouveau.erl
@@ -49,7 +49,7 @@ create(Db, {Indexes, Trace}, Selector, Opts) ->
         end,
 
     NouveauLimit = get_nouveau_limit(),
-    Limit = erlang:min(NouveauLimit, couch_util:get_value(limit, Opts, mango_opts:default_limit())),
+    Limit = min(NouveauLimit, couch_util:get_value(limit, Opts, mango_opts:default_limit())),
     Skip = couch_util:get_value(skip, Opts, 0),
     Fields = couch_util:get_value(fields, Opts, all_fields),
 
@@ -297,7 +297,7 @@ update_query_args(CAcc) ->
     }.
 
 get_limit(CAcc) ->
-    erlang:min(get_nouveau_limit(), CAcc#cacc.limit + CAcc#cacc.skip).
+    min(get_nouveau_limit(), CAcc#cacc.limit + CAcc#cacc.skip).
 
 get_nouveau_limit() ->
     config:get_integer("nouveau", "max_limit", 200).

--- a/src/mango/src/mango_cursor_text.erl
+++ b/src/mango/src/mango_cursor_text.erl
@@ -55,7 +55,7 @@ create(Db, {Indexes, Trace}, Selector, Opts0) ->
     Stats = mango_execution_stats:stats_init(DbName),
 
     DreyfusLimit = get_dreyfus_limit(),
-    Limit = erlang:min(DreyfusLimit, couch_util:get_value(limit, Opts, mango_opts:default_limit())),
+    Limit = min(DreyfusLimit, couch_util:get_value(limit, Opts, mango_opts:default_limit())),
     Skip = couch_util:get_value(skip, Opts, 0),
     Fields = couch_util:get_value(fields, Opts, all_fields),
 
@@ -327,7 +327,7 @@ update_query_args(CAcc) ->
     }.
 
 get_limit(CAcc) ->
-    erlang:min(get_dreyfus_limit(), CAcc#cacc.limit + CAcc#cacc.skip).
+    min(get_dreyfus_limit(), CAcc#cacc.limit + CAcc#cacc.skip).
 
 get_dreyfus_limit() ->
     config:get_integer("dreyfus", "max_limit", 200).

--- a/src/mango/src/mango_idx_special.erl
+++ b/src/mango/src/mango_idx_special.erl
@@ -28,16 +28,16 @@
 -include("mango.hrl").
 
 validate(_) ->
-    erlang:exit(invalid_call).
+    exit(invalid_call).
 
 add(_, _) ->
-    erlang:exit(invalid_call).
+    exit(invalid_call).
 
 remove(_, _) ->
-    erlang:exit(invalid_call).
+    exit(invalid_call).
 
 from_ddoc(_) ->
-    erlang:exit(invalid_call).
+    exit(invalid_call).
 
 to_json(#idx{def = all_docs}) ->
     {[

--- a/src/mango/src/mango_native_proc.erl
+++ b/src/mango/src/mango_native_proc.erl
@@ -98,7 +98,7 @@ handle_call(Msg, _From, St) ->
     {stop, {invalid_call, Msg}, {invalid_call, Msg}, St}.
 
 handle_cast(garbage_collect, St) ->
-    erlang:garbage_collect(),
+    garbage_collect(),
     {noreply, St};
 handle_cast(stop, St) ->
     {stop, normal, St};

--- a/src/mango/src/mango_util.erl
+++ b/src/mango/src/mango_util.erl
@@ -114,7 +114,7 @@ load_ddoc(Db, DDocId, DbOpts) ->
     end.
 
 defer(Mod, Fun, Args) ->
-    {Pid, Ref} = erlang:spawn_monitor(?MODULE, do_defer, [Mod, Fun, Args]),
+    {Pid, Ref} = spawn_monitor(?MODULE, do_defer, [Mod, Fun, Args]),
     receive
         {'DOWN', Ref, process, Pid, {mango_defer_ok, Value}} ->
             Value;
@@ -123,23 +123,23 @@ defer(Mod, Fun, Args) ->
         {'DOWN', Ref, process, Pid, {mango_defer_error, Value}} ->
             error(Value);
         {'DOWN', Ref, process, Pid, {mango_defer_exit, Value}} ->
-            erlang:exit(Value)
+            exit(Value)
     end.
 
 do_defer(Mod, Fun, Args) ->
-    try erlang:apply(Mod, Fun, Args) of
+    try apply(Mod, Fun, Args) of
         Resp ->
-            erlang:exit({mango_defer_ok, Resp})
+            exit({mango_defer_ok, Resp})
     catch
         throw:Error:Stack ->
             couch_log:error("Defered error: ~w~n    ~p", [{throw, Error}, Stack]),
-            erlang:exit({mango_defer_throw, Error});
+            exit({mango_defer_throw, Error});
         error:Error:Stack ->
             couch_log:error("Defered error: ~w~n    ~p", [{error, Error}, Stack]),
-            erlang:exit({mango_defer_error, Error});
+            exit({mango_defer_error, Error});
         exit:Error:Stack ->
             couch_log:error("Defered error: ~w~n    ~p", [{exit, Error}, Stack]),
-            erlang:exit({mango_defer_exit, Error})
+            exit({mango_defer_exit, Error})
     end.
 
 assert_ejson({Props}) ->

--- a/src/mem3/src/mem3.erl
+++ b/src/mem3/src/mem3.erl
@@ -74,7 +74,7 @@ restart() ->
     ].
 compare_nodelists() ->
     Nodes = mem3:nodes(),
-    AllNodes = erlang:nodes([this, visible]),
+    AllNodes = nodes([this, visible]),
     {Replies, BadNodes} = gen_server:multi_call(Nodes, mem3_nodes, get_nodelist),
     Dict = lists:foldl(
         fun({Node, Nodelist}, D) ->
@@ -473,7 +473,7 @@ gather_ping_results(Refs, Until, Results) ->
             end;
         false ->
             Fun = fun(Ref, true, Acc) ->
-                erlang:demonitor(Ref, [flush]),
+                demonitor(Ref, [flush]),
                 Acc#{Ref => timeout}
             end,
             maps:fold(Fun, Results, Refs)

--- a/src/mem3/src/mem3_hash.erl
+++ b/src/mem3/src/mem3_hash.erl
@@ -36,7 +36,7 @@ calculate(Props, DocId) when is_list(Props) ->
     MFA = get_hash_fun(Props),
     calculate(MFA, DocId);
 calculate({Mod, Fun, Args}, DocId) ->
-    erlang:apply(Mod, Fun, [DocId | Args]).
+    apply(Mod, Fun, [DocId | Args]).
 
 get_hash_fun(#shard{dbname = DbName}) ->
     get_hash_fun(DbName);

--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -435,7 +435,7 @@ push_purges(Db, BatchSize, SrcShard, Tgt, HashFun) ->
                 couch_util:get_value(<<"purge_seq">>, Props);
             {not_found, _} ->
                 Oldest = couch_db:get_oldest_purge_seq(Db),
-                erlang:max(0, Oldest - 1)
+                max(0, Oldest - 1)
         end,
     BelongsFun = fun(Id) when is_binary(Id) ->
         case TgtRange of

--- a/src/mem3/src/mem3_reshard.erl
+++ b/src/mem3/src/mem3_reshard.erl
@@ -512,7 +512,7 @@ kill_job_int(#job{pid = undefined} = Job) ->
 kill_job_int(#job{pid = Pid, ref = Ref} = Job) ->
     couch_log:info("~p kill_job_int ~p", [?MODULE, jobfmt(Job)]),
     demonitor(Ref, [flush]),
-    case erlang:is_process_alive(Pid) of
+    case is_process_alive(Pid) of
         true ->
             ok = mem3_reshard_job_sup:terminate_child(Pid);
         false ->
@@ -799,7 +799,7 @@ db_exists(Name) ->
 -spec db_monitor(pid()) -> no_return().
 db_monitor(Server) ->
     couch_log:notice("~p db monitor ~p starting", [?MODULE, self()]),
-    EvtRef = erlang:monitor(process, couch_event_server),
+    EvtRef = monitor(process, couch_event_server),
     couch_event:register_all(self()),
     db_monitor_loop(Server, EvtRef).
 

--- a/src/mem3/src/mem3_rpc.erl
+++ b/src/mem3/src/mem3_rpc.erl
@@ -197,7 +197,7 @@ load_purge_infos_rpc(DbName, SrcUUID, BatchSize) ->
                         couch_util:get_value(<<"purge_seq">>, Props);
                     {not_found, _} ->
                         Oldest = couch_db:get_oldest_purge_seq(Db),
-                        erlang:max(0, Oldest - 1)
+                        max(0, Oldest - 1)
                 end,
             FoldFun = fun({PSeq, UUID, Id, Revs}, {Count, Infos, _}) ->
                 NewCount = Count + length(Revs),
@@ -265,7 +265,7 @@ compare_rev_epochs([{_, SourceSeq} | _], []) ->
     SourceSeq;
 compare_rev_epochs([{_, SourceSeq} | _], [{_, TargetSeq} | _]) ->
     % The source was moved to a new location independently, take the minimum
-    erlang:min(SourceSeq, TargetSeq) - 1.
+    min(SourceSeq, TargetSeq) - 1.
 
 %% @doc This adds a new update sequence checkpoint to the replication
 %%      history. Checkpoints are keyed by the source node so that we

--- a/src/mem3/src/mem3_sync_event_listener.erl
+++ b/src/mem3/src/mem3_sync_event_listener.erl
@@ -240,7 +240,7 @@ teardown_all(_) ->
 
 setup() ->
     {ok, Pid} = ?MODULE:start_link(),
-    erlang:unlink(Pid),
+    unlink(Pid),
     wait_config_subscribed(Pid),
     Pid.
 
@@ -300,7 +300,7 @@ should_terminate(Pid) ->
         EventMgr = whereis(config_event),
         EventMgrWasAlive = (catch is_process_alive(EventMgr)),
 
-        Ref = erlang:monitor(process, Pid),
+        Ref = monitor(process, Pid),
 
         RestartFun = fun() -> exit(EventMgr, kill) end,
         {_, _} = test_util:with_process_restart(config_event, RestartFun),

--- a/src/mem3/src/mem3_sync_security.erl
+++ b/src/mem3/src/mem3_sync_security.erl
@@ -20,7 +20,7 @@
 maybe_sync(#shard{} = Src, #shard{} = Dst) ->
     case is_local(Src#shard.name) of
         false ->
-            erlang:spawn(?MODULE, maybe_sync_int, [Src, Dst]);
+            spawn(?MODULE, maybe_sync_int, [Src, Dst]);
         true ->
             ok
     end.

--- a/src/mem3/test/eunit/mem3_rep_test.erl
+++ b/src/mem3/test/eunit/mem3_rep_test.erl
@@ -209,7 +209,7 @@ get_all_docs(DbName) ->
     get_all_docs(DbName, #mrargs{}).
 
 get_all_docs(DbName, #mrargs{} = QArgs0) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(
         fun() ->
             Cb = fun
@@ -235,11 +235,11 @@ to_map({[_ | _]} = EJson) ->
     jiffy:decode(jiffy:encode(EJson), [return_maps]).
 
 create_db(DbName, Opts) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:create_db(DbName, Opts) end, GL).
 
 delete_db(DbName) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:delete_db(DbName, [?ADMIN_CTX]) end, GL).
 
 create_local_db(DbName) ->
@@ -259,7 +259,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
     {Pid, Ref} = spawn_monitor(fun() ->
         case GroupLeader of
             undefined -> ok;
-            _ -> erlang:group_leader(GroupLeader, self())
+            _ -> group_leader(GroupLeader, self())
         end,
         exit({with_proc_res, Fun()})
     end),
@@ -269,7 +269,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
         {'DOWN', Ref, process, Pid, Error} ->
             error(Error)
     after Timeout ->
-        erlang:demonitor(Ref, [flush]),
+        demonitor(Ref, [flush]),
         exit(Pid, kill),
         error({with_proc_timeout, Fun, Timeout})
     end.

--- a/src/mem3/test/eunit/mem3_reshard_changes_feed_test.erl
+++ b/src/mem3/test/eunit/mem3_reshard_changes_feed_test.erl
@@ -295,11 +295,11 @@ changes_callback({stop, EndSeq, _Pending}, Acc) ->
 %% common helpers from here
 
 create_db(DbName, Opts) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:create_db(DbName, Opts) end, GL).
 
 delete_db(DbName) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:delete_db(DbName, [?ADMIN_CTX]) end, GL).
 
 with_proc(Fun) ->
@@ -312,7 +312,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
     {Pid, Ref} = spawn_monitor(fun() ->
         case GroupLeader of
             undefined -> ok;
-            _ -> erlang:group_leader(GroupLeader, self())
+            _ -> group_leader(GroupLeader, self())
         end,
         exit({with_proc_res, Fun()})
     end),
@@ -322,7 +322,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
         {'DOWN', Ref, process, Pid, Error} ->
             error(Error)
     after Timeout ->
-        erlang:demonitor(Ref, [flush]),
+        demonitor(Ref, [flush]),
         exit(Pid, kill),
         error({with_proc_timeout, Fun, Timeout})
     end.

--- a/src/mem3/test/eunit/mem3_reshard_test.erl
+++ b/src/mem3/test/eunit/mem3_reshard_test.erl
@@ -851,7 +851,7 @@ get_all_docs(DbName) ->
     get_all_docs(DbName, #mrargs{}).
 
 get_all_docs(DbName, #mrargs{} = QArgs0) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(
         fun() ->
             Cb = fun
@@ -913,11 +913,11 @@ to_map({[_ | _]} = EJson) ->
     jiffy:decode(jiffy:encode(EJson), [return_maps]).
 
 create_db(DbName, Opts) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:create_db(DbName, Opts) end, GL).
 
 delete_db(DbName) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:delete_db(DbName, [?ADMIN_CTX]) end, GL).
 
 with_proc(Fun) ->
@@ -930,7 +930,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
     {Pid, Ref} = spawn_monitor(fun() ->
         case GroupLeader of
             undefined -> ok;
-            _ -> erlang:group_leader(GroupLeader, self())
+            _ -> group_leader(GroupLeader, self())
         end,
         exit({with_proc_res, Fun()})
     end),
@@ -940,7 +940,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
         {'DOWN', Ref, process, Pid, Error} ->
             error(Error)
     after Timeout ->
-        erlang:demonitor(Ref, [flush]),
+        demonitor(Ref, [flush]),
         exit(Pid, kill),
         error({with_proc_timeout, Fun, Timeout})
     end.

--- a/src/mem3/test/eunit/mem3_shards_test.erl
+++ b/src/mem3/test/eunit/mem3_shards_test.erl
@@ -110,11 +110,11 @@ is_partitioned(Db) ->
     couch_db:is_partitioned(Db).
 
 create_db(DbName, Opts) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:create_db(DbName, Opts) end, GL).
 
 delete_db(DbName) ->
-    GL = erlang:group_leader(),
+    GL = group_leader(),
     with_proc(fun() -> fabric:delete_db(DbName, [?ADMIN_CTX]) end, GL).
 
 with_proc(Fun) ->
@@ -127,7 +127,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
     {Pid, Ref} = spawn_monitor(fun() ->
         case GroupLeader of
             undefined -> ok;
-            _ -> erlang:group_leader(GroupLeader, self())
+            _ -> group_leader(GroupLeader, self())
         end,
         exit({with_proc_res, Fun()})
     end),
@@ -137,7 +137,7 @@ with_proc(Fun, GroupLeader, Timeout) ->
         {'DOWN', Ref, process, Pid, Error} ->
             error(Error)
     after Timeout ->
-        erlang:demonitor(Ref, [flush]),
+        demonitor(Ref, [flush]),
         exit(Pid, kill),
         error({with_proc_timeout, Fun, Timeout})
     end.

--- a/src/rexi/src/rexi_monitor.erl
+++ b/src/rexi/src/rexi_monitor.erl
@@ -27,7 +27,7 @@ start(Procs) ->
     ),
     spawn_link(fun() ->
         [notify_parent(Parent, P, noconnect) || P <- Skip],
-        [erlang:monitor(process, P) || P <- Mon],
+        [monitor(process, P) || P <- Mon],
         wait_monitors(Parent)
     end).
 

--- a/src/rexi/src/rexi_server.erl
+++ b/src/rexi/src/rexi_server.erl
@@ -206,7 +206,7 @@ notify_caller({Caller, Ref}, Reason) ->
 kill_worker(FromRef, #st{clients = Clients} = St) ->
     case find_worker(FromRef, Clients) of
         #job{worker = KeyRef, worker_pid = Pid} = Job ->
-            erlang:demonitor(KeyRef),
+            demonitor(KeyRef),
             exit(Pid, kill),
             remove_job(Job, St),
             ok;

--- a/src/rexi/src/rexi_utils.erl
+++ b/src/rexi/src/rexi_utils.erl
@@ -38,7 +38,7 @@ send(Dest, Msg) ->
 recv(Refs, Keypos, Fun, Acc0, infinity, PerMsgTO) ->
     process_mailbox(Refs, Keypos, Fun, Acc0, nil, PerMsgTO);
 recv(Refs, Keypos, Fun, Acc0, GlobalTimeout, PerMsgTO) ->
-    TimeoutRef = erlang:make_ref(),
+    TimeoutRef = make_ref(),
     TRef = erlang:send_after(GlobalTimeout, self(), {timeout, TimeoutRef}),
     try
         process_mailbox(Refs, Keypos, Fun, Acc0, TimeoutRef, PerMsgTO)

--- a/src/rexi/test/rexi_tests.erl
+++ b/src/rexi/test/rexi_tests.erl
@@ -143,7 +143,7 @@ t_stream2(_) ->
 t_stream2_acks(_) ->
     Ref = rexi:cast(node(), {?MODULE, rpc_test_fun, [stream2_acks]}),
     {WPid, _Tag} = From = stream_init(Ref),
-    Mon = erlang:monitor(process, WPid),
+    Mon = monitor(process, WPid),
     rexi:stream_start(From),
     ?assertEqual(a, recv(Ref)),
     ?assertEqual(b, recv(Ref)),
@@ -168,7 +168,7 @@ t_stream2_acks(_) ->
 t_stream2_cancel(_) ->
     Ref = rexi:cast(node(), {?MODULE, rpc_test_fun, [stream2_init]}),
     {WPid, _Tag} = From = stream_init(Ref),
-    Mon = erlang:monitor(process, WPid),
+    Mon = monitor(process, WPid),
     rexi:stream_cancel(From),
     Res =
         receive

--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -169,8 +169,8 @@ handle_info({Ref, {ok, Pid}}, #state{} = State) when is_reference(Ref) ->
             LogMsg = "~s: Started compaction for ~s",
             LogArgs = [Name, smoosh_utils:stringify(Key)],
             couch_log:Level(LogMsg, LogArgs),
-            erlang:monitor(process, Pid),
-            erlang:demonitor(Ref, [flush]),
+            monitor(process, Pid),
+            demonitor(Ref, [flush]),
             Active1 = Active#{Key => Pid},
             State1 = State#state{active = Active1, starting = Starting1},
             {noreply, set_status(State1)};
@@ -350,7 +350,7 @@ start_compact(#state{} = State, {Shard, GroupId} = Key) ->
             case couch_index_server:get_index(couch_mrview_index, Shard, GroupId) of
                 {ok, Pid} ->
                     schedule_cleanup_index_files(Shard),
-                    Ref = erlang:monitor(process, Pid),
+                    Ref = monitor(process, Pid),
                     Pid ! {'$gen_call', {self(), Ref}, compact},
                     State#state{starting = Starting#{Ref => Key}};
                 Error ->
@@ -370,12 +370,12 @@ start_compact(#state{} = State, Db) ->
             case couch_db:get_compactor_pid(Db) of
                 nil ->
                     DbPid = couch_db:get_pid(Db),
-                    Ref = erlang:monitor(process, DbPid),
+                    Ref = monitor(process, DbPid),
                     DbPid ! {'$gen_call', {self(), Ref}, start_compact},
                     State#state{starting = Starting#{Ref => Key}};
                 % Compaction is already running, so monitor existing compaction pid.
                 CPid when is_pid(CPid) ->
-                    erlang:monitor(process, CPid),
+                    monitor(process, CPid),
                     Level = smoosh_utils:log_level("compaction_log_level", "notice"),
                     LogMsg = "~s : db ~s continuing compaction",
                     LogArgs = [Name, smoosh_utils:stringify(Key)],
@@ -398,7 +398,7 @@ maybe_remonitor_cpid(#state{} = State, DbName, Reason) when is_binary(DbName) ->
                     re_enqueue(DbName),
                     State;
                 CPid when is_pid(CPid) ->
-                    erlang:monitor(process, CPid),
+                    monitor(process, CPid),
                     Level = smoosh_utils:log_level("compaction_log_level", "notice"),
                     LogMsg = "~s: ~s compaction already running. Re-monitor Pid ~p",
                     LogArgs = [Name, smoosh_utils:stringify(DbName), CPid],

--- a/src/smoosh/test/smoosh_tests.erl
+++ b/src/smoosh/test/smoosh_tests.erl
@@ -183,17 +183,17 @@ t_suspend_resume(DbName) ->
     ok = wait_to_enqueue(DbName),
     CompPid = wait_db_compactor_pid(),
     ok = smoosh:suspend(),
-    ?assertEqual({status, suspended}, erlang:process_info(CompPid, status)),
+    ?assertEqual({status, suspended}, process_info(CompPid, status)),
     ?assertEqual({1, 0, 0}, sync_status("ratio_dbs")),
     % Suspending twice should work too
     ok = smoosh:suspend(),
-    ?assertEqual({status, suspended}, erlang:process_info(CompPid, status)),
+    ?assertEqual({status, suspended}, process_info(CompPid, status)),
     ?assertEqual({1, 0, 0}, sync_status("ratio_dbs")),
     ok = smoosh:resume(),
-    ?assertNotEqual({status, suspended}, erlang:process_info(CompPid, status)),
+    ?assertNotEqual({status, suspended}, process_info(CompPid, status)),
     % Resuming twice should work too
     ok = smoosh:resume(),
-    ?assertNotEqual({status, suspended}, erlang:process_info(CompPid, status)),
+    ?assertNotEqual({status, suspended}, process_info(CompPid, status)),
     CompPid ! continue,
     wait_compacted(DbName).
 
@@ -205,7 +205,7 @@ t_check_window_can_resume(DbName) ->
     ok = wait_to_enqueue(DbName),
     CompPid = wait_db_compactor_pid(),
     ok = smoosh:suspend(),
-    ?assertEqual({status, suspended}, erlang:process_info(CompPid, status)),
+    ?assertEqual({status, suspended}, process_info(CompPid, status)),
     get_channel_pid("ratio_dbs") ! check_window,
     CompPid ! continue,
     wait_compacted(DbName).
@@ -252,7 +252,7 @@ t_checkpointing_works(DbName) ->
     checkpoint(),
     % Stop smoosh and then crash the compaction
     ok = application:stop(smoosh),
-    Ref = erlang:monitor(process, CompPid),
+    Ref = monitor(process, CompPid),
     CompPid ! {raise, exit, kapow},
     receive
         {'DOWN', Ref, _, _, kapow} ->
@@ -276,7 +276,7 @@ t_ignore_checkpoint_resume_if_compacted_already(DbName) ->
     checkpoint(),
     % Stop smoosh and then let the compaction finish
     ok = application:stop(smoosh),
-    Ref = erlang:monitor(process, CompPid),
+    Ref = monitor(process, CompPid),
     CompPid ! continue,
     receive
         {'DOWN', Ref, _, _, normal} -> ok

--- a/src/weatherreport/src/weatherreport_check_mem3_sync.erl
+++ b/src/weatherreport/src/weatherreport_check_mem3_sync.erl
@@ -43,7 +43,7 @@ valid() ->
 
 -spec check(list()) -> [{atom(), term()}].
 check(_Opts) ->
-    case erlang:whereis(mem3_sync) of
+    case whereis(mem3_sync) of
         undefined ->
             [{warning, mem3_sync_not_found}];
         Pid ->

--- a/src/weatherreport/src/weatherreport_check_node_stats.erl
+++ b/src/weatherreport/src/weatherreport_check_node_stats.erl
@@ -60,7 +60,7 @@ mean_to_message({Statistic, Mean}) ->
 -spec check(list()) -> [{atom(), term()}].
 check(_Opts) ->
     SumOfStats = recon:node_stats(?SAMPLES, 100, fun sum_absolute_stats/2, []),
-    MeanStats = [{K, erlang:round(V / ?SAMPLES)} || {K, V} <- SumOfStats],
+    MeanStats = [{K, round(V / ?SAMPLES)} || {K, V} <- SumOfStats],
     lists:map(fun mean_to_message/1, MeanStats).
 
 -spec format(term()) -> {io:format(), [term()]}.

--- a/src/weatherreport/src/weatherreport_check_nodes_connected.erl
+++ b/src/weatherreport/src/weatherreport_check_nodes_connected.erl
@@ -50,7 +50,7 @@ valid() ->
 -spec check(list()) -> [{atom(), term()}].
 check(_Opts) ->
     NodeName = node(),
-    ConnectedNodes = [NodeName | erlang:nodes()],
+    ConnectedNodes = [NodeName | nodes()],
     Members = mem3:nodes(),
     [
         {warning, {node_disconnected, N}}

--- a/src/weatherreport/src/weatherreport_check_process_calls.erl
+++ b/src/weatherreport/src/weatherreport_check_process_calls.erl
@@ -62,7 +62,7 @@ fold_processes([{Count, {M, F, A}} | T], Acc, Lim, CallType, Opts) ->
         case proplists:get_value(expert, Opts) of
             true ->
                 PidFun = list_to_atom("find_by_" ++ CallType ++ "_call"),
-                Pids = erlang:apply(recon, PidFun, [M, F]),
+                Pids = apply(recon, PidFun, [M, F]),
                 Pinfos = lists:map(
                     fun(Pid) ->
                         Pinfo = recon:info(Pid),

--- a/src/weatherreport/src/weatherreport_node.erl
+++ b/src/weatherreport/src/weatherreport_node.erl
@@ -75,7 +75,7 @@ local_command(Module, Function, Args, Timeout) ->
                 "Local function call: ~p:~p(~p)",
                 [Module, Function, Args]
             ),
-            erlang:apply(Module, Function, Args);
+            apply(Module, Function, Args);
         _ ->
             weatherreport_log:log(
                 node(),

--- a/src/weatherreport/src/weatherreport_util.erl
+++ b/src/weatherreport/src/weatherreport_util.erl
@@ -54,7 +54,7 @@ run_command(Command) ->
         "Running shell command: ~s",
         [Command]
     ),
-    Port = erlang:open_port({spawn, Command}, [exit_status, stderr_to_stdout]),
+    Port = open_port({spawn, Command}, [exit_status, stderr_to_stdout]),
     do_read(Port, []).
 
 do_read(Port, Acc) ->


### PR DESCRIPTION
Inspired by Jessica's recent commit 12b40b8f1ba974af64c40a02eca080f98ac3677e to clean up `erlang:error` there are a few more auto-imported functions we don't need to use the `erlang` prefix for, so make them local as well.

The benefit is two-fold:
  - Compiler automatically detects typos in these names.
  - Reduces visual clutter a bit.

There is probably no performance benefit as the compiler will internally turn these into `erlang:Fun` calls or directly to BIF calls, like it might do for `length/1`.

The commands used to replace looked like:

```
% git grep -l erlang:is_process_alive | xargs gsed -ri 's|erlang:is_process_alive|is_process_alive|g'
% git grep -l erlang:open_port | xargs gsed -ri 's|erlang:open_port|open_port|g'
...
```

