### PR TITLE
change deleted_document_ttl to match scanner repeat format

### DIFF
--- a/src/couch/test/eunit/couch_auto_purge_plugin_tests.erl
+++ b/src/couch/test/eunit/couch_auto_purge_plugin_tests.erl
@@ -62,7 +62,7 @@ t_no_auto_purge_by_default({_, DbName}) ->
     ok.
 
 t_auto_purge_after_config_ttl({_, DbName}) ->
-    config:set(atom_to_list(?PLUGIN), "deleted_document_ttl", "-1000000", false),
+    config:set(atom_to_list(?PLUGIN), "deleted_document_ttl", "-3_hour", false),
     ok = add_doc(DbName, <<"doc1">>, #{<<"_deleted">> => true}),
     ?assertEqual(1, doc_del_count(DbName)),
     meck:reset(couch_scanner_server),
@@ -73,7 +73,7 @@ t_auto_purge_after_config_ttl({_, DbName}) ->
     ok.
 
 t_auto_purge_after_db_ttl({_, DbName}) ->
-    ok = fabric:set_auto_purge_props(DbName, [{<<"deleted_document_ttl">>, -1000000}]),
+    ok = fabric:set_auto_purge_props(DbName, [{<<"deleted_document_ttl">>, "-3_hour"}]),
     ok = add_doc(DbName, <<"doc1">>, #{<<"_deleted">> => true}),
     ?assertEqual(1, doc_del_count(DbName)),
     meck:reset(couch_scanner_server),

--- a/src/couch_scanner/src/couch_scanner_util.erl
+++ b/src/couch_scanner/src/couch_scanner_util.erl
@@ -22,7 +22,8 @@
     compile_regexes/1,
     match_regexes/2,
     on_first_node/0,
-    consistent_hash_nodes/1
+    consistent_hash_nodes/1,
+    parse_non_weekday_period/1
 ]).
 
 -define(SECOND, 1).

--- a/src/docs/src/api/database/misc.rst
+++ b/src/docs/src/api/database/misc.rst
@@ -373,12 +373,12 @@ following behavior:
         Date: Mon, 22 Sep 2025 11:01:00 GMT
         Server: CouchDB (Erlang/OTP)
 
-        {"deleted_document_ttl": 259200}
+        {"deleted_document_ttl": "3_mon"}
 
 .. http:put:: /{db}/_auto_purge
     :synopsis: Update auto purge settings
 
-    Retrieves the auto purge settings for the database. These settings
+    Updates the auto purge settings for the database. These settings
     are used by the :ref:`auto purge plugin <config/auto_purge_plugin>`.
 
     :param db: Database name
@@ -403,7 +403,7 @@ following behavior:
         Content-Type: application/json
         Host: localhost:5984
 
-        {"deleted_document_ttl": 259200}
+        {"deleted_document_ttl": "3_hour"}
 
     **Response**:
 

--- a/src/docs/src/config/scanner.rst
+++ b/src/docs/src/config/scanner.rst
@@ -256,7 +256,10 @@ settings in their ``[{plugin}]`` section.
 
     .. config:option:: deleted_document_ttl
 
-        Set the default interval, in seconds, before the plugin will purge
-        a deleted document. The database may override this setting with the
+        Set the default interval before the plugin will purge
+        a deleted document. Possible ttl formats are: ``{num}_{timeunit}`` (ex.:
+        ``1000_sec``, ``30_min``, ``8_hours``, ``24_hour``, ``2_days``,
+        ``3_weeks``, ``1_month``).
+        The database may override this setting with the
         :ref:`api/db/auto_purge` endpoint. If neither is set, the
         plugin will not purge deleted documents.


### PR DESCRIPTION
## Overview

Use the scanner repeat format to make deleted_document_ttl easier to use.

## Testing recommendations

covered by tests.

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/5655

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
