### PR TITLE
Tighten the rules for parsing time periods

### DIFF
--- a/src/couch_scanner/src/couch_scanner_util.erl
+++ b/src/couch_scanner/src/couch_scanner_util.erl
@@ -32,6 +32,7 @@
 -define(DAY, 24 * ?HOUR).
 -define(WEEK, 7 * ?DAY).
 -define(MONTH, 30 * ?DAY).
+-define(YEAR, 365 * ?DAY).
 
 new_scan_id() ->
     TSec = integer_to_binary(erlang:system_time(second)),
@@ -241,15 +242,17 @@ parse_non_weekday_period(Period) ->
             undefined
     end.
 
-parse_period_unit(Period) when is_list(Period) ->
-    case Period of
-        "sec" ++ _ -> ?SECOND;
-        "min" ++ _ -> ?MINUTE;
-        "hour" ++ _ -> ?HOUR;
-        "day" ++ _ -> ?DAY;
-        "week" ++ _ -> ?WEEK;
-        "month" ++ _ -> ?MONTH;
-        _ -> undefined
+%% erlfmt-ignore
+parse_period_unit(P) when is_list(P) ->
+    if
+        P == "s";   P == "sec";    P == "second";  P == "seconds" -> ?SECOND;
+        P == "min"; P == "minute"; P == "minutes"                 -> ?MINUTE;
+        P == "h";   P == "hrs";    P == "hour";    P == "hours"   -> ?HOUR;
+        P == "d";   P == "day";    P == "days"                    -> ?DAY;
+        P == "w";   P == "week";   P == "weeks"                   -> ?WEEK;
+        P == "mon"; P == "month";  P == "months"                  -> ?MONTH;
+        P == "y";   P == "year";   P == "years"                   -> ?YEAR;
+        true                                                      -> undefined
     end.
 
 % Logging bits
@@ -298,6 +301,9 @@ parse_after_test() ->
 parse_repeat_test() ->
     ?assertEqual(undefined, parse_repeat("foo")),
     ?assertEqual(undefined, parse_repeat("ReStarT")),
+    ?assertEqual(undefined, parse_repeat("1_ms")),
+    ?assertEqual(undefined, parse_repeat("1_x")),
+    ?assertEqual(undefined, parse_repeat("1_m")),
     ?assertEqual({weekday, 1}, parse_repeat("mon")),
     ?assertEqual({weekday, 1}, parse_repeat("Monday")),
     ?assertEqual({weekday, 2}, parse_repeat("tuesday")),
@@ -307,16 +313,25 @@ parse_repeat_test() ->
     ?assertEqual({weekday, 6}, parse_repeat("sAt")),
     ?assertEqual({weekday, 7}, parse_repeat("sundays")),
     ?assertEqual(1, parse_repeat("1_sec")),
+    ?assertEqual(1, parse_repeat("1_s")),
     ?assertEqual(1, parse_repeat("1_second")),
     ?assertEqual(1, parse_repeat("1_sec")),
     ?assertEqual(2, parse_repeat("2_sec")),
     ?assertEqual(3, parse_repeat("3_seconds")),
     ?assertEqual(60, parse_repeat("1_min")),
+    ?assertEqual(60, parse_repeat("1_minute")),
     ?assertEqual(2 * 60, parse_repeat("2_minutes")),
     ?assertEqual(60 * 60, parse_repeat("1_hour")),
+    ?assertEqual(3 * 60 * 60, parse_repeat("3_hours")),
+    ?assertEqual(2 * 60 * 60, parse_repeat("2_h")),
     ?assertEqual(24 * 60 * 60, parse_repeat("1_day")),
     ?assertEqual(7 * 24 * 60 * 60, parse_repeat("1_week")),
-    ?assertEqual(30 * 24 * 60 * 60, parse_repeat("1_month")).
+    ?assertEqual(2 * 7 * 24 * 60 * 60, parse_repeat("2_weeks")),
+    ?assertEqual(30 * 24 * 60 * 60, parse_repeat("1_month")),
+    ?assertEqual(30 * 24 * 60 * 60, parse_repeat("1_mon")),
+    ?assertEqual(2 * 30 * 24 * 60 * 60, parse_repeat("2_months")),
+    ?assertEqual(365 * 24 * 60 * 60, parse_repeat("1_year")),
+    ?assertEqual(2 * 365 * 24 * 60 * 60, parse_repeat("2_year")).
 
 repeat_period_test() ->
     %Fri, May 31, 2024 16:08:37


### PR DESCRIPTION
These are used by the scanner config setting and for the auto-purge document ttl value. Remove some of the sloppiness such as allowing "secfoo" and "secbar" as "seconds".
