### PR TITLE
Optimize revid parsing: 50-90% faster

### DIFF
--- a/src/couch/src/couch_doc.erl
+++ b/src/couch/src/couch_doc.erl
@@ -189,11 +189,9 @@ from_json_obj(_Other, _) ->
     throw({bad_request, "Document must be a JSON object"}).
 
 parse_revid(RevId) when is_binary(RevId), size(RevId) =:= 32 ->
-    RevInt = binary_to_integer(RevId, 16),
-    <<RevInt:128>>;
+    binary:decode_hex(RevId);
 parse_revid(RevId) when is_list(RevId), length(RevId) =:= 32 ->
-    RevInt = list_to_integer(RevId, 16),
-    <<RevInt:128>>;
+    binary:decode_hex(list_to_binary(RevId));
 parse_revid(RevId) when is_binary(RevId) ->
     RevId;
 parse_revid(RevId) when is_list(RevId) ->


### PR DESCRIPTION
Latest Erlang has `binary:decode_hex/1` which seems to be faster [1] than doing a conversion to bigint and then building a binary from that.

[1] https://gist.github.com/nickva/d43b7ffd9997cd251f4573e2be25abec

Erlang 26, Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz, Debian 11

```
> bench_parse_revid:go().
* N: 10
* b2i + <<_:128>>  : 30
* decode_hex       : 3 (faster pct:90)
* l2i + <<_:128>>  : 8
* l2b + decode_hex : 4 (faster pct:50)
************

* N: 100
* b2i + <<_:128>>  : 54
* decode_hex       : 30 (faster pct:44)
* l2i + <<_:128>>  : 76
* l2b + decode_hex : 45 (faster pct:41)
************

* N: 500
* b2i + <<_:128>>  : 294
* decode_hex       : 159 (faster pct:46)
* l2i + <<_:128>>  : 411
* l2b + decode_hex : 238 (faster pct:42)
************

* N: 1000
* b2i + <<_:128>>  : 582
* decode_hex       : 316 (faster pct:46)
* l2i + <<_:128>>  : 820
* l2b + decode_hex : 465 (faster pct:43)
************

* N: 2500
* b2i + <<_:128>>  : 1472
* decode_hex       : 874 (faster pct:41)
* l2i + <<_:128>>  : 2154
* l2b + decode_hex : 1224 (faster pct:43)
************
```
