### PR TITLE
Increase timeout for `process_response/3` to fix flaky tests

### DIFF
--- a/test/elixir/test/changes_async_test.exs
+++ b/test/elixir/test/changes_async_test.exs
@@ -394,7 +394,7 @@ defmodule ChangesAsyncTest do
     end
   end
 
-  defp process_response(id, chunk_parser, timeout \\ 1000) do
+  defp process_response(id, chunk_parser, timeout \\ 3000) do
     receive do
       %HTTPotion.AsyncChunk{id: ^id} = msg ->
         chunk_parser.(msg)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

`changes_async_test.exs` become unstable when running Elixir tests
with `OTP 27.3.4.3` and `Elixir 1.18.4`. Tests are passing when
running against `OTP 27.3.4.2` and `OTP 27.3.4.1`.

Increate timeout for `process_response/3` to mediate it.


Error log:

```log
[2025-10-13T21:10:06.495Z]   1) test continuous filtered changes with doc ids (ChangesAsyncTest)
[2025-10-13T21:10:06.495Z]      src/couchdb/test/elixir/test/changes_async_test.exs:309
[2025-10-13T21:10:06.495Z]      Expected truthy, got false
[2025-10-13T21:10:06.495Z]      code: assert Enum.member?(changes_ids, "doc3")
[2025-10-13T21:10:06.495Z]      arguments:
[2025-10-13T21:10:06.495Z] 
[2025-10-13T21:10:06.495Z]          # 1
[2025-10-13T21:10:06.495Z]          ["doc1"]
[2025-10-13T21:10:06.495Z] 
[2025-10-13T21:10:06.495Z]          # 2
[2025-10-13T21:10:06.495Z]          "doc3"
[2025-10-13T21:10:06.495Z] 
[2025-10-13T21:10:06.495Z]      stacktrace:
[2025-10-13T21:10:06.495Z]        src/couchdb/test/elixir/test/changes_async_test.exs:338: (test)
```

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
