### PR TITLE
Remove purge max_document_id_number and change max_revisions_number

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -168,11 +168,8 @@ view_index_dir = {{view_index_dir}}
 ;db_btree_cache_depth = 3
 
 [purge]
-; Allowed maximum number of documents in one purge request
-;max_document_id_number = 100
-
 ; Allowed maximum number of accumulated revisions in one purge request
-;max_revisions_number = 1000
+;max_revisions_number = infinity
 
 ; Allowed durations when index is not updated for local purge checkpoint
 ; document. Default is 24 hours.

--- a/src/docs/src/cluster/purging.rst
+++ b/src/docs/src/cluster/purging.rst
@@ -141,10 +141,8 @@ These settings can be updated in the default.ini or local.ini:
 +-----------------------+--------------------------------------------+----------+
 | Field                 | Description                                | Default  |
 +=======================+============================================+==========+
-| max_document_id_number| Allowed maximum number of documents in one | 100      |
-|                       | purge request                              |          |
 +-----------------------+--------------------------------------------+----------+
-| max_revisions_number  | Allowed maximum number of accumulated      | 1000     |
+| max_revisions_number  | Allowed maximum number of accumulated      | infinity |
 |                       | revisions in one purge request             |          |
 +-----------------------+--------------------------------------------+----------+
 | allowed_purge_seq_lag | Beside purged_infos_limit, allowed         | 100      |

--- a/src/docs/src/config/misc.rst
+++ b/src/docs/src/config/misc.rst
@@ -313,26 +313,17 @@ Configuration of Database Purge
 
 .. config:section:: purge :: Configuration of Database Purge
 
-    .. config:option:: max_document_id_number :: Allowed number of documents \
-        per Delete-Request
-
-        .. versionadded:: 3.0
-
-        Sets the maximum number of documents allowed in a single purge request::
-
-            [purge]
-            max_document_id_number = 100
-
     .. config:option:: max_revisions_number :: Allowed number of accumulated \
         revisions per Purge-Request
 
         .. versionadded:: 3.0
+        .. versionchanged:: 3.6
 
         Sets the maximum number of accumulated revisions allowed in a single purge
         request::
 
             [purge]
-            max_revisions_number = 1000
+            max_revisions_number = infinity
 
     .. config:option:: index_lag_warn_seconds :: Allowed duration for purge \
         checkpoint document


### PR DESCRIPTION
 * Remove `max_document_id_number` setting. Purged revisions are already limited via `max_revisions_number` so it's somewhat redundant to also limit them via doc ids. For example, the effect of setting max docs ids = 1000, and max revisions = 500 would be odd since the limits are dependent, and max revisions will limit the max docs ids anyway (unless we discard case of users posting doc ID entries with empty revisions lists). How these limits interact can be confusing so let's have just one of them.

 * Make max_revisions_number unlimited by default. None of the other bulk endpoints like `_bulk_docs` and `_bulk_get` have limits so it's awkward to pick a limit for `_purge`. Depending on hardware environment some systems can handle more than 1000 revisions, some smaller ones might not be able to handle 1000, so let's not pick a default. However still keep the setting around for compatibility, some users may still want limit the revisions if they wants based on their needs.
