### PR TITLE
Docs: Update the /_up endpoint docs to include status response's

### DIFF
--- a/src/docs/src/api/server/common.rst
+++ b/src/docs/src/api/server/common.rst
@@ -2320,7 +2320,15 @@ See :ref:`Configuration of Prometheus Endpoint <config/prometheus>` for details.
 
     Confirms that the server is up, running, and ready to respond to requests.
     If :config:option:`maintenance_mode <couchdb/maintenance_mode>` is
-    ``true`` or ``nolb``, the endpoint will return a 404 response.
+    ``true`` or ``nolb``, the endpoint will return a 404 response. The status field
+    in the response body also changes to reflect the current ``maintenance_mode``
+    defaulting to ``ok``.
+
+    If :config:option:`maintenance_mode <couchdb/maintenance_mode>` is ``true`` the status
+    field is set to ``maintenance_mode``.
+
+    If :config:option:`maintenance_mode <couchdb/maintenance_mode>` is set to ``nolb`` the
+    status field is set to ``nolb``.
 
     :>header Content-Type: :mimetype:`application/json`
     :code 200: Request completed successfully


### PR DESCRIPTION

## Overview
Mention the change in response body when maintenance mode is set to true or nolb.  

## Testing recommendations

## Related Issues or Pull Requests
## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
