### PR TITLE
Improve index cleanup

### DIFF
--- a/src/couch_mrview/src/couch_mrview_cleanup.erl
+++ b/src/couch_mrview/src/couch_mrview_cleanup.erl
@@ -14,11 +14,8 @@
 
 -export([
     run/1,
-    cleanup_purges/3,
-    cleanup_indices/2
+    cleanup/2
 ]).
-
--include_lib("couch/include/couch_db.hrl").
 
 run(Db) ->
     Indices = couch_mrview_util:get_index_files(Db),
@@ -28,15 +25,26 @@ run(Db) ->
     ok = cleanup_purges(Db1, Sigs, Checkpoints),
     ok = cleanup_indices(Sigs, Indices).
 
-cleanup_purges(DbName, Sigs, Checkpoints) when is_binary(DbName) ->
-    couch_util:with_db(DbName, fun(Db) ->
-        cleanup_purges(Db, Sigs, Checkpoints)
-    end);
-cleanup_purges(Db, #{} = Sigs, #{} = CheckpointsMap) ->
-    InactiveMap = maps:without(maps:keys(Sigs), CheckpointsMap),
-    InactiveCheckpoints = maps:values(InactiveMap),
-    DeleteFun = fun(DocId) -> delete_checkpoint(Db, DocId) end,
-    lists:foreach(DeleteFun, InactiveCheckpoints).
+% erpc endpoint for fabric_index_cleanup:cleanup_indexes/2
+%
+cleanup(Dbs, #{} = Sigs) ->
+    try
+        lists:foreach(
+            fun(Db) ->
+                Indices = couch_mrview_util:get_index_files(Db),
+                Checkpoints = couch_mrview_util:get_purge_checkpoints(Db),
+                ok = cleanup_purges(Db, Sigs, Checkpoints),
+                ok = cleanup_indices(Sigs, Indices)
+            end,
+            Dbs
+        )
+    catch
+        error:database_does_not_exist ->
+            ok
+    end.
+
+cleanup_purges(Db, Sigs, Checkpoints) ->
+    couch_index_util:cleanup_purges(Db, Sigs, Checkpoints).
 
 cleanup_indices(#{} = Sigs, #{} = IndexMap) ->
     Fun = fun(_, Files) -> lists:foreach(fun delete_file/1, Files) end,
@@ -52,22 +60,5 @@ delete_file(File) ->
         Tag:Error ->
             ErrLog = "~p : error deleting inactive index file ~s ~p:~p",
             couch_log:error(ErrLog, [?MODULE, File, Tag, Error]),
-            ok
-    end.
-
-delete_checkpoint(Db, DocId) ->
-    DbName = couch_db:name(Db),
-    LogMsg = "~p : deleting inactive purge checkpoint ~s : ~s",
-    couch_log:debug(LogMsg, [?MODULE, DbName, DocId]),
-    try couch_db:open_doc(Db, DocId, []) of
-        {ok, Doc = #doc{}} ->
-            Deleted = Doc#doc{deleted = true, body = {[]}},
-            couch_db:update_doc(Db, Deleted, [?ADMIN_CTX]);
-        {not_found, _} ->
-            ok
-    catch
-        Tag:Error ->
-            ErrLog = "~p : error deleting checkpoint ~s : ~s error: ~p:~p",
-            couch_log:error(ErrLog, [?MODULE, DbName, DocId, Tag, Error]),
             ok
     end.

--- a/src/dreyfus/src/clouseau_rpc.erl
+++ b/src/dreyfus/src/clouseau_rpc.erl
@@ -262,10 +262,17 @@ rename(DbName) ->
 %% and an analyzer represented in a Javascript function in a design document.
 %% `Sig` is used to check if an index description is changed,
 %% and the index needs to be reconstructed.
--spec cleanup(DbName :: string_as_binary(_), ActiveSigs :: [sig()]) ->
+-spec cleanup(DbName :: string_as_binary(_), SigList :: list() | SigMap :: #{sig() => true}) ->
     ok.
 
-cleanup(DbName, ActiveSigs) ->
+% Compatibility clause to help when running search index cleanup during
+% a mixed cluster state. Remove after version 3.6
+%
+cleanup(DbName, SigList) when is_list(SigList) ->
+    SigMap = #{Sig => true || Sig <- SigList},
+    cleanup(DbName, SigMap);
+cleanup(DbName, #{} = SigMap) ->
+    ActiveSigs = maps:keys(SigMap),
     gen_server:cast({cleanup, clouseau()}, {cleanup, DbName, ActiveSigs}).
 
 %% a binary with value <<"tokens">>

--- a/src/dreyfus/src/dreyfus_fabric_cleanup.erl
+++ b/src/dreyfus/src/dreyfus_fabric_cleanup.erl
@@ -14,99 +14,50 @@
 
 -module(dreyfus_fabric_cleanup).
 
--include("dreyfus.hrl").
--include_lib("mem3/include/mem3.hrl").
--include_lib("couch/include/couch_db.hrl").
-
--export([go/1]).
+-export([go/1, go_local/3]).
 
 go(DbName) ->
-    DesignDocs =
-        case fabric:design_docs(DbName) of
-            {ok, DDocs} when is_list(DDocs) ->
-                DDocs;
-            Else ->
-                couch_log:debug("Invalid design docs: ~p~n", [Else]),
-                []
-        end,
-    ActiveSigs = lists:usort(
-        lists:flatmap(
-            fun active_sigs/1,
-            [couch_doc:from_json_obj(DD) || DD <- DesignDocs]
-        )
-    ),
-    cleanup_local_purge_doc(DbName, ActiveSigs),
-    clouseau_rpc:cleanup(DbName, ActiveSigs),
-    ok.
-
-active_sigs(#doc{body = {Fields}} = Doc) ->
-    try
-        {RawIndexes} = couch_util:get_value(<<"indexes">>, Fields, {[]}),
-        {IndexNames, _} = lists:unzip(RawIndexes),
-        [
-            begin
-                {ok, Index} = dreyfus_index:design_doc_to_index(Doc, IndexName),
-                Index#index.sig
-            end
-         || IndexName <- IndexNames
-        ]
-    catch
-        error:{badmatch, _Error} ->
-            []
+    case fabric_util:get_design_doc_records(DbName) of
+        {ok, DDocs} when is_list(DDocs) ->
+            Sigs = dreyfus_util:get_signatures_from_ddocs(DbName, DDocs),
+            Shards = mem3:shards(DbName),
+            ByNode = maps:groups_from_list(fun mem3:node/1, fun mem3:name/1, Shards),
+            Fun = fun(Node, Dbs, Acc) ->
+                erpc:send_request(Node, ?MODULE, go_local, [DbName, Dbs, Sigs], Node, Acc)
+            end,
+            Reqs = maps:fold(Fun, erpc:reqids_new(), ByNode),
+            recv(DbName, Reqs, fabric_util:abs_request_timeout());
+        Error ->
+            couch_log:error("~p : error fetching ddocs db:~p ~p", [?MODULE, DbName, Error]),
+            Error
     end.
 
-cleanup_local_purge_doc(DbName, ActiveSigs) ->
-    {ok, BaseDir} = clouseau_rpc:get_root_dir(),
-    DbNamePattern = <<DbName/binary, ".*">>,
-    Pattern0 = filename:join([BaseDir, "shards", "*", DbNamePattern, "*"]),
-    Pattern = binary_to_list(iolist_to_binary(Pattern0)),
-    DirListStrs = filelib:wildcard(Pattern),
-    DirList = [iolist_to_binary(DL) || DL <- DirListStrs],
-    LocalShards = mem3:local_shards(DbName),
-    ActiveDirs = lists:foldl(
-        fun(LS, AccOuter) ->
-            lists:foldl(
-                fun(Sig, AccInner) ->
-                    DirName = filename:join([BaseDir, LS#shard.name, Sig]),
-                    [DirName | AccInner]
-                end,
-                AccOuter,
-                ActiveSigs
-            )
-        end,
-        [],
-        LocalShards
-    ),
+% erpc endpoint for go/1 and fabric_index_cleanup:cleanup_indexes/2
+%
+go_local(DbName, Dbs, #{} = Sigs) ->
+    try
+        lists:foreach(
+            fun(Db) ->
+                Checkpoints = dreyfus_util:get_purge_checkpoints(Db),
+                ok = couch_index_util:cleanup_purges(Db, Sigs, Checkpoints)
+            end,
+            Dbs
+        ),
+        clouseau_rpc:cleanup(DbName, Sigs),
+        ok
+    catch
+        error:database_does_not_exist ->
+            ok
+    end.
 
-    DeadDirs = DirList -- ActiveDirs,
-    lists:foreach(
-        fun(IdxDir) ->
-            Sig = dreyfus_util:get_signature_from_idxdir(IdxDir),
-            case Sig of
-                undefined ->
-                    ok;
-                _ ->
-                    DocId = dreyfus_util:get_local_purge_doc_id(Sig),
-                    LocalShards = mem3:local_shards(DbName),
-                    lists:foreach(
-                        fun(LS) ->
-                            ShardDbName = LS#shard.name,
-                            {ok, ShardDb} = couch_db:open_int(ShardDbName, []),
-                            case couch_db:open_doc(ShardDb, DocId, []) of
-                                {ok, LocalPurgeDoc} ->
-                                    couch_db:update_doc(
-                                        ShardDb,
-                                        LocalPurgeDoc#doc{deleted = true},
-                                        [?ADMIN_CTX]
-                                    );
-                                {not_found, _} ->
-                                    ok
-                            end,
-                            couch_db:close(ShardDb)
-                        end,
-                        LocalShards
-                    )
-            end
-        end,
-        DeadDirs
-    ).
+recv(DbName, Reqs, Timeout) ->
+    case erpc:receive_response(Reqs, Timeout, true) of
+        {ok, _Lable, Reqs1} ->
+            recv(DbName, Reqs1, Timeout);
+        {Error, Label, Reqs1} ->
+            ErrMsg = "~p : error cleaning dreyfus indexes db:~p req:~p error:~p",
+            couch_log:error(ErrMsg, [?MODULE, DbName, Label, Error]),
+            recv(DbName, Reqs1, Timeout);
+        no_request ->
+            ok
+    end.

--- a/src/dreyfus/src/dreyfus_rpc.erl
+++ b/src/dreyfus/src/dreyfus_rpc.erl
@@ -46,7 +46,7 @@ call(Fun, DbName, DDoc, IndexName, QueryArgs0) ->
         stale = Stale
     } = QueryArgs,
     {_LastSeq, MinSeq} = calculate_seqs(Db, Stale),
-    case dreyfus_index:design_doc_to_index(DDoc, IndexName) of
+    case dreyfus_index:design_doc_to_index(DbName, DDoc, IndexName) of
         {ok, Index} ->
             try
                 rexi:reply(index_call(Fun, DbName, Index, QueryArgs, MinSeq))
@@ -81,7 +81,7 @@ info(DbName, DDoc, IndexName) ->
 info_int(DbName, DDoc, IndexName) ->
     erlang:put(io_priority, {search, DbName}),
     check_interactive_mode(),
-    case dreyfus_index:design_doc_to_index(DDoc, IndexName) of
+    case dreyfus_index:design_doc_to_index(DbName, DDoc, IndexName) of
         {ok, Index} ->
             case dreyfus_index_manager:get_index(DbName, Index) of
                 {ok, Pid} ->
@@ -102,7 +102,7 @@ info_int(DbName, DDoc, IndexName) ->
 disk_size(DbName, DDoc, IndexName) ->
     erlang:put(io_priority, {search, DbName}),
     check_interactive_mode(),
-    case dreyfus_index:design_doc_to_index(DDoc, IndexName) of
+    case dreyfus_index:design_doc_to_index(DbName, DDoc, IndexName) of
         {ok, Index} ->
             Result = dreyfus_index_manager:get_disk_size(DbName, Index),
             rexi:reply(Result);

--- a/src/dreyfus/src/dreyfus_util.erl
+++ b/src/dreyfus/src/dreyfus_util.erl
@@ -25,9 +25,11 @@
     ensure_local_purge_docs/2,
     get_value_from_options/2,
     get_local_purge_doc_id/1,
+    get_purge_checkpoints/1,
     get_local_purge_doc_body/4,
     maybe_create_local_purge_doc/2,
     maybe_create_local_purge_doc/3,
+    get_signatures_from_ddocs/2,
     get_signature_from_idxdir/1,
     verify_index_exists/2
 ]).
@@ -305,7 +307,7 @@ ensure_local_purge_docs(DbName, DDocs) ->
                     undefined ->
                         false;
                     _ ->
-                        try dreyfus_index:design_doc_to_indexes(DDoc) of
+                        try dreyfus_index:design_doc_to_indexes(DbName, DDoc) of
                             SIndexes -> ensure_local_purge_doc(Db, SIndexes)
                         catch
                             _:_ ->
@@ -359,6 +361,32 @@ maybe_create_local_purge_doc(Db, IndexPid, Index) ->
 
 get_local_purge_doc_id(Sig) ->
     ?l2b(?LOCAL_DOC_PREFIX ++ "purge-" ++ "dreyfus-" ++ Sig).
+
+% Returns a map of `Sig => DocId` elements for all the purge view
+% checkpoint docs. Sig is a hex-encoded binary.
+%
+get_purge_checkpoints(Db) ->
+    couch_index_util:get_purge_checkpoints(Db, <<"dreyfus">>).
+
+get_signatures_from_ddocs(DbName, DesignDocs) ->
+    SigList = lists:flatmap(fun(Doc) -> active_sigs(DbName, Doc) end, DesignDocs),
+    #{Sig => true || Sig <- SigList}.
+
+active_sigs(DbName, #doc{body = {Fields}} = Doc) ->
+    try
+        {RawIndexes} = couch_util:get_value(<<"indexes">>, Fields, {[]}),
+        {IndexNames, _} = lists:unzip(RawIndexes),
+        [
+            begin
+                {ok, Index} = dreyfus_index:design_doc_to_index(DbName, Doc, IndexName),
+                Index#index.sig
+            end
+         || IndexName <- IndexNames
+        ]
+    catch
+        error:{badmatch, _Error} ->
+            []
+    end.
 
 get_signature_from_idxdir(IdxDir) ->
     IdxDirList = filename:split(IdxDir),
@@ -415,7 +443,7 @@ verify_index_exists(DbName, Props) ->
                     case couch_db:get_design_doc(Db, DDocId) of
                         {ok, #doc{} = DDoc} ->
                             {ok, IdxState} = dreyfus_index:design_doc_to_index(
-                                DDoc, IndexName
+                                DbName, DDoc, IndexName
                             ),
                             IdxState#index.sig == Sig;
                         {not_found, _} ->

--- a/src/dreyfus/test/eunit/dreyfus_purge_test.erl
+++ b/src/dreyfus/test/eunit/dreyfus_purge_test.erl
@@ -1102,17 +1102,17 @@ get_sigs(DbName) ->
     {ok, DesignDocs} = fabric:design_docs(DbName),
     lists:usort(
         lists:flatmap(
-            fun active_sigs/1,
+            fun(Doc) -> active_sigs(DbName, Doc) end,
             [couch_doc:from_json_obj(DD) || DD <- DesignDocs]
         )
     ).
 
-active_sigs(#doc{body = {Fields}} = Doc) ->
+active_sigs(DbName, #doc{body = {Fields}} = Doc) ->
     {RawIndexes} = couch_util:get_value(<<"indexes">>, Fields, {[]}),
     {IndexNames, _} = lists:unzip(RawIndexes),
     [
         begin
-            {ok, Index} = dreyfus_index:design_doc_to_index(Doc, IndexName),
+            {ok, Index} = dreyfus_index:design_doc_to_index(DbName, Doc, IndexName),
             Index#index.sig
         end
      || IndexName <- IndexNames

--- a/src/fabric/src/fabric_index_cleanup.erl
+++ b/src/fabric/src/fabric_index_cleanup.erl
@@ -1,0 +1,81 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(fabric_index_cleanup).
+
+-export([
+    cleanup_all_nodes/0,
+    cleanup_all_nodes/1,
+    cleanup_this_node/0,
+    cleanup_this_node/1
+]).
+
+cleanup_all_nodes() ->
+    Fun = fun(DbName, _) -> cleanup_all_nodes(DbName) end,
+    mem3:fold_dbs(Fun, nil),
+    ok.
+
+cleanup_all_nodes(DbName) ->
+    cleanup_indexes(DbName, mem3_util:live_nodes()).
+
+cleanup_this_node() ->
+    Fun = fun(DbName, _) ->
+        case mem3:local_shards(DbName) of
+            [_ | _] -> cleanup_this_node(DbName);
+            [] -> ok
+        end
+    end,
+    mem3:fold_dbs(Fun, nil),
+    ok.
+
+cleanup_this_node(DbName) ->
+    cleanup_indexes(DbName, [config:node_name()]).
+
+cleanup_indexes(DbName, Nodes) ->
+    try fabric_util:get_design_doc_records(DbName) of
+        {ok, DDocs} when is_list(DDocs) ->
+            VSigs = couch_mrview_util:get_signatures_from_ddocs(DbName, DDocs),
+            DSigs = dreyfus_util:get_signatures_from_ddocs(DbName, DDocs),
+            NSigs = nouveau_util:get_signatures_from_ddocs(DbName, DDocs),
+            Shards = [S || S <- mem3:shards(DbName), lists:member(mem3:node(S), Nodes)],
+            ByNode = maps:groups_from_list(fun mem3:node/1, fun mem3:name/1, Shards),
+            Fun = fun(Node, Dbs, Acc) ->
+                Acc1 = send(Node, couch_mrview_cleanup, cleanup, [Dbs, VSigs], Acc),
+                Acc2 = send(Node, dreyfus_fabric_cleanup, go_local, [DbName, Dbs, DSigs], Acc1),
+                Acc3 = send(Node, nouveau_fabric_cleanup, go_local, [DbName, Dbs, NSigs], Acc2),
+                Acc3
+            end,
+            Reqs = maps:fold(Fun, erpc:reqids_new(), ByNode),
+            recv(DbName, Reqs, fabric_util:abs_request_timeout());
+        Error ->
+            couch_log:error("~p : error fetching ddocs db:~p ~p", [?MODULE, DbName, Error]),
+            Error
+    catch
+        error:database_does_not_exist ->
+            ok
+    end.
+
+send(Node, M, F, A, Reqs) ->
+    Label = {Node, M, F},
+    erpc:send_request(Node, M, F, A, Label, Reqs).
+
+recv(DbName, Reqs, Timeout) ->
+    case erpc:receive_response(Reqs, Timeout, true) of
+        {ok, _Label, Reqs1} ->
+            recv(DbName, Reqs1, Timeout);
+        {Error, Label, Reqs1} ->
+            ErrMsg = "~p : error cleaning indexes db:~p req:~p error:~p",
+            couch_log:error(ErrMsg, [?MODULE, DbName, Label, Error]),
+            recv(DbName, Reqs1, Timeout);
+        no_request ->
+            ok
+    end.

--- a/src/fabric/test/eunit/fabric_tests.erl
+++ b/src/fabric/test/eunit/fabric_tests.erl
@@ -47,17 +47,20 @@ teardown({Ctx, DbName}) ->
     test_util:stop_couch(Ctx).
 
 t_cleanup_index_files(_) ->
-    CheckFun = fun(Res) -> Res =:= ok end,
-    ?assert(lists:all(CheckFun, fabric:cleanup_index_files())).
+    ?assertEqual(ok, fabric:cleanup_index_files_this_node()),
+    ?assertEqual(ok, fabric:cleanup_index_files_all_nodes()).
 
 t_cleanup_index_files_with_existing_db({_, DbName}) ->
-    ?assertEqual(ok, fabric:cleanup_index_files(DbName)).
+    ?assertEqual(ok, fabric:cleanup_index_files_this_node(DbName)),
+    ?assertEqual(ok, fabric:cleanup_index_files_all_nodes(DbName)),
+    ?assertEqual(ok, fabric:cleanup_index_files_this_node(<<"non_existent">>)),
+    ?assertEqual(ok, fabric:cleanup_index_files_all_nodes(<<"non_existent">>)).
 
 t_cleanup_index_files_with_view_data({_, DbName}) ->
     Sigs = sigs(DbName),
     Indices = indices(DbName),
     Purges = purges(DbName),
-    ok = fabric:cleanup_index_files(DbName),
+    ok = fabric:cleanup_index_files_all_nodes(DbName),
     % We haven't inadvertently removed any active index bits
     ?assertEqual(Sigs, sigs(DbName)),
     ?assertEqual(Indices, indices(DbName)),
@@ -65,7 +68,7 @@ t_cleanup_index_files_with_view_data({_, DbName}) ->
 
 t_cleanup_index_files_with_deleted_db(_) ->
     SomeDb = ?tempdb(),
-    ?assertEqual(ok, fabric:cleanup_index_files(SomeDb)).
+    ?assertEqual(ok, fabric:cleanup_index_files_all_nodes(SomeDb)).
 
 t_cleanup_index_file_after_ddoc_update({_, DbName}) ->
     ?assertEqual(
@@ -84,7 +87,7 @@ t_cleanup_index_file_after_ddoc_update({_, DbName}) ->
     ),
 
     update_ddoc(DbName, <<"_design/foo">>, <<"bar1">>),
-    ok = fabric:cleanup_index_files(DbName),
+    ok = fabric:cleanup_index_files_all_nodes(DbName),
     {ok, _} = fabric:query_view(DbName, <<"foo">>, <<"bar1">>),
 
     % One 4bc stays, da8 should  gone and 9e3 is added
@@ -120,7 +123,7 @@ t_cleanup_index_file_after_ddoc_delete({_, DbName}) ->
     ),
 
     delete_ddoc(DbName, <<"_design/foo">>),
-    ok = fabric:cleanup_index_files(DbName),
+    ok = fabric:cleanup_index_files_all_nodes(DbName),
 
     % 4bc stays the same, da8 should be gone
     ?assertEqual(
@@ -137,13 +140,13 @@ t_cleanup_index_file_after_ddoc_delete({_, DbName}) ->
     ),
 
     delete_ddoc(DbName, <<"_design/boo">>),
-    ok = fabric:cleanup_index_files(DbName),
+    ok = fabric:cleanup_index_files_all_nodes(DbName),
 
     ?assertEqual([], indices(DbName)),
     ?assertEqual([], purges(DbName)),
 
     % cleaning a db with all deleted indices should still work
-    ok = fabric:cleanup_index_files(DbName),
+    ok = fabric:cleanup_index_files_all_nodes(DbName),
 
     ?assertEqual([], indices(DbName)),
     ?assertEqual([], purges(DbName)).

--- a/src/ken/src/ken_server.erl
+++ b/src/ken/src/ken_server.erl
@@ -341,7 +341,7 @@ update_ddoc_indexes(Name, #doc{} = Doc, State) ->
 search_updated(Name, Doc, Seq, State) ->
     case should_update(Doc, <<"indexes">>) of
         true ->
-            try dreyfus_index:design_doc_to_indexes(Doc) of
+            try dreyfus_index:design_doc_to_indexes(Name, Doc) of
                 SIndexes -> update_ddoc_search_indexes(Name, SIndexes, Seq, State)
             catch
                 _:_ ->

--- a/src/mem3/src/mem3_reshard_index.erl
+++ b/src/mem3/src/mem3_reshard_index.erl
@@ -101,7 +101,7 @@ nouveau_indices(DbName, Doc) ->
 
 dreyfus_indices(DbName, Doc) ->
     try
-        Indices = dreyfus_index:design_doc_to_indexes(Doc),
+        Indices = dreyfus_index:design_doc_to_indexes(DbName, Doc),
         [{?DREYFUS, DbName, Index} || Index <- Indices]
     catch
         Tag:Err ->

--- a/src/mem3/test/eunit/mem3_reshard_test.erl
+++ b/src/mem3/test/eunit/mem3_reshard_test.erl
@@ -371,7 +371,7 @@ indices_can_be_built_with_errors(#{db1 := Db}) ->
         end)}.
 
 mock_dreyfus_indices() ->
-    meck:expect(dreyfus_index, design_doc_to_indexes, fun(Doc) ->
+    meck:expect(dreyfus_index, design_doc_to_indexes, fun(_, Doc) ->
         #doc{body = {BodyProps}} = Doc,
         case couch_util:get_value(<<"indexes">>, BodyProps) of
             undefined ->

--- a/src/nouveau/src/nouveau_fabric_cleanup.erl
+++ b/src/nouveau/src/nouveau_fabric_cleanup.erl
@@ -14,40 +14,52 @@
 
 -module(nouveau_fabric_cleanup).
 
--include_lib("couch/include/couch_db.hrl").
-
--include("nouveau.hrl").
--include_lib("mem3/include/mem3.hrl").
-
--export([go/1]).
+-export([go/1, go_local/3]).
 
 go(DbName) ->
-    DesignDocs =
-        case fabric:design_docs(DbName) of
-            {ok, DDocs} when is_list(DDocs) ->
-                DDocs;
-            Else ->
-                couch_log:debug("Invalid design docs: ~p~n", [Else]),
-                []
-        end,
-    ActiveSigs =
-        lists:usort(
-            lists:flatmap(
-                fun(Doc) -> active_sigs(DbName, Doc) end,
-                [couch_doc:from_json_obj(DD) || DD <- DesignDocs]
-            )
-        ),
-    Shards = mem3:shards(DbName),
-    lists:foreach(
-        fun(Shard) ->
-            Path =
-                <<"shards/", (mem3_util:range_to_hex(Shard#shard.range))/binary, "/", DbName/binary,
-                    ".*/*">>,
-            rexi:cast(Shard#shard.node, {nouveau_rpc, cleanup, [Path, ActiveSigs]})
-        end,
-        Shards
-    ).
+    case fabric_util:get_design_doc_records(DbName) of
+        {ok, DDocs} when is_list(DDocs) ->
+            Sigs = nouveau_util:get_signatures_from_ddocs(DbName, DDocs),
+            Shards = mem3:shards(DbName),
+            ByNode = maps:groups_from_list(fun mem3:node/1, fun mem3:name/1, Shards),
+            Fun = fun(Node, Dbs, Acc) ->
+                erpc:send_request(Node, ?MODULE, go_local, [DbName, Dbs, Sigs], Node, Acc)
+            end,
+            Reqs = maps:fold(Fun, erpc:reqids_new(), ByNode),
+            recv(DbName, Reqs, fabric_util:abs_request_timeout());
+        Error ->
+            couch_log:error("~p : error fetching ddocs db:~p ~p", [?MODULE, DbName, Error]),
+            Error
+    end.
 
-active_sigs(DbName, #doc{} = Doc) ->
-    Indexes = nouveau_util:design_doc_to_indexes(DbName, Doc),
-    lists:map(fun(Index) -> Index#index.sig end, Indexes).
+% erpc endpoint for go/1 and fabric_index_cleanup:cleanup_indexes/2
+%
+go_local(DbName, Dbs, Sigs) ->
+    try
+        lists:foreach(
+            fun(Db) ->
+                Sz = byte_size(DbName),
+                <<"shards/", Range:17/binary, "/", DbName:Sz/binary, ".", _/binary>> = Db,
+                Checkpoints = nouveau_util:get_purge_checkpoints(Db),
+                ok = couch_index_util:cleanup_purges(Db, Sigs, Checkpoints),
+                Path = <<"shards/", Range/binary, "/", DbName/binary, ".*/*">>,
+                nouveau_api:delete_path(nouveau_util:index_name(Path), maps:keys(Sigs))
+            end,
+            Dbs
+        )
+    catch
+        error:database_does_not_exist ->
+            ok
+    end.
+
+recv(DbName, Reqs, Timeout) ->
+    case erpc:receive_response(Reqs, Timeout, true) of
+        {ok, _Label, Reqs1} ->
+            recv(DbName, Reqs1, Timeout);
+        {Error, Label, Reqs1} ->
+            ErrMsg = "~p : error cleaning nouveau indexes db:~p node: ~p error:~p",
+            couch_log:error(ErrMsg, [?MODULE, DbName, Label, Error]),
+            recv(DbName, Reqs1, Timeout);
+        no_request ->
+            ok
+    end.

--- a/src/nouveau/src/nouveau_rpc.erl
+++ b/src/nouveau/src/nouveau_rpc.erl
@@ -17,8 +17,7 @@
 
 -export([
     search/3,
-    info/2,
-    cleanup/2
+    info/2
 ]).
 
 -include("nouveau.hrl").
@@ -88,7 +87,3 @@ info(DbName, #index{} = Index0) ->
         {error, Reason} ->
             rexi:reply({error, Reason})
     end.
-
-cleanup(Path, Exclusions) ->
-    nouveau_api:delete_path(nouveau_util:index_name(Path), Exclusions),
-    rexi:reply(ok).

--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -451,7 +451,7 @@ re_enqueue(Obj) ->
 
 cleanup_index_files(DbName) ->
     case should_clean_up_indices() of
-        true -> fabric:cleanup_index_files(DbName);
+        true -> fabric:cleanup_index_files_this_node(DbName);
         false -> ok
     end.
 

--- a/src/smoosh/test/smoosh_tests.erl
+++ b/src/smoosh/test/smoosh_tests.erl
@@ -155,7 +155,7 @@ t_index_cleanup_happens_by_default(DbName) ->
     get_channel_pid("index_cleanup") ! unpause,
     {ok, _} = fabric:query_view(DbName, <<"foo">>, <<"bar">>),
     % View cleanup should have been invoked
-    meck:wait(fabric, cleanup_index_files, [DbName], 4000),
+    meck:wait(fabric, cleanup_index_files_this_node, [DbName], 4000),
     wait_view_compacted(DbName, <<"foo">>).
 
 t_index_cleanup_can_be_disabled(DbName) ->


### PR DESCRIPTION
Fix these issues:

  * Index cleanup triggered by smoosh only cleaned view indexes and purge checkpoints, make sure to also clean nouveau and search indexes and checkpoints.

  * `/_search_cleanup` endpoint only cleaned indexes on the coordinator node, despite being a clustered fabric endpoint. Fix it so it cleans indexes on other nodes as well as most users would expect.

  * Nouveau cleanup didn't clean purge checkpoints, so make it do so. Use the mrview purge checkpoint strategy for all indexes. This improves dreyfus logic to avoid traversing internal disk paths from clouseau.

  * Make `_view_cleanup` clean all the index types. This is a bit dirty, but it may be better than adding another cleanup `_index_cleanup` API. Left `_search_cleanup` and `_nouveau_cleanup` APIs as is for now.

Some optimizations:

  * For each index clean request fetch ddocs once. Calculate signatures and then call the remote node cleanup logic with them. This avoids fetching design documents multiple times or sending all of them to the worker nodes. This is what Nouveau is doing so stick with that nice pattern.

  * Use erpc for remote calls. Our Erlang version is high enough (25+) to use the multple requests pattern from erpc. This is more compact than rexi. The absolute timeout pattern makes it simpler to have a global timeout for the whole request.

Cleanups:

  * Make purge checkpoint fetching and cleanup more uniform. Use common utility logic in `couch_index_util` for all indexes.

  * Make index cleanup similar between all three indexes. Use the same erpc pattern for all of them.

  * Move index cleanup functions from fabric.erl to its own module -- fabric_index_cleanup.erl

  * Rename fabric function names more uniform and clearly indicate if it cleans indexes on all nodes or just the current node.

  * Add the db name to dreyfus `#index{}` record when it initializes so it matches Nouveau.
