### PR TITLE
Introduce a minimum batch size for auto purge

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1195,6 +1195,9 @@ url = {{nouveau_url}}
 ;[couch_quickjs_scanner_plugin.skip_{dbs,ddoc,docs}]
 
 [couch_auto_purge_plugin]
+; The fewest id/rev pairs the plugin will attempt to purge in
+; one request, excepting at the end of a database scan.
+;min_batch_size = 250
 ; The most id/rev pairs the plugin will attempt to purge in
 ; one request.
 ;max_batch_size = 500


### PR DESCRIPTION
## Overview

Use purge more efficiently by building up a queue and then issuing a batch at once. There is a minimum batch size (for efficiency) and a maximum (to prevent heavily conflicted documents forcing a very large purge request).

## Testing recommendations

eunit

## Related Issues or Pull Requests

https://github.com/apache/couchdb/pull/5655

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
