### PR TITLE
Avoid using function closures in mem3

### DIFF
--- a/src/mem3/test/eunit/mem3_distribution_test.erl
+++ b/src/mem3/test/eunit/mem3_distribution_test.erl
@@ -143,4 +143,5 @@ ping_nodes_test(_) ->
 dead_nodes_test(_) ->
     meck:expect(mem3, nodes, 0, [n1, n2, n3]),
     meck:expect(mem3_util, live_nodes, 0, [n1, n2]),
-    ?assertEqual([n3], couch_debug:dead_nodes()).
+    Node = node(),
+    ?assertEqual([{Node, [n3]}], couch_debug:dead_nodes()).


### PR DESCRIPTION
Those are for debugging in remsh but still function closure are fragile when sent between nodes so avoid them and rely on the new erpc module with plain M, F, A args.

While at it, improve `dead_nodes/0,1` function. Make it return the node from whose perspective we noticed the dead nodes. That makes it a bit more clear what the network partition might look like.
