### PR TITLE
Cleanup fabric r/w parameter handling

### DIFF
--- a/src/fabric/src/fabric_doc_open.erl
+++ b/src/fabric/src/fabric_doc_open.erl
@@ -41,11 +41,11 @@ go(DbName, Id, Options) ->
     ),
     SuppressDeletedDoc = not lists:member(deleted, Options),
     N = mem3:n(DbName),
-    R = couch_util:get_value(r, Options, integer_to_list(mem3:quorum(DbName))),
+    R = fabric_util:r_from_opts(DbName, Options),
     Acc0 = #acc{
         dbname = DbName,
         workers = Workers,
-        r = min(N, list_to_integer(R)),
+        r = min(N, R),
         state = r_not_met,
         replies = []
     },

--- a/src/fabric/src/fabric_doc_open_revs.erl
+++ b/src/fabric/src/fabric_doc_open_revs.erl
@@ -37,12 +37,11 @@ go(DbName, Id, Revs, Options) ->
         open_revs,
         [Id, Revs, Options]
     ),
-    R = couch_util:get_value(r, Options, integer_to_list(mem3:quorum(DbName))),
     State = #state{
         dbname = DbName,
         worker_count = length(Workers),
         workers = Workers,
-        r = list_to_integer(R),
+        r = fabric_util:r_from_opts(DbName, Options),
         revs = Revs,
         latest = lists:member(latest, Options),
         replies = []

--- a/src/fabric/src/fabric_doc_purge.erl
+++ b/src/fabric/src/fabric_doc_purge.erl
@@ -62,7 +62,7 @@ go(DbName, IdsRevs, Options) ->
         worker_uuids = WorkerUUIDs,
         resps = Responses,
         uuid_counts = UUIDCounts,
-        w = w(DbName, Options)
+        w = fabric_util:w_from_opts(DbName, Options)
     },
     Callback = fun handle_message/3,
     Acc2 =
@@ -127,14 +127,6 @@ group_reqs_by_shard(DbName, Reqs) ->
             lists:foldl(AppendFun, Map0, mem3:shards(DbName, Id))
         end,
     lists:foldl(ReqFoldFun, #{}, Reqs).
-
-w(DbName, Options) ->
-    try
-        list_to_integer(couch_util:get_value(w, Options))
-    catch
-        _:_ ->
-            mem3:quorum(DbName)
-    end.
 
 % Failed WorkerUUIDs = #{#shard{} => [UUIDs, ...]}
 % Resps = #{UUID => [{ok, ...} | {error, ...}]

--- a/src/fabric/src/fabric_doc_update.erl
+++ b/src/fabric/src/fabric_doc_update.erl
@@ -42,11 +42,10 @@ go(DbName, AllDocs0, Opts) ->
     ),
     {Workers, _} = lists:unzip(GroupedDocs),
     RexiMon = fabric_util:create_monitors(Workers),
-    W = couch_util:get_value(w, Options, integer_to_list(mem3:quorum(DbName))),
     Acc0 = #acc{
         waiting_count = length(Workers),
         doc_count = length(AllDocs),
-        w = list_to_integer(W),
+        w = fabric_util:w_from_opts(DbName, Options),
         grouped_docs = GroupedDocs,
         reply = dict:new()
     },

--- a/src/fabric/src/fabric_open_revs.erl
+++ b/src/fabric/src/fabric_open_revs.erl
@@ -83,8 +83,7 @@ handle_message(Reason, Worker, #st{} = St) ->
     handle_error(Reason, St#st{workers = Workers1, reqs = Reqs1}).
 
 init_state(DbName, IdsRevsOpts, Options) ->
-    DefaultR = integer_to_list(mem3:quorum(DbName)),
-    R = list_to_integer(couch_util:get_value(r, Options, DefaultR)),
+    R = fabric_util:r_from_opts(DbName, Options),
     {ArgRefs, Reqs0} = build_req_map(IdsRevsOpts),
     ShardMap = build_worker_map(DbName, Reqs0),
     {Workers, Reqs} = spawn_workers(Reqs0, ShardMap, Options),


### PR DESCRIPTION
For some odd reasons we parse the request `r` and `w` parameters as lists in chttpd. Then, in fabric, we jump through hoops switching them to integers (we switch get_value defaults to lists, then parse the result back to an integer).

Add a helper function in fabric_util to DRY-up the quorum option fetching and make it accept both lists and integers. For now chttpd still sends the values as lists but in the future we can gradually switch to using integers.

