### PR TITLE
Remove hastings references

### DIFF
--- a/build-aux/xref-helper.sh
+++ b/build-aux/xref-helper.sh
@@ -9,7 +9,6 @@ mkdir -p ./tmp
 $REBAR --keep-going --recursive xref $DIALYZE_OPTS | \
                                       grep -v '==>' | \
                                       grep -v 'WARN' | \
-                                      grep -v hastings | \
                                       sort > ./tmp/xref-output.txt
 
 # compare result against known allowed output

--- a/src/ken/rebar.config.script
+++ b/src/ken/rebar.config.script
@@ -14,9 +14,6 @@
 
 HaveDreyfus = element(1, file:list_dir("../dreyfus")) == ok.
 
-HastingsHome = os:getenv("HASTINGS_HOME", "../hastings").
-HaveHastings = element(1, file:list_dir(HastingsHome)) == ok.
-
 CurrOpts = case lists:keyfind(erl_opts, 1, CONFIG) of
     {erl_opts, Opts} -> Opts;
     false -> []
@@ -24,7 +21,6 @@ end,
 
 NewOpts =
     if HaveDreyfus -> [{d, 'HAVE_DREYFUS'}]; true -> [] end ++
-    if HaveHastings -> [{d, 'HAVE_HASTINGS'}]; true -> [] end ++
     [{i, "../"}] ++ CurrOpts.
 
 lists:keystore(erl_opts, 1, CONFIG, {erl_opts, NewOpts}).

--- a/src/ken/src/ken.app.src.script
+++ b/src/ken/src/ken.app.src.script
@@ -11,7 +11,6 @@
 % the License.
 
 HaveDreyfus = code:lib_dir(dreyfus) /= {error, bad_name}.
-HaveHastings = code:lib_dir(hastings) /= {error, bad_name}.
 
 BaseApplications = [
     kernel,
@@ -24,7 +23,6 @@ BaseApplications = [
 
 Applications =
     if HaveDreyfus -> [dreyfus]; true -> [] end ++
-    if HaveHastings -> [hastings]; true -> [] end ++
     BaseApplications.
 
 {application, ken, [

--- a/src/mem3/src/mem3_reshard_index.erl
+++ b/src/mem3/src/mem3_reshard_index.erl
@@ -21,7 +21,6 @@
 
 -define(MRVIEW, mrview).
 -define(DREYFUS, dreyfus).
--define(HASTINGS, hastings).
 -define(NOUVEAU, nouveau).
 
 -include_lib("mem3/include/mem3.hrl").
@@ -63,8 +62,7 @@ fabric_design_docs(DbName) ->
 indices(DbName, Doc) ->
     mrview_indices(DbName, Doc) ++
         nouveau_indices(DbName, Doc) ++
-        [dreyfus_indices(DbName, Doc) || has_app(dreyfus)] ++
-        [hastings_indices(DbName, Doc) || has_app(hastings)].
+        [dreyfus_indices(DbName, Doc) || has_app(dreyfus)].
 
 mrview_indices(DbName, Doc) ->
     try
@@ -110,17 +108,6 @@ dreyfus_indices(DbName, Doc) ->
             []
     end.
 
-hastings_indices(DbName, Doc) ->
-    try
-        Indices = hastings_index:design_doc_to_indexes(Doc),
-        [{?HASTINGS, DbName, Index} || Index <- Indices]
-    catch
-        Tag:Err ->
-            Msg = "~p couldn't get hasting indices ~p ~p ~p:~p",
-            couch_log:error(Msg, [?MODULE, DbName, Doc, Tag, Err]),
-            []
-    end.
-
 build_index({?MRVIEW, DbName, MRSt} = Ctx, Try) ->
     ioq:set_io_priority({reshard, DbName}),
     await_retry(
@@ -136,13 +123,6 @@ build_index({?DREYFUS, DbName, DIndex} = Ctx, Try) ->
     await_retry(
         dreyfus_index_manager:get_index(DbName, DIndex),
         fun dreyfus_index:await/2,
-        Ctx,
-        Try
-    );
-build_index({?HASTINGS, DbName, HIndex} = Ctx, Try) ->
-    await_retry(
-        hastings_index_manager:get_index(DbName, HIndex),
-        fun hastings_index:await/2,
         Ctx,
         Try
     ).
@@ -196,8 +176,6 @@ index_info({?MRVIEW, DbName, MRSt}) ->
     GroupName = couch_mrview_index:get(idx_name, MRSt),
     {DbName, GroupName};
 index_info({?DREYFUS, DbName, Index}) ->
-    {DbName, Index};
-index_info({?HASTINGS, DbName, Index}) ->
     {DbName, Index}.
 
 has_app(App) ->


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Hastings was a geospatial search application from cloudant-labs [1] that is no longer supported because Cloudant no longer supports geospatial search in its product. The last hastings bug fix was in 2021, so it seems likely that this scaffolding is safe to remove.

[1] https://github.com/cloudant-labs/hastings

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
