### PR TITLE
Use W=N for auto-purge plugin

### DIFF
--- a/src/couch/test/eunit/couch_auto_purge_plugin_tests.erl
+++ b/src/couch/test/eunit/couch_auto_purge_plugin_tests.erl
@@ -117,7 +117,7 @@ t_min_batch_size_2({_, DbName}) ->
     meck:reset(?PLUGIN),
     config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
     wait_exit(10000),
-    ?assertEqual(4, meck:num_calls(fabric, purge_docs, '_')),
+    ?assertEqual(3, meck:num_calls(fabric, purge_docs, '_')),
     ?assertEqual(0, doc_del_count(DbName)),
     ok.
 


### PR DESCRIPTION
The idea is we would like to do as much work in the auto-purge request itself and leave as little as possible for the internal replicator.

While at it, strengthen some state map matches by asserting that we expect the fields to always by there. Also, ensure to always reset queue to empty as when we're opening a new db shard.
