### PR TITLE
Update elp toml file

### DIFF
--- a/.elp.toml
+++ b/.elp.toml
@@ -1,3 +1,38 @@
 [build_info]
 apps = ["src/*"]
-include_dirs = ["src", "src/*/include"]
+# 3rd party dependencies (not type-checked), defaults to [] (see rebar.config.script)
+deps = [
+    "src/erlfmt",
+    "src/rebar",
+    "src/rebar3",
+    "src/meck",
+    "src/cowlib",
+    "src/gun",
+    "src/recon",
+    "src/proper",
+    "src/faxton",
+    "src/docs",
+    "src/meck",
+    "src/jiffy",
+    "src/ibrowse",
+    "src/mochiweb",
+    "src/snappy"
+]
+# List of OTP application names to exclude from indexing. This can help improve performance by not loading rarely used OTP apps.
+[otp]
+exclude_apps = [
+    "megaco",
+    "common_test",
+    "edoc",
+    "eldap",
+    "erl_docgen",
+    "et",
+    "ftp",
+    "mnesia",
+    "odbc",
+    "observer",
+    "snmp",
+    "tftp",
+    "wx",
+    "xmerl"
+]

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -150,6 +150,8 @@ SubDirs = [
     "rel"
 ].
 
+% Try to keep deps in sync with .elp.toml deps
+
 DepDescs = [
 %% Independent Apps
 {snappy,           "snappy",           {tag, "CouchDB-1.0.9"}},


### PR DESCRIPTION
Explicitly set deps. Other projects have a separate `deps` directory but our deps are all mixed in between the main apps at the same level. According to [1] deps are 3rd party dependencies which are not type-checked.

A top level `include_dir` doesn't seem to do anything so remove it.

As per [2] don't ignore some unlikely to be used OTP apps.

[1] https://whatsapp.github.io/erlang-language-platform/docs/get-started/configure-project/custom-project/
[2] https://whatsapp.github.io/erlang-language-platform/docs/get-started/configure-project/elp-toml/#otp
