### PR TITLE
Ignore design docs in the shards db in the scanner

### DIFF
--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -300,6 +300,9 @@ scan_dbs(#st{cursor = Cursor} = St) ->
         couch_db:close(Db)
     end.
 
+scan_dbs_fold(#full_doc_info{id = <<?DESIGN_DOC_PREFIX, _/binary>>}, Acc) ->
+    % In case user added a design doc in the dbs database
+    {ok, Acc};
 scan_dbs_fold(#full_doc_info{} = FDI, #st{shards_db = Db} = Acc) ->
     Acc1 = Acc#st{cursor = FDI#full_doc_info.id},
     Acc2 = maybe_checkpoint(Acc1),

--- a/src/couch_scanner/test/eunit/couch_scanner_test.erl
+++ b/src/couch_scanner/test/eunit/couch_scanner_test.erl
@@ -63,6 +63,10 @@ setup() ->
     ok = fabric:create_db(DbName1, [{q, "2"}, {n, "1"}]),
     ok = fabric:create_db(DbName2, [{q, "2"}, {n, "1"}]),
     ok = fabric:create_db(DbName3, [{q, "2"}, {n, "1"}]),
+    % Add a design doc the shards db. Scanner should ignore it.
+    {ok, _} = couch_util:with_db(mem3_sync:shards_db(), fun(Db) ->
+        couch_db:update_doc(Db, #doc{id = <<"_design/foo">>}, [])
+    end),
     ok = add_doc(DbName1, ?DOC1, #{foo1 => bar}),
     ok = add_doc(DbName1, ?DOC2, #{
         foo2 => baz,
@@ -113,6 +117,7 @@ teardown({Ctx, {DbName1, DbName2, DbName3}}) ->
     fabric:delete_db(DbName1),
     fabric:delete_db(DbName2),
     fabric:delete_db(DbName3),
+    couch_server:delete(mem3_sync:shards_db(), [?ADMIN_CTX]),
     test_util:stop_couch(Ctx),
     meck:unload().
 


### PR DESCRIPTION
Skip them in the odd chance users users added any in there.

Coverage report shows we're skipping it:

<img width="528" height="100" alt="Screenshot 2025-10-29 at 4 22 42 PM" src="https://github.com/user-attachments/assets/e3f3ad33-19df-4fb5-8876-075b46edf2d5" />