### PR TITLE
Fix time_seq since bug

### DIFF
--- a/src/couch/src/couch_time_seq.erl
+++ b/src/couch/src/couch_time_seq.erl
@@ -162,10 +162,14 @@ update(#{v := ?VER} = Ctx, Time, Seq) when is_integer(Time), is_integer(Seq), Se
 since(#{v := ?VER} = Ctx, Time) when is_integer(Time) ->
     #{bins := Bins} = Ctx,
     Resolution = resolution_sec(),
-    case lists:dropwhile(fun({T, _}) -> Time < T end, Bins) of
-        [] -> 0;
-        [{T, _} | _] when Time > (T + Resolution) -> now;
-        [{_, Seq} | _] -> Seq
+    case Bins of
+        [{T, _} | _] when Time > T + Resolution ->
+            now;
+        _ ->
+            case lists:dropwhile(fun({T, _}) -> Time < T end, Bins) of
+                [] -> 0;
+                [{_, Seq} | _] -> Seq
+            end
     end.
 
 % @edoc: Return a histogram of formatted time and number of sequence updates which

--- a/src/couch/test/eunit/couch_time_seq_tests.erl
+++ b/src/couch/test/eunit/couch_time_seq_tests.erl
@@ -172,19 +172,36 @@ update_10_000_with_large_interval_test() ->
     {FirstTime, _} = lists:last(Bins),
     ?assertEqual(test_time(), FirstTime).
 
-before_test() ->
+since_test() ->
     T = test_time(),
-    New = couch_time_seq:new(),
-    TSeq0 = couch_time_seq:update(New, T, 42),
-    TSeq = couch_time_seq:update(TSeq0, T + hours(3), 43),
-    % [{T + 3H, 43}, {T, 42}]
+    T3 = T + hours(3),
+    T9 = T + hours(9),
+    T15 = T + hours(15),
+    TSeq0 = couch_time_seq:update(couch_time_seq:new(), T, 0),
+    TSeq1 = couch_time_seq:update(TSeq0, T3, 42),
+    TSeq2 = couch_time_seq:update(TSeq1, T9, 43),
+    TSeq = couch_time_seq:update(TSeq2, T15, 44),
+
+    % [{T15, 44}, {T9, 43}, {T3, 42}, {T, 0}]
+
     ?assertEqual(0, couch_time_seq:since(TSeq, 0)),
+
     ?assertEqual(0, couch_time_seq:since(TSeq, T - 1)),
-    ?assertEqual(42, couch_time_seq:since(TSeq, T)),
-    ?assertEqual(42, couch_time_seq:since(TSeq, T + 1)),
-    ?assertEqual(42, couch_time_seq:since(TSeq, T + hours(3) - 1)),
-    ?assertEqual(43, couch_time_seq:since(TSeq, T + hours(3))),
-    ?assertEqual(43, couch_time_seq:since(TSeq, T + hours(3) + 1)),
+    ?assertEqual(0, couch_time_seq:since(TSeq, T)),
+    ?assertEqual(0, couch_time_seq:since(TSeq, T + 1)),
+
+    ?assertEqual(0, couch_time_seq:since(TSeq, T3 - 1)),
+    ?assertEqual(42, couch_time_seq:since(TSeq, T3)),
+    ?assertEqual(42, couch_time_seq:since(TSeq, T3 + 1)),
+
+    ?assertEqual(42, couch_time_seq:since(TSeq, T9 - 1)),
+    ?assertEqual(43, couch_time_seq:since(TSeq, T9)),
+    ?assertEqual(43, couch_time_seq:since(TSeq, T9 + 1)),
+
+    ?assertEqual(43, couch_time_seq:since(TSeq, T15 - 1)),
+    ?assertEqual(44, couch_time_seq:since(TSeq, T15)),
+    ?assertEqual(44, couch_time_seq:since(TSeq, T15 + 1)),
+
     ?assertEqual(now, couch_time_seq:since(TSeq, T + hours(999))).
 
 histogram_test() ->


### PR DESCRIPTION
The special case where we check if time is too recent and return `now` should only be checked on the first entry, not after we find the bin with the dropwhile, like we did before.

Extend the test with more entries to ensure we check this scenario.
