### PR TITLE
Configurable reduce limit threshold and ratio

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -563,6 +563,11 @@ authentication_db = _users
 ; think you're hitting reduce_limit with a "good" reduce function, please let
 ; us know on the mailing list so we can fine tune the heuristic.
 ;reduce_limit = true
+; Don't log/crash a reduce if the result is less than this number of bytes;
+;reduce_limit_threshold = 5000
+; Don't log/crash a reduce if the result is less than the ratio multiplied
+; by input size
+;reduce_limit_ratio = 2.0
 ;os_process_limit = 100
 ;os_process_idle_limit = 300
 ;os_process_soft_limit = 100

--- a/share/server/views.js
+++ b/share/server/views.js
@@ -36,9 +36,9 @@ var Views = (function() {
     var reduce_line = JSON.stringify(reductions);
     var reduce_length = reduce_line.length;
     var input_length =  State.line_length - code_size
-    // TODO make reduce_limit config into a number
     if (State.query_config && State.query_config.reduce_limit &&
-          reduce_length > 4096 && ((reduce_length * 2) > input_length)) {
+        reduce_length > State.query_config.reduce_limit_threshold &&
+        ((reduce_length * State.query_config.reduce_limit_ratio) > input_length)) {
       var log_message = [
           "Reduce output must shrink more rapidly:",
           "input size:", input_length,

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -732,6 +732,8 @@ remove_waiting_client(#client{wait_key = Key}) ->
 get_proc_config() ->
     {[
         {<<"reduce_limit">>, get_reduce_limit()},
+        {<<"reduce_limit_threshold">>, couch_query_servers:reduce_limit_threshold()},
+        {<<"reduce_limit_ratio">>, couch_query_servers:reduce_limit_ratio()},
         {<<"timeout">>, get_os_process_timeout()}
     ]}.
 

--- a/src/docs/src/config/query-servers.rst
+++ b/src/docs/src/config/query-servers.rst
@@ -150,6 +150,16 @@ Query Servers Configuration
         option since main propose of `reduce` functions is to *reduce* the
         input.
 
+    .. config:option:: reduce_limit_threshold :: Reduce limit threshold
+
+        The number of bytes a reduce result must exceed to trigger the ``reduce_limit``
+        control. Defaults to 5000.
+
+    .. config:option:: reduce_limit_ratio :: Reduce limit ratio
+
+        The ratio of input/output that must be exceeded to trigger the ``reduce_limit``
+        control. Defaults to 2.0.
+
 .. _config/native_query_servers:
 
 Native Erlang Query Server


### PR DESCRIPTION
## Overview

Make the reduce limit threshold and ratio configurable.

## Testing recommendations

Existing feature is covered by existing tests, configurability covered by new tests.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
