### PR TITLE
include useful context when logging a bad reduction

### DIFF
--- a/share/server/views.js
+++ b/share/server/views.js
@@ -16,7 +16,7 @@ var Views = (function() {
 
   var map_results = []; // holds temporary emitted values during doc map
 
-  function runReduce(reduceFuns, keys, values, rereduce) {
+  function runReduce(reduceFuns, keys, values, rereduce, ctx) {
     var code_size = 0;
     for (var i in reduceFuns) {
       var fun_body =  reduceFuns[i];
@@ -42,7 +42,8 @@ var Views = (function() {
       var log_message = [
           "Reduce output must shrink more rapidly:",
           "input size:", input_length,
-          "output size:", reduce_length
+          "output size:", reduce_length,
+          "context:", ctx
       ].join(" ");
       if (State.query_config.reduce_limit === "log") {
           log("reduce_overflow_error: " + log_message);
@@ -65,8 +66,8 @@ var Views = (function() {
       // fatal_error. But by default if they don't do error handling we
       // just eat the exception and carry on.
       //
-      // In this case we abort map processing but don't destroy the 
-      // JavaScript process. If you need to destroy the JavaScript 
+      // In this case we abort map processing but don't destroy the
+      // JavaScript process. If you need to destroy the JavaScript
       // process, throw the error form matched by the block below.
       throw(["error", "map_runtime_error", "function raised 'fatal_error'"]);
     } else if (err[0] == "fatal") {
@@ -93,17 +94,17 @@ var Views = (function() {
       }
       return rv;
     },
-    reduce : function(reduceFuns, kvs) {
+    reduce : function(reduceFuns, kvs, ctx) {
       var keys = new Array(kvs.length);
       var values = new Array(kvs.length);
       for(var i = 0; i < kvs.length; i++) {
           keys[i] = kvs[i][0];
           values[i] = kvs[i][1];
       }
-      runReduce(reduceFuns, keys, values, false);
+      runReduce(reduceFuns, keys, values, false, ctx);
     },
-    rereduce : function(reduceFuns, values) {
-      runReduce(reduceFuns, null, values, true);
+    rereduce : function(reduceFuns, values, ctx) {
+      runReduce(reduceFuns, null, values, true, ctx);
     },
     mapDoc : function(doc) {
       // Compute all the map functions against the document.

--- a/src/couch/src/couch_native_process.erl
+++ b/src/couch/src/couch_native_process.erl
@@ -183,7 +183,7 @@ run(State, [<<"map_doc">>, Doc]) ->
         State#evstate.funs
     ),
     {State, Resp};
-run(State, [<<"reduce">>, Funs, KVs]) ->
+run(State, [<<"reduce">>, Funs, KVs, _Ctx]) ->
     {Keys, Vals} =
         lists:foldl(
             fun([K, V], {KAcc, VAcc}) ->
@@ -195,7 +195,7 @@ run(State, [<<"reduce">>, Funs, KVs]) ->
     Keys2 = lists:reverse(Keys),
     Vals2 = lists:reverse(Vals),
     {State, catch reduce(State, Funs, Keys2, Vals2, false)};
-run(State, [<<"rereduce">>, Funs, Vals]) ->
+run(State, [<<"rereduce">>, Funs, Vals, _Ctx]) ->
     {State, catch reduce(State, Funs, null, Vals, true)};
 run(#evstate{ddocs = DDocs} = State, [<<"ddoc">>, <<"new">>, DDocId, DDoc]) ->
     DDocs2 = store_ddoc(DDocs, DDocId, DDoc),

--- a/src/fabric/include/fabric.hrl
+++ b/src/fabric/include/fabric.hrl
@@ -12,6 +12,8 @@
 
 -record(collector, {
     db_name=nil,
+    ddoc_name=nil,
+    view_name=nil,
     query_args,
     callback,
     counters,


### PR DESCRIPTION
## Overview

Include originating db, ddoc and view when logging a bad reduce function.

## Testing recommendations

1. create a bad reduce (`function(ks,vs){ return vs;}` which a map function that emits a non-empty list as value, say).
2. enable reduce_limit = log
3. call the view and see the enhanced error message

## Related Issues or Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
