### PR TITLE
Fix a few regressions from recent updates

### DIFF
--- a/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
+++ b/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
@@ -1,6 +1,6 @@
---- quickjs-master/quickjs.c	2025-11-03 12:53:32
-+++ quickjs/quickjs.c	2025-11-03 16:58:35
-@@ -31279,10 +31279,24 @@
+--- quickjs-master/quickjs.c	2025-11-05 05:46:20
++++ quickjs/quickjs.c	2025-11-05 09:54:50
+@@ -31286,10 +31286,24 @@
      if (s->token.val == TOK_FUNCTION ||
          (token_is_pseudo_keyword(s, JS_ATOM_async) &&
           peek_token(s, TRUE) == TOK_FUNCTION)) {

--- a/src/couch_quickjs/patches/02-test262-errors.patch
+++ b/src/couch_quickjs/patches/02-test262-errors.patch
@@ -1,5 +1,5 @@
---- quickjs-master/test262_errors.txt	2025-11-03 12:53:32
-+++ quickjs/test262_errors.txt	2025-11-03 16:58:35
+--- quickjs-master/test262_errors.txt	2025-11-05 05:46:20
++++ quickjs/test262_errors.txt	2025-11-05 09:54:50
 @@ -19,6 +19,8 @@
  test262/test/language/expressions/compound-assignment/S11.13.2_A6.10_T1.js:24: Test262Error: #1: innerX === 2. Actual: 5
  test262/test/language/expressions/compound-assignment/S11.13.2_A6.11_T1.js:24: Test262Error: #1: innerX === 2. Actual: 5


### PR DESCRIPTION
 * Fix exception handling in `put_var` operation https://github.com/bellard/quickjs/commit/d10613f8f93c6d8f7eefbeb955ea75eb4a51ef95

 * Fix `JS_PROP_AUTOINIT` handling in `js_closure_define_global_var()` https://github.com/bellard/quickjs/commit/b07ad11c313225b74bcc121068325b0bd28b7736

 * Restore a mistakenly removed goto on error in `js_build_module_ns()` https://github.com/bellard/quickjs/commit/9688007ccbba2024b339ddcd52044b23e2a4d982
