### PR TITLE
Cleanup off-heap/priority flags

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1233,19 +1233,3 @@ url = {{nouveau_url}}
 ; from the _first_ authentication failure.
 ; note: changing this setting requires a couchdb restart.
 ;max_lifetime = 300000
-
-[off_heap_mqd]
-; Set Erlang process_flag(message_queue_data, off_heap) for the respective
-; module if the setting is true. Off-heap messages do not participate in the
-; process garbage collection. If processes expect to get a large message queue,
-; it usually make sense to set to true, as otherwise GC may take too long.
-; However in some cases that could affect latency as it takes an extra copy
-; step to copy them into the process heap.
-;rexi_server = true
-;couch_log_server = true
-;couch_server = true
-;couch_event_server = true
-;ddoc_cache_lru = true
-;mem3_shards = true
-;nouveau_index_manager = true
-;dreyfus_index_manager = true

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -279,8 +279,7 @@ close_db_if_idle(DbName) ->
     end.
 
 init([N]) ->
-    couch_util:set_mqd_off_heap(?MODULE),
-    couch_util:set_process_priority(?MODULE, high),
+    erlang:process_flag(message_queue_data, off_heap),
 
     % Mark pluggable storage engines as a supported feature
     config:enable_feature('pluggable-storage-engines'),

--- a/src/couch/src/couch_util.erl
+++ b/src/couch/src/couch_util.erl
@@ -39,8 +39,6 @@
 -export([unique_monotonic_integer/0]).
 -export([check_config_blacklist/1]).
 -export([check_md5/2]).
--export([set_mqd_off_heap/1]).
--export([set_process_priority/2]).
 -export([hmac/3]).
 -export([version_to_binary/1]).
 -export([verify_hash_names/2]).
@@ -684,29 +682,6 @@ validate_callback_exists(Module, Function, Arity) ->
 check_md5(_NewSig, <<>>) -> ok;
 check_md5(Sig, Sig) -> ok;
 check_md5(_, _) -> throw(md5_mismatch).
-
-set_mqd_off_heap(Module) ->
-    case config:get_boolean("off_heap_mqd", atom_to_list(Module), true) of
-        true ->
-            try
-                erlang:process_flag(message_queue_data, off_heap),
-                ok
-            catch
-                error:badarg ->
-                    ok
-            end;
-        false ->
-            ok
-    end.
-
-set_process_priority(Module, Level) ->
-    case config:get_boolean("process_priority", atom_to_list(Module), false) of
-        true ->
-            process_flag(priority, Level),
-            ok;
-        false ->
-            ok
-    end.
 
 ensure_loaded(Module) when is_atom(Module) ->
     case code:ensure_loaded(Module) of

--- a/src/couch_event/src/couch_event_server.erl
+++ b/src/couch_event/src/couch_event_server.erl
@@ -33,7 +33,7 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, nil, []).
 
 init(_) ->
-    couch_util:set_mqd_off_heap(?MODULE),
+    erlang:process_flag(message_queue_data, off_heap),
     {ok, #st{
         by_pid = #{},
         by_dbname = #{}

--- a/src/couch_log/src/couch_log_server.erl
+++ b/src/couch_log/src/couch_log_server.erl
@@ -47,7 +47,7 @@ log(Entry) ->
     ?SEND(Entry).
 
 init(_) ->
-    couch_util:set_mqd_off_heap(?MODULE),
+    erlang:process_flag(message_queue_data, off_heap),
     process_flag(trap_exit, true),
     {ok, #st{
         writer = couch_log_writer:init()

--- a/src/ddoc_cache/src/ddoc_cache_lru.erl
+++ b/src/ddoc_cache/src/ddoc_cache_lru.erl
@@ -77,7 +77,7 @@ refresh(DbName, DDocIds) ->
     gen_server:cast(?MODULE, {refresh, DbName, DDocIds}).
 
 init(_) ->
-    couch_util:set_mqd_off_heap(?MODULE),
+    erlang:process_flag(message_queue_data, off_heap),
     process_flag(trap_exit, true),
     BaseOpts = [public, named_table],
     CacheOpts =

--- a/src/dreyfus/src/dreyfus_index_manager.erl
+++ b/src/dreyfus/src/dreyfus_index_manager.erl
@@ -46,7 +46,7 @@ get_disk_size(DbName, #index{sig = Sig}) ->
 % gen_server functions.
 
 init([]) ->
-    couch_util:set_mqd_off_heap(?MODULE),
+    erlang:process_flag(message_queue_data, off_heap),
     ets:new(?BY_SIG, [set, private, named_table]),
     ets:new(?BY_PID, [set, private, named_table]),
     couch_event:link_listener(?MODULE, handle_db_event, nil, [all_dbs]),

--- a/src/mem3/src/mem3_shards.erl
+++ b/src/mem3/src/mem3_shards.erl
@@ -230,7 +230,7 @@ handle_config_terminate(_Server, _Reason, _State) ->
     erlang:send_after(?RELISTEN_DELAY, whereis(?MODULE), restart_config_listener).
 
 init([]) ->
-    couch_util:set_mqd_off_heap(?MODULE),
+    erlang:process_flag(message_queue_data, off_heap),
     CacheEtsOpts = [public, named_table, {read_concurrency, true}, {write_concurrency, auto}],
     ets:new(?OPTS, CacheEtsOpts),
     ets:new(?SHARDS, [bag, {keypos, #shard.dbname}] ++ CacheEtsOpts),

--- a/src/nouveau/src/nouveau_index_manager.erl
+++ b/src/nouveau/src/nouveau_index_manager.erl
@@ -53,7 +53,7 @@ update_index(#index{} = Index) ->
     end.
 
 init(_) ->
-    couch_util:set_mqd_off_heap(?MODULE),
+    erlang:process_flag(message_queue_data, off_heap),
     ets:new(?BY_DBSIG, [set, named_table]),
     ets:new(?BY_REF, [set, named_table]),
     couch_event:link_listener(?MODULE, handle_db_event, nil, [all_dbs]),

--- a/src/rexi/src/rexi_server.erl
+++ b/src/rexi/src/rexi_server.erl
@@ -43,7 +43,7 @@ start_link(ServerId) ->
     gen_server:start_link({local, ServerId}, ?MODULE, [], []).
 
 init([]) ->
-    couch_util:set_mqd_off_heap(?MODULE),
+    erlang:process_flag(message_queue_data, off_heap),
     {ok, #st{}}.
 
 handle_call(get_errors, _From, #st{errors = Errors} = St) ->


### PR DESCRIPTION
Make all processes run at normal priority.

In production observed cases which had a very high couch cfile cleaner queue (500k messages). That's likely because couch_servers are running at high priority on every scheduler, opening/closing files, and the single couch_cfile janitor process runs at normal priority, and can't keep up with cleanup. Since there is no super-high-priority to set the janitor to, let's just set them all to normal. Besides, we've had issues with high priority processes before triggering various OTP bugs and had to revert at least once before: https://github.com/erlang/otp/issues/4078.

Also, in the same vein, we never had to disable the off_heap flag in 7 years since it's been made configurable, so let's remove the extra config fluff and always set it unconditionally.
