### PR TITLE
Add skip option to doc_fdi calback in quickjs scanner

### DIFF
--- a/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
+++ b/src/couch_quickjs/src/couch_quickjs_scanner_plugin.erl
@@ -165,7 +165,7 @@ doc_id(#st{doc_cnt = C} = St, _DocId, _Db) ->
 
 doc_fdi(#st{} = St, #full_doc_info{deleted = true}, _Db) ->
     % Skip deleted; don't even open the doc body
-    {stop, St};
+    {skip, St};
 doc_fdi(#st{} = St, #full_doc_info{}, _Db) ->
     {ok, St}.
 

--- a/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
+++ b/src/couch_quickjs/test/couch_quickjs_scanner_plugin_tests.erl
@@ -38,6 +38,7 @@ couch_quickjs_scanner_plugin_test_() ->
         ]
     }.
 
+-define(DOC0, <<"doc0">>).
 -define(DOC1, <<"doc1">>).
 -define(DOC2, <<"doc2">>).
 -define(DOC3, <<"doc3">>).
@@ -55,6 +56,7 @@ setup() ->
     Ctx = test_util:start_couch([fabric, couch_scanner]),
     DbName = ?tempdb(),
     ok = fabric:create_db(DbName, [{q, "2"}, {n, "1"}]),
+    ok = add_doc(DbName, ?DOC0, #{a => d, <<"_deleted">> => true}),
     ok = add_doc(DbName, ?DOC1, #{a => x}),
     ok = add_doc(DbName, ?DOC2, #{a => y}),
     ok = add_doc(DbName, ?DOC3, #{a => z}),

--- a/src/couch_scanner/src/couch_scanner_plugin.erl
+++ b/src/couch_scanner/src/couch_scanner_plugin.erl
@@ -132,7 +132,7 @@
 % Optional. If doc is not defined, then doc_fdi default action is {stop, St}.
 % If it is defined, the default action is {ok, St}.
 -callback doc_fdi(St :: term(), FDI :: #full_doc_info{}, Db :: term()) ->
-    {ok | stop, St1 :: term()}.
+    {ok | skip | stop, St1 :: term()}.
 
 % Optional.
 -callback doc(St :: term(), Db :: term(), #doc{}) ->
@@ -404,6 +404,7 @@ scan_fdi(#full_doc_info{} = FDI, #st{} = St) ->
     St1 = St#st{pst = PSt1},
     case Go of
         ok -> scan_doc(FDI, St1);
+        skip -> {ok, St1};
         stop -> {stop, St1}
     end.
 


### PR DESCRIPTION
Add a `skip` to the scanner to skip over a particular doc `fdi`. This makes it similar to the `db/2` and `doc_id/3` callbacks. Use this option in the quickjs plugin and add a test for it by inserting a deleted doc seeing that we skip over it.

