### PR TITLE
QuickJS features and fixes: closure optimization, iterators, UAF

### DIFF
--- a/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
+++ b/src/couch_quickjs/patches/01-spidermonkey-185-mode.patch
@@ -1,6 +1,6 @@
---- quickjs-master/quickjs.c	2025-11-05 05:46:20
-+++ quickjs/quickjs.c	2025-11-05 09:54:50
-@@ -31286,10 +31286,24 @@
+--- quickjs-master/quickjs.c	2025-11-15 08:52:50
++++ quickjs/quickjs.c	2025-11-17 17:35:22
+@@ -31337,10 +31337,24 @@
      if (s->token.val == TOK_FUNCTION ||
          (token_is_pseudo_keyword(s, JS_ATOM_async) &&
           peek_token(s, TRUE) == TOK_FUNCTION)) {

--- a/src/couch_quickjs/patches/02-test262-errors.patch
+++ b/src/couch_quickjs/patches/02-test262-errors.patch
@@ -1,5 +1,5 @@
---- quickjs-master/test262_errors.txt	2025-11-05 05:46:20
-+++ quickjs/test262_errors.txt	2025-11-05 09:54:50
+--- quickjs-master/test262_errors.txt	2025-11-15 08:52:50
++++ quickjs/test262_errors.txt	2025-11-17 17:35:22
 @@ -19,6 +19,8 @@
  test262/test/language/expressions/compound-assignment/S11.13.2_A6.10_T1.js:24: Test262Error: #1: innerX === 2. Actual: 5
  test262/test/language/expressions/compound-assignment/S11.13.2_A6.11_T1.js:24: Test262Error: #1: innerX === 2. Actual: 5

--- a/src/couch_quickjs/quickjs/quickjs-atom.h
+++ b/src/couch_quickjs/quickjs/quickjs-atom.h
@@ -233,6 +233,7 @@ DEF(WeakMap, "WeakMap") /* Map + 2 */
 DEF(WeakSet, "WeakSet") /* Map + 3 */
 DEF(Iterator, "Iterator")
 DEF(IteratorHelper, "Iterator Helper")
+DEF(IteratorConcat, "Iterator Concat")
 DEF(IteratorWrap, "Iterator Wrap")
 DEF(Map_Iterator, "Map Iterator")
 DEF(Set_Iterator, "Set Iterator")

--- a/src/couch_quickjs/quickjs/test262.conf
+++ b/src/couch_quickjs/quickjs/test262.conf
@@ -143,7 +143,7 @@ Intl.RelativeTimeFormat=skip
 Intl.Segmenter=skip
 IsHTMLDDA
 iterator-helpers
-iterator-sequencing=skip
+iterator-sequencing
 json-modules
 json-parse-with-source=skip
 json-superset


### PR DESCRIPTION
 * Closure optimization quadratic -> linear on number of vars https://github.com/bellard/quickjs/commit/ae7219b1a1b2f409435d00b32c1e10d250e0d064

 * Add error checking in `JS_InstantiateFunctionListItem()` https://github.com/bellard/quickjs/commit/125b01279c49f2df6d8a49e93d0d58798d32be75

 * Optimize add/sub int32 overflow https://github.com/bellard/quickjs/commit/3d0cc291d440bc4788fcf72e5ebf6608a701f956

 * Add `Iterator.concat` https://github.com/bellard/quickjs/commit/4bd485d713dd9f99f91b5eb6f85f401afaa012b4

 * Fix BJSON array serialization (fixes use-after-free in [#475](https://github.com/bellard/quickjs/issues/457)) https://github.com/bellard/quickjs/commit/fcbf5ea2a63510f35f9ab2baadd59781be16a167
