### PR TITLE
Allow javascript_quickjs in ken

### DIFF
--- a/src/ken/src/ken_server.erl
+++ b/src/ken/src/ken_server.erl
@@ -532,6 +532,8 @@ prune_worker_table(State) ->
     State#state{pruned_last = erlang:monotonic_time()}.
 
 allowed_languages() ->
+    % These are always available
+    BuiltIn = [<<"javascript">>, <<"javascript_quickjs">>, <<"query">>],
     Config =
         couch_proc_manager:get_servers_from_env("COUCHDB_QUERY_SERVER_") ++
             couch_proc_manager:get_servers_from_env("COUCHDB_NATIVE_QUERY_SERVER_"),
@@ -541,7 +543,7 @@ allowed_languages() ->
             true -> [<<"erlang">> | Allowed0];
             _Else -> Allowed0
         end,
-    [<<"query">> | Allowed].
+    lists:usort(BuiltIn ++ Allowed).
 
 config(Key, Default) ->
     config:get("ken", Key, Default).


### PR DESCRIPTION
Previously, ken only allowed languages defined via env vars which excluded javascript_quickjs.

