### PR TITLE
Fix local doc rev parsing

### DIFF
--- a/src/couch/test/eunit/couch_doc_json_tests.erl
+++ b/src/couch/test/eunit/couch_doc_json_tests.erl
@@ -94,6 +94,16 @@ from_json_success_cases() ->
             "_rev stored in revs."
         },
         {
+            {[{<<"_rev">>, <<"0-11111111111111111111111111111111">>}]},
+            #doc{revs = {0, [<<"11111111111111111111111111111111">>]}},
+            "_rev with start 0 stored in revs (local docs case)."
+        },
+        {
+            {[{<<"_rev">>, <<"2-11111111111111111111111111111111">>}]},
+            #doc{revs = {2, [<<17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17>>]}},
+            "_rev with start 1 and size 32 stored in revs."
+        },
+        {
             {[{<<"soap">>, 35}]},
             #doc{body = {[{<<"soap">>, 35}]}},
             "Non underscore prefixed fields stored in body."
@@ -287,7 +297,7 @@ from_json_error_cases() ->
             {[
                 {<<"_revisions">>,
                     {[
-                        {<<"start">>, 0},
+                        {<<"start">>, 1},
                         {<<"ids">>, [<<"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">>]}
                     ]}}
             ]},


### PR DESCRIPTION
Previously, we applied the same "magic" hex decoding to revision ids for local docs as we did for regular docs. The "magic" is to detect the case of binaries with length 32 and assume they are hex-encoded, and then hex-decode them. When encoding them we did the opposite -- checked if they are 16 bytes long, and if, so we hex-encoded them. That's a nice optimization to half the storage needed for revs internally.

However, the trick above doesn't really apply to local docs. For local docs revision ids have the format <<"0-$N">>. Where N is a decimal number. It starts at 1 with the first update, then gets bumped on every update. The `0` prefix though never changes, it's always `0`.

Since regular (non-local) docs cannot have a revision depth of 0, it's only the case for local docs, we can detect the case of encoding local doc revisions and skip the magic hex encoding and decoding to remove the strange corner case.

