### PR TITLE
Fix purge mem3_rep client verification

### DIFF
--- a/src/mem3/src/mem3_rep.erl
+++ b/src/mem3/src/mem3_rep.erl
@@ -191,7 +191,7 @@ verify_purge_checkpoint(DbName, Props) ->
                             end
                         end,
                         [],
-                        mem3:shards(DbName)
+                        mem3:shards(mem3:dbname(DbName))
                     ),
                     lists:member(Source, Nodes) andalso lists:member(Target, Nodes)
                 catch


### PR DESCRIPTION
Previously `verify_purge_checkpoint/2` was returning `false` for valid purge internal replicator clients becuase `mem3:shards(DbName)` threw a `database_does_not_exist` error, since `mem3:shards(DbName)` works with cluster db names not shard names.

This error leads to a valid internal replication client not being recognized and so the purge infos cleanup could stall with invalid_purge_seq errors thrown. The symptoms would be log error lines that look like the following:

```
Missing or stale purge doc '_local/purge-mem3-1c8980f090d010a0570f69c22b216a2a-ef6642a7a3a78239f33b46ffdc600a81' on <<"shards/50000000-5fffffff/.../bench_db_1762663269.1762663269">> with purge_seq '2796726'

mfa: mem3_rpc:load_purge_infos_rpc/3
  error:{invalid_start_purge_seq,2900788,3030215}
  [
    {couch_bt_engine,fold_purge_infos,5,[{file,"src/couch_bt_engine.erl"},{line,619}]},
    {mem3_rpc,load_purge_infos_rpc,3,[{file,"src/mem3_rpc.erl"},{line,214}]},
    {rexi_server,init_p,3,[{file,"src/rexi_server.erl"},{line,141}]}
  ]
```
