### PR TITLE
validate content-type for PUT /db/_auto_purge

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -398,6 +398,7 @@ handle_auto_purge_req(#httpd{method = 'GET'} = Req, Db) ->
             chttpd:send_error(Req, Reason)
     end;
 handle_auto_purge_req(#httpd{method = 'PUT'} = Req, Db) ->
+    chttpd:validate_ctype(Req, "application/json"),
     {AutoPurgeProps} = chttpd:json_body_obj(Req),
     validate_auto_purge_props(AutoPurgeProps),
     case fabric:set_auto_purge_props(Db, AutoPurgeProps) of


### PR DESCRIPTION
## Overview

validate content-type for PUT /db/_auto_purge

## Testing recommendations

## Related Issues or Pull Requests

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
