### PR TITLE
Disable Clouseau tests in containers

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -39,7 +39,7 @@ meta = [
     name: 'CentOS 8',
     spidermonkey_vsn: '60',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/usr',
     quickjs_test262: true,
     image: "apache/couchdbci-centos:8-erlang-${ERLANG_VERSION}"
@@ -49,7 +49,7 @@ meta = [
     name: 'CentOS 9',
     spidermonkey_vsn: '78',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/usr',
     quickjs_test262: true,
     image: "apache/couchdbci-centos:9-erlang-${ERLANG_VERSION}"
@@ -59,7 +59,7 @@ meta = [
     name: 'Ubuntu 22.04',
     spidermonkey_vsn: '91',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     quickjs_test262: true,
     image: "apache/couchdbci-ubuntu:jammy-erlang-${ERLANG_VERSION}"
@@ -69,7 +69,7 @@ meta = [
     name: 'Ubuntu 24.04',
     spidermonkey_vsn: '115',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     quickjs_test262: true,
     image: "apache/couchdbci-ubuntu:noble-erlang-${ERLANG_VERSION}"
@@ -79,7 +79,7 @@ meta = [
     name: 'Debian x86_64',
     spidermonkey_vsn: '78',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     quickjs_test262: true,
     image: "apache/couchdbci-debian:bullseye-erlang-${ERLANG_VERSION}"
@@ -122,7 +122,7 @@ meta = [
     name: 'Debian x86_64',
     spidermonkey_vsn: '78',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     // Test this in in the bookworm-quickjs variant
     quickjs_test262: false,
@@ -133,7 +133,7 @@ meta = [
     name: 'Debian x86_64',
     spidermonkey_vsn: '78',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     quickjs_test262: false,
     image: "${DOCKER_IMAGE_BASE}-${MAXIMUM_ERLANG_VERSION}"
@@ -143,7 +143,7 @@ meta = [
     name: 'Debian 12 with QuickJS',
     disable_spidermonkey: true,
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     quickjs_test262: true,
     image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}"
@@ -161,7 +161,7 @@ meta = [
     name: 'Debian ARM64',
     spidermonkey_vsn: '78',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     // Test this in in the bookworm-quickjs variant
     quickjs_test262: false,
@@ -173,7 +173,7 @@ meta = [
     name: 'Debian x86_64',
     spidermonkey_vsn: '128',
     with_nouveau: true,
-    with_clouseau: true,
+    with_clouseau: false,
     clouseau_java_home: '/opt/java/openjdk',
     quickjs_test262: true,
     image: "apache/couchdbci-debian:trixie-erlang-${ERLANG_VERSION}"


### PR DESCRIPTION
Running the search tests with Clouseau 3.0 amplified the flakiness for containers which is making hard to use the CI — disable those for now until they root cause is investigated and a fix is provided.  Mind that native builds, e.g. FreeBSD and Windows are still there to catch Search-related regressions.