### PR TITLE
Fix Credo 1.7.14 ExpensiveEmptyEnumCheck warningsFix Credo 1.7.14 ExpensiveEmptyEnumCheck warnings

### DIFF
--- a/test/elixir/lib/couch/dbtest.ex
+++ b/test/elixir/lib/couch/dbtest.ex
@@ -196,7 +196,7 @@ defmodule Couch.DBTest do
           query: [feed: "longpoll", timeout: 5000, filter: "_design"]
         )
       results = resp.body["results"]
-      is_list(results) && length(results) > 0
+      is_list(results) && not Enum.empty?(results)
     end, 500, 60_000)
   end
 

--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -64,7 +64,7 @@ defmodule BasicsTest do
     db_count = length(Couch.get("/_all_dbs").body)
     assert db_count > 0
     assert Couch.get("/_all_dbs?limit=0").body == []
-    assert length(Couch.get("/_all_dbs?limit=1").body) >= 1
+    assert not Enum.empty?(Couch.get("/_all_dbs?limit=1").body)
     assert length(Couch.get("/_all_dbs?skip=1").body) == (db_count - 1)
     assert [db] == Couch.get("/_all_dbs?start_key=\"#{db}\"&limit=1").body
   end

--- a/test/elixir/test/partition_size_limit_test.exs
+++ b/test/elixir/test/partition_size_limit_test.exs
@@ -228,7 +228,7 @@ defmodule PartitionSizeLimitTest do
     assert resp.status_code in [200, 202]
     %{body: body} = resp
 
-    assert length(body["rows"]) > 0
+    assert not Enum.empty?(body["rows"])
   end
 
   test "purging docs allows writes", context do

--- a/test/elixir/test/replication_test.exs
+++ b/test/elixir/test/replication_test.exs
@@ -1671,7 +1671,7 @@ defmodule ReplicationTest do
     revs_checked = task["revisions_checked"]
     changes = get_db_changes(src_db_name, %{:since => through_seq})
 
-    if length(changes["results"]) > 0 or revs_checked < expect_revs_checked do
+    if not Enum.empty?(changes["results"]) or revs_checked < expect_revs_checked do
       :timer.sleep(500)
       wait_for_repl(src_db_name, repl_id, expect_revs_checked, wait_left - 500)
     end


### PR DESCRIPTION
This PR fixes the Credo 1.7.14 warnings introduced by the `ExpensiveEmptyEnumCheck` check.

## Changes

Replaced expensive `length/1` checks with `Enum.empty?/1` in 4 test files:
- `test/elixir/test/replication_test.exs` - Line 1674
- `test/elixir/lib/couch/dbtest.ex` - Line 199
- `test/elixir/test/partition_size_limit_test.exs` - Line 231
- `test/elixir/test/basics_test.exs` - Line 67

## Rationale

The `Enum.empty?/1` function is more performant than `length/1` for checking if a list is empty because:
- `Enum.empty?/1` only needs to check if there's at least one element
- `length/1` must traverse the entire list to count all elements

These changes are semantically equivalent:
- `length(list) > 0` ≡ `not Enum.empty?(list)`
- `length(list) >= 1` ≡ `not Enum.empty?(list)`

## Testing

All changes are in test files and maintain the same logical behavior. The modifications follow Elixir best practices for performance optimization.

Fixes #5799Replace expensive length/1 checks with Enum.empty?/1 in test files to resolve Credo warnings introduced in version 1.7.14.

Changes:
- test/elixir/test/replication_test.exs: Replace length(list) > 0
- test/elixir/lib/couch/dbtest.ex: Replace length(list) > 0
- test/elixir/test/partition_size_limit_test.exs: Replace length(list) > 0
- test/elixir/test/basics_test.exs: Replace length(list) >= 1

These changes are semantically equivalent but more performant as Enum.empty?/1 only checks for the first element instead of traversing the entire list.

Fixes #5799

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
