### PR TITLE
Fix: Ken drops databases on nodedown

### DIFF
--- a/src/ken/src/ken_server.erl
+++ b/src/ken/src/ken_server.erl
@@ -269,16 +269,20 @@ update_db_indexes(Name, State) ->
                 true -> ok
             end;
         {error, timeout} ->
+            exit(resubmit);
+        {error, {nodedown, _}} ->
+            exit(resubmit);
+        {error, {maintenance_mode, _, _}} ->
             exit(resubmit)
     end.
 
 design_docs(Name) ->
     try
         case fabric:design_docs(mem3:dbname(Name)) of
-            {error, {maintenance_mode, _, _Node}} ->
-                {ok, []};
-            {error, {nodedown, _Reason}} ->
-                {ok, []};
+            {error, {maintenance_mode, _, _Node}} = Error ->
+                Error;
+            {error, {nodedown, _Reason}} = Error ->
+                Error;
             {ok, DDocs} when is_list(DDocs) ->
                 {ok, DDocs};
             {ok, _Resp} ->


### PR DESCRIPTION
## Description
This PR fixes an issue where Ken (the background indexer) would drop a database from its indexing queue if `fabric:design_docs/1` returned a `nodedown` or `maintenance_mode` error.

Previously, these errors were caught and treated as an empty list of design documents (`{ok, []}`), causing Ken to believe there was nothing to index and removing the database from the pending queue.

## Changes
- Modified `ken_server:design_docs/1` to propagate `{error, {nodedown, ...}}` and `{error, {maintenance_mode, ...}}` instead of swallowing them.
- Modified `ken_server:update_db_indexes/2` to handle these specific errors by exiting with `resubmit`. This triggers Ken's built-in retry mechanism, ensuring the database is added back to the queue to be retried later.

## Testing
- Added a reproduction test case in `src/ken/test/ken_repro_test.erl` (if applicable to include in PR).
- Verified that `nodedown` errors now trigger a resubmit instead of a silent drop.

Fixes #5392<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
