### PR TITLE
fix(tests): Fix and enable JWTRolesClaimTest

### DIFF
--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -836,5 +836,12 @@
     "no index without fallback",
     "uses all docs when fields do not match selector",
     "uses all docs when selector doesnt require fields to exist"
-  ]
+  ],
+  "JwtRolesClaimTest": [
+      "case: roles_claim_name (defined) / roles_claim_path (defined)",
+      "case: roles_claim_name (defined) / roles_claim_path (undefined)",
+      "case: roles_claim_name (undefined) / roles_claim_path (defined)",
+      "case: roles_claim_name (undefined) / roles_claim_path (undefined)",
+      "case: roles_claim_path with bad input"
+    ]
 }

--- a/test/elixir/test/jwt_roles_claim_test.exs
+++ b/test/elixir/test/jwt_roles_claim_test.exs
@@ -14,15 +14,15 @@ defmodule JwtRolesClaimTest do
     %{
       :section => "jwt_keys",
       :key => "hmac:myjwttestkey",
+      # "a-string-secret-at-least-256-bits-long"
       :value => ~w(
-        NTNv7j0TuYARvmNMmWXo6fKvM4o6nv/aUi9ryX38ZH+L1bkrnD1ObOQ8JAUmHCBq7
-        Iy7otZcyAagBLHVKvvYaIpmMuxmARQ97jUVG16Jkpkp1wXOPsrF9zwew6TpczyH
-        kHgX5EuLg2MeBuiT/qJACs1J0apruOOJCg/gOtkjB4c=
+        YS1zdHJpbmctc2VjcmV0LWF0LWxlYXN0LTI1Ni1iaXRzLWxvbmc=
         ) |> Enum.join()
     },
     %{
       :section => "jwt_keys",
       :key => "hmac:myjwttestkey2",
+      # "Undoubtedly-Engaging-Roadway-029"
       :value => ~w(
         VW5kb3VidGVkbHktRW5nYWdpbmctUm9hZHdheS0wMjk=
        ) |> Enum.join()
@@ -133,17 +133,19 @@ defmodule JwtRolesClaimTest do
   end
 
   def test_roles(roles) do
+    # myjwttestkey
+    # Token expires after Thu Dec 31 2099 22:59:59 GMT+0000
     token = ~w(
       eyJ0eXAiOiJKV1QiLCJraWQiOiJteWp3dHRlc3RrZXkiLCJhbGciOiJIUzI1NiJ9.
       eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRyd
-      WUsImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxNzU1Mjk5NDEwLCJteSI6eyJuZXN0ZW
+      WUsImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxOTI0OTg4Mzk5LCJteSI6eyJuZXN0ZW
       QiOnsiX2NvdWNoZGIucm9sZXMiOlsibXlfbmVzdGVkX2NvdWNoZGIucm9sZXNfMSI
       sIm15X25lc3RlZF9jb3VjaGRiLnJvbGVzXzEiXX19LCJfY291Y2hkYi5yb2xlcyI6
       WyJfY291Y2hkYi5yb2xlc18xIiwiX2NvdWNoZGIucm9sZXNfMiJdLCJteS5fY291Y
       2hkYi5yb2xlcyI6WyJteS5fY291Y2hkYi5yb2xlc18xIiwibXkuX2NvdWNoZGIucm
       9sZXNfMiJdLCJmb28iOnsiYmFyLnpvbmsiOnsiYmF6LmJ1dSI6eyJiYWEiOnsiYmF
       hLmJlZSI6eyJyb2xlcyI6WyJteV9uZXN0ZWRfcm9sZV8xIiwibXlfbmVzdGVkX3Jv
-      bGVfMiJdfX19fX19.F6kQK-FK0z1kP01bTyw-moXfy2klWfubgF7x7Xitd-0) |> Enum.join()
+      bGVfMiJdfX19fX19._3BgqHB8ETk4QPOn_LMgUkjgsjgqDCf7AUlV3XRmP6A) |> Enum.join()
 
     resp =
       Couch.get("/_session",
@@ -156,19 +158,20 @@ defmodule JwtRolesClaimTest do
   end
 
   def test_roles_as_string(roles) do
-      # Different token
+      # myjwttestkey2
+      # Token expires after Thu Dec 31 2099 22:59:59 GMT+0000
       token = ~w(
         eyJ0eXAiOiJKV1QiLCJraWQiOiJteWp3dHRlc3RrZXkyIiwiYWxnIjoiSFMyNTYifQ.
         eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWU
-        sImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxNzU1Mjk5NDEwLCJteSI6eyJuZXN0ZWQiOn
+        sImlhdCI6MTY1NTI5NTgxMCwiZXhwIjo0MTAyNDQxMTk5LCJteSI6eyJuZXN0ZWQiOn
         siX2NvdWNoZGIucm9sZXMiOiJteV9uZXN0ZWRfY291Y2hkYl9zdHJpbmcucm9sZXNfM
         SwgbXlfbmVzdGVkX2NvdWNoZGJfc3RyaW5nLnJvbGVzXzEifX0sIl9jb3VjaGRiLnJv
         bGVzIjoiX2NvdWNoZGJfc3RyaW5nLnJvbGVzXzEsX2NvdWNoZGJfc3RyaW5nLnJvbGV
         zXzIiLCJteS5fY291Y2hkYi5yb2xlcyI6Im15Ll9jb3VjaGRiX3N0cmluZy5yb2xlc1
         8xLCBteS5fY291Y2hkYl9zdHJpbmcucm9sZXNfMiIsImZvbyI6eyJiYXIuem9uayI6e
         yJiYXouYnV1Ijp7ImJhYSI6eyJiYWEuYmVlIjp7InJvbGVzIjoibXlfbmVzdGVkX3N0
-        cmluZ19yb2xlXzEsIG15X25lc3RlZF9zdHJpbmdfcm9sZV8yIn19fX19fQ.rzaLmcA2
-        0R291XuGYNNTM9ypGL3UD_GlVp3DmBtWrZI
+        cmluZ19yb2xlXzEsIG15X25lc3RlZF9zdHJpbmdfcm9sZV8yIn19fX19fQ.nUQYe_Fy
+        1LBY0F4jbfLwj47p2468v0lrCzHXMWpkfA4
         ) |> Enum.join()
 
       resp =
@@ -182,17 +185,19 @@ defmodule JwtRolesClaimTest do
     end
 
   def test_roles_with_bad_input() do
+    # myjwttestkey
+    # Token expires after Thu Dec 31 2099 22:59:59 GMT+0000
     token = ~w(
       eyJ0eXAiOiJKV1QiLCJraWQiOiJteWp3dHRlc3RrZXkiLCJhbGciOiJIUzI1NiJ9.
       eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRyd
-      WUsImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxNzU1Mjk5NDEwLCJteSI6eyJuZXN0ZW
+      WUsImlhdCI6MTY1NTI5NTgxMCwiZXhwIjoxOTI0OTg4Mzk5LCJteSI6eyJuZXN0ZW
       QiOnsiX2NvdWNoZGIucm9sZXMiOlsibXlfbmVzdGVkX2NvdWNoZGIucm9sZXNfMSI
       sIm15X25lc3RlZF9jb3VjaGRiLnJvbGVzXzEiXX19LCJfY291Y2hkYi5yb2xlcyI6
       WyJfY291Y2hkYi5yb2xlc18xIiwiX2NvdWNoZGIucm9sZXNfMiJdLCJteS5fY291Y
       2hkYi5yb2xlcyI6WyJteS5fY291Y2hkYi5yb2xlc18xIiwibXkuX2NvdWNoZGIucm
       9sZXNfMiJdLCJmb28iOnsiYmFyLnpvbmsiOnsiYmF6LmJ1dSI6eyJiYWEiOnsiYmF
       hLmJlZSI6eyJyb2xlcyI6WyJteV9uZXN0ZWRfcm9sZV8xIiwibXlfbmVzdGVkX3Jv
-      bGVfMiJdfX19fX19.F6kQK-FK0z1kP01bTyw-moXfy2klWfubgF7x7Xitd-0) |> Enum.join()
+      bGVfMiJdfX19fX19._3BgqHB8ETk4QPOn_LMgUkjgsjgqDCf7AUlV3XRmP6A) |> Enum.join()
 
     resp =
       Couch.get("/_session",


### PR DESCRIPTION
Jessica discovered [1] that the “JWTRolesClaimTest” test suite was not activated during testing and was therefore not called. In addition, the tests failed because the used JWT test tokens had an expiration date (Sat Aug 16 2025 01:10:10 GMT+0200).

1. For all used JWT test tokens, the expiration date was increased to Thu Dec 31 2099 22:59:59 GMT+0000.
2. The JWT token signatures were adjusted.
3. Tests were activated in the Elixir suite.

[1] https://github.com/apache/couchdb/pull/5822#discussion_r2615970826

```elixir
JwtRolesClaimTest [test/elixir/test/jwt_roles_claim_test.exs]
  * test case: roles_claim_name (undefined) / roles_claim_path (defined) (118.3ms) [L#57]
  * test case: roles_claim_name (defined) / roles_claim_path (defined) (71.7ms) [L#73]
  * test case: roles_claim_name (undefined) / roles_claim_path (undefined) (42.6ms) [L#32]
  * test case: roles_claim_name (defined) / roles_claim_path (undefined) (61.8ms) [L#41]
  * test case: roles_claim_path with bad input (159.0ms) [L#94]

Finished in 0.5 seconds (0.00s async, 0.5s sync)
5 tests, 0 failures
```