### PR TITLE
use secret from config if ETS not populated

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -460,21 +460,9 @@ ensure_cookie_auth_secret() ->
         undefined ->
             NewSecret = ?b2l(couch_uuids:random()),
             config:set("chttpd_auth", "secret", NewSecret),
-            wait_for_secret(10),
             NewSecret;
         Secret ->
             Secret
-    end.
-
-wait_for_secret(0) ->
-    ok;
-wait_for_secret(N) ->
-    case couch_secrets:secret_is_set() of
-        true ->
-            ok;
-        false ->
-            timer:sleep(50),
-            wait_for_secret(N - 1)
     end.
 
 % session handlers


### PR DESCRIPTION
This helps with startup race conditions in the test suite where the secret is set in config but the gen_server in couch_secrets hasn't received it via config_change callback yet.
