### PR TITLE
feat: concat eunit test logs and remove test tmp dirs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,8 @@ eunit: export ERL_AFLAGS = -config $(CURDIR)/rel/files/eunit.config
 eunit: export COUCHDB_QUERY_SERVER_JAVASCRIPT = $(CURDIR)/bin/couchjs $(CURDIR)/share/server/main.js
 eunit: export COUCHDB_TEST_ADMIN_PARTY_OVERRIDE=1
 eunit: ${SUBDIRS}
+	@cat tmp/couchdb-tests/*/log/couch.log > tmp/couch.log
+	@rm -rf tmp/couchdb-tests/*
 
 $(SUBDIRS): setup-eunit
 	@COUCHDB_VERSION=$(COUCHDB_VERSION) COUCHDB_GIT_SHA=$(COUCHDB_GIT_SHA) $(REBAR) -r eunit $(EUNIT_OPTS) apps=$@ #|| exit 1

--- a/src/couch/src/test_util.erl
+++ b/src/couch/src/test_util.erl
@@ -131,7 +131,8 @@ stop_couch() ->
     ok = stop_applications(?DEFAULT_APPS).
 
 stop_couch(#test_context{started = Apps, dir = RandomDir}) ->
-    file:del_dir_r(RandomDir),
+    % deletion now happens in Makefile
+    % file:del_dir_r(RandomDir),
     stop_applications(Apps);
 stop_couch(_) ->
     stop_couch().


### PR DESCRIPTION
This allows debugging of test runs in a unified log.

It also retains individual test run state dirs if
`make eunit` fails. The next successful run will clean it up
