### PR TITLE
Fix handling shards dbs purge checkpoints in mem3_rep

### DIFF
--- a/src/mem3/src/mem3.erl
+++ b/src/mem3/src/mem3.erl
@@ -130,8 +130,7 @@ shards_int(DbName, Options) when is_list(DbName) ->
     shards_int(list_to_binary(DbName), Options);
 shards_int(DbName, Options) ->
     Ordered = lists:member(ordered, Options),
-    ShardDbName =
-        list_to_binary(config:get("mem3", "shards_db", "_dbs")),
+    ShardDbName = mem3_sync:shards_db(),
     case DbName of
         ShardDbName when Ordered ->
             %% shard_db is treated as a single sharded db to support calls to db_info
@@ -141,7 +140,7 @@ shards_int(DbName, Options) ->
                     node = config:node_name(),
                     name = ShardDbName,
                     dbname = ShardDbName,
-                    range = [0, (2 bsl 31) - 1],
+                    range = [0, ?RING_END],
                     order = undefined
                 }
             ];
@@ -153,7 +152,7 @@ shards_int(DbName, Options) ->
                     node = config:node_name(),
                     name = ShardDbName,
                     dbname = ShardDbName,
-                    range = [0, (2 bsl 31) - 1]
+                    range = [0, ?RING_END]
                 }
             ];
         _ ->


### PR DESCRIPTION
Previous PR [1] failed to account for shards db itself. Shards db (`_dbs`) is managed differently than regular shard copies. Its `mem3:shards(Dbs)` result is a single element shard list with a `#shard{}` having `node = node()` and `range = [0, ff..]`. They are replicated in a ring across all nodes, we expect to find a purge checkpoint pushing changes to the "next" node in a ring only.

[1] https://github.com/apache/couchdb/pull/5827
