### PR TITLE
Skip some smoosh persist eunit tests as root

### DIFF
--- a/src/smoosh/src/smoosh_persist.erl
+++ b/src/smoosh/src/smoosh_persist.erl
@@ -202,15 +202,23 @@ t_check_setup(_) ->
     TDir = ?tempfile(),
     meck:expect(config, get, fun("smoosh", "state_dir", _) -> TDir end),
     ?assertEqual({error, {"read", enoent}}, check_setup()),
-
     Dir = state_dir(),
     ok = file:make_dir(Dir),
-    % Can't write, only read
+    % Can't write, only read. This works only when running as non-admin/non-root.
     ok = file:change_mode(Dir, 8#500),
-    ?assertEqual({error, {"write", eacces}}, check_setup()),
-    % Can't read, only write
-    ok = file:change_mode(Dir, 8#300),
-    ?assertEqual({error, {"read access", write}}, check_setup()),
+    % Did the setup work?
+    {ok, #file_info{access = Access}} = file:read_file_info(Dir),
+    case Access of
+        read ->
+            ?assertEqual({error, {"write", eacces}}, check_setup()),
+            % Can't read, only write
+            ok = file:change_mode(Dir, 8#300),
+            ?assertEqual({error, {"read access", write}}, check_setup());
+        read_write ->
+            % We must be running as root/admin and we can't really make Dir
+            % unreadable for ourselves, so skip this part.
+            ok
+    end,
     ok = file:del_dir_r(Dir).
 
 t_persist_unpersist_disabled(_) ->
@@ -271,15 +279,21 @@ t_persist_unpersist_errors(_) ->
 
     Dir = state_dir(),
     ok = file:make_dir(Dir),
-
-    % Can't write, only read
+    % Can't write, only read. This works only when not running as root/admin.
     ok = file:change_mode(Dir, 8#500),
-    ?assertEqual({error, eacces}, persist(Q1, #{}, #{})),
-
-    Q3 = unpersist(Name),
-    ?assertEqual(Name, smoosh_priority_queue:name(Q3)),
-    ?assertEqual(#{max => 0, min => 0, size => 0}, smoosh_priority_queue:info(Q3)),
-
+    % Did the setup work?
+    {ok, #file_info{access = Access}} = file:read_file_info(Dir),
+    case Access of
+        read ->
+            ?assertEqual({error, eacces}, persist(Q1, #{}, #{})),
+            Q3 = unpersist(Name),
+            ?assertEqual(Name, smoosh_priority_queue:name(Q3)),
+            ?assertEqual(#{max => 0, min => 0, size => 0}, smoosh_priority_queue:info(Q3));
+        read_write ->
+            % We must be running as root/admin so we can't really make dir
+            % unreadable for ourselves so skip this part
+            ok
+    end,
     ok = file:del_dir_r(Dir).
 
 drain_q(Q) ->


### PR DESCRIPTION
Normally we don't run our eunit or ci tests as root but rarely it happens, such as when when Ronny was investing ARM64 perf issues on one of the CI nodes. There we noticed two smoosh state persisting tests failed. In order to test lack of fs access, those tests set up a file so it's unreadable or unwritable by current user. That doesn't work, however, if that user is root or admin, as they can't remove their own access with plain chmods. So add a quick exception for those cases to skip part of the tests if the setup cannot be accomplished as planned.
