### PR TITLE
Disable FreeBSD ARM64 for now

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -191,14 +191,19 @@ meta = [
 
   // Spidermonkey 91 has issues on ARM64 FreeBSD
   // use QuickJS for now
-  'freebsd-arm64': [
-     name: 'FreeBSD ARM64 QuickJS',
-     disable_spidermonkey: true,
-     with_clouseau: true,
-     clouseau_java_home: '/usr/local/openjdk21',
-     quickjs_test262: false,
-     gnu_make: 'gmake'
-  ],
+  //
+  // Disable for now due to repeated failures in elixir tests:
+  // 1) test Server-side password hashing, and raw updates disabling that (ConfigTest)
+  // ** (KeyError) key :status_code not found in: %HTTPotion.ErrorResponse{message: "retry_later"}
+  //
+  // 'freebsd-arm64': [
+  //    name: 'FreeBSD ARM64 QuickJS',
+  //    disable_spidermonkey: true,
+  //    with_clouseau: true,
+  //    clouseau_java_home: '/usr/local/openjdk21',
+  //    quickjs_test262: false,
+  //    gnu_make: 'gmake'
+  // ],
 
   'macos': [
      name: 'macOS',


### PR DESCRIPTION
Due to repeated failures in:

```
15:02:03    1) test Server-side password hashing, and raw updates disabling that (ConfigTest)
15:02:03       test/elixir/test/config_test.exs:89
15:02:03       ** (KeyError) key :status_code not found in: %HTTPotion.ErrorResponse{message: "retry_later"}
15:02:03       code: delete_config(context, "admins", "administrator")
15:02:03       stacktrace:
15:02:03         test/elixir/test/config_test.exs:69: ConfigTest.delete_config/4
15:02:03         test/elixir/test/config_test.exs:98: (test)
   2) test Non-2-tuples in the whitelist are ignored (ConfigTest)
14:58:20       test/elixir/test/config_test.exs:127
14:58:20       ** (KeyError) key :status_code not found in: %HTTPotion.ErrorResponse{message: "retry_later"}
14:58:20       stacktrace:
14:58:20         test/elixir/test/config_test.exs:15: ConfigTest.__ex_unit_setup_1/1
14:58:20         test/elixir/test/config_test.exs:1: ConfigTest.__ex_unit__/2
```

Often all 3 retries fail in a row
