### PR TITLE
Tolerate invalid typ claim when not required

### DIFF
--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -168,7 +168,8 @@ validate_typ(Props, Checks) ->
     Required = prop(typ, Checks),
     TYP = prop(<<"typ">>, Props),
     case {Required, TYP} of
-        {undefined, undefined} ->
+        % ignore unrequired check
+        {undefined, _} ->
             ok;
         {true, undefined} ->
             throw({bad_request, <<"Missing typ header parameter">>});

--- a/src/jwtf/test/jwtf_tests.erl
+++ b/src/jwtf/test/jwtf_tests.erl
@@ -88,6 +88,15 @@ invalid_typ_test() ->
         jwtf:decode(Encoded, [typ], nil)
     ).
 
+ignored_typ_test() ->
+    Encoded = encode({[{<<"typ">>, <<"NOPE">>}]}, {[]}),
+    Ref = make_ref(),
+    KS = fun(_, _) -> throw(Ref) end,
+    ?assertEqual(
+        {error, Ref},
+        jwtf:decode(Encoded, [], KS)
+    ).
+
 missing_alg_test() ->
     Encoded = encode({[]}, []),
     ?assertEqual(


### PR DESCRIPTION
NB The test causes an error at sig verification stage which comes after claim verification.

closes: https://github.com/apache/couchdb/issues/5838
