### PR TITLE
Implement dry-run for auto-purge plugin

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1215,13 +1215,24 @@ url = {{nouveau_url}}
 ; The fewest id/rev pairs the plugin will attempt to purge in
 ; one request, excepting at the end of a database scan.
 ;min_batch_size = 250
+
 ; The most id/rev pairs the plugin will attempt to purge in
 ; one request.
 ;max_batch_size = 500
+
 ; The default time-to-live, measured in seconds, before a
 ; deleted document is eligible to be purged by the plugin.
 ; Defaults to undefined, which disables auto purging.
 ;deleted_document_ttl =
+
+; Set the log level for starting, stopping and purge report summary log entries.
+;log_level = info
+
+; When set to "true" the plugin does everything (scanning, revision processing,
+; etc) but skips the purge step. Optionally use the "log_level" plugin setting
+; to increase the severity of log reports so it's clear when the plugin starts,
+; stops and how many revisions it found to purge.
+;dry_run = false
 
 [nouveau_index_upgrader]
 ; Common scanner scheduling settings

--- a/src/docs/src/config/scanner.rst
+++ b/src/docs/src/config/scanner.rst
@@ -263,3 +263,21 @@ settings in their ``[{plugin}]`` section.
         The database may override this setting with the
         :ref:`api/db/auto_purge` endpoint. If neither is set, the
         plugin will not purge deleted documents.
+
+    .. config:option:: log_level
+
+        Set the log level for starting, stopping and purge report summary log entries. ::
+
+            [couch_auto_purge_plugin]
+            log_level = info
+
+    .. config:option:: dry_run
+
+        When set to ``true`` the plugin does everything (scanning, revision
+        processing, etc) but skips the actual purge step. Optionally use the
+        ``log_level`` plugin setting to increase the severity of log reports so
+        it's clear when the plugin starts, stops and how many revisions it found
+        to purge. ::
+
+            [couch_auto_purge_plugin]
+            dry_run = false


### PR DESCRIPTION
Add a dry-run mode for the auto-purge plugin. Users can enable it and schedule the plugin to run to see how many deleted documents would have been purged for each db shard range. Users may adjust the ttl or the plugin schedule (to run more or less often) and get an idea how long it would take to scan over all the data on the cluster.
