### PR TITLE
View compaction duration log

### DIFF
--- a/src/couch_mrview/include/couch_mrview.hrl
+++ b/src/couch_mrview/include/couch_mrview.hrl
@@ -30,7 +30,8 @@
     doc_queue,
     write_queue,
     qserver=nil,
-    view_info=#{}
+    view_info=#{},
+    start_time
 }).
 
 


### PR DESCRIPTION
## Overview

Log how long it took for a view compaction to reach the point that the .mrview file is swapped into use. This helps administrators determine the lower bound for server uptime.

## Testing recommendations

N/A

## Related Issues or Pull Requests

None

## Checklist

- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
