### PR TITLE
dev: Update .gitattributes for Nouveau

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-nouveau/**/* text eol=lf
-nouveau/**/*.bat text eol=crlf
-nouveau/**/*.jar binary
+extra/nouveau/**/* text eol=lf
+extra/nouveau/**/*.bat text eol=crlf
+extra/nouveau/**/*.jar binary


### PR DESCRIPTION
After moving Nouveau from `nouveau` to `extra/nouveau` we need to update the `.gitattributes` file, that Windows will use LF as line ending, when no `core.autocrlf` is configured within git.