### PR TITLE
fix(`mango`): formatting of `text` bookmarks in `_explain` output

### DIFF
--- a/test/elixir/test/config/search.elixir
+++ b/test/elixir/test/config/search.elixir
@@ -34,6 +34,10 @@
     "facet ranges, non-empty",
     "timeouts do not expose internal state"
   ],
+  "BasicTextTest": [
+    "explain options",
+    "explain with bookmarks"
+  ],
   "ElemMatchTests": [
     "elem match non object"
   ],
@@ -62,5 +66,9 @@
   ],
   "RegexVsTextIndexTest": [
     "regex works with text index"
+  ],
+  "PartitionMangoTest": [
+    "explain options (text)",
+    "explain works with bookmarks (text)"
   ]
 }

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -361,6 +361,8 @@
   "PartitionMangoTest": [
     "explain works with non partitioned db",
     "explain works with partitions",
+    "explain works with bookmarks",
+    "explain options",
     "global query does not use partition index",
     "global query uses global index",
     "non-partitioned query using _all_docs and $eq",
@@ -763,6 +765,7 @@
     "unsatisfiable range",
     "explain view args",
     "explain options",
+    "explain with bookmarks",
     "sort with all docs"
   ],
   "IgnoreDesignDocsForAllDocsIndexTests": [

--- a/test/elixir/test/mango/02_basic_find_test.exs
+++ b/test/elixir/test/mango/02_basic_find_test.exs
@@ -315,6 +315,17 @@ defmodule BasicFindTest do
     assert opts["allow_fallback"] == true
   end
 
+  test "explain with bookmarks" do
+    query = %{"age" => %{"$gt" => 42}}
+
+    {:ok, resp} = MangoDatabase.find(@db_name, query, limit: 1, return_raw: true)
+    assert length(resp["docs"]) == 1
+    assert resp["bookmark"] != "nil"
+    {:ok, explain} = MangoDatabase.find(@db_name, query, bookmark: resp["bookmark"], explain: true)
+    assert is_binary(explain["opts"]["bookmark"])
+    assert resp["bookmark"] == explain["opts"]["bookmark"]
+  end
+
   test "sort with all docs" do
     {:ok, explain} = MangoDatabase.find(@db_name,
       %{"_id" => %{"$gt" => 0}, "age" => %{"$gt" => 0}},


### PR DESCRIPTION
In the Explain output, bookmarks for queries on `text` (Search) indexes are added in their unpacked format to the options.  This leads to at least two problems:

- it is inconsistent with how empty bookmarks are rendered for `json` indexes, where the string `"nil"` is used,

- for non-trivial bookmarks, contents cannot be translated by `jiffy:encode/1` to a JSON representation so that it will crash.

Mitigate this issue by deferring the unpacking of bookmarks to the execution phase so that explain will get affected by that.

Thanks @mojito317 for reporting this issue, and thanks @rnewson for revisiting my original fix and guiding me about it.

## Testing recommendations

The change comes with tests that may be run as follows.

```
make elixir EXUNIT_OPTS="test/elixir/test/mango/02_basic_find_test.exs test/elixir/test/partition_mango_test.exs"
```

and 

```
make elixir-search EXUNIT_OPTS="test/elixir/test/mango/06_basic_text_test.exs test/elixir/test/partition_mango_test.exs"
```

Otherwise just try to start a `_find` query on a `text` index, grab the bookmark, and feed it into an `_explain` request with the same query.  It should not crash any more.  When running a `_explain` query on a `text` with no bookmark provided, the `opts` field in the body should show `nil` instead of an empty array as it did previously.

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
