### PR TITLE
chore(docs): Update Performance documentation to include SDio Flag

### DIFF
--- a/src/docs/src/maintenance/performance.rst
+++ b/src/docs/src/maintenance/performance.rst
@@ -58,7 +58,7 @@ operations add the following to ``(prefix)/etc/defaults/couchdb``
 
 .. _command line flag +A in erl(1): http://erlang.org/doc/man/erl.html
 
-Since Erlang OTP 21, the linked-in drivers have been migrated to dirty IO schedulers. 
+Since Erlang OTP 21, the linked-in drivers have been migrated to dirty IO schedulers.
 These schedulers can be configured by ``ERL_FLAGS`` environment
 variable. For example, to give Erlang 80 dirty schedulers
 add the following to ``(prefix)/etc/defaults/couchdb``


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Setting the `+A` flag currently doesn't do anything meaningful to the performance of CouchDB. 

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->
Doc update

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [x] Documentation changes were backported (separated PR) to affected branches
