### PR TITLE
Fix intermittent _scheduler/docs 500 error

### DIFF
--- a/src/couch_replicator/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator/src/couch_replicator_doc_processor.erl
@@ -563,7 +563,7 @@ doc(Db, DocId) ->
     end.
 
 -spec doc_lookup(binary(), binary(), integer()) ->
-    {ok, {[_]}} | {error, not_found}.
+    {ok, {[_]} | nil} | {error, not_found}.
 doc_lookup(Db, DocId, HealthThreshold) ->
     case ets:lookup(?MODULE, {Db, DocId}) of
         [#rdoc{} = RDoc] ->


### PR DESCRIPTION
Previously, if users called the `_scheduler/docs` API at just the right moment, when a job would appear in the replicator doc processor ets table as `scheduled`, but it would not be in the replicator scheduler's ets table, users would get a function clause error that looks like this along with a 500 HTTP response:

```
req_err(2666435525) unknown_error : function_clause [
 <<"couch_replicator_httpd_util:update_db_name/1 L183">>,
 <<"couch_replicator_httpd:handle_scheduler_doc/3 L157">>,
 <<"chttpd:handle_req_after_auth/2 L432">>,
 ...
]
```

To fix it, explicitly handle this state as transitional pending state returning all the information we have about the job in the replicator doc processor.

There is a second commit that fixes a wrong type-spec. `doc_lookup/3` can also return an `{ok, nil}` tuple. We handle it in https://github.com/apache/couchdb/blob/21d96992ec484a08198cf9c45d0ea3701b8e25ff/src/couch_replicator/src/couch_replicator_fabric_rpc.erl#L82 it's just that we never declared it in the spec.
