### PR TITLE
Send 404 for /_all_dbs and /_dbs_info with extra path parts

### DIFF
--- a/test/elixir/test/basics_test.exs
+++ b/test/elixir/test/basics_test.exs
@@ -388,4 +388,19 @@ defmodule BasicsTest do
     resp = Couch.get("/", headers: ["X-Couch-Request-ID": uuid])
     assert resp.headers["X-Couch-Request-ID"] == uuid
   end
+
+  @tag
+  test "_all_dbs/_all_docs is not found", _context do
+    resp = Couch.get("/_all_dbs/_all_docs")
+    assert resp.status_code == 404
+    assert resp.body["error"] == "not_found"
+  end
+
+  @tag
+  test "_dbs_info/_all_docs is not found", _context do
+    resp = Couch.get("/_dbs_info/_all_docs")
+    assert resp.status_code == 404
+    assert resp.body["error"] == "not_found"
+  end
+
 end

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -81,7 +81,9 @@
     "_all_docs POST error when multi-get is not a {'key': [...]} structure",
     "_bulk_docs POST error when body not an object",
     "oops, the doc id got lost in code nirwana",
-    "request ID can be specified at the client"
+    "request ID can be specified at the client",
+    "_all_dbs/_all_docs is not found",
+    "_dbs_info/_all_docs is not found"
   ],
   "BatchSaveTest": [
     "batch post",


### PR DESCRIPTION
## Overview

Send a clean 404 response for requests like `/_all_dbs/_all_docs` and `/_dbs_info/_all_docs` as these are invalid and cause a function_clause error as the callback function has restrictive guard clauses. I think this is a regression from the introduction and DRY'ing done when we added `/_dbs_info`.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

https://github.com/apache/couchdb/issues/5892

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
