### PR TITLE
Fix time_seq since function clause

### DIFF
--- a/src/chttpd/test/eunit/chttpd_changes_test.erl
+++ b/src/chttpd/test/eunit/chttpd_changes_test.erl
@@ -534,6 +534,14 @@ t_time_since({_, DbUrl}) ->
         "Invalid time"
     ),
 
+    Params4 = "?since=1000-01-01T01:01:01Z",
+    Res4 = {_, _, _} = changes(DbUrl, Params4),
+    ?assertEqual(
+        Res4,
+        changes(DbUrl, "?since=0"),
+        "Expected the same result as from '?since=0'"
+    ),
+
     {TSeqCode, TSeqRes} = reqraw(get, DbUrl ++ "/_time_seq"),
     ?assertEqual(200, TSeqCode),
     Year = integer_to_binary(element(1, date())),

--- a/src/fabric/src/fabric.erl
+++ b/src/fabric/src/fabric.erl
@@ -678,6 +678,8 @@ time_seq_since(DbName, Time) when is_list(Time) ->
         _:_ ->
             {error, invalid_time_format}
     end;
+time_seq_since(DbName, Time) when is_integer(Time), Time < 0 ->
+    time_seq_since(DbName, 0);
 time_seq_since(DbName, Time) when is_integer(Time), Time >= 0 ->
     fabric_time_seq:since(dbname(DbName), Time).
 


### PR DESCRIPTION
If user specifies a correctly formatted timestamp but it's before 0 unix time, return entries since 0 unix time (`1970-01-01T00:00:00Z`) instead of a function clause error.
