### PR TITLE
Allow infinity for auto purge ttl setting

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1224,9 +1224,11 @@ url = {{nouveau_url}}
 ; one request.
 ;max_batch_size = 500
 
-; The default time-to-live, measured in seconds, before a
-; deleted document is eligible to be purged by the plugin.
-; Defaults to undefined, which disables auto purging.
+; The default time-to-live before a deleted document is eligible to be purged
+; by the plugin. Possible formats are: {num}_{timeunit} (ex: 1000_sec, 30_min,
+; 8_hours, 24_hours, 2_days, 3_weeks, 1_month, 2_years). Defaults to undefined
+; (or "infinity") which disables auto purging. Individual database ttl settings
+; will override this value.
 ;deleted_document_ttl =
 
 ; Set the log level for starting, stopping and purge report summary log entries.

--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -412,6 +412,10 @@ handle_auto_purge_req(#httpd{} = Req, _Db) ->
 
 validate_auto_purge_props([]) ->
     ok;
+validate_auto_purge_props([{<<"deleted_document_ttl">>, <<"infinity">>} | Rest]) ->
+    % Setting the value to "infinity" is way to explicilty disable auto-purge
+    % individual databases while allowing cluster level auto-purge to happen
+    validate_auto_purge_props(Rest);
 validate_auto_purge_props([{<<"deleted_document_ttl">>, Value} | Rest]) when is_binary(Value) ->
     case couch_scanner_util:parse_non_weekday_period(?b2l(Value)) of
         undefined ->

--- a/src/docs/src/config/scanner.rst
+++ b/src/docs/src/config/scanner.rst
@@ -259,10 +259,13 @@ settings in their ``[{plugin}]`` section.
         Set the default interval before the plugin will purge
         a deleted document. Possible ttl formats are: ``{num}_{timeunit}`` (ex.:
         ``1000_sec``, ``30_min``, ``8_hours``, ``24_hour``, ``2_days``,
-        ``3_weeks``, ``1_month``).
+        ``3_weeks``, ``1_month``) or ``infinity``.
+
         The database may override this setting with the
-        :ref:`api/db/auto_purge` endpoint. If neither is set, the
-        plugin will not purge deleted documents.
+        :ref:`api/db/auto_purge` endpoint. If neither is set, the plugin will
+        not purge deleted documents. Setting the config value to ``infinity``
+        disables cluster level auto-purge, which may be used to run auto-purge
+        only for specific databases with the database level settings.
 
     .. config:option:: log_level
 


### PR DESCRIPTION
The explicit `infinity` value can work better with multiple config levels.

Also, users can now enable ttl for the whole cluster but disable it for specific dbs by setting their ttl in {db}/_auto_purge to `infinity`.

While at it, update the etc default.ini config comment since we switched to using the `{num}_{timeunit}` format.
