### PR TITLE
unset node env in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,3 @@
-[env]
-NODE_ENV = 'production'
-
 [tools]
 elixir = "1.19.5-otp-26"
 erlang = '26'


### PR DESCRIPTION
Setting node env to production broke the fauxton build as it makes `npm install` not install dev dependencies. oops.