### PR TITLE
Some stats for the auto-purge plugin

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -494,3 +494,19 @@
      {type, gauge},
      {desc, <<"set to 1 when upgrade_in_progress is toggled">>}
 ]}.
+{[auto_purge, start], [
+     {type, counter},
+     {desc, <<"count of auto-purge starts or resumes">>}
+]}.
+{[auto_purge, complete], [
+     {type, counter},
+     {desc, <<"count of auto-purge completions">>}
+]}.
+{[auto_purge, db_open], [
+     {type, counter},
+     {desc, <<"count of db opens by auto-purge plugin">>}
+]}.
+{[auto_purge, purge], [
+     {type, counter},
+     {desc, <<"count of purges by auto-purge plugin">>}
+]}.

--- a/src/couch/src/couch_auto_purge_plugin.erl
+++ b/src/couch/src/couch_auto_purge_plugin.erl
@@ -34,6 +34,7 @@ start(ScanId, #{}) ->
             skip;
         false ->
             St = init_config(ScanId),
+            couch_stats:increment_counter([auto_purge, start]),
             ?LOG(level(), "Starting.", [], St),
             {ok, St}
     end.
@@ -45,12 +46,14 @@ resume(ScanId, #{}) ->
             skip;
         false ->
             St = init_config(ScanId),
+            couch_stats:increment_counter([auto_purge, start]),
             ?LOG(level(), "Resuming.", [], St),
             {ok, St}
     end.
 
 complete(St) ->
     ?LOG(level(), "Completed.", [], St),
+    couch_stats:increment_counter([auto_purge, complete]),
     {ok, #{}}.
 
 checkpoint(St) ->
@@ -74,6 +77,7 @@ db(St, DbName) ->
     end.
 
 db_opened(#{} = St, Db) ->
+    couch_stats:increment_counter([auto_purge, db_open]),
     #{ttl := TTL, queue := Queue} = St,
     ?assert(Queue == [], "Queue is not empty from previous operations"),
     EndSeq = couch_time_seq:since(couch_db:get_time_seq(Db), couch_time_seq:timestamp() - TTL),
@@ -144,12 +148,14 @@ flush_queue(#{queue := IdRevs} = St, Db) ->
                 meta(St)
             ),
             #{count := Count, limiter := Limiter0} = St,
+            ResCount = length(Results),
+            couch_stats:increment_counter([auto_purge, purge], ResCount),
             {Wait, Limiter1} = couch_scanner_rate_limiter:update(
-                Limiter0, doc_write, length(Results)
+                Limiter0, doc_write, ResCount
             ),
             timer:sleep(Wait),
             St#{
-                count := Count + length(Results),
+                count := Count + ResCount,
                 limiter := Limiter1,
                 queue := []
             };

--- a/src/couch/test/eunit/couch_auto_purge_plugin_tests.erl
+++ b/src/couch/test/eunit/couch_auto_purge_plugin_tests.erl
@@ -91,6 +91,10 @@ t_auto_purge_after_db_ttl({_, DbName}) ->
     config:set("couch_scanner_plugins", atom_to_list(?PLUGIN), "true", false),
     wait_exit(10000),
     ?assertEqual(0, doc_del_count(DbName)),
+    ?assertEqual(1, couch_stats:sample([auto_purge, start])),
+    ?assertEqual(1, couch_stats:sample([auto_purge, complete])),
+    ?assertEqual(2, couch_stats:sample([auto_purge, db_open])),
+    ?assertEqual(1, couch_stats:sample([auto_purge, purge])),
     ok.
 
 t_no_auto_purge_after_config_ttl_set_to_infinity({_, DbName}) ->
@@ -249,7 +253,11 @@ reset_stats() ->
     Counters = [
         [couchdb, query_server, process_error_exits],
         [couchdb, query_server, process_errors],
-        [couchdb, query_server, process_exits]
+        [couchdb, query_server, process_exits],
+        [auto_purge, start],
+        [auto_purge, complete],
+        [auto_purge, db_open],
+        [auto_purge, purge]
     ],
     [reset_counter(C) || C <- Counters].
 


### PR DESCRIPTION
Add a few stats for the auto-purge plugin. We'd like to know when is starts, completes, opens a db and how many purges it does.
