### PR TITLE
fix(`dev/run`): use `couchdb.uri` only when auto-ports is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,6 +508,7 @@ endif
 .PHONY: devclean
 # target: devclean - Remove dev cluster artifacts
 devclean:
+	@rm -rf dev/lib/*/couch.uri
 	@rm -rf dev/lib/*/data
 	@rm -rf dev/lib/*/etc
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -463,6 +463,9 @@ endif
 .PHONY: devclean
 # target: devclean - Remove dev cluster artifacts
 devclean:
+	-@del dev\lib\node1\couch.uri >NUL 2>&1 || true
+	-@del dev\lib\node2\couch.uri >NUL 2>&1 || true
+	-@del dev\lib\node3\couch.uri >NUL 2>&1 || true
 	-@rmdir /s/q dev\lib\node1\data >NUL 2>&1 || true
 	-@rmdir /s/q dev\lib\node2\data >NUL 2>&1 || true
 	-@rmdir /s/q dev\lib\node3\data >NUL 2>&1 || true

--- a/dev/run
+++ b/dev/run
@@ -917,12 +917,13 @@ def hack_default_ini(ctx, node, contents):
         flags=re.MULTILINE,
     )
 
-    contents = re.sub(
-        r"^;uri_file =$",
-        "uri_file = ./dev/lib/{}/couch.uri".format(node),
-        contents,
-        flags=re.MULTILINE,
-    )
+    if ctx["auto_ports"]:
+        contents = re.sub(
+            r"^;uri_file =$",
+            "uri_file = ./dev/lib/{}/couch.uri".format(node),
+            contents,
+            flags=re.MULTILINE,
+        )
 
     if ctx["enable_erlang_views"]:
         contents = re.sub(


### PR DESCRIPTION
On tweaking the `default.ini` for setting up the launch for the CouchDB cluster, the `couchdb.uri` file with information on the published ports is being referenced even when it does not exist. It is only created when the `--auto-ports` flag is set, so we will have to make the reconfiguration of cluster consistent with that to avoid potential errors and making the startup fail.

## Testing recommendations

The `dev/lib/nodeN/couch.uri` should be only in use in `default.ini` when `--auto-ports` is passed for `dev/run`.  Note that with this change, `couch.uri` will not be considered by default any more as `--auto-ports` is not automatically enabled.

## Related Issues or Pull Requests

This is a follow-up to #5687.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly