### PR TITLE
docs: fix 'seperate'/'comma-seperated' typos

### DIFF
--- a/src/config/src/config_util.erl
+++ b/src/config/src/config_util.erl
@@ -51,7 +51,7 @@ implode([H], Sep, Acc) ->
 implode([H | T], Sep, Acc) ->
     implode(T, Sep, [Sep, H | Acc]).
 
-% if this as an executable with arguments, seperate out the arguments
+% if this as an executable with arguments, separate out the arguments
 % ""./foo\ bar.sh -baz=blah" -> {"./foo\ bar.sh", " -baz=blah"}
 separate_cmd_args("", CmdAcc) ->
     {lists:reverse(CmdAcc), ""};

--- a/src/docs/src/api/server/authn.rst
+++ b/src/docs/src/api/server/authn.rst
@@ -414,7 +414,7 @@ list as long as the JWT token is valid.
 .. note::
 
     Before CouchDB v3.3.2 it was only possible to define roles as a JSON
-    array of strings. Now you can also use a comma-seperated list to define
+    array of strings. Now you can also use a comma-separated list to define
     the user roles in your JWT token. The following declarations
     are equal:
 
@@ -426,7 +426,7 @@ list as long as the JWT token is valid.
             "_couchdb.roles": ["accounting-role", "view-role"]
         }
 
-    JSON comma-seperated strings:
+    JSON comma-separated strings:
 
     .. code-block:: json
 


### PR DESCRIPTION
Small typo fixes:

- `src/config/src/config_util.erl`: comment typo `seperate` → `separate`
- `src/docs/src/api/server/authn.rst`: two instances of `comma-seperated` → `comma-separated` in JWT role docs

Comment/doc-only change, no functional impact.