### PR TITLE
Fix typos in comments and docs: 'seperate', 'accomodate'

### DIFF
--- a/src/config/src/config_util.erl
+++ b/src/config/src/config_util.erl
@@ -51,7 +51,7 @@ implode([H], Sep, Acc) ->
 implode([H | T], Sep, Acc) ->
     implode(T, Sep, [Sep, H | Acc]).
 
-% if this as an executable with arguments, seperate out the arguments
+% if this as an executable with arguments, separate out the arguments
 % ""./foo\ bar.sh -baz=blah" -> {"./foo\ bar.sh", " -baz=blah"}
 separate_cmd_args("", CmdAcc) ->
     {lists:reverse(CmdAcc), ""};

--- a/src/couch_stats/src/couch_stats_histogram.erl
+++ b/src/couch_stats/src/couch_stats_histogram.erl
@@ -68,7 +68,7 @@
 % and then the histogram time index is computed as `Time rem TimeWindow`. So,
 % as the monotonic time is advancing forward, the histogram time index will
 % loop around. This comes with a minor annoynance of having to allocate a
-% larger time window to accomodate some process which cleans stale (expired)
+% larger time window to accommodate some process which cleans stale (expired)
 % histogram entries, possibly with some extra buffers to ensure the currently
 % updated interval and the interval ready to be cleaned would not overlap.
 %

--- a/src/docs/src/api/server/authn.rst
+++ b/src/docs/src/api/server/authn.rst
@@ -414,7 +414,7 @@ list as long as the JWT token is valid.
 .. note::
 
     Before CouchDB v3.3.2 it was only possible to define roles as a JSON
-    array of strings. Now you can also use a comma-seperated list to define
+    array of strings. Now you can also use a comma-separated list to define
     the user roles in your JWT token. The following declarations
     are equal:
 
@@ -426,7 +426,7 @@ list as long as the JWT token is valid.
             "_couchdb.roles": ["accounting-role", "view-role"]
         }
 
-    JSON comma-seperated strings:
+    JSON comma-separated strings:
 
     .. code-block:: json
 


### PR DESCRIPTION
Trivial typo fixes in comments and rst docs:

- `config_util.erl`: `seperate out the arguments` -> `separate out the arguments`
- `couch_stats_histogram.erl`: `window to accomodate` -> `window to accommodate`
- `docs/src/api/server/authn.rst` (2x): `comma-seperated` -> `comma-separated`

No behavior changes.