### PR TITLE
dev/run: make file path for `couch.uri` absolute

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -920,7 +920,7 @@ def hack_default_ini(ctx, node, contents):
     if ctx["auto_ports"]:
         contents = re.sub(
             r"^;uri_file =$",
-            "uri_file = ./dev/lib/{}/couch.uri".format(node),
+            "uri_file = {}/dev/lib/{}/couch.uri".format(ctx["rootdir"], node),
             contents,
             flags=re.MULTILINE,
         )


### PR DESCRIPTION
In certain settings, CouchDB is made to run from a directory different from that of its root.  That is why nodes may have problems with finding the location for creating and populating the `couch.uri` file with the information on the automatically assigned ports.  Address this by switching over an absolute path on specifying the actual place of the file.

## Testing recommendations

Go to a directory other than the CouchDB root and try running it "remotely":

```
COUCHDB_ROOT=$(pwd)
cd
$COUCHDB_ROOT/dev/run -a adm:pass -n 1
```

With commits before disabling the creation of `couch.uri`, this shall fail.  With this change, it shall not.

## Related Issues or Pull Requests

Another iteration of #5964.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly