### PR TITLE
chore(`dev/run`): make creation of `couch.uri` independent of `--auto-ports`

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -274,6 +274,13 @@ def get_args_parser():
         default=None,
         help="Use TCP for specified node when TLS distribution is enabled",
     )
+    parser.add_option(
+        "--write-uri-file",
+        dest="write_uri_file",
+        default=False,
+        action="store_true",
+        help="Create the couch.uri file with allocated ports (implied by --auto-ports)",
+    )
     return parser
 
 
@@ -312,6 +319,7 @@ def setup_context(opts, args):
         "erlang_cookie": opts.erlang_cookie,
         "enable_tls": opts.enable_tls,
         "no_tls": opts.no_tls,
+        "write_uri_file": opts.write_uri_file,
     }
 
 
@@ -378,10 +386,27 @@ def setup_configs(ctx):
             "nouveau_url": "http://127.0.0.1:5987",
             "_default": "",
         }
+        cleanup_uri_file(ctx, node)
         write_config(ctx, node, env)
         write_locald_configs(ctx, node, env)
     generate_haproxy_config(ctx)
     generate_nouveau_config(ctx)
+
+
+def need_uri_file(ctx):
+    return ctx["auto_ports"] or ctx["write_uri_file"]
+
+
+def uri_file_path(ctx, node):
+    return "{}/dev/lib/{}/couch.uri".format(ctx["rootdir"], node)
+
+
+def cleanup_uri_file(ctx, node):
+    if not need_uri_file(ctx):
+        try:
+            os.remove(uri_file_path(ctx, node))
+        except FileNotFoundError:
+            pass
 
 
 def write_locald_configs(ctx, node, env):
@@ -917,10 +942,10 @@ def hack_default_ini(ctx, node, contents):
         flags=re.MULTILINE,
     )
 
-    if ctx["auto_ports"]:
+    if need_uri_file(ctx):
         contents = re.sub(
             r"^;uri_file =$",
-            "uri_file = {}/dev/lib/{}/couch.uri".format(ctx["rootdir"], node),
+            "uri_file = {}".format(uri_file_path(ctx, node)),
             contents,
             flags=re.MULTILINE,
         )


### PR DESCRIPTION
Introduce a new flag, `--write-uri-file` that makes the script to configure CouchDB for laying down the `couch.uri` for each node. This is implictly assumed when using `--auto-ports` because in that case the presence of those files can contribute to easier discovery of the exposed ports.  But sometimes it may make sense to get the `couch.uri` files rendered even if the ports were allocated deterministically.  Also, make it sure that no `.uri` files are left behind when they are not in use.

## Testing recommendations

When running `dev/run` without either `--write-uri-file` or `--auto-ports`, no `couch.uri` files shall be present under `dev/lib/*/`.  On the contrary, when any of those is used, the files should be there and they should hold the actual, working references to exposed ports.

## Related Issues or Pull Requests

This is an enhancement to #5964 and #5967, per the suggestion of @rnewson.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly