### PR TITLE
chore: Remove backend_port leftovers

### DIFF
--- a/configure
+++ b/configure
@@ -394,7 +394,6 @@ cat > rel/couchdb.config << EOF
 {with_spidermonkey, $WITH_SPIDERMONKEY}.
 {node_name, "-name couchdb@127.0.0.1"}.
 {cluster_port, 5984}.
-{backend_port, 5986}.
 {prometheus_port, 17986}.
 EOF
 

--- a/configure.ps1
+++ b/configure.ps1
@@ -210,7 +210,6 @@ $CouchDBConfig = @"
 {with_spidermonkey, $WithSpiderMonkey}.
 {node_name, "-name couchdb@127.0.0.1"}.
 {cluster_port, 5984}.
-{backend_port, 5986}.
 {prometheus_port, 17986}.
 "@
 $CouchDBConfig | Out-File "$rootdir\rel\couchdb.config" -encoding ascii

--- a/dev/run
+++ b/dev/run
@@ -361,7 +361,7 @@ def check_boot_script(ctx):
 @log("Prepare configuration files")
 def setup_configs(ctx):
     for idx, node in enumerate(ctx["nodes"]):
-        cluster_port, backend_port, prometheus_port = get_ports(
+        cluster_port, prometheus_port = get_ports(
             ctx, idx + ctx["node_number_seed"]
         )
         env = {
@@ -379,7 +379,6 @@ def setup_configs(ctx):
             "node_name": "-name %s@127.0.0.1" % node,
             "cluster_port": cluster_port,
             "clouseau_name": "clouseau%d@127.0.0.1" % (idx + 1),
-            "backend_port": backend_port,
             "prometheus_port": prometheus_port,
             "uuid": "fake_uuid_for_dev",
             "nouveau_enable": str(ctx["with_nouveau"]).lower(),
@@ -486,11 +485,10 @@ def get_ports(ctx, idnode):
     if idnode <= 5 and not ctx["auto_ports"]:
         return (
             (10000 * idnode) + 5984,
-            (10000 * idnode) + 5986,
             (10000 * idnode) + 7986,
         )
     else:
-        return tuple(get_available_ports(2))
+        return tuple(get_available_ports(1))
 
 
 def get_available_ports(num):
@@ -933,13 +931,6 @@ def maybe_check_clouseau_node_alive(ctx, idx):
 
 
 def hack_default_ini(ctx, node, contents):
-    contents = re.sub(
-        r"^\[httpd\]$",
-        "[httpd]\nenable = true",
-        contents,
-        flags=re.MULTILINE,
-    )
-
     if need_uri_file(ctx):
         contents = re.sub(
             r"^;uri_file =$",

--- a/rel/files/eunit.ini
+++ b/rel/files/eunit.ini
@@ -20,10 +20,6 @@
 uuid = 74696d6520746f2072656c617821
 default_security = everyone
 
-[httpd]
-enable = true
-port = 0
-
 [chttpd]
 port = 0
 

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -372,10 +372,6 @@ bind_address = 127.0.0.1
 ;database_prefix = userdb-
 
 [httpd]
-port = {{backend_port}}
-bind_address = 127.0.0.1
-;authentication_handlers = {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}
-
 ; Options for the MochiWeb HTTP server.
 ;server_options = [{backlog, 128}, {acceptor_pool_size, 16}]
 
@@ -384,7 +380,7 @@ bind_address = 127.0.0.1
 ;socket_options = [{sndbuf, 262144}]
 
 ; These settings were moved to [chttpd]
-; secure_rewrites, allow_jsonp, enable_cors, enable_xframe_options,
+; authentication_handlers, secure_rewrites, allow_jsonp, enable_cors, enable_xframe_options,
 ; max_uri_length, changes_timeout, config_whitelist, rewrite_limit,
 ; x_forwarded_host, x_forwarded_proto, x_forwarded_ssl, max_http_request_size
 

--- a/setup_eunit.template
+++ b/setup_eunit.template
@@ -1,7 +1,6 @@
 {variables, [
     {package_author_name, "The Apache Software Foundation"},
     {cluster_port, 0},
-    {backend_port, 0},
     {prometheus_port, 0},
     {node_name, "-name couchdbtest@127.0.0.1"},
 


### PR DESCRIPTION
## Overview

The backend_port functionality was removed. Remove some code leftovers too.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [ ] Code is written and works correctly