### PR TITLE
Fix Jenkins badge link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Apache CouchDB README
 | |1| |2| |
 +---------+
 
-.. |1| image:: https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/main/badge/icon?subject=main
-    :target: https://ci-couchdb.apache.org/blue/organizations/jenkins/jenkins-cm1%2FFullPlatformMatrix/activity?branch=main
+.. |1| image:: https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/main/badge/icon
+    :target: https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/main/
 .. |2| image:: https://readthedocs.org/projects/couchdb/badge/?version=latest
     :target: https://docs.couchdb.org/en/latest/?badge=latest
 


### PR DESCRIPTION
## Overview

After a Jenkins upgrade we need to updated the badge link for the build job in README.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
