### PR TITLE
Use unportected CI badge URL in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Apache CouchDB README
 | |1| |2| |
 +---------+
 
-.. |1| image:: https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/main/badge/icon
+.. |1| image:: https://ci-couchdb.apache.org/buildStatus/icon?job=jenkins-cm1%2FFullPlatformMatrix%2Fmain&subject=main
     :target: https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/main/
 .. |2| image:: https://readthedocs.org/projects/couchdb/badge/?version=latest
     :target: https://docs.couchdb.org/en/latest/?badge=latest


### PR DESCRIPTION
## Overview

Use the unprotected badge url so that a non jenkins user can see the image. Follow up of #5973.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
