### PR TITLE
Use errstr() instead of toSource() in nouveau js wrapper

### DIFF
--- a/share/server/nouveau.js
+++ b/share/server/nouveau.js
@@ -20,7 +20,7 @@ var Nouveau = (function () {
     } else if (err[0] == "fatal") {
       throw (err);
     }
-    var message = "function raised exception " + err.toSource();
+    var message = "function raised exception " + errstr(err);
     if (doc) message += " with doc._id " + doc._id;
     log(message);
   };

--- a/test/elixir/test/config/nouveau.elixir
+++ b/test/elixir/test/config/nouveau.elixir
@@ -31,6 +31,7 @@
     "purge with conflicts",
     "index same field with different field types",
     "index not found",
+    "index function throws",
     "meta",
     "stale search"
   ]

--- a/test/elixir/test/nouveau_test.exs
+++ b/test/elixir/test/nouveau_test.exs
@@ -705,6 +705,30 @@ defmodule NouveauTest do
   end
 
   @tag :with_db
+  test "index function throws", context do
+    db_name = context[:db_name]
+    create_search_docs(db_name)
+    ddoc =  %{
+      nouveau: %{
+        bar: %{
+          default_analyzer: "standard",
+          index: """
+            function (doc) {
+              throw(new Error("some error"));
+              index("string", "foo", doc.foo, {store: true});
+            }
+          """
+        }
+      }
+    }
+    create_ddoc(db_name, ddoc)
+    url = "/#{db_name}/_design/foo/_nouveau/bar"
+    resp = Couch.post(url, body: %{q: "foo:bar", include_docs: true})
+    assert_status_code(resp, 200)
+    assert resp.body["hits"] == []
+  end
+
+  @tag :with_db
   test "meta", context do
     db_name = context[:db_name]
     create_search_docs(db_name)


### PR DESCRIPTION
`toSource()` is a Spidermonkey special, use our `errstr()` warpper function which checks if `toSource()` is available, and if not,  it runs `toString()` instead

This one line fix (minus the test) was originally submitted by a new contributor in https://github.com/apache/couchdb/pull/5951.  When we requested a few changes they closed the pr without comments 🤷 