### PR TITLE
Optimize view building

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -491,7 +491,7 @@ hash_algorithms = sha256, sha
 ;max_write_delay = 500
 ;update_db = true
 
-;[view_updater]
+[view_updater]
 ; Configure the queue capacity used during indexing. These settings apply to
 ; both the queue between the changes feed and the JS mapper, and between the
 ; JS mapper and the disk writer.
@@ -504,6 +504,13 @@ hash_algorithms = sha256, sha
 
 ;min_writer_items = 100
 ;min_writer_size = 16777216
+
+; After how many processed docs to run garbage collection in view index updater
+; process (infinity is a also a possible setting, to let the Erlang VM run GC
+; as it sees fit), version >= 27 should do that much better than before
+; Previously in versions < 3.5.1 this this was running after every single doc
+; update
+;gc_interval_docs = 1000
 
 [couch_httpd_auth]
 ; WARNING! This only affects the node-local port (5986 by default).

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -497,8 +497,10 @@ hash_algorithms = sha256, sha
 ; JS mapper and the disk writer.
 ; Whichever limit happens to be hit first is the one that takes effect.
 
-; The maximum queue memory size
-;queue_memory_cap = 100000
+; The maximum queue memory size. view update gen_server batch size is 100, so the
+; 10MB default would keep about 10 batches of 10KB docs in the queue. Also 10MB is
+; also slightly smaller than the min_writer_size of 16MB
+;queue_memory_cap = 10485760
 ; The maximum queue length
 ;queue_item_cap = 500
 

--- a/src/couch/test/eunit/couchdb_file_compression_tests.erl
+++ b/src/couch/test/eunit/couchdb_file_compression_tests.erl
@@ -70,6 +70,14 @@ setup() ->
     {ok, _} = couch_db:update_doc(Db, DDoc, []),
     ok = couch_db:close(Db),
     ok = refresh_index(DbName),
+    % Another update and refresh. A forced second b-tree update will guarantee
+    % to create garbage so compaction has something to chew on. Otherwise a
+    % single bulk build can pack the tree optimally so compact_view won't have
+    % anything to do.
+    {ok, Db2} = couch_db:open_int(DbName, [?ADMIN_CTX]),
+    ok = populate_db(Db2, ?DOCS_COUNT),
+    ok = couch_db:close(Db2),
+    ok = refresh_index(DbName),
     DbName.
 
 teardown(DbName) ->

--- a/src/couch_index/src/couch_index_updater.erl
+++ b/src/couch_index/src/couch_index_updater.erl
@@ -159,15 +159,24 @@ update(Idx, Mod, IdxState) ->
             end
         end,
 
-        Proc = fun(DocInfo, {IdxStateAcc, _}) ->
-            case CommittedOnly and (GetSeq(DocInfo) > DbCommittedSeq) of
+        GcInterval = config:get_integer_or_infinity("view_updater", "gc_interval_docs", 1000),
+        Proc = fun(DocInfo, {IdxStateAcc, _, NDocs}) ->
+            case CommittedOnly andalso (GetSeq(DocInfo) > DbCommittedSeq) of
                 true ->
-                    {stop, {IdxStateAcc, false}};
+                    {stop, {IdxStateAcc, false, NDocs}};
                 false ->
                     {Doc, Seq} = LoadDoc(DocInfo),
                     {ok, NewSt} = Mod:process_doc(Doc, Seq, IdxStateAcc),
-                    garbage_collect(),
-                    {ok, {NewSt, true}}
+                    NDocs1 = NDocs + 1,
+                    case GcInterval of
+                        infinity ->
+                            ok;
+                        _ when NDocs1 rem GcInterval == 0 ->
+                            garbage_collect();
+                        _ ->
+                            ok
+                    end,
+                    {ok, {NewSt, true, NDocs1}}
             end
         end,
         {ok, InitIdxState} = Mod:start_update(
@@ -177,9 +186,9 @@ update(Idx, Mod, IdxState) ->
             NumPurgeChanges
         ),
 
-        Acc0 = {InitIdxState, true},
+        Acc0 = {InitIdxState, true, 0},
         {ok, Acc} = couch_db:fold_changes(Db, CurrSeq, Proc, Acc0, []),
-        {ProcIdxSt, SendLast} = Acc,
+        {ProcIdxSt, SendLast, _} = Acc,
 
         % If we didn't bail due to hitting the last committed seq we need
         % to send our last update_seq through.

--- a/src/couch_mrview/src/couch_mrview_updater.erl
+++ b/src/couch_mrview/src/couch_mrview_updater.erl
@@ -20,7 +20,7 @@
 -define(REM_VAL, removed).
 
 start_update(Partial, State, NumChanges, NumChangesDone) ->
-    MaxSize = config:get_integer("view_updater", "queue_memory_cap", 100000),
+    MaxSize = config:get_integer("view_updater", "queue_memory_cap", 10485760),
     MaxItems = config:get_integer("view_updater", "queue_item_cap", 500),
     QueueOpts = [{max_size, MaxSize}, {max_items, MaxItems}],
     {ok, DocQueue} = couch_work_queue:new(QueueOpts),

--- a/src/couch_mrview/src/couch_mrview_updater.erl
+++ b/src/couch_mrview/src/couch_mrview_updater.erl
@@ -229,11 +229,10 @@ accumulate_writes(State, W, Acc0) ->
 
 accumulate_more(NumDocIds, Acc) ->
     % check if we have enough items now
-    MinItems = config:get("view_updater", "min_writer_items", "100"),
-    MinSize = config:get("view_updater", "min_writer_size", "16777216"),
+    MinItems = config:get_integer("view_updater", "min_writer_items", 100),
+    MinSize = config:get_integer("view_updater", "min_writer_size", 16777216),
     CurrMem = ?term_size(Acc),
-    NumDocIds < list_to_integer(MinItems) andalso
-        CurrMem < list_to_integer(MinSize).
+    NumDocIds < MinItems andalso CurrMem < MinSize.
 
 merge_results([], SeqAcc, ViewKVs, DocIdKeys) ->
     {SeqAcc, ViewKVs, DocIdKeys};


### PR DESCRIPTION
Two small optimizations and a cleanup

(Commits in order)

1. **Do not run full GC after each doc update in the indexer**

Run it after 1000 docs, ensuring it still forced to run as a safe default.
However, in OTP 27+ this should not be needed at all. So infinity is also a
possible config setting, we may change to that in the future.

Comments from John Hogberg in OTP repo regarding behavior change in OTP 27:

https://github.com/erlang/otp/issues/8229#issuecomment-1988858134

> the GC pressure of off-heap binaries ("vheap") was vastly under-counted prior
to 24ef4cb [1]. In these tests this caused it to GC less often and, crucially, when
there was less live data to keep.

[1]
https://github.com/erlang/otp/commit/24ef4cbaeda9b9c26682cba75f2f15b0c58722aa
 

2. **Increase view queue size from 100KB to 10MB**
100KB was undersized given the 100 batch size used in the process_doc call.
100 docs as small as 1KB will already start to get serialized and not take
advantage of the work queue buffering. Make it 10MB to fit about 10 batches of
1MB each and be a bit under the min_writer_size default of 16MB.

3. **Use config:get_integer/3 in couch_mrview_updater**

This avoids re-parsing the string values into integers when defaults are used
every time we run the check. It's more of a code cleanup but can regarded as a
micro-optimization as well

**Benchmark**
With this bench script https://gist.github.com/nickva/0c00947fc7405d260e1d5226f7e9c104 got about a 10-12% speed improvement locally on my laptop

11k -> 12k docs indexed per second

With main

```
 % ./view_bench.py
URL: http://localhost:15984  db: db  ndocs: 500000  doc_size: ~1024 B  batch: 500
Loading docs...
Load done in 43.0s
View URL: db/_design/ddoc/_view/view
Timing build...
Build time: 46638 ms (46.6 s) for 500000 docs  (10,721 docs/s)

 % ./view_bench.py
URL: http://localhost:15984  db: db  ndocs: 500000  doc_size: ~1024 B  batch: 500
Loading docs...
Load done in 42.5s
View URL: db/_design/ddoc/_view/view
Timing build...
Build time: 45955 ms (46.0 s) for 500000 docs  (10,880 docs/s)

 % ./view_bench.py
URL: http://localhost:15984  db: db  ndocs: 500000  doc_size: ~1024 B  batch: 500
Loading docs...
Load done in 43.7s
View URL: db/_design/ddoc/_view/view
Timing build...
Build time: 48753 ms (48.8 s) for 500000 docs  (10,256 docs/s)
```

With the PR

```
% ./view_bench.py
URL: http://localhost:15984  db: db  ndocs: 500000  doc_size: ~1024 B  batch: 500
Loading docs...
Load done in 43.4s
View URL: db/_design/ddoc/_view/view
Timing build...
Build time: 40627 ms (40.6 s) for 500000 docs  (12,307 docs/s)

  % ./view_bench.py
URL: http://localhost:15984  db: db  ndocs: 500000  doc_size: ~1024 B  batch: 500
Loading docs...
Load done in 43.3s
View URL: db/_design/ddoc/_view/view
Timing build...
Build time: 39337 ms (39.3 s) for 500000 docs  (12,711 docs/s)

 % ./view_bench.py
URL: http://localhost:15984  db: db  ndocs: 500000  doc_size: ~1024 B  batch: 500
Loading docs...
Load done in 43.6s
View URL: db/_design/ddoc/_view/view
Timing build...
Build time: 41181 ms (41.2 s) for 500000 docs  (12,142 docs/s)
```