### PR TITLE
Update dependencies before 3.5.2 release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -83,7 +83,7 @@ defmodule CouchDBTest.Mixfile do
     deps1 = [
       {:junit_formatter, "~> 3.4", only: [:dev, :test, :integration]},
       {:httpotion, ">= 3.2.0", only: [:dev, :test, :integration], runtime: false},
-      {:excoveralls, "~> 0.18.3", only: :test},
+      {:excoveralls, "~> 0.18.5", only: :test},
       {:ibrowse, path: path("ibrowse"), override: true},
       {:credo, "== 1.7.16", only: [:dev, :test, :integration], runtime: false}
     ]

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -154,16 +154,16 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{snappy,           "snappy",           {tag, "CouchDB-1.0.9"}},
+{snappy,           "snappy",           {tag, "CouchDB-1.0.10"}},
 
 %% %% Non-Erlang deps
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},
-                   {tag, "v1.3.5"}, [raw]},
-{ibrowse,          "ibrowse",          {tag, "CouchDB-4.4.2-6"}},
+                   {tag, "v1.3.6"}, [raw]},
+{ibrowse,          "ibrowse",          {tag, "v4.5.0"}},
 {gun,              "gun",              {tag, "2.2.0-couchdb"}},
 {jiffy,            "jiffy",            {tag, "2.0.0"}},
 {mochiweb,         "mochiweb",         {tag, "v3.3.0"}},
-{meck,             "meck",             {tag, "v1.1.0"}},
+{meck,             "meck",             {tag, "v1.1.1"}},
 {recon,            "recon",            {tag, "2.5.6"}}
 ].
 


### PR DESCRIPTION
 * snappy https://github.com/apache/couchdb-snappy/releases/tag/CouchDB-1.0.10
 * meck https://github.com/apache/couchdb-meck/releases/tag/v1.1.1
 * fauxton https://github.com/apache/couchdb-fauxton/releases/tag/v1.3.6
 * excoveralls https://github.com/parroty/excoveralls/releases/tag/v0.18.5
 * ibrowse https://github.com/cmullaparthi/ibrowse/releases/tag/v4.5.0