### PR TITLE
chore: remove duplicate ioq section entry in default.ini

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -927,7 +927,8 @@ state_dir = {{state_dir}}
 ;min_priority = 536870912
 
 [ioq]
-; The maximum number of concurrent in-flight IO requests that
+; The maximum number of concurrent in-flight IO requests that the queueing
+; system will submit:
 ;concurrency = 10
 
 ; The fraction of the time that a background IO request will be selected

--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -391,10 +391,6 @@ bind_address = 127.0.0.1
 ;[httpd_design_handlers]
 ;_view =
 
-;[ioq]
-;concurrency = 10
-;ratio = 0.01
-
 [ssl]
 ;port = 6984
 


### PR DESCRIPTION
We have a documented section here https://github.com/apache/couchdb/blob/main/rel/overlay/etc/default.ini#L933-L939