### PR TITLE
ci: Use Ubuntu Resolute Raccoon (26.04)

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -99,6 +99,17 @@ meta = [
     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
   ],
 
+  'resolute': [
+    name: 'Ubuntu 26.04',
+    spidermonkey_vsn: '128',
+    with_nouveau: true,
+    with_clouseau: true,
+    clouseau_java_home: '/opt/java/openjdk',
+    quickjs_test262: true,
+    image: "apache/couchdbci-ubuntu:resolute-erlang-${ERLANG_VERSION}",
+    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+  ],
+
   'bullseye': [
     name: 'Debian x86_64',
     spidermonkey_vsn: '78',


### PR DESCRIPTION
## Overview

Use Ubuntu Resolute Racoon in CI.

## Testing recommendations

Prerequisite: When https://github.com/apache/couchdb-ci/pull/101 gets merged and image is uploaded to Docker Hub.

## Related Issues or Pull Requests

https://github.com/apache/couchdb-ci/pull/101

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
