### PR TITLE
dev: Allow OTP 29 compiler

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -194,7 +194,7 @@ end.
 AddConfig = [
     {cover_enabled, true},
     {cover_print_enabled, true},
-    {require_otp_vsn, "26|27|28"},
+    {require_otp_vsn, "26|27|28|29"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},


### PR DESCRIPTION
## Overview

With release of [Erlang/OTP 29](https://www.erlang.org/news/188) add it as an option
as allowed OTP versions.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly