### PR TITLE
Fix function clause on auto_purge ttl = infinity

### DIFF
--- a/src/couch/src/couch_auto_purge_plugin.erl
+++ b/src/couch/src/couch_auto_purge_plugin.erl
@@ -70,6 +70,8 @@ db(St, DbName) ->
         TTL when is_integer(TTL) ->
             {ok, St#{ttl => TTL}};
         undefined ->
+            {skip, St};
+        infinity ->
             {skip, St}
     catch
         error:database_does_not_exist ->


### PR DESCRIPTION
Fix function_clause when per-db values was not set and the default in config was set to "infinity".

The clause is already covered by eunit tests it's just that now it logs should show an function_clause error.

<img width="406" height="160" alt="Screenshot 2026-05-21 at 17 44 33" src="https://github.com/user-attachments/assets/d5561955-a84e-4a3f-8954-ea70e9e96aa6" />
