### PR TITLE
Fix leaked opened db handle in smoosh

### DIFF
--- a/src/smoosh/src/smoosh_channel.erl
+++ b/src/smoosh/src/smoosh_channel.erl
@@ -390,27 +390,31 @@ maybe_remonitor_cpid(#state{} = State, DbName, Reason) when is_binary(DbName) ->
     #state{name = Name, active = Active} = State,
     case couch_db:open_int(DbName, []) of
         {ok, Db} ->
-            try couch_db:get_compactor_pid_sync(Db) of
-                nil ->
-                    LogMsg = "~s : exit for compaction of ~p: ~p",
-                    LogArgs = [Name, smoosh_utils:stringify(DbName), Reason],
-                    couch_log:warning(LogMsg, LogArgs),
-                    re_enqueue(DbName),
-                    State;
-                CPid when is_pid(CPid) ->
-                    monitor(process, CPid),
-                    Level = smoosh_utils:log_level("compaction_log_level", "notice"),
-                    LogMsg = "~s: ~s compaction already running. Re-monitor Pid ~p",
-                    LogArgs = [Name, smoosh_utils:stringify(DbName), CPid],
-                    couch_log:Level(LogMsg, LogArgs),
-                    State#state{active = Active#{DbName => CPid}}
+            try
+                case couch_db:get_compactor_pid_sync(Db) of
+                    nil ->
+                        LogMsg = "~s : exit for compaction of ~p: ~p",
+                        LogArgs = [Name, smoosh_utils:stringify(DbName), Reason],
+                        couch_log:warning(LogMsg, LogArgs),
+                        re_enqueue(DbName),
+                        State;
+                    CPid when is_pid(CPid) ->
+                        monitor(process, CPid),
+                        Level = smoosh_utils:log_level("compaction_log_level", "notice"),
+                        LogMsg = "~s: ~s compaction already running. Re-monitor Pid ~p",
+                        LogArgs = [Name, smoosh_utils:stringify(DbName), CPid],
+                        couch_log:Level(LogMsg, LogArgs),
+                        State#state{active = Active#{DbName => CPid}}
+                end
             catch
                 _:Error ->
-                    LogMsg = "~s: error remonitoring db compaction ~p error:~p",
-                    LogArgs = [Name, smoosh_utils:stringify(DbName), Error],
-                    couch_log:warning(LogMsg, LogArgs),
+                    ErrLogMsg = "~s: error remonitoring db compaction ~p error:~p",
+                    ErrLogArgs = [Name, smoosh_utils:stringify(DbName), Error],
+                    couch_log:warning(ErrLogMsg, ErrLogArgs),
                     re_enqueue(DbName),
                     State
+            after
+                couch_db:close(Db)
             end;
         Error = {not_found, no_db_file} ->
             LogMsg = "~s : exit for compaction of ~p: ~p",


### PR DESCRIPTION
`smoosh_channel:maybe_remonitor_cpid/3` opened db and never closed it. That left a dangling reference (monitor to it) which prevented that db handle from becoming idle.

We noticed this after inspecting dangling deleted fd handles which were still left open by something. That something turned to be smoosh_channel gen_server.
