### PR TITLE
Improve CI by matching variants to the number of workers

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -179,16 +179,20 @@ meta = [
     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
   ],
 
-  'base-intermediate-erlang': [
-    name: 'Debian x86_64',
-    spidermonkey_vsn: '78',
-    with_nouveau: true,
-    with_clouseau: true,
-    clouseau_java_home: '/opt/java/openjdk',
-    quickjs_test262: false,
-    image: "${DOCKER_IMAGE_BASE}-${INTERMEDIATE_ERLANG_VERSION}",
-    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
+  // Skip this temporarily. We have too many CI jobs for the workers available
+  // which forces a CI job to wait for some of the worker to full run the CI
+  // before continuing effectively making the runs take about 2x the time. When
+  // we remove bullseye we can uncomment this perhaps
+  // 'base-intermediate-erlang': [
+  //   name: 'Debian x86_64',
+  //   spidermonkey_vsn: '78',
+  //   with_nouveau: true,
+  //   with_clouseau: true,
+  //   clouseau_java_home: '/opt/java/openjdk',
+  //   quickjs_test262: false,
+  //   image: "${DOCKER_IMAGE_BASE}-${INTERMEDIATE_ERLANG_VERSION}",
+  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+  // ],
 
   'base-quickjs': [
     name: 'Debian 12 with QuickJS',


### PR DESCRIPTION
Previously, after we added trixie we ended up with N+1 variants for N worker slots for generic docker workers. This means CI jobs have to wait until one of the workers finishes completely before even starting. To improve the situation, let's skip intermediate (27 currently) CI run to hopefully restore the speed back.

There is some separate docker pull or java run flakiness we noticed but that's not related to this most likely.
