### PR TITLE
dev: Print synchronized ouput of make during builds

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -566,7 +566,7 @@ def generateContainerStage(platform) {
                   sh( script: "tar -xf apache-couchdb-*.tar.gz -C ${platform}/couchdb", label: 'Unpack release' )
                   sh( script: "cd ${platform} && git clone https://github.com/apache/couchdb-pkg", label: 'Clone packaging helper repo' )
                   dir( "${platform}/couchdb-pkg" ) {
-                    sh( script: 'make', label: 'Build packages' )
+                    sh( script: 'make --output-sync=target', label: 'Build packages' )
                   }
                   sh( label: 'Stage package artifacts for archival', script: """
                     rm -rf pkgs/${platform}
@@ -706,7 +706,7 @@ pipeline {
         sh 'make erlfmt-check'
         sh 'make elixir-source-checks'
         sh 'make python-black'
-        sh 'make -j4 dist'
+        sh 'make -j4 --output-sync=target dist'
       }
       post {
         success {


### PR DESCRIPTION
## Overview

If make uses multiple processes, the generated output isn't synced to terminal.
Add additional option to make call during dist/package building.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
