### PR TITLE
Add all_dbs_active metric

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -306,6 +306,10 @@
     {type, counter},
     {desc, <<"number of couch_server LRU operations skipped">>}
 ]}.
+{[couchdb, couch_server, all_dbs_active], [
+    {type, counter},
+    {desc, <<"number of times couch_servers hit all_dbs_active limit">>}
+]}.
 {[couchdb, query_server, vdu_rejects], [
     {type, counter},
     {desc, <<"number of rejections by validate_doc_update function">>}

--- a/src/couch/src/couch_server.erl
+++ b/src/couch/src/couch_server.erl
@@ -478,6 +478,7 @@ maybe_close_lru_db(#server{lru = Lru} = Server) ->
         {true, NewLru} ->
             {ok, db_closed(Server#server{lru = NewLru}, [])};
         false ->
+            couch_stats:increment_counter([couchdb, couch_server, all_dbs_active]),
             {error, all_dbs_active}
     end.
 

--- a/src/couch/test/eunit/couch_db_tests.erl
+++ b/src/couch/test/eunit/couch_db_tests.erl
@@ -89,6 +89,23 @@ open_db_test_() ->
         }
     }.
 
+all_dbs_active_test_() ->
+    {
+        "all_dbs_active metric tests",
+        {
+            setup,
+            fun test_util:start_couch/0,
+            fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun() -> ?tempdb() end,
+                [
+                    fun should_bump_all_dbs_active_metric/1
+                ]
+            }
+        }
+    }.
+
 should_create_db(DbName) ->
     ?_test(begin
         {ok, Before} = couch_server:all_databases(),
@@ -197,6 +214,18 @@ locking_should_work(DbName) ->
         couch_server:unlock(DbName),
         {ok, Db1} = couch_db:open(DbName, [{create_if_missing, true}]),
         ok = couch_db:close(Db1)
+    end).
+
+should_bump_all_dbs_active_metric(DbName) ->
+    ?_test(begin
+        Metric = [couchdb, couch_server, all_dbs_active],
+        Shard = couch_server:couch_server(DbName),
+        ok = gen_server:call(Shard, {set_max_dbs_open, 0}),
+        Before = couch_stats:sample(Metric),
+        ?assertEqual({error, all_dbs_active}, couch_db:create(DbName, [])),
+        ?assertEqual(Before + 1, couch_stats:sample(Metric)),
+        ?assertEqual({error, all_dbs_active}, couch_db:open(DbName, [])),
+        ?assertEqual(Before + 2, couch_stats:sample(Metric))
     end).
 
 create_db(DbName) ->


### PR DESCRIPTION
Bump a counter when couch_server reaches an `all_dbs_active` state.

Users may use that to decide if they need to bump their max_dbs_open setting.
