### PR TITLE
Fsync on reset

### DIFF
--- a/src/couch/src/couch_bt_engine.erl
+++ b/src/couch/src/couch_bt_engine.erl
@@ -172,7 +172,7 @@ init(FilePath, Options) ->
                 delete_compaction_files(FilePath),
                 Header0 = couch_bt_engine_header:new(),
                 Header1 = init_set_props(Fd, Header0, Options),
-                ok = couch_file:write_header(Fd, Header1),
+                ok = couch_file:write_header(Fd, Header1, [sync]),
                 Header1;
             false ->
                 case couch_file:read_header(Fd) of
@@ -181,7 +181,7 @@ init(FilePath, Options) ->
                     no_valid_header ->
                         delete_compaction_files(FilePath),
                         Header0 = couch_bt_engine_header:new(),
-                        ok = couch_file:write_header(Fd, Header0),
+                        ok = couch_file:write_header(Fd, Header0, [sync]),
                         Header0
                 end
         end,

--- a/src/couch/src/couch_bt_engine_compactor.erl
+++ b/src/couch/src/couch_bt_engine_compactor.erl
@@ -658,7 +658,7 @@ open_compaction_file(FilePath) ->
 
 reset_compaction_file(Fd, Header) ->
     ok = couch_file:truncate(Fd, 0),
-    ok = couch_file:write_header(Fd, Header).
+    ok = couch_file:write_header(Fd, Header, [sync]).
 
 commit_compaction_data(#comp_st{new_st = St} = CompSt) ->
     % Compaction needs to write headers to both the data file

--- a/src/couch_mrview/src/couch_mrview_util.erl
+++ b/src/couch_mrview/src/couch_mrview_util.erl
@@ -926,7 +926,7 @@ delete_file(FName) ->
 
 reset_index(Db, Fd, #mrst{sig = Sig} = State) ->
     ok = couch_file:truncate(Fd, 0),
-    ok = couch_file:write_header(Fd, {Sig, nil}),
+    ok = couch_file:write_header(Fd, {Sig, nil}, [sync]),
     {_Commit, NewSt} = init_state(Db, Fd, reset_state(State), nil),
     NewSt.
 


### PR DESCRIPTION
Let's sync when we truncate/reset headers. In case of truncate that's also a metadata operation so it dirties the inode but doesn't necessarily sync. Calling datasync will write that metadata change to disk [*]. These resets should be very rare so shouldn't be a performance impact.

[*] fdatasync despite its name also syncs metadata required for data operations to work correctly, one of those is file size changes when it affects data operations (writes at eof or truncates).
