### PR TITLE
Mochiweb 3.4.0

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -237,16 +237,18 @@ meta = [
     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
   ],
 
-  'freebsd-x86_64': [
-      name: 'FreeBSD x86_64',
-      spidermonkey_vsn: '91',
-      with_nouveau: false,
-      with_clouseau: true,
-      clouseau_java_home: '/usr/local/openjdk21',
-      quickjs_test262: false,
-      gnu_make: 'gmake',
-      gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  ],
+  // Disable temporarily to not block PR merging. Worker unexpectedly went
+  // offline.
+  // 'freebsd-x86_64': [
+  //     name: 'FreeBSD x86_64',
+  //     spidermonkey_vsn: '91',
+  //     with_nouveau: false,
+  //     with_clouseau: true,
+  //     clouseau_java_home: '/usr/local/openjdk21',
+  //     quickjs_test262: false,
+  //     gnu_make: 'gmake',
+  //     gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+  // ],
 
   // Spidermonkey 91 has issues on ARM64 FreeBSD
   // use QuickJS for now

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -162,7 +162,7 @@ DepDescs = [
 {ibrowse,          "ibrowse",          {tag, "v4.5.0"}},
 {gun,              "gun",              {tag, "2.2.0-couchdb"}},
 {jiffy,            "jiffy",            {tag, "2.0.0"}},
-{mochiweb,         "mochiweb",         {tag, "v3.3.0"}},
+{mochiweb,         "mochiweb",         {tag, "v3.4.0"}},
 {meck,             "meck",             {tag, "v1.1.1"}},
 {recon,            "recon",            {tag, "2.5.6"}}
 ].


### PR DESCRIPTION
* Mochweb 3.4.0  (for OTP 29 support)
* Temporarily disable FreeBSD x86 to unblock CI
