### PR TITLE
Update snappy dependency to CouchDB-1.0.11

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -154,7 +154,7 @@ SubDirs = [
 
 DepDescs = [
 %% Independent Apps
-{snappy,           "snappy",           {tag, "CouchDB-1.0.10"}},
+{snappy,           "snappy",           {tag, "CouchDB-1.0.11"}},
 
 %% %% Non-Erlang deps
 {fauxton,          {url, "https://github.com/apache/couchdb-fauxton"},


### PR DESCRIPTION
## Overview

- replaced depreacted catch-statement for OTP29
- simplified nif loading code

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
