### PR TITLE
ci: Use OTP27 as minimum version

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -19,19 +19,19 @@ DOCKER_IMAGE_BASE = 'apache/couchdbci-debian:bookworm-erlang'
 
 // Erlang version embedded in binary packages. Also the version most builds
 // will run.
-ERLANG_VERSION = '26.2.5.20'
+ERLANG_VERSION = '27.3.4.13'
 
 // Erlang version used for rebar in release process. CouchDB will not build from
 // the release tarball on Erlang versions older than this
-MINIMUM_ERLANG_VERSION = '26.2.5.20'
+MINIMUM_ERLANG_VERSION = '27.3.4.13'
 
 // Highest support Erlang version.
-MAXIMUM_ERLANG_VERSION = '28.4.3'
+MAXIMUM_ERLANG_VERSION = '29.0.2'
 
 // Test a min + 1 version. This is specially useful before we're about
 // to bump the minimum version to at least make sure the CI image
 // works.
-INTERMEDIATE_ERLANG_VERSION = '27.3.4.11'
+INTERMEDIATE_ERLANG_VERSION = '28.5.0.2'
 
 // Default GNU Make Eunit Options for supported platforms
 DEFAULT_GNU_MAKE_EUNIT_OPTS = '-j2 --output-sync=target'


### PR DESCRIPTION
## Overview

Use CI images from Erlang OTP27-29.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
