### PR TITLE
Make OTP 27 the minimum OTP version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-elixir = "1.19.5-otp-26"
-erlang = '26'
+elixir = "1.20.1-otp-27"
+erlang = '27'
 java = '21'
 nodejs = '24'
 python = '3'

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -194,7 +194,7 @@ end.
 AddConfig = [
     {cover_enabled, true},
     {cover_print_enabled, true},
-    {require_otp_vsn, "26|27|28|29"},
+    {require_otp_vsn, "27|28|29"},
     {deps_dir, "src"},
     {deps, lists:map(MakeDep, DepDescs ++ OptionalDeps)},
     {sub_dirs, SubDirs},


### PR DESCRIPTION
OTP 27-29 are aready the only versions tested in CI so we don't test 26 any longer and it's gone out of support.

We can take advantage of OTP 27+ with some of these features:

* Tripple quotes strings

```
    J = """
        {"a":"b"}
        """
```

Nice for json blobs

* Sigils. Nice for binaries.

```
B = ~"a binary"
```

* `maybe` is always enabled

* New json module. Jiffy is faster but for small and quick command line scripts it may be nice to not have to load a NIF

* Process labels

`proc_lib:set_label({client_proc, IP})`

Then we can filter by that and or see them in observer and other debug tools.

* ets:first_lookup/ets:next_lookup

Traverse ets tables easier
