### PR TITLE
docs: Hint for CouchDB 3.5.2.1

### DIFF
--- a/src/docs/src/whatsnew/3.5.rst
+++ b/src/docs/src/whatsnew/3.5.rst
@@ -25,6 +25,12 @@
 Version 3.5.2
 =============
 
+.. hint::
+    Shortly after the release of CouchDB 3.5.2, the Erlang team released a new version of
+    `Erlang/OTP 26 <https://www.erlang.org/patches/OTP-26.2.5.21>`_ containing security fixes.
+    We have therefore decided to update our convenience binaries as well, to use the updated
+    Erlang/OTP version. For some platforms, these are being released as CouchDB 3.5.2.1.
+
 Features
 --------
 


### PR DESCRIPTION
## Overview

Document the convenience binaries update with version 3.5.2.1.

Preview:

<img width="728" height="399" alt="grafik" src="https://github.com/user-attachments/assets/372bc001-1ba8-40cb-a35f-d922bcecfe22" />
