### PR TITLE
add QUERY method support

### DIFF
--- a/src/chttpd/src/chttpd_db.erl
+++ b/src/chttpd/src/chttpd_db.erl
@@ -106,7 +106,7 @@ handle_request(#httpd{path_parts = [DbName | RestParts], method = Method} = Req)
             do_db_req(Req, Handler)
     end.
 
-handle_changes_req(#httpd{method = 'POST'} = Req, Db) ->
+handle_changes_req(#httpd{method = Method} = Req, Db) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     case chttpd:body_length(Req) of
         0 ->
@@ -118,7 +118,7 @@ handle_changes_req(#httpd{method = 'POST'} = Req, Db) ->
 handle_changes_req(#httpd{method = 'GET'} = Req, Db) ->
     handle_changes_req1(Req, Db);
 handle_changes_req(#httpd{path_parts = [_, <<"_changes">>]} = Req, _Db) ->
-    send_method_not_allowed(Req, "GET,POST,HEAD").
+    send_method_not_allowed(Req, "GET,POST,QUERY,HEAD").
 
 handle_changes_req1(#httpd{} = Req, Db) ->
     #changes_args{filter = Raw, style = Style} = Args0 = parse_changes_query(Req),
@@ -163,7 +163,7 @@ handle_changes_req1(#httpd{} = Req, Db) ->
 
 % callbacks for continuous feed (newline-delimited JSON Objects)
 changes_callback(start, #cacc{feed = continuous} = Acc) ->
-    {ok, Resp} = chttpd:start_delayed_json_response(Acc#cacc.mochi, 200),
+    {ok, Resp} = chttpd:start_delayed_json_response(Acc#cacc.mochi, 200, [?ACCEPT_QUERY]),
     {ok, Acc#cacc{mochi = Resp, responding = true}};
 changes_callback({change, Change}, #cacc{feed = continuous} = Acc) ->
     chttpd_stats:incr_rows(),
@@ -185,7 +185,8 @@ changes_callback(start, #cacc{feed = eventsource} = Acc) ->
     #cacc{mochi = Req} = Acc,
     Headers = [
         {"Content-Type", "text/event-stream"},
-        {"Cache-Control", "no-cache"}
+        {"Cache-Control", "no-cache"},
+        ?ACCEPT_QUERY
     ],
     {ok, Resp} = chttpd:start_delayed_json_response(Req, 200, Headers),
     {ok, Acc#cacc{mochi = Resp, responding = true}};
@@ -218,14 +219,14 @@ changes_callback(start, #cacc{feed = normal} = Acc) ->
     {ok, Resp} = chttpd:start_delayed_json_response(
         Req,
         200,
-        [{"ETag", Etag}],
+        [{"ETag", Etag}, ?ACCEPT_QUERY],
         FirstChunk
     ),
     {ok, Acc#cacc{mochi = Resp, responding = true}};
 changes_callback(start, Acc) ->
     #cacc{mochi = Req} = Acc,
     FirstChunk = "{\"results\":[\n",
-    {ok, Resp} = chttpd:start_delayed_json_response(Req, 200, [], FirstChunk),
+    {ok, Resp} = chttpd:start_delayed_json_response(Req, 200, [?ACCEPT_QUERY], FirstChunk),
     {ok, Acc#cacc{mochi = Resp, responding = true}};
 changes_callback({change, Change}, Acc) ->
     chttpd_stats:incr_rows(),
@@ -708,7 +709,9 @@ db_req(#httpd{method = 'POST', path_parts = [_, <<"_bulk_docs">>], user_ctx = Ct
     end;
 db_req(#httpd{path_parts = [_, <<"_bulk_docs">>]} = Req, _Db) ->
     send_method_not_allowed(Req, "POST");
-db_req(#httpd{method = 'POST', path_parts = [_, <<"_bulk_get">>]} = Req, Db) ->
+db_req(#httpd{method = Method, path_parts = [_, <<"_bulk_get">>]} = Req, Db) when
+    ?POST_OR_QUERY(Method)
+->
     couch_stats:increment_counter([couchdb, httpd, bulk_requests]),
     couch_httpd:validate_ctype(Req, "application/json"),
     {JsonProps} = chttpd:json_body_obj(Req),
@@ -726,7 +729,7 @@ db_req(#httpd{method = 'POST', path_parts = [_, <<"_bulk_get">>]} = Req, Db) ->
             end
     end;
 db_req(#httpd{path_parts = [_, <<"_bulk_get">>]} = Req, _Db) ->
-    send_method_not_allowed(Req, "POST");
+    send_method_not_allowed(Req, "POST,QUERY");
 db_req(#httpd{method = 'POST', path_parts = [_, <<"_purge">>]} = Req, Db) ->
     couch_stats:increment_counter([couchdb, httpd, purge_requests]),
     chttpd:validate_ctype(Req, "application/json"),
@@ -780,11 +783,11 @@ db_req(#httpd{method = 'GET', path_parts = [_, OP]} = Req, Db) when ?IS_ALL_DOCS
     end;
 db_req(
     #httpd{
-        method = 'POST',
+        method = Method,
         path_parts = [_, OP, <<"queries">>]
     } = Req,
     Db
-) when ?IS_ALL_DOCS(OP) ->
+) when ?IS_ALL_DOCS(OP), ?POST_OR_QUERY(Method) ->
     Props = chttpd:json_body_obj(Req),
     case couch_mrview_util:get_view_queries(Props) of
         undefined ->
@@ -796,8 +799,10 @@ db_req(
     #httpd{path_parts = [_, OP, <<"queries">>]} = Req,
     _Db
 ) when ?IS_ALL_DOCS(OP) ->
-    send_method_not_allowed(Req, "POST");
-db_req(#httpd{method = 'POST', path_parts = [_, OP]} = Req, Db) when ?IS_ALL_DOCS(OP) ->
+    send_method_not_allowed(Req, "POST,QUERY");
+db_req(#httpd{method = Method, path_parts = [_, OP]} = Req, Db) when
+    ?IS_ALL_DOCS(OP), ?POST_OR_QUERY(Method)
+->
     chttpd:validate_ctype(Req, "application/json"),
     {Fields} = chttpd:json_body_obj(Req),
     case couch_util:get_value(<<"keys">>, Fields, nil) of
@@ -809,8 +814,10 @@ db_req(#httpd{method = 'POST', path_parts = [_, OP]} = Req, Db) when ?IS_ALL_DOC
             throw({bad_request, "`keys` body member must be an array."})
     end;
 db_req(#httpd{path_parts = [_, OP]} = Req, _Db) when ?IS_ALL_DOCS(OP) ->
-    send_method_not_allowed(Req, "GET,HEAD,POST");
-db_req(#httpd{method = 'POST', path_parts = [_, <<"_missing_revs">>]} = Req, Db) ->
+    send_method_not_allowed(Req, "GET,HEAD,POST,QUERY");
+db_req(#httpd{method = Method, path_parts = [_, <<"_missing_revs">>]} = Req, Db) when
+    ?POST_OR_QUERY(Method)
+->
     chttpd:validate_ctype(Req, "application/json"),
     {JsonDocIdRevs} = chttpd:json_body_obj(Req),
     case fabric:get_missing_revs(Db, JsonDocIdRevs) of
@@ -829,8 +836,10 @@ db_req(#httpd{method = 'POST', path_parts = [_, <<"_missing_revs">>]} = Req, Db)
             )
     end;
 db_req(#httpd{path_parts = [_, <<"_missing_revs">>]} = Req, _Db) ->
-    send_method_not_allowed(Req, "POST");
-db_req(#httpd{method = 'POST', path_parts = [_, <<"_revs_diff">>]} = Req, Db) ->
+    send_method_not_allowed(Req, "POST,QUERY");
+db_req(#httpd{method = Method, path_parts = [_, <<"_revs_diff">>]} = Req, Db) when
+    ?POST_OR_QUERY(Method)
+->
     chttpd:validate_ctype(Req, "application/json"),
     {JsonDocIdRevs} = chttpd:json_body_obj(Req),
     case fabric:get_missing_revs(Db, JsonDocIdRevs) of
@@ -858,7 +867,7 @@ db_req(#httpd{method = 'POST', path_parts = [_, <<"_revs_diff">>]} = Req, Db) ->
             send_json(Req, {Results2})
     end;
 db_req(#httpd{path_parts = [_, <<"_revs_diff">>]} = Req, _Db) ->
-    send_method_not_allowed(Req, "POST");
+    send_method_not_allowed(Req, "POST,QUERY");
 db_req(
     #httpd{method = 'PUT', path_parts = [_, <<"_security">>], user_ctx = Ctx} = Req,
     Db
@@ -983,7 +992,7 @@ multi_all_docs_view(Req, Db, OP, Queries) ->
     {ok, Resp0} = chttpd:start_delayed_json_response(
         VAcc0#vacc.req,
         200,
-        [],
+        [?ACCEPT_QUERY],
         FirstChunk
     ),
     VAcc1 = VAcc0#vacc{resp = Resp0},
@@ -2136,7 +2145,14 @@ parse_doc_query({Key, Value}, Args) ->
             Args
     end.
 
-parse_changes_query(Req) ->
+parse_changes_query(#httpd{method = 'QUERY'} = Req) ->
+    {JsonProps0} = Req#httpd.req_body,
+    JsonProps1 = lists:map(fun to_qs/1, JsonProps0),
+    parse_changes_query(Req, JsonProps1);
+parse_changes_query(#httpd{} = Req) ->
+    parse_changes_query(Req, chttpd:qs(Req)).
+
+parse_changes_query(#httpd{} = Req, Props) ->
     erlang:erase(changes_seq_interval),
     ChangesArgs = lists:foldl(
         fun({Key, Value}, Args) ->
@@ -2205,7 +2221,7 @@ parse_changes_query(Req) ->
             end
         end,
         #changes_args{},
-        chttpd:qs(Req)
+        Props
     ),
     %% if it's an EventSource request with a Last-event-ID header
     %% that should override the `since` query string, since it's
@@ -2221,6 +2237,13 @@ parse_changes_query(Req) ->
         _ ->
             ChangesArgs
     end.
+
+to_qs({Key, Value}) when is_binary(Key), is_binary(Value) ->
+    {binary_to_list(Key), binary_to_list(Value)};
+to_qs({Key, Value}) when is_binary(Key), is_integer(Value) ->
+    {binary_to_list(Key), integer_to_list(Value)};
+to_qs({Key, Value}) when is_list(Key), is_list(Value) ->
+    {Key, Value}.
 
 extract_header_rev(Req, ExplicitRev) when is_binary(ExplicitRev) or is_list(ExplicitRev) ->
     extract_header_rev(Req, couch_doc:parse_rev(ExplicitRev));

--- a/src/chttpd/src/chttpd_misc.erl
+++ b/src/chttpd/src/chttpd_misc.erl
@@ -174,7 +174,9 @@ all_dbs_info_callback({error, Reason}, #vacc{resp = Resp0} = Acc) ->
 
 handle_dbs_info_req(#httpd{method = 'GET', path_parts = [<<"_dbs_info">>]} = Req) ->
     handle_all_dbs_info_req(Req);
-handle_dbs_info_req(#httpd{method = 'POST', path_parts = [<<"_dbs_info">>]} = Req) ->
+handle_dbs_info_req(#httpd{method = Method, path_parts = [<<"_dbs_info">>]} = Req) when
+    ?POST_OR_QUERY(Method)
+->
     chttpd:validate_ctype(Req, "application/json"),
     Props = chttpd:json_body_obj(Req),
     Keys = couch_mrview_util:get_view_keys(Props),
@@ -191,7 +193,7 @@ handle_dbs_info_req(#httpd{method = 'POST', path_parts = [<<"_dbs_info">>]} = Re
         true -> ok;
         false -> throw({bad_request, too_many_keys})
     end,
-    {ok, Resp} = chttpd:start_json_response(Req, 200),
+    {ok, Resp} = chttpd:start_json_response(Req, 200, [?ACCEPT_QUERY]),
     send_chunk(Resp, "["),
     lists:foldl(
         fun(DbName, AccSeparator) ->
@@ -212,11 +214,11 @@ handle_dbs_info_req(#httpd{method = 'POST', path_parts = [<<"_dbs_info">>]} = Re
     send_chunk(Resp, "]"),
     chttpd:end_json_response(Resp);
 handle_dbs_info_req(#httpd{method = Method, path_parts = [<<"_dbs_info">> | _]} = Req) when
-    Method == 'GET'; Method == 'POST'
+    Method == 'GET'; ?POST_OR_QUERY(Method)
 ->
     chttpd:send_error(Req, not_found);
 handle_dbs_info_req(Req) ->
-    send_method_not_allowed(Req, "GET,HEAD,POST").
+    send_method_not_allowed(Req, "GET,HEAD,POST,QUERY").
 
 handle_task_status_req(#httpd{method = 'GET'} = Req) ->
     ok = chttpd:verify_is_server_admin(Req),

--- a/src/chttpd/src/chttpd_view.erl
+++ b/src/chttpd/src/chttpd_view.erl
@@ -125,12 +125,12 @@ handle_view_req(
     design_doc_view(Req, Db, DDoc, ViewName, Keys);
 handle_view_req(
     #httpd{
-        method = 'POST',
+        method = Method,
         path_parts = [_, _, _, _, ViewName]
     } = Req,
     Db,
     DDoc
-) ->
+) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     Props = couch_httpd:json_body_obj(Req),
     assert_no_queries_param(couch_mrview_util:get_view_queries(Props)),
@@ -138,7 +138,7 @@ handle_view_req(
     couch_stats:increment_counter([couchdb, httpd, view_reads]),
     design_doc_post_view(Req, Props, Db, DDoc, ViewName, Keys);
 handle_view_req(Req, _Db, _DDoc) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST,HEAD").
+    chttpd:send_method_not_allowed(Req, "GET,POST,QUERY,HEAD").
 
 handle_temp_view_req(Req, _Db) ->
     Msg = <<"Temporary views are not supported in CouchDB">>,

--- a/src/couch/include/couch_db.hrl
+++ b/src/couch/include/couch_db.hrl
@@ -36,6 +36,9 @@
 -define(term_to_bin(T, O), term_to_binary(T, O ++ [{minor_version, 1}])).
 -define(term_size(T), erlang:external_size(T, [{minor_version, 1}])).
 
+-define(POST_OR_QUERY(Method), (Method == 'POST' orelse Method == 'QUERY')).
+-define(ACCEPT_QUERY, {<<"Accept-Query">>, <<"\"application/json\"">>}).
+
 -define(DEFAULT_ATTACHMENT_CONTENT_TYPE, <<"application/octet-stream">>).
 
 -define(ADMIN_USER, #user_ctx{roles=[<<"_admin">>]}).

--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -170,6 +170,10 @@
     {type, counter},
     {desc, <<"number of HTTP PUT requests">>}
 ]}.
+{[couchdb, httpd_request_methods, 'QUERY'], [
+    {type, counter},
+    {desc, <<"number of HTTP QUERY requests">>}
+]}.
 {[couchdb, httpd_status_codes, 200], [
     {type, counter},
     {desc, <<"number of HTTP 200 OK responses">>}

--- a/src/couch_mrview/src/couch_mrview_http.erl
+++ b/src/couch_mrview/src/couch_mrview_http.erl
@@ -45,30 +45,30 @@
 
 handle_all_docs_req(#httpd{method = 'GET'} = Req, Db) ->
     all_docs_req(Req, Db, undefined);
-handle_all_docs_req(#httpd{method = 'POST'} = Req, Db) ->
+handle_all_docs_req(#httpd{method = Method} = Req, Db) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     Keys = couch_mrview_util:get_view_keys(chttpd:json_body_obj(Req)),
     all_docs_req(Req, Db, Keys);
 handle_all_docs_req(Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST,HEAD").
+    chttpd:send_method_not_allowed(Req, "GET,POST,QUERY,HEAD").
 
 handle_local_docs_req(#httpd{method = 'GET'} = Req, Db) ->
     all_docs_req(Req, Db, undefined, <<"_local">>);
-handle_local_docs_req(#httpd{method = 'POST'} = Req, Db) ->
+handle_local_docs_req(#httpd{method = Method} = Req, Db) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     Keys = couch_mrview_util:get_view_keys(chttpd:json_body_obj(Req)),
     all_docs_req(Req, Db, Keys, <<"_local">>);
 handle_local_docs_req(Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST,HEAD").
+    chttpd:send_method_not_allowed(Req, "GET,POST,QUERY,HEAD").
 
 handle_design_docs_req(#httpd{method = 'GET'} = Req, Db) ->
     all_docs_req(Req, Db, undefined, <<"_design">>);
-handle_design_docs_req(#httpd{method = 'POST'} = Req, Db) ->
+handle_design_docs_req(#httpd{method = Method} = Req, Db) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     Keys = couch_mrview_util:get_view_keys(chttpd:json_body_obj(Req)),
     all_docs_req(Req, Db, Keys, <<"_design">>);
 handle_design_docs_req(Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST,HEAD").
+    chttpd:send_method_not_allowed(Req, "GET,POST,QUERY,HEAD").
 
 handle_reindex_req(
     #httpd{
@@ -108,7 +108,7 @@ handle_view_req(#httpd{method = 'GET'} = Req, Db, DDoc) ->
     [_, _, _, _, ViewName] = Req#httpd.path_parts,
     couch_stats:increment_counter([couchdb, httpd, view_reads]),
     design_doc_view(Req, Db, DDoc, ViewName, undefined);
-handle_view_req(#httpd{method = 'POST'} = Req, Db, DDoc) ->
+handle_view_req(#httpd{method = Method} = Req, Db, DDoc) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     [_, _, _, _, ViewName] = Req#httpd.path_parts,
     Props = chttpd:json_body_obj(Req),
@@ -125,13 +125,13 @@ handle_view_req(#httpd{method = 'POST'} = Req, Db, DDoc) ->
         {undefined, undefined} ->
             throw({
                 bad_request,
-                "POST body must contain `keys` or `queries` field"
+                "request body must contain `keys` or `queries` field"
             });
         {_, _} ->
             throw({bad_request, "`keys` and `queries` are mutually exclusive"})
     end;
 handle_view_req(Req, _Db, _DDoc) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST,HEAD").
+    chttpd:send_method_not_allowed(Req, "GET,POST,QUERY,HEAD").
 
 handle_temp_view_req(#httpd{method = 'POST'} = Req, Db) ->
     chttpd:validate_ctype(Req, "application/json"),
@@ -346,11 +346,12 @@ view_cb({error, Reason}, #vacc{resp = undefined} = Acc) ->
     {ok, Acc#vacc{resp = Resp}};
 view_cb(complete, #vacc{resp = undefined} = Acc) ->
     % Nothing in view
-    {ok, Resp} = chttpd:send_json(Acc#vacc.req, 200, {[{rows, []}]}),
+    Headers = [?ACCEPT_QUERY],
+    {ok, Resp} = chttpd:send_json(Acc#vacc.req, 200, Headers, {[{rows, []}]}),
     {ok, Acc#vacc{resp = Resp}};
 view_cb(Msg, #vacc{resp = undefined} = Acc) ->
     %% Start response
-    Headers = [],
+    Headers = [?ACCEPT_QUERY],
     {ok, Resp} = chttpd:start_delayed_json_response(Acc#vacc.req, 200, Headers),
     view_cb(Msg, Acc#vacc{resp = Resp, should_close = true});
 %% ---------------------------------------------------
@@ -502,7 +503,7 @@ parse_params(Props, Keys, #mrargs{} = Args0, Options) ->
         Props
     ).
 
-parse_body_and_query(#httpd{method = 'POST'} = Req, Keys) ->
+parse_body_and_query(#httpd{method = Method} = Req, Keys) when ?POST_OR_QUERY(Method) ->
     Props = chttpd:json_body_obj(Req),
     parse_body_and_query(Req, Props, Keys);
 parse_body_and_query(Req, Keys) ->

--- a/src/dreyfus/src/dreyfus_httpd.erl
+++ b/src/dreyfus/src/dreyfus_httpd.erl
@@ -26,7 +26,7 @@
 -include_lib("couch/include/couch_db.hrl").
 -import(chttpd, [
     send_method_not_allowed/2,
-    send_json/2, send_json/3,
+    send_json/2, send_json/3, send_json/4,
     send_error/2
 ]).
 
@@ -40,7 +40,7 @@ handle_search_req(
     RetryCount,
     RetryPause
 ) when
-    Method == 'GET'; Method == 'POST'
+    Method == 'GET'; ?POST_OR_QUERY(Method)
 ->
     verify_search_available(),
     DbName = couch_db:name(Db),
@@ -85,7 +85,7 @@ handle_search_req(
                                 _ ->
                                     [{ranges, facets_to_json(Ranges0)}]
                             end,
-                        send_json(Req, 200, {
+                        send_json(Req, 200, [?ACCEPT_QUERY], {
                             [
                                 {total_rows, TotalHits},
                                 {bookmark, Bookmark},
@@ -132,7 +132,7 @@ handle_search_req(
     couch_stats:update_histogram([dreyfus, httpd, search], RequestTime),
     Response;
 handle_search_req(#httpd{path_parts = [_, _, _, _, _]} = Req, _Db, _DDoc, _RetryCount, _RetryPause) ->
-    send_method_not_allowed(Req, "GET,POST");
+    send_method_not_allowed(Req, "GET,POST,QUERY");
 handle_search_req(Req, _Db, _DDoc, _RetryCount, _RetryPause) ->
     send_error(Req, {bad_request, "path not recognized"}).
 
@@ -195,7 +195,7 @@ handle_analyze_req(#httpd{method = 'GET'} = Req) ->
     Analyzer = couch_httpd:qs_value(Req, "analyzer"),
     Text = couch_httpd:qs_value(Req, "text"),
     analyze(Req, Analyzer, Text);
-handle_analyze_req(#httpd{method = 'POST'} = Req) ->
+handle_analyze_req(#httpd{method = Method} = Req) when ?POST_OR_QUERY(Method) ->
     verify_search_available(),
     couch_httpd:validate_ctype(Req, "application/json"),
     {Fields} = chttpd:json_body_obj(Req),
@@ -203,7 +203,7 @@ handle_analyze_req(#httpd{method = 'POST'} = Req) ->
     Text = couch_util:get_value(<<"text">>, Fields),
     analyze(Req, Analyzer, Text);
 handle_analyze_req(Req) ->
-    send_method_not_allowed(Req, "GET,POST").
+    send_method_not_allowed(Req, "GET,POST,QUERY").
 
 analyze(Req, Analyzer, Text) ->
     case Analyzer of
@@ -235,7 +235,7 @@ analyze(Req, Analyzer, Text) ->
         )
     of
         {ok, Tokens} ->
-            send_json(Req, 200, {[{tokens, Tokens}]});
+            send_json(Req, 200, [?ACCEPT_QUERY], {[{tokens, Tokens}]});
         {error, Reason} ->
             send_error(Req, Reason)
     end.
@@ -246,7 +246,7 @@ parse_index_params(#httpd{method = 'GET'} = Req, Db) ->
         chttpd:qs(Req)
     ),
     parse_index_params(IndexParams, Db);
-parse_index_params(#httpd{method = 'POST'} = Req, Db) ->
+parse_index_params(#httpd{method = Method} = Req, Db) when ?POST_OR_QUERY(Method) ->
     {JsonBody} = chttpd:json_body_obj(Req),
     QSEntry =
         case chttpd:qs_value(Req, "partition") of
@@ -692,7 +692,7 @@ send_grouped_response(Req, {TotalHits, TotalGroupedHits, Groups}, UseNewApi) ->
             false ->
                 [{total_hits, TotalHits}, {total_grouped_hits, TotalGroupedHits}, {groups, Groups}]
         end,
-    send_json(Req, 200, {GroupResponsePairs}).
+    send_json(Req, 200, [?ACCEPT_QUERY], {GroupResponsePairs}).
 
 handle_error(Req, Db, DDoc, RetryCount, RetryPause, {exit, _} = Err) ->
     backoff_and_retry(Req, Db, DDoc, RetryCount, RetryPause, Err);

--- a/src/mango/src/mango_httpd.erl
+++ b/src/mango/src/mango_httpd.erl
@@ -194,17 +194,17 @@ handle_index_req(
 handle_index_req(Req, _Db) ->
     chttpd:send_error(Req, not_found).
 
-handle_explain_req(#httpd{method = 'POST'} = Req, Db) ->
+handle_explain_req(#httpd{method = Method} = Req, Db) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     Body = maybe_set_partition(Req),
     {ok, Opts0} = mango_opts:validate_find(Body),
     {value, {selector, Sel}, Opts} = lists:keytake(selector, 1, Opts0),
     Resp = mango_crud:explain(Db, Sel, Opts),
-    chttpd:send_json(Req, Resp);
+    chttpd:send_json(Req, 200, [?ACCEPT_QUERY], Resp);
 handle_explain_req(Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "POST").
+    chttpd:send_method_not_allowed(Req, "POST,QUERY").
 
-handle_find_req(#httpd{method = 'POST'} = Req, Db) ->
+handle_find_req(#httpd{method = Method} = Req, Db) when ?POST_OR_QUERY(Method) ->
     chttpd:validate_ctype(Req, "application/json"),
     Body = maybe_set_partition(Req),
     {ok, Opts0} = mango_opts:validate_find(Body),
@@ -222,7 +222,7 @@ handle_find_req(#httpd{method = 'POST'} = Req, Db) ->
             chttpd:send_error(Req, Error)
     end;
 handle_find_req(Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "POST").
+    chttpd:send_method_not_allowed(Req, "POST,QUERY").
 
 set_user_ctx(#httpd{user_ctx = Ctx}, Db) ->
     {ok, NewDb} = couch_db:set_user_ctx(Db, Ctx),
@@ -277,7 +277,7 @@ convert_to_design_id(DDocId) ->
     end.
 
 start_find_resp(Req) ->
-    chttpd:start_delayed_json_response(Req, 200, [], "{\"docs\":[").
+    chttpd:start_delayed_json_response(Req, 200, [?ACCEPT_QUERY], "{\"docs\":[").
 
 end_find_resp(Acc0) ->
     #vacc{resp = Resp00, buffer = Buf, kvs = KVs, threshold = Max} = Acc0,

--- a/src/nouveau/src/nouveau_httpd.erl
+++ b/src/nouveau/src/nouveau_httpd.erl
@@ -27,14 +27,14 @@
 
 -import(chttpd, [
     send_method_not_allowed/2,
-    send_json/2, send_json/3,
+    send_json/2, send_json/3, send_json/4,
     send_error/2
 ]).
 
 -define(RETRY_LIMIT, 20).
 -define(RETRY_SLEEP, 500).
 
-handle_analyze_req(#httpd{method = 'POST'} = Req) ->
+handle_analyze_req(#httpd{method = Method} = Req) when ?POST_OR_QUERY(Method) ->
     check_if_enabled(),
     couch_httpd:validate_ctype(Req, "application/json"),
     {Fields} = chttpd:json_body_obj(Req),
@@ -42,12 +42,12 @@ handle_analyze_req(#httpd{method = 'POST'} = Req) ->
     Text = couch_util:get_value(<<"text">>, Fields),
     case nouveau_api:analyze(Text, Analyzer) of
         {ok, Tokens} ->
-            send_json(Req, 200, {[{<<"tokens">>, Tokens}]});
+            send_json(Req, 200, [?ACCEPT_QUERY], {[{<<"tokens">>, Tokens}]});
         {error, Reason} ->
             send_error(Req, Reason)
     end;
 handle_analyze_req(Req) ->
-    send_method_not_allowed(Req, "POST").
+    send_method_not_allowed(Req, "POST,QUERY").
 
 handle_search_req(Req, Db, DDoc) ->
     check_if_enabled(),
@@ -79,8 +79,8 @@ handle_search_req_int(#httpd{method = 'GET', path_parts = [_, _, _, _, IndexName
     }),
     handle_search_req(Req, DbName, DDoc, IndexName, QueryArgs, ?RETRY_LIMIT);
 handle_search_req_int(
-    #httpd{method = 'POST', path_parts = [_, _, _, _, IndexName]} = Req, Db, DDoc
-) ->
+    #httpd{method = Method, path_parts = [_, _, _, _, IndexName]} = Req, Db, DDoc
+) when ?POST_OR_QUERY(Method) ->
     couch_httpd:validate_ctype(Req, "application/json"),
     DbName = couch_db:name(Db),
     ReqBody = chttpd:json_body(Req, [return_maps]),
@@ -99,7 +99,7 @@ handle_search_req_int(
     }),
     handle_search_req(Req, DbName, DDoc, IndexName, QueryArgs, ?RETRY_LIMIT);
 handle_search_req_int(Req, _Db, _DDoc) ->
-    send_method_not_allowed(Req, "GET, POST").
+    send_method_not_allowed(Req, "GET,POST,QUERY").
 
 handle_search_req(#httpd{} = Req, DbName, DDoc, IndexName, QueryArgs, Retry) ->
     IncludeDocs = maps:get(include_docs, QueryArgs, false),
@@ -118,7 +118,7 @@ handle_search_req(#httpd{} = Req, DbName, DDoc, IndexName, QueryArgs, Retry) ->
             },
             HitCount = length(maps:get(<<"hits">>, RespBody)),
             incr_stats(HitCount, IncludeDocs),
-            send_json(Req, 200, RespBody);
+            send_json(Req, 200, [?ACCEPT_QUERY], RespBody);
         {error, {service_unavailable, _}} when Retry > 1 ->
             couch_log:warning("search unavailable, retrying (~p of ~p)", [
                 ?RETRY_LIMIT - Retry + 1, ?RETRY_LIMIT


### PR DESCRIPTION
## Overview

Accept QUERY method wherever POST is allowed when querying the database. Only endpoints that make no state changes are eligible. Send Accept-Query: "application/json" for all requests to such endpoints to aid discovery.

## Testing recommendations

TBD

## Related Issues or Pull Requests

N/A

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
