### PR TITLE
Let auth lockout identify clients by a trusted proxy header

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1305,6 +1305,16 @@ url = {{nouveau_url}}
 ; note: changing this setting requires a couchdb restart.
 ;max_lifetime = 300000
 
+; By default the client is identified by the socket peer address. Behind a
+; reverse proxy or CDN that peer is the proxy, so all clients share one address
+; and the lockout becomes ineffective. Set client_ip_header to the request
+; header that carries the real client IP (e.g. X-Forwarded-For, X-Real-IP,
+; CF-Connecting-IP); the first address is used when the header holds a list.
+; SECURITY: only enable this when a trusted proxy *overwrites* this header on
+; every request, otherwise a client can spoof it to evade the lockout. When
+; unset (the default) the socket peer is used.
+;client_ip_header = X-Forwarded-For
+
 [config]
 ; periodically reload configuration from file.
 ; Set to infinity to disable.

--- a/src/couch/src/couch_auth_lockout.erl
+++ b/src/couch/src/couch_auth_lockout.erl
@@ -81,5 +81,125 @@ peer(#httpd{mochi_req = MochiReq}) ->
         {remote, _Pid, _Ref} ->
             nopeer;
         _ ->
-            mochiweb_request:get(peer, MochiReq)
+            client_ip(MochiReq)
     end.
+
+client_ip(MochiReq) ->
+    case configured_client_ip(MochiReq) of
+        undefined ->
+            mochiweb_request:get(peer, MochiReq);
+        Peer ->
+            Peer
+    end.
+
+configured_client_ip(MochiReq) ->
+    case client_ip_header() of
+        undefined ->
+            undefined;
+        Header ->
+            case mochiweb_request:get_header_value(Header, MochiReq) of
+                undefined -> undefined;
+                Value -> first_address(Value)
+            end
+    end.
+
+first_address(Value) ->
+    case string:lexemes(Value, ", ") of
+        [Client | _] -> Client;
+        [] -> undefined
+    end.
+
+client_ip_header() ->
+    case config:get("chttpd_auth_lockout", "client_ip_header", undefined) of
+        "" -> undefined;
+        Header -> Header
+    end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(SOCKET_PEER, "203.0.113.9").
+
+peer_resolution_test_() ->
+    {
+        foreach,
+        fun setup/0,
+        fun teardown/1,
+        [
+            fun t_no_header_configured_uses_socket_peer/1,
+            fun t_blank_header_config_uses_socket_peer/1,
+            fun t_absent_header_falls_back_to_socket_peer/1,
+            fun t_empty_header_falls_back_to_socket_peer/1,
+            fun t_single_address_header_is_used/1,
+            fun t_first_address_of_forwarded_for_is_used/1,
+            fun t_remote_socket_has_no_peer/1
+        ]
+    }.
+
+setup() ->
+    meck:new(config, [passthrough]),
+    meck:new(mochiweb_request, [passthrough]),
+    meck:expect(mochiweb_request, get, fun
+        (peer, _Req) -> ?SOCKET_PEER;
+        (Key, Req) -> meck:passthrough([Key, Req])
+    end),
+    set_client_ip_header(undefined),
+    ok.
+
+teardown(_) ->
+    meck:unload().
+
+set_client_ip_header(Value) ->
+    meck:expect(config, get, fun
+        ("chttpd_auth_lockout", "client_ip_header", _Default) -> Value;
+        (Section, Key, Default) -> meck:passthrough([Section, Key, Default])
+    end).
+
+req(Headers) ->
+    req(fake_socket, Headers).
+
+req(Socket, Headers) ->
+    MochiReq = mochiweb_request:new(
+        Socket, 'GET', "/", {1, 1}, mochiweb_headers:make(Headers)
+    ),
+    #httpd{mochi_req = MochiReq}.
+
+t_no_header_configured_uses_socket_peer(_) ->
+    ?_assertEqual(?SOCKET_PEER, peer(req([{"X-Forwarded-For", "198.51.100.23"}]))).
+
+t_blank_header_config_uses_socket_peer(_) ->
+    set_client_ip_header(""),
+    ?_assertEqual(?SOCKET_PEER, peer(req([{"X-Forwarded-For", "198.51.100.23"}]))).
+
+t_absent_header_falls_back_to_socket_peer(_) ->
+    set_client_ip_header("X-Forwarded-For"),
+    ?_assertEqual(?SOCKET_PEER, peer(req([{"Host", "example.com"}]))).
+
+t_empty_header_falls_back_to_socket_peer(_) ->
+    set_client_ip_header("X-Forwarded-For"),
+    ?_assertEqual(?SOCKET_PEER, peer(req([{"X-Forwarded-For", "  "}]))).
+
+t_single_address_header_is_used(_) ->
+    set_client_ip_header("CF-Connecting-IP"),
+    ?_assertEqual("198.51.100.23", peer(req([{"CF-Connecting-IP", "198.51.100.23"}]))).
+
+t_first_address_of_forwarded_for_is_used(_) ->
+    set_client_ip_header("X-Forwarded-For"),
+    Req = req([{"X-Forwarded-For", "198.51.100.23, 203.0.113.9, 10.0.0.1"}]),
+    ?_assertEqual("198.51.100.23", peer(Req)).
+
+t_remote_socket_has_no_peer(_) ->
+    set_client_ip_header("X-Forwarded-For"),
+    Req = req({remote, self(), make_ref()}, [{"X-Forwarded-For", "198.51.100.23"}]),
+    ?_assertEqual(nopeer, peer(Req)).
+
+first_address_test_() ->
+    [
+        ?_assertEqual("198.51.100.23", first_address("198.51.100.23")),
+        ?_assertEqual("198.51.100.23", first_address("198.51.100.23, 203.0.113.9")),
+        ?_assertEqual("198.51.100.23", first_address("  198.51.100.23 , 203.0.113.9")),
+        ?_assertEqual(undefined, first_address("")),
+        ?_assertEqual(undefined, first_address("  "))
+    ].
+
+-endif.

--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -617,3 +617,24 @@ Authentication Configuration
 
            [chttpd_auth_lockout]
            max_lifetime = 300000
+
+    .. config:option:: client_ip_header :: header carrying the real client IP
+
+        By default the client is identified by the socket peer address. When
+        CouchDB runs behind a reverse proxy or CDN, that peer is the proxy, so
+        every client shares a single address and the lockout becomes
+        ineffective (and may lock out unrelated clients sharing a proxy egress
+        IP). Set ``client_ip_header`` to the request header that carries the
+        real client IP, such as ``X-Forwarded-For``, ``X-Real-IP`` or
+        ``CF-Connecting-IP``. When the header holds a comma-separated list, the
+        first address is used. When unset (the default), the socket peer is
+        used. ::
+
+           [chttpd_auth_lockout]
+           client_ip_header = X-Forwarded-For
+
+        .. warning::
+            Only enable this when a trusted proxy **overwrites** this header on
+            every request. If clients can reach CouchDB directly, or the proxy
+            merely appends to a client-supplied header, an attacker can spoof
+            the header to evade the lockout.

--- a/test/elixir/test/auth_lockout_test.exs
+++ b/test/elixir/test/auth_lockout_test.exs
@@ -35,6 +35,51 @@ defmodule AuthLockoutTest do
     run_on_modified_server(server_config, &test_chttpd_auth_lockout_warning/0)
   end
 
+  test "lockout is tracked per client_ip_header, not the shared socket peer", _context do
+    server_config = [
+      %{
+        :section => "chttpd_auth_lockout",
+        :key => "mode",
+        :value => "enforce"
+      },
+      %{
+        :section => "chttpd_auth_lockout",
+        :key => "client_ip_header",
+        :value => "X-Forwarded-For"
+      }
+    ]
+
+    run_on_modified_server(server_config, &test_chttpd_auth_lockout_per_client_ip/0)
+  end
+
+  defp test_chttpd_auth_lockout_per_client_ip do
+    locked_out_client = "192.0.2.10"
+    other_client = "192.0.2.20"
+
+    # exceed the lockout threshold as one forwarded-for client
+    for _n <- 1..5 do
+      assert auth_failure(locked_out_client).status_code == 401
+    end
+
+    # that client is now locked out, even though every request shares the
+    # same socket peer (127.0.0.1)
+    assert auth_failure(locked_out_client).status_code == 403
+
+    # a different forwarded-for client is unaffected: it still gets a plain
+    # 401, proving the lockout keys on the header and not the socket peer
+    assert auth_failure(other_client).status_code == 401
+  end
+
+  defp auth_failure(forwarded_for) do
+    Couch.get("/_all_dbs",
+      no_auth: true,
+      headers: [
+        "X-Forwarded-For": forwarded_for,
+        authorization: "Basic #{:base64.encode("chttpd_auth_lockout:baz")}"
+      ]
+    )
+  end
+
   defp test_chttpd_auth_lockout_enforcement do
     # exceed the lockout threshold
     for _n <- 1..5 do

--- a/test/elixir/test/config/suite.elixir
+++ b/test/elixir/test/config/suite.elixir
@@ -47,7 +47,8 @@
   ],
   "AuthLockoutTest": [
     "lockout after multiple failed authentications",
-    "do not lockout after multiple failed authentications"
+    "do not lockout after multiple failed authentications",
+    "lockout is tracked per client_ip_header, not the shared socket peer"
   ],
   "BasicsTest": [
     "'+' in document name should encode to '+'",


### PR DESCRIPTION
## Overview

The auth lockout from 3.4 identifies clients by the socket peer. Behind a reverse proxy or CDN that peer is the proxy, so the lockout stops working: an attacker rotates the upstream IP, and clients sharing a proxy egress IP can lock each other out.

This adds an optional `[chttpd_auth_lockout] client_ip_header` setting that names the header carrying the real client IP (`X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`). The first address is used if the header holds a list. Unset by default, so current behaviour is unchanged.

## Testing recommendations

`make eunit apps=couch suites=couch_auth_lockout` and `make elixir tests=test/elixir/test/auth_lockout_test.exs`.

The integration test sets `client_ip_header = X-Forwarded-For` and checks that one forwarded client gets locked out (403) while another still gets 401, so the lockout keys on the header and not on the shared socket peer.

## Related Issues or Pull Requests

Fixes #6052

## Checklist

- [ ] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches

## Note on AI assistance

I used AI to help me understand the codebase and explore the approach. I reviewed and validated the design, the tests and the final code myself, so this is not an unreviewed AI dump. I am Spanish and my English is not great, so I also used AI to translate this message. Flagging it for transparency.
