### PR TITLE
nouveau: always use cacertfile if specified; explicit peer verification

### DIFF
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -1075,6 +1075,9 @@ url = {{nouveau_url}}
 ; Path to file containing CA certificate for the remote nouveau server (optional).
 ;ssl_cacert_file =
 
+; Verify peers
+;ssl_verify = true
+
 [disk_monitor]
 ;enable = false
 ;background_view_indexing_threshold = 80

--- a/src/nouveau/src/nouveau_gun.erl
+++ b/src/nouveau/src/nouveau_gun.erl
@@ -129,8 +129,16 @@ start_gun(URL) ->
     KeyFile = config:get("nouveau", "ssl_key_file"),
     CertFile = config:get("nouveau", "ssl_cert_file"),
     Password = config:get("nouveau", "ssl_password"),
+    Verify = verify(config:get_boolean("nouveau", "ssl_verify", true)),
     Transport = scheme_to_transport(Scheme),
     BaseConnOptions = #{transport => Transport, protocols => [http2]},
+    BaseTLSOptions =
+        if
+            CACertFile /= undefined ->
+                [{verify, Verify}, {cacertfile, CACertFile}];
+            true ->
+                [{verify, Verify}]
+        end,
     ConnOptions =
         if
             Transport == tls andalso KeyFile /= undefined andalso CertFile /= undefined ->
@@ -142,7 +150,11 @@ start_gun(URL) ->
                 },
                 CertKeyConf1 = maps:filter(fun remove_undefined/2, CertKeyConf0),
                 BaseConnOptions#{
-                    tls_opts => [{certs_keys, [CertKeyConf1]}]
+                    tls_opts => [{certs_keys, [CertKeyConf1]} | BaseTLSOptions]
+                };
+            Transport == tls ->
+                BaseConnOptions#{
+                    tls_opts => BaseTLSOptions
                 };
             true ->
                 BaseConnOptions
@@ -160,3 +172,8 @@ scheme_to_transport("http") ->
     tcp;
 scheme_to_transport("https") ->
     tls.
+
+verify(false) ->
+    verify_none;
+verify(true) ->
+    verify_peer.


### PR DESCRIPTION
## Overview

Unless client certificates are used the cacertfile setting is ignored. There are legitimate reasons you might want to specify the allowed CA certificates without using client certificates, so always set this.

Erlang 26 and above uses verify_peer by default but it doesn't hurt to be explicit. The new ssl_verify also allowes the ability to disable peer verification which might be useful in dev and testing environments.

## Testing recommendations

N/A

## Related Issues or Pull Requests

N/A

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [x] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
