### PR TITLE
Update jiffy to 2.0.2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -161,7 +161,7 @@ DepDescs = [
                    {tag, "v1.3.6"}, [raw]},
 {ibrowse,          "ibrowse",          {tag, "CouchDB-4.5.0-1"}},
 {gun,              "gun",              {tag, "CouchDB-2.4.1-1"}},
-{jiffy,            "jiffy",            {tag, "2.0.1"}},
+{jiffy,            "jiffy",            {tag, "2.0.2"}},
 {mochiweb,         "mochiweb",         {tag, "v3.4.0"}},
 {meck,             "meck",             {tag, "v1.1.1"}},
 {recon,            "recon",            {tag, "2.5.6"}}


### PR DESCRIPTION
* Reduce encoder memory allocations https://github.com/davisp/jiffy/pull/301
* Encode maps directly without an intermediate EJSON proplist  https://github.com/davisp/jiffy/pull/302
* Fix out-of-bounds heap write in string encoder https://github.com/davisp/jiffy/pull/304
