### PR TITLE
Clouseau: Separate write folders for each instance

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -631,17 +631,26 @@ config: [
       name: clouseau1
       domain: 127.0.0.1
     }
+    clouseau: {
+      dir: dev/lib/node1/indexes
+    }
   }
   {
     node: {
       name: clouseau2
       domain: 127.0.0.1
     }
+    clouseau: {
+      dir: dev/lib/node2/indexes
+    }
   }
   {
     node: {
       name: clouseau3
       domain: 127.0.0.1
+    }
+    clouseau: {
+      dir: dev/lib/node3/indexes
     }
   }
 ]
@@ -803,7 +812,7 @@ def boot_clouseau(ctx, idx):
 
         if is_ziose:
             clouseau_jars = glob.glob(
-                os.path.join(clouseau_dir, "clouseau", "target", "**", "*.jar"),
+                os.path.join(clouseau_dir, "target", "**", "clouseau", "*.jar"),
                 recursive=True,
             )
 
@@ -890,6 +899,7 @@ def boot_clouseau(ctx, idx):
         + clouseau_cookie
         + [main_class, config_path]
     )
+    print(f"Starting clouseau as {cmd}")
 
     try:
         return sp.Popen(
@@ -1186,6 +1196,7 @@ def boot_node(ctx, node):
 
 @log("Running cluster setup")
 def cluster_setup(ctx):
+    print("Running setup")
     lead_port = cluster_port(ctx, ctx["node_number_seed"])
     if enable_cluster(ctx["N"], lead_port, *ctx["admin"]):
         for num in range(1, ctx["N"]):
@@ -1260,6 +1271,7 @@ def set_cookie(port, user, pswd):
 
 
 def finish_cluster(port, user, pswd):
+    print("finishing cluster ", port, " ", user, " ", pswd)
     status, response = try_request(
         "127.0.0.1",
         port,

--- a/dev/run
+++ b/dev/run
@@ -812,7 +812,7 @@ def boot_clouseau(ctx, idx):
 
         if is_ziose:
             clouseau_jars = glob.glob(
-                os.path.join(clouseau_dir, "target", "**", "clouseau", "*.jar"),
+                os.path.join(clouseau_dir, "clouseau", "target", "**", "*.jar"),
                 recursive=True,
             )
 
@@ -899,7 +899,6 @@ def boot_clouseau(ctx, idx):
         + clouseau_cookie
         + [main_class, config_path]
     )
-    print(f"Starting clouseau as {cmd}")
 
     try:
         return sp.Popen(
@@ -1196,7 +1195,6 @@ def boot_node(ctx, node):
 
 @log("Running cluster setup")
 def cluster_setup(ctx):
-    print("Running setup")
     lead_port = cluster_port(ctx, ctx["node_number_seed"])
     if enable_cluster(ctx["N"], lead_port, *ctx["admin"]):
         for num in range(1, ctx["N"]):
@@ -1271,7 +1269,6 @@ def set_cookie(port, user, pswd):
 
 
 def finish_cluster(port, user, pswd):
-    print("finishing cluster ", port, " ", user, " ", pswd)
     status, response = try_request(
         "127.0.0.1",
         port,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info.

     Artificial Intelligence and Large Language Models Contributions Policy

     It is expressly forbidden to contribute material generated by
     AI, LLMs, and similar technologies, to the CouchDB project. 
     This includes, but is not limited to, source code, documentation,
     commit messages, or any other areas of the project.

-->

## Overview

The default Clouseau configuration in `./dev/run` results in all Clouseau instances trying to write index files to the same folder. That creates a race condition. Observable symptom of the race condition is the following `curl` output:

```
$ curl -v -X GET --location 'http://admin:secret@localhost:25984/movies/_design/by-director-search/_search/by-director?query=director_3astring:*&include_docs=true'
``` 
Output:
```
{"error":"unknown_error","reason":"Lock obtain timed out: NativeFSLock@/Users/arturpoor/repo/couchdb/target/indexes/shards/00000000-7fffffff/movies.1782896092/c146b6fb754fa06bbbcbf78855ddb020/write.lock"}
* Connection #0 to host localhost left intact
```

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
