### PR TITLE
improve JWT error messages

### DIFF
--- a/src/jwtf/src/jwtf.erl
+++ b/src/jwtf/src/jwtf.erl
@@ -297,7 +297,7 @@ public_key_verify(Algorithm, Message, Signature, PublicKey) ->
         true ->
             ok;
         false ->
-            throw({bad_request, <<"Bad signature">>})
+            throw({bad_request, <<"Bad signature in authentication token">>})
     end.
 
 hmac_verify(Algorithm, Message, HMAC, SecretKey) ->
@@ -305,7 +305,7 @@ hmac_verify(Algorithm, Message, HMAC, SecretKey) ->
         HMAC ->
             ok;
         _ ->
-            throw({bad_request, <<"Bad HMAC">>})
+            throw({bad_request, <<"Bad HMAC in authentication token">>})
     end.
 
 jose_to_der(Signature) ->
@@ -325,7 +325,7 @@ rs_len(<<"ES", SizeBin/binary>>) ->
 split(EncodedToken) ->
     case binary:split(EncodedToken, <<$.>>, [global]) of
         [_, _, _] = Split -> Split;
-        _ -> throw({bad_request, <<"Malformed token">>})
+        _ -> throw({bad_request, <<"Malformed authentication token">>})
     end.
 
 decode_passthrough(B64UrlEncoded) ->
@@ -341,7 +341,7 @@ decode_b64url_json(B64UrlEncoded) ->
         end
     catch
         _:_ ->
-            throw({bad_request, <<"Malformed token">>})
+            throw({bad_request, <<"Malformed authentication token">>})
     end.
 
 props({Props}) ->

--- a/src/jwtf/test/jwtf_tests.erl
+++ b/src/jwtf/test/jwtf_tests.erl
@@ -49,28 +49,28 @@ jwt_io_ec_pubkey() ->
 b64_badarg_test() ->
     Encoded = <<"0.0.0">>,
     ?assertEqual(
-        {error, {bad_request, <<"Malformed token">>}},
+        {error, {bad_request, <<"Malformed authentication token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 
 b64_bad_block_test() ->
     Encoded = <<" aGVsbG8. aGVsbG8. aGVsbG8">>,
     ?assertEqual(
-        {error, {bad_request, <<"Malformed token">>}},
+        {error, {bad_request, <<"Malformed authentication token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 
 invalid_json_test() ->
     Encoded = <<"fQ.fQ.fQ">>,
     ?assertEqual(
-        {error, {bad_request, <<"Malformed token">>}},
+        {error, {bad_request, <<"Malformed authentication token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 
 truncated_json_test() ->
     Encoded = <<"ew.ew.ew">>,
     ?assertEqual(
-        {error, {bad_request, <<"Malformed token">>}},
+        {error, {bad_request, <<"Malformed authentication token">>}},
         jwtf:decode(Encoded, [], nil)
     ).
 
@@ -190,7 +190,7 @@ bad_rs256_sig_test() ->
     ),
     KS = fun(<<"RS256">>, undefined) -> jwt_io_rsa_pubkey() end,
     ?assertEqual(
-        {error, {bad_request, <<"Bad signature">>}},
+        {error, {bad_request, <<"Bad signature in authentication token">>}},
         jwtf:decode(Encoded, [], KS)
     ).
 
@@ -201,13 +201,13 @@ bad_hs256_sig_test() ->
     ),
     KS = fun(<<"HS256">>, undefined) -> <<"bad">> end,
     ?assertEqual(
-        {error, {bad_request, <<"Bad HMAC">>}},
+        {error, {bad_request, <<"Bad HMAC in authentication token">>}},
         jwtf:decode(Encoded, [], KS)
     ).
 
 malformed_token_test() ->
     ?assertEqual(
-        {error, {bad_request, <<"Malformed token">>}},
+        {error, {bad_request, <<"Malformed authentication token">>}},
         jwtf:decode(<<"a.b.c.d">>, [], nil)
     ).
 


### PR DESCRIPTION
## Overview

Improve JWT error messages. for example, "Bad signature" is confusing, "Bad signature in authentication token" is more helpful.

## Testing recommendations

covered by tests

## Related Issues or Pull Requests

N/A

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
