### PR TITLE
feat(couch): add process_count gauge to query server manager

### DIFF
--- a/src/couch/priv/stats_descriptions.cfg
+++ b/src/couch/priv/stats_descriptions.cfg
@@ -322,6 +322,10 @@
     {type, counter},
     {desc, <<"number of acquired external processes">>}
 ]}.
+{[couchdb, query_server, process_count], [
+    {type, gauge},
+    {desc, <<"number of active query server processes">>}
+]}.
 {[couchdb, query_server, process_starts], [
     {type, counter},
     {desc, <<"number of OS process starts">>}

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -141,6 +141,8 @@ init([]) ->
 
     ok = configure_language_servers(),
 
+    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()),
+
     {ok, #state{
         config = get_proc_config(),
         threshold_ts = timestamp(),
@@ -250,6 +252,7 @@ handle_info({'EXIT', Pid, spawn_error}, State) ->
     % Assert when removing that we always expect the opener to have been there
     [{Pid, #client{lang = Lang}}] = ets:take(?OPENING, Pid),
     dec_count(Lang),
+    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()),
     ok = flush_waiters(State, Lang),
     {noreply, State};
 handle_info({'EXIT', Pid, Reason}, State) ->
@@ -370,7 +373,8 @@ find_proc(Lang, DbPat, DDocKey) when
 spawn_proc(#client{} = Client) ->
     Pid = spawn_link(?MODULE, new_proc, [Client]),
     ets:insert(?OPENING, {Pid, Client}),
-    inc_count(Client#client.lang).
+    inc_count(Client#client.lang),
+    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()).
 
 % This instance was spawned without a client to replenish
 % the untagged pool asynchronously
@@ -686,7 +690,8 @@ remove_proc(#proc{pid = Pid} = Proc) ->
         false ->
             ok
     end,
-    dec_count(Proc#proc.lang).
+    dec_count(Proc#proc.lang),
+    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()).
 
 flush_waiters(#state{} = State, Lang) ->
     #state{hard_limit = HardLimit, config = {[_ | _] = Cfg}} = State,

--- a/src/couch/src/couch_proc_manager.erl
+++ b/src/couch/src/couch_proc_manager.erl
@@ -252,7 +252,6 @@ handle_info({'EXIT', Pid, spawn_error}, State) ->
     % Assert when removing that we always expect the opener to have been there
     [{Pid, #client{lang = Lang}}] = ets:take(?OPENING, Pid),
     dec_count(Lang),
-    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()),
     ok = flush_waiters(State, Lang),
     {noreply, State};
 handle_info({'EXIT', Pid, Reason}, State) ->
@@ -373,8 +372,7 @@ find_proc(Lang, DbPat, DDocKey) when
 spawn_proc(#client{} = Client) ->
     Pid = spawn_link(?MODULE, new_proc, [Client]),
     ets:insert(?OPENING, {Pid, Client}),
-    inc_count(Client#client.lang),
-    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()).
+    inc_count(Client#client.lang).
 
 % This instance was spawned without a client to replenish
 % the untagged pool asynchronously
@@ -690,8 +688,7 @@ remove_proc(#proc{pid = Pid} = Proc) ->
         false ->
             ok
     end,
-    dec_count(Proc#proc.lang),
-    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()).
+    dec_count(Proc#proc.lang).
 
 flush_waiters(#state{} = State, Lang) ->
     #state{hard_limit = HardLimit, config = {[_ | _] = Cfg}} = State,
@@ -803,10 +800,12 @@ foreach_proc(Fun) when is_function(Fun, 1) ->
 
 inc_count(Lang) ->
     ets:update_counter(?COUNTERS, Lang, 1, {Lang, 0}),
+    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()),
     ok.
 
 dec_count(Lang) ->
     ets:update_counter(?COUNTERS, Lang, -1, {Lang, 0}),
+    couch_stats:update_gauge([couchdb, query_server, process_count], get_proc_count()),
     ok.
 
 get_count(Lang) ->


### PR DESCRIPTION
## Overview
Track the number of active query server processes to provide visibility into resource usage. The gauge is updated when processes spawn/remove.

## Testing recommendations
```
./dev/run

curl http://localhost:15984/_node/_local/_prometheus | grep couchdb_query_server_process_count
```

## Checklist
- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches