### PR TITLE
Try to re-enable s390x and ppc64le

### DIFF
--- a/build-aux/Jenkinsfile
+++ b/build-aux/Jenkinsfile
@@ -126,35 +126,36 @@ meta = [
   // agents at a time and often time out even with retries. The build times
   // take close to an hour, which is at least x2 as long as it takes to run
   // other arch CI jobs and they still time out often and fail. Disable for
-  // now. This is a low demand arch distro, maybe remove support altogether?
+  // now. That's why we have the ppc64le_own label and not ppc64le.
   //
-  // 'base-ppc64': [
-  //   name: 'Debian POWER',
-  //   spidermonkey_vsn: '78',
-  //   with_nouveau: true,
-  //   with_clouseau: true,
-  //   quickjs_test262: true,
-  //   image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
-  //   node_label: 'ppc64le',
-  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  // ],
+  'base-ppc64': [
+    name: 'Debian POWER',
+    spidermonkey_vsn: '78',
+    with_nouveau: true,
+    with_clouseau: true,
+    quickjs_test262: true,
+    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
+    node_label: 'ppc64le_own',
+    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+  ],
 
-  // Just like in the ppc64le case we sometimes "pick up" built-in s390x workers added to
-  // our jenkins, but since those are managed by us, our .mix/.venv/.hex packaging
-  // cache hack in /home/jenkins doesn't work, and so elixir tests fail. Skip this arch build
-  // until we figure out caching (probably need to use a proper caching plugin).
+  // Just like in the ppc64le case we sometimes "pick up" built-in s390x
+  // workers added to our jenkins, but since those are managed by us, our
+  // .mix/.venv/.hex packaging cache hack in /home/jenkins doesn't work, and so
+  // elixir tests fail. That's why we're using the s390x_own label instead of
+  // s390x
   //
-  // 'base-s390x': [
-  //   name: 'Debian s390x',
-  //   spidermonkey_vsn: '78',
-  //   with_nouveau: true,
-  //   // QuickJS test262 shows a discrepancy typedarray-arg-set-values-same-buffer-other-type.js
-  //   // Test262Error: 51539607552,42,0,4,5,6,7,8
-  //   quickjs_test262: false,
-  //   image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
-  //   node_label: 's390x',
-  //   gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
-  // ],
+  'base-s390x': [
+    name: 'Debian s390x',
+    spidermonkey_vsn: '78',
+    with_nouveau: true,
+    // QuickJS test262 shows a discrepancy typedarray-arg-set-values-same-buffer-other-type.js
+    // Test262Error: 51539607552,42,0,4,5,6,7,8
+    quickjs_test262: false,
+    image: "${DOCKER_IMAGE_BASE}-${ERLANG_VERSION}",
+    node_label: 's390x_own',
+    gnu_make_eunit_opts: "${DEFAULT_GNU_MAKE_EUNIT_OPTS}"
+  ],
 
   'base': [
     name: 'Debian x86_64',

--- a/src/couch/test/eunit/couch_cfile_prop_tests.erl
+++ b/src/couch/test/eunit/couch_cfile_prop_tests.erl
@@ -19,7 +19,7 @@
 -include_lib("kernel/include/file.hrl").
 
 property_test_() ->
-    ?EUNIT_QUICKCHECK(60, 25000).
+    ?EUNIT_QUICKCHECK(90, 25000).
 
 -define(SIZE_LIMIT, 5000).
 -define(CFILE_FD, cfile_fd).


### PR DESCRIPTION
Previous failures were often from picking up ASF Jenkins generic workers with `s390x` and `ppc64le` labels. Those workers were often over-subscribed and pretty flaky. To avoid that use different label that only our project would match.

s390x seems to have a slower disk and times out on a disk heavy prop test, so let's bump the timeout value there a bit.

I ran the the CI 3 times in a row and s390x architecture passed all 3 times https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/jenkins-enable-ppc64le-and-s390x/

<img width="395" height="87" alt="Screenshot 2026-07-23 at 18 47 05" src="https://github.com/user-attachments/assets/3e51ba05-14f2-42c3-9dcc-16830643b3f8" />


Thanks to the IBM Linux Z team for debugging and improving the speed of our s390x worker!
