### PR TITLE
fix(nouveau): fix relevance sorting doc

### DIFF
--- a/src/docs/src/ddocs/nouveau.rst
+++ b/src/docs/src/ddocs/nouveau.rst
@@ -512,8 +512,9 @@ If you provide a ``sort`` parameter, then matches are returned in that order, ig
 relevance.
 
 If you want to use a ``sort`` parameter, and also include ordering by relevance in your
-search results, use the special fields ``-<score>`` or ``<score>`` within the ``sort``
-parameter.
+search results, use the special field ``relevance`` within the ``sort`` parameter. Note
+that the ``relevance`` cannot be inverted like other fields using ``-relevance`` and it
+will be ignored as unknown field.
 
 POSTing search queries
 ----------------------


### PR DESCRIPTION
## Overview

Fix the documentation of Nouveau sorting to use `<score>` instead of `relevance` for Lucene score based sorting.

## Related Issues or Pull Requests

#6075

Referenced parameter from https://github.com/apache/couchdb/blob/977fecb535c4e50a2d1356469b670c6da0e6d7b9/extra/nouveau/src/main/java/org/apache/couchdb/nouveau/lucene/LuceneIndex.java#L383

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches