### PR TITLE
test(mango-cursor): increase timeouts

### DIFF
--- a/src/mango/src/mango_cursor.erl
+++ b/src/mango/src/mango_cursor.erl
@@ -1103,9 +1103,9 @@ extract_selector_hints_test_() ->
             meck:unload()
         end,
         [
-            ?TDEF_FE(t_extract_selector_hints_view),
-            ?TDEF_FE(t_extract_selector_hints_text),
-            ?TDEF_FE(t_extract_selector_hints_nouveau)
+            ?TDEF_FE(t_extract_selector_hints_view, 100),
+            ?TDEF_FE(t_extract_selector_hints_text, 100),
+            ?TDEF_FE(t_extract_selector_hints_nouveau, 100)
         ]
     }.
 


### PR DESCRIPTION
this should help with the PPC builds failing