### PR TITLE
base64:decode throws error:badarg too

### DIFF
--- a/src/couch/src/couch_httpd_auth.erl
+++ b/src/couch/src/couch_httpd_auth.erl
@@ -93,7 +93,7 @@ basic_name_pw(Req) ->
                 _ ->
                     nil
             catch
-                error:function_clause ->
+                error:_ ->
                     throw({bad_request, "Authorization header has invalid base64 value"})
             end;
         _ ->
@@ -860,5 +860,25 @@ simple_pbkdf2_test() ->
             ]
         )
     ).
+
+basic_name_pw_valid_test_() ->
+    [
+        ?_assertEqual(
+            {"foo", "bar"}, basic_name_pw(mock_request([{"Authorization", "Basic Zm9vOmJhcg=="}]))
+        ),
+        ?_assertThrow(
+            {bad_request, "Authorization header has invalid base64 value"},
+            basic_name_pw(mock_request([{"Authorization", "Basic x"}]))
+        ),
+        ?_assertThrow(
+            {bad_request, "Authorization header has invalid base64 value"},
+            basic_name_pw(mock_request([{"Authorization", "Basic XX="}]))
+        )
+    ].
+
+mock_request(Headers) ->
+    MochiReq = mochiweb_request:new(nil, 'GET', "/", {1, 1}, mochiweb_headers:make(Headers)),
+    MochiReq:cleanup(),
+    #httpd{mochi_req = MochiReq}.
 
 -endif.


### PR DESCRIPTION
## Overview

Expand what errors when base64 decoding we handle

## Testing recommendations

Try `curl http://localhost:5984/_all_dbs -H 'Authorization: Basic foo' etc.

## Related Issues or Pull Requests

N/A

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [x] Code is written and works correctly
- [x] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
