### PR TITLE
docs: Fix inline link

### DIFF
--- a/src/docs/src/config/auth.rst
+++ b/src/docs/src/config/auth.rst
@@ -32,11 +32,11 @@ Server Administrators
 
     CouchDB server administrators and passwords are not stored in the
     ``_users`` database, but in the last ``[admins]`` section that CouchDB
-    finds when loading its ini files. See :config:intro for details on config
+    finds when loading its ini files. See :ref:`config/intro` for details on config
     file order and behaviour. This file (which could be something like
     ``/opt/couchdb/etc/local.ini`` or
     ``/opt/couchdb/etc/local.d/10-admins.ini`` when CouchDB is installed from
-    packages) should be appropriately secured and     readable only by system
+    packages) should be appropriately secured and readable only by system
     administrators::
 
         [admins]


### PR DESCRIPTION
Before:

<img width="1408" height="244" alt="grafik" src="https://github.com/user-attachments/assets/0090aad0-da8a-4801-ad98-2fa9099615c0" />


After:

<img width="1406" height="290" alt="grafik" src="https://github.com/user-attachments/assets/45932723-ffc5-4536-9b20-3c91d2261327" />


## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
