### PR TITLE
chore: Update build status image link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Apache CouchDB README
 | |1| |2| |
 +---------+
 
-.. |1| image:: https://ci-couchdb.apache.org/buildStatus/icon?job=jenkins-cm1%2FFullPlatformMatrix%2Fmain&subject=main
-    :target: https://ci-couchdb.apache.org/job/jenkins-cm1/job/FullPlatformMatrix/job/main/
+.. |1| image:: https://ci-couchdb.apache.org/buildStatus/icon?job=FullPlatformMatrix%2Fmain&subject=main
+    :target: https://ci-couchdb.apache.org/job/FullPlatformMatrix/job/main
 .. |2| image:: https://readthedocs.org/projects/couchdb/badge/?version=latest
     :target: https://docs.couchdb.org/en/latest/?badge=latest
 


### PR DESCRIPTION
## Overview

The ASF Infra team restored the Jenkins CI instance and the path for the build status has changed.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [ ] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
