### PR TITLE
chore(`docs`): update the Search installation instructions for Clouseau 3.x

### DIFF
--- a/src/docs/src/install/search.rst
+++ b/src/docs/src/install/search.rst
@@ -84,12 +84,6 @@ the following::
          com.cloudant.ziose.clouseau.Main \
          /path/to/clouseau.conf
 
-Chef
-====
-
-The CouchDB `cookbook`_ can build the search plugin from source and install it
-on a server alongside CouchDB.
-
 Kubernetes
 ==========
 

--- a/src/docs/src/install/search.rst
+++ b/src/docs/src/install/search.rst
@@ -18,16 +18,14 @@ Search Plugin Installation
 
 .. versionadded:: 3.0
 
-.. highlight:: ini
-
 CouchDB can build and query full-text search indexes using an external Java
 service that embeds `Apache Lucene <http://lucene.apache.org>`_. Typically, this
 service is installed on the same host as CouchDB and communicates with it over
 the loopback network.
 
-The search plugin is runtime-compatible with Java JDKs 6, 7 and 8. Building a
-release from source requires JDK 6. **It will not work with any newer version of
-Java.** Sorry about that.
+The search plugin is runtime-compatible with Java JDKs 21 and later. Building a
+release from source requires at least JDK 17. **It will not work with any older
+version of Java.** Sorry about that.
 
 Installation of Binary Packages
 ===============================
@@ -43,46 +41,48 @@ to the server command below. If clouseau is installed in ``/opt/clouseau`` the l
 
     -classpath '/opt/clouseau/*'
 
-The service expects to find a couple of configuration files
-conventionally called ``clouseau.ini`` and ``log4j.properties`` with the following
-content:
+The service expects to find its configuration file conventionally called ``clouseau.conf``
+with the following content:
 
-**clouseau.ini**::
+**clouseau.conf**::
 
-    [clouseau]
+    logger: {
+      format: Raw
+      output: Stdout
+      level: debug
+    }
+    config: [
+      {
+        node: {
+          # the name of the Erlang node created by the service, leave this unchanged
+          name: clouseau
+          domain: 127.0.0.1
 
-    ; the name of the Erlang node created by the service, leave this unchanged
-    name=clouseau@127.0.0.1
+          # set this to the same distributed Erlang cookie used by the CouchDB nodes
+          cookie: brumbrum
+        }
+        clouseau: {
+          # the path where you would like to store the search index files
+          dir: /path/to/index/storage
 
-    ; set this to the same distributed Erlang cookie used by the CouchDB nodes
-    cookie=brumbrum
+          # the number of search indexes that can be open simultaneously
+          max_indexes_open: 500
+        }
+      }
+    ]
 
-    ; the path where you would like to store the search index files
-    dir=/path/to/index/storage
-
-    ; the number of search indexes that can be open simultaneously
-    max_indexes_open=500
-
-**log4j.properties**::
-
-    log4j.rootLogger=debug, CONSOLE
-    log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-    log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-    log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %c [%p] %m%n
-
-Once these files are in place the service can be started with an invocation like
+Once this file is in place the service can be started with an invocation like
 the following::
 
     java -server \
          -Xmx2G \
          -Dsun.net.inetaddr.ttl=30 \
          -Dsun.net.inetaddr.negative.ttl=30 \
-         -Dlog4j.configuration=file:/path/to/log4j.properties \
-         -XX:OnOutOfMemoryError="kill -9 %p" \
-         -XX:+UseConcMarkSweepGC \
-         -XX:+CMSParallelRemarkEnabled \
-         com.cloudant.clouseau.Main \
-         /path/to/clouseau.ini
+         -XX:+ExitOnOutOfMemoryError \
+         -XX:+UseG1GC \
+         -XX:+ParallelRefProcEnabled \
+         com.cloudant.ziose.clouseau.Main \
+         /path/to/clouseau.conf
 
 Chef
 ====


### PR DESCRIPTION
## Overview

Clouseau 3.x has now become the supported version of Search, which works with more recent Java versions, and it features a new configuration syntax.  Update the respective part of the installation guide to chase these changes.

## Testing recommendations

Make sure that documentation is enabled for the build and then build it:

```
make docs
```

Once finished, open `src/docs/build/html/install/search.html` and verify the contents of the updated page.

## Checklist

- [x] This is my own work, I did not use AI, LLM's or similar technology
- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [ ] Documentation changes were backported (separated PR) to affected branches
