### PR TITLE
Fix typo in source check in mem3 reshard logic

### DIFF
--- a/src/mem3/src/mem3_reshard_dbdoc.erl
+++ b/src/mem3/src/mem3_reshard_dbdoc.erl
@@ -152,13 +152,7 @@ check_source_removed(#shard{name = Name}) ->
     Nodes = lists:usort([N || N <- ShardNodes, lists:member(N, Live)]),
     {Responses, _} = rpc:multicall(Nodes, mem3, shards, [DbName]),
     Shards = lists:usort(lists:flatten(Responses)),
-    SourcePresent = [
-        S
-     || S = #shard{name = S, node = N} <- Shards,
-        S =:= Name,
-        N =:= node()
-    ],
-    case SourcePresent of
-        [] -> true;
-        [_ | _] -> false
-    end.
+    [] =:= matching_shards(Name, node(), Shards).
+
+matching_shards(Name, Node, Shards) ->
+    [S || #shard{name = SN, node = N} = S <- Shards, SN =:= Name, N =:= Node].


### PR DESCRIPTION
Previously we matched both the shard record and the shard name to the same variable. Fix the match and slighly improve readability by making a small function for it.
